### PR TITLE
performance: align structures for 64-bit platforms 

### DIFF
--- a/composite/compint.h
+++ b/composite/compint.h
@@ -157,12 +157,13 @@ typedef struct _CompScreen {
     Bool pendingScreenUpdate;
 
     int numAlternateVisuals;
+    CloseScreenProcPtr CloseScreen;
     VisualID *alternateVisuals;
-    int numImplicitRedirectExceptions;
     CompImplicitRedirectException *implicitRedirectExceptions;
+    int numImplicitRedirectExceptions;
 
-    WindowPtr pOverlayWin;
     Window overlayWid;
+    WindowPtr pOverlayWin;
     CompOverlayClientPtr pOverlayClients;
 
     SourceValidateProcPtr SourceValidate;

--- a/include/eventstr.h
+++ b/include/eventstr.h
@@ -101,6 +101,7 @@ enum DeviceEventSource {
  */
 struct _DeviceEvent {
     unsigned char header; /**< Always ET_Internal */
+    int16_t root_x;       /**< Pos relative to root window in integral data */
     enum EventType type;  /**< One of EventType */
     int length;           /**< Length in bytes */
     Time time;            /**< Time in ms */
@@ -112,10 +113,10 @@ struct _DeviceEvent {
         uint32_t key;     /**< Key code */
     } detail;
     uint32_t touchid;     /**< Touch ID (client_id) */
-    int16_t root_x;       /**< Pos relative to root window in integral data */
-    float root_x_frac;    /**< Pos relative to root window in frac part */
     int16_t root_y;       /**< Pos relative to root window in integral part */
+    float root_x_frac;    /**< Pos relative to root window in frac part */
     float root_y_frac;    /**< Pos relative to root window in frac part */
+    enum DeviceEventSource source_type; /**< How this event was provoked */
     uint8_t buttons[(MAX_BUTTONS + 7) / 8];  /**< Button mask */
     struct {
         uint8_t mask[(MAX_VALUATORS + 7) / 8];/**< Valuator mask */
@@ -139,7 +140,6 @@ struct _DeviceEvent {
     int key_repeat;   /**< Internally-generated key repeat event */
     uint32_t flags;   /**< Flags to be copied into the generated event */
     uint32_t resource; /**< Touch event resource, only for TOUCH_REPLAYING */
-    enum DeviceEventSource source_type; /**< How this event was provoked */
 };
 
 /**
@@ -239,12 +239,12 @@ struct _RawDeviceEvent {
         uint32_t button;  /**< Button number */
         uint32_t key;     /**< Key code */
     } detail;
+    uint32_t flags;       /**< Flags to be copied into the generated event */
     struct {
         uint8_t mask[(MAX_VALUATORS + 7) / 8];/**< Valuator mask */
         double data[MAX_VALUATORS];           /**< Valuator data */
         double data_raw[MAX_VALUATORS];       /**< Valuator data as posted */
     } valuators;
-    uint32_t flags;       /**< Flags to be copied into the generated event */
 };
 
 struct _BarrierEvent {

--- a/include/extnsionst.h
+++ b/include/extnsionst.h
@@ -55,10 +55,10 @@ SOFTWARE.
 #include "privates.h"
 
 typedef struct _ExtensionEntry {
-    int index;
     void (*CloseDown) (         /* called at server shutdown */
                           struct _ExtensionEntry * /* extension */ );
     const char *name;           /* extension name */
+    int index;
     int base;                   /* base request number */
     int eventBase;
     int eventLast;

--- a/include/inputstr.h
+++ b/include/inputstr.h
@@ -179,9 +179,9 @@ union _GrabMask {
  */
 typedef struct _GrabRec {
     GrabPtr next;               /* for chain of passive grabs */
-    XID resource;
     DeviceIntPtr device;
     WindowPtr window;
+    XID resource;
     unsigned ownerEvents:1;
     unsigned keyboardMode:1;
     unsigned pointerMode:1;

--- a/include/inputstr.h
+++ b/include/inputstr.h
@@ -352,8 +352,8 @@ typedef struct _GestureInfo {
 
 typedef struct _GestureClassRec {
     int sourceid;
-    GestureInfoRec gesture;
     unsigned short max_touches; /* maximum number of touches, may be 0 */
+    GestureInfoRec gesture;
 } GestureClassRec;
 
 typedef struct _ButtonClassRec {

--- a/include/inputstr.h
+++ b/include/inputstr.h
@@ -374,8 +374,8 @@ typedef struct _ButtonClassRec {
 } ButtonClassRec, *ButtonClassPtr;
 
 typedef struct _FocusClassRec {
-    int sourceid;
     WindowPtr win;              /* May be set to a int constant (e.g. PointerRootWin)! */
+    int sourceid;
     int revert;
     TimeStamp time;
     WindowPtr *trace;

--- a/include/inputstr.h
+++ b/include/inputstr.h
@@ -527,11 +527,11 @@ typedef struct _SpriteInfoRec {
 typedef struct _DeviceIntRec {
     DeviceRec public;
     DeviceIntPtr next;
+    DeviceProc deviceProc;      /* proc(DevicePtr, DEVICE_xx). It is
+                               used to initialize, turn on, or
+                               turn off the device */
     Bool startup;               /* true if needs to be turned on at
                                    server initialization time */
-    DeviceProc deviceProc;      /* proc(DevicePtr, DEVICE_xx). It is
-                                   used to initialize, turn on, or
-                                   turn off the device */
     Bool inited;                /* TRUE if INIT returns Success */
     Bool enabled;               /* TRUE if ON returns Success */
     Bool coreEvents;            /* TRUE if device also sends core */
@@ -539,7 +539,6 @@ typedef struct _DeviceIntRec {
     int type;                   /* MASTER_POINTER, MASTER_KEYBOARD, SLAVE */
     Atom xinput_type;
     char *name;
-    int id;
     KeyClassPtr key;
     ValuatorClassPtr valuator;
     TouchClassPtr touch;
@@ -553,10 +552,11 @@ typedef struct _DeviceIntRec {
     StringFeedbackPtr stringfeed;
     BellFeedbackPtr bell;
     LedFeedbackPtr leds;
+    int id;
+    int saved_master_id;        /* for slaves while grabbed */
     struct _XkbInterest *xkb_interest;
     char *config_info;          /* used by the hotplug layer */
     ClassesPtr unused_classes;  /* for master devices */
-    int saved_master_id;        /* for slaves while grabbed */
     PrivateRec *devPrivates;
     DeviceUnwrapProc unwrapProc;
     SpriteInfoPtr spriteInfo;
@@ -573,9 +573,9 @@ typedef struct _DeviceIntRec {
     struct {
         double valuators[MAX_VALUATORS];
         int numValuators;
+        int num_touches;        /* size of the touches array */
         DeviceIntPtr slave;
         ValuatorMask *scroll;
-        int num_touches;        /* size of the touches array */
         DDXTouchPointInfoPtr touches;
     } last;
 
@@ -592,11 +592,11 @@ typedef struct _DeviceIntRec {
        [1/scale] . [transform] . [scale]. See DeviceSetTransform */
     struct pixman_f_transform scale_and_transform;
 
-    /* XTest related master device id */
-    int xtest_master_id;
-    DeviceSendEventsProc sendEventsProc;
-
     struct _SyncCounter *idle_counter;
+
+    /* XTest related master device id */
+    DeviceSendEventsProc sendEventsProc;
+    int xtest_master_id;
 
     Bool ignoreXkbActionsBehaviors; /* TRUE if keys don't trigger behaviors and actions */
 } DeviceIntRec;

--- a/include/inputstr.h
+++ b/include/inputstr.h
@@ -319,8 +319,8 @@ typedef struct _TouchPointInfo {
 } TouchPointInfoRec;
 
 typedef struct _TouchClassRec {
-    int sourceid;
     TouchPointInfoPtr touches;
+    int sourceid;
     unsigned short num_touches; /* number of allocated touches */
     unsigned short max_touches; /* maximum number of touches, may be 0 */
     CARD8 mode;                 /* ::XIDirectTouch, XIDependentTouch */

--- a/include/inputstr.h
+++ b/include/inputstr.h
@@ -248,8 +248,8 @@ typedef struct _KeyClassRec {
 } KeyClassRec, *KeyClassPtr;
 
 typedef struct _ScrollInfo {
-    enum ScrollType type;
     double increment;
+    enum ScrollType type;
     int flags;
 } ScrollInfo, *ScrollInfoPtr;
 

--- a/include/inputstr.h
+++ b/include/inputstr.h
@@ -342,12 +342,12 @@ typedef struct _GestureListener {
 typedef struct _GestureInfo {
     int sourceid;               /* Source device's ID for this gesture */
     Bool active;                /* whether or not the gesture is active */
+    uint8_t num_touches;        /* The number of touches in the gesture */
     uint8_t type;               /* Gesture type: either ET_GesturePinchBegin or
-                                   ET_GestureSwipeBegin. Valid if active == TRUE */
-    int num_touches;            /* The number of touches in the gesture */
+                           ET_GestureSwipeBegin. Valid if active == TRUE */
+    Bool has_listener;          /* true if listener has been setup already */
     SpriteRec sprite;           /* window trace for delivery */
     GestureListener listener;   /* the listener that will receive events */
-    Bool has_listener;          /* true if listener has been setup already */
 } GestureInfoRec;
 
 typedef struct _GestureClassRec {

--- a/include/scrnintstr.h
+++ b/include/scrnintstr.h
@@ -709,12 +709,12 @@ typedef struct _ScreenInfo {
     int bitmapScanlineUnit;
     int bitmapScanlinePad;
     int bitmapBitOrder;
-    int numPixmapFormats;
-     PixmapFormatRec formats[MAXFORMATS];
-    int numScreens;
     ScreenPtr screens[MAXSCREENS];
-    int numGPUScreens;
     ScreenPtr gpuscreens[MAXGPUSCREENS];
+    PixmapFormatRec formats[MAXFORMATS];
+    uint16_t numScreens;
+    uint16_t numGPUScreens;
+    uint8_t numPixmapFormats;
     int x;                      /* origin */
     int y;                      /* origin */
     int width;                  /* total width of all screens together */

--- a/include/scrnintstr.h
+++ b/include/scrnintstr.h
@@ -71,8 +71,8 @@ typedef struct _Visual {
     short nplanes;              /* = log2 (ColormapEntries). This does not
                                  * imply that the screen has this many planes.
                                  * it may have more or fewer */
-    unsigned long redMask, greenMask, blueMask;
     int offsetRed, offsetGreen, offsetBlue;
+    unsigned long redMask, greenMask, blueMask;
 } VisualRec;
 
 typedef struct _Depth {

--- a/include/scrnintstr.h
+++ b/include/scrnintstr.h
@@ -514,12 +514,13 @@ typedef struct _Screen {
     short x, y, width, height;
     short mmWidth, mmHeight;
     short numDepths;
-    unsigned char rootDepth;
+    short numVisuals;
     DepthPtr allowedDepths;
     unsigned long rootVisual;
     unsigned long defColormap;
-    short minInstalledCmaps, maxInstalledCmaps;
+    unsigned char rootDepth;
     char backingStoreSupport, saveUnderSupport;
+    short minInstalledCmaps, maxInstalledCmaps;
     unsigned long whitePixel, blackPixel;
     GCPtr GCperDepth[MAXFORMATS + 1];
     /* next field is a stipple to use as default in a GC.  we don't build
@@ -529,7 +530,6 @@ typedef struct _Screen {
      */
     PixmapPtr defaultStipple;
     void *devPrivate;
-    short numVisuals;
     VisualPtr visuals;
     WindowPtr root;
     ScreenSaverStuffRec screensaver;
@@ -621,6 +621,7 @@ typedef struct _Screen {
     NameWindowPixmapProcPtr NameWindowPixmap;
 
     unsigned int totalPixmapSize;
+    int output_secondarys;
 
     MarkWindowProcPtr MarkWindow;
     MarkOverlappedWindowsProcPtr MarkOverlappedWindows;
@@ -651,7 +652,6 @@ typedef struct _Screen {
     /* Info on this screen's secondarys (if any) */
     struct xorg_list secondary_list;
     struct xorg_list secondary_head;
-    int output_secondarys;
     /* Info for when this screen is a secondary */
     ScreenPtr current_primary;
     Bool is_output_secondary;

--- a/render/picturestr.h
+++ b/render/picturestr.h
@@ -39,8 +39,8 @@ typedef struct _DirectFormat {
 
 typedef struct _IndexFormat {
     VisualID vid;
-    ColormapPtr pColormap;
     int nvalues;
+    ColormapPtr pColormap;
     xIndexValue *pValues;
     void *devPrivate;
 } IndexFormatRec;


### PR DESCRIPTION
@metux, 

<img alt="x11libre vs xserver vs wayland" src="https://github.com/user-attachments/assets/355b6acd-2bad-4fd1-95e9-77bde0e9af7e" width="50%" height="50%">

## About PR

Migrated from: https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1757

I decided to support X11Libre instead Xorg, and I think I'll start optimizing, refactoring, and finding bugs in your fork. I hope you can help me, as you have a lot of experience in X server.

## More info about PR changes

If you are well versed in optimization for C/C++/C# compilers, then you know about Pahole memory analyzer tool (https://linux.die.net/man/1/pahole).

Structure fields change readable as possible from original code style.

This commit reduced cpu cost time move, copy, create objects with changed structures.

Smaller size structure or class, higher chance putting into CPU cache. Most processors are already 64 bit, so the change won't make it any worse.

Perhaps X11Test will not cover structures of interest, but I will try to conduct both before and after all my changes.

For interest, I'll test my PR on a very old hardware with S3 Graphics 4xx/5xx graphics, on a 2004 single-core Celeron. Also on my modern PC configuration in games and graphics renderers with MangoHUD metrics.

## Pahole example with `_DeviceEvent`:

- Comment `/* XXX {n} bytes hole, try to pack */` shows where optimization is possible by rearranging the order of fields structures and classes

## Master branch

```c
struct _DeviceEvent {
        unsigned char              header;               /*     0     1 */

        /* XXX 3 bytes hole, try to pack */

        enum EventType             type;                 /*     4     4 */
        int                        length;               /*     8     4 */
        Time                       time;                 /*    12     4 */
        int                        deviceid;             /*    16     4 */
        int                        sourceid;             /*    20     4 */
        union {
                uint32_t           button;               /*    24     4 */
                uint32_t           key;                  /*    24     4 */
        } detail;                                        /*    24     4 */
        uint32_t                   touchid;              /*    28     4 */
        int16_t                    root_x;               /*    32     2 */

        /* XXX 2 bytes hole, try to pack */

        float                      root_x_frac;          /*    36     4 */
        int16_t                    root_y;               /*    40     2 */

        /* XXX 2 bytes hole, try to pack */

        float                      root_y_frac;          /*    44     4 */
        uint8_t                    buttons[32];          /*    48    32 */
        /* --- cacheline 1 boundary (64 bytes) was 16 bytes ago --- */
        struct {
                uint8_t            mask[5];              /*    80     5 */
                uint8_t            mode[5];              /*    85     5 */

                /* XXX 6 bytes hole, try to pack */

                double             data[36];             /*    96   288 */
        } valuators;                                     /*    80   304 */

        /* XXX last struct has 1 hole */

        /* --- cacheline 6 boundary (384 bytes) --- */
        struct {
                uint32_t           base;                 /*   384     4 */
                uint32_t           latched;              /*   388     4 */
                uint32_t           locked;               /*   392     4 */
                uint32_t           effective;            /*   396     4 */
        } mods;                                          /*   384    16 */
        struct {
                uint8_t            base;                 /*   400     1 */
                uint8_t            latched;              /*   401     1 */
                uint8_t            locked;               /*   402     1 */
                uint8_t            effective;            /*   403     1 */
        } group;                                         /*   400     4 */
        Window                     root;                 /*   404     4 */
        int                        corestate;            /*   408     4 */
        int                        key_repeat;           /*   412     4 */
        uint32_t                   flags;                /*   416     4 */
        uint32_t                   resource;             /*   420     4 */
        enum DeviceEventSource     source_type;          /*   424     4 */

        /* size: 432, cachelines: 7, members: 22 */
        /* sum members: 421, holes: 3, sum holes: 7 */
        /* padding: 4 */
        /* member types with holes: 1, total: 1 */
        /* last cacheline: 48 bytes */
};
```

## PR branch

```c
struct _DeviceEvent {
        unsigned char              header;               /*     0     1 */

        /* XXX 1 byte hole, try to pack */

        int16_t                    root_x;               /*     2     2 */
        enum EventType             type;                 /*     4     4 */
        int                        length;               /*     8     4 */
        Time                       time;                 /*    12     4 */
        int                        deviceid;             /*    16     4 */
        int                        sourceid;             /*    20     4 */
        union {
                uint32_t           button;               /*    24     4 */
                uint32_t           key;                  /*    24     4 */
        } detail;                                        /*    24     4 */
        uint32_t                   touchid;              /*    28     4 */
        int16_t                    root_y;               /*    32     2 */

        /* XXX 2 bytes hole, try to pack */

        float                      root_x_frac;          /*    36     4 */
        float                      root_y_frac;          /*    40     4 */
        enum DeviceEventSource     source_type;          /*    44     4 */
        uint8_t                    buttons[32];          /*    48    32 */
        /* --- cacheline 1 boundary (64 bytes) was 16 bytes ago --- */
        struct {
                uint8_t            mask[5];              /*    80     5 */
                uint8_t            mode[5];              /*    85     5 */

                /* XXX 6 bytes hole, try to pack */

                double             data[36];             /*    96   288 */
        } valuators;                                     /*    80   304 */

        /* XXX last struct has 1 hole */

        /* --- cacheline 6 boundary (384 bytes) --- */
        struct {
                uint32_t           base;                 /*   384     4 */
                uint32_t           latched;              /*   388     4 */
                uint32_t           locked;               /*   392     4 */
                uint32_t           effective;            /*   396     4 */
        } mods;                                          /*   384    16 */
        struct {
                uint8_t            base;                 /*   400     1 */
                uint8_t            latched;              /*   401     1 */
                uint8_t            locked;               /*   402     1 */
                uint8_t            effective;            /*   403     1 */
        } group;                                         /*   400     4 */
        Window                     root;                 /*   404     4 */
        int                        corestate;            /*   408     4 */
        int                        key_repeat;           /*   412     4 */
        uint32_t                   flags;                /*   416     4 */
        uint32_t                   resource;             /*   420     4 */

        /* size: 424, cachelines: 7, members: 22 */
        /* sum members: 421, holes: 2, sum holes: 3 */
        /* member types with holes: 1, total: 1 */
        /* last cacheline: 40 bytes */
};
```

## Info about technique:

- https://wr.informatik.uni-hamburg.de/_media/teaching/wintersemester_2013_2014/epc-14-haase-svenhendrik-alignmentinc-presentation.pdf
- https://hpc.rz.rptu.de/Tutorials/AVX/alignment.shtml
- https://en.wikipedia.org/wiki/Data_structure_alignment
- https://stackoverflow.com/a/20882083
- https://zijishi.xyz/post/optimization-technique/learning-to-use-data-alignment/

## Affected structs

- _Visual 56      48      8 saved bytes
- _IndexFormat    40      32      8 saved bytes
- _GrabRec        120     112     8 saved bytes
- _DeviceIntRec   880     ~~856     24~~ 848 32 saved bytes **(saved 1 CPU cacheline!!!)**
- _TouchClassRec  32      24      8 saved bytes
- _GestureClassRec        360     352     8 saved bytes
- _GestureInfo    344     340     4
- _ScrollInfo     24      16      8
- _FocusClassRec  48      40      8
- _ExtensionEntry 72      64      8 **(saved 1 CPU cacheline!!!)**
- _ScreenInfo     328     324     4
- _PictureScreen  264     248     16 **(saved 1 CPU cacheline!!!)**
- _damage 112     104     8
- _Font   184     176     8
- _TouchOwnershipEvent    40      36      4
- _BarrierEvent   88      80      8
- _GestureEvent   128     120     8
- _DGAEvent       40      36      4
- _XkbSrvInfo     240     224     16
- _XkbInterest    72      64      8 **(saved 1 CPU cacheline!!!)**
- _XkbClientMapRec        48      40      8
- _LFclosure      616     608     8
- _LFWIclosure    616     608     8
- _OFclosure      72      64      8 **(saved 1 CPU cacheline!!!)**
- _ITclosure      56      48      8
- _rrTransform    216     208     8
- _PropertyFilterParam    104     96      8
- _DeviceVelocityRec      136     128     8 **(saved 1 CPU cacheline!!!)**
- _IO_FILE        216     208     8
- BeforeValidate  24      16      8
- _rrProvider     72      64      8 **(saved 1 CPU cacheline!!!)**
- dri3_syncobj    88      80      8
- _ExaOffscreenArea       72      64      8 **(saved 1 CPU cacheline!!!)**
- _glamor_program 104     96      8
- glamor_screen_private   19560   19544   16
- glamor_pixmap_private   120     104     16
- __GLXcontext    200     184     16
- __GLXscreen     104     96      8
- GlxContextTagInfoRec    48      40      8
- _miPolyArc      48      40      8
- _EdgeTableEntry 64      56      8
- _osComm 48      40      8
- _host   32      24      8
- xauth   64      48      16
- _XtransConnInfo 96      80      16
- auth    32      24      8
- msghdr  56      48      8
- _rrCrtc 736     720     16
- _rrOutput       144     128     16 **(saved 1 CPU cacheline!!!)**
- present_vblank  224     216     8
- present_screen_info     88      80      8
- present_screen_priv     208     200     8
- _rrMonitor      56      48      8
- _rrLease        72      64      8 **(saved 1 CPU cacheline!!!)**
- _rrScrPriv      392     376     16
- parent  32      24      8
- foo     24      16      8
- _ScreenSaverAttr        88      80      8
- _ShmDesc        64      56      8
- _CursorEvent    40      32      8
- _SelectionEvent 48      40      8
- PointerBarrierClient    80      72      8
- _XkbRF_Rule     96      88      8
- _XkbRF_Rules    32      24      8
- _XkbNameChanges 32      24      8
- _XkbOverlay     40      32      8