### PR TITLE
Xext: remove excess double-check pointer (IsSystemCounter already have)

### DIFF
--- a/Xext/sync.c
+++ b/Xext/sync.c
@@ -436,7 +436,7 @@ SyncInitTrigger(ClientPtr client, SyncTrigger * pTrigger, XID syncObject,
     if (newSyncObject) {
         SyncAddTriggerToSyncObject(pTrigger);
     }
-    else if (pCounter && IsSystemCounter(pCounter)) {
+    else if (IsSystemCounter(pCounter)) {
         SyncComputeBracketValues(pCounter);
     }
 


### PR DESCRIPTION
@metux, minor cleaning unnecessary check in conditional block.