### PR TITLE
Fix build on arch linux (cast between struct and union gcc error)

### DIFF
--- a/Xi/exevents.c
+++ b/Xi/exevents.c
@@ -1568,7 +1568,7 @@ static void
 DeliverEmulatedMotionEvent(DeviceIntPtr dev, TouchPointInfoPtr ti,
                            InternalEvent *ev)
 {
-    DeviceEvent motion;
+    InternalEvent motion;
 
     if (ti->num_listeners) {
         ClientPtr client;
@@ -1580,27 +1580,27 @@ DeliverEmulatedMotionEvent(DeviceIntPtr dev, TouchPointInfoPtr ti,
             ti->listeners[0].type != TOUCH_LISTENER_POINTER_GRAB)
             return;
 
-        motion = ev->device_event;
-        motion.type = ET_TouchUpdate;
-        motion.detail.button = 0;
+        motion.device_event = ev->device_event;
+        motion.device_event.type = ET_TouchUpdate;
+        motion.device_event.detail.button = 0;
 
-        if (!RetrieveTouchDeliveryData(dev, ti, (InternalEvent*)&motion,
+        if (!RetrieveTouchDeliveryData(dev, ti, &motion,
                                        &ti->listeners[0], &client, &win, &grab,
                                        &mask))
             return;
 
-        DeliverTouchEmulatedEvent(dev, ti, (InternalEvent*)&motion, &ti->listeners[0], client,
+        DeliverTouchEmulatedEvent(dev, ti, &motion, &ti->listeners[0], client,
                                   win, grab, mask);
     }
     else {
         InternalEvent button;
         int converted;
 
-        converted = TouchConvertToPointerEvent(ev, (InternalEvent*)&motion, &button);
+        converted = TouchConvertToPointerEvent(ev, &motion, &button);
 
         BUG_WARN(converted == 0);
         if (converted)
-            ProcessOtherEvent((InternalEvent*)&motion, dev);
+            ProcessOtherEvent(&motion, dev);
     }
 }
 


### PR DESCRIPTION
Fixes this build error on arch linux:
```
../Xi/exevents.c:1394:26: error: array subscript ‘InternalEvent {aka union _InternalEvent}[0]’ is partly outside array bounds of ‘DeviceEvent[1]’ {aka ‘struct _DeviceEvent[1]’} [-Werror=array-bounds=]
 1394 |                 evtype = GetXI2Type(ev->any.type);
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~
../Xi/exevents.c: In function ‘DeliverEmulatedMotionEvent’:
../Xi/exevents.c:1571:17: note: object ‘motion’ of size 432
 1571 |     DeviceEvent motion;
      |
```
which happens because of change in build options compared to master and gcc 15.1 in arch. I think this warning (and error) is a bug in gcc.

gcc 15.1 doesn't like when struct DeviceEvent is cast to union InternalEvent. InternalEvent has a union `any` type and `DeviceEvent` type and these have to have a matching structure (for the header part). When the InternalEvent is used in RetrieveTouchDeliveryData function it access the any field, which accessed the data defined previously in the device_event fields.
This change matches how its done in touch.c TouchEmitTouchEnd for example and it's "more correct", since we are no longer casting from a smaller struct (DeviceEvent) to a larger struct (InternalEvent) when calling RetrieveTouchDeliveryData.