### PR TITLE
randr/dix/xfree86/Xi/xkb: fixes bit shifting by CWE-190 Integer Overflow or Wraparound

### DIFF
--- a/Xi/xiproperty.c
+++ b/Xi/xiproperty.c
@@ -272,7 +272,7 @@ get_property(ClientPtr client, DeviceIntPtr dev, Atom property, Atom type,
 
     /* Return type, format, value to client */
     n = (prop_value->format / 8) * prop_value->size;    /* size (bytes) of prop */
-    ind = offset << 2;
+    ind = (unsigned long)offset << 2;
 
     /* If offset is invalid such that it causes "len" to
        be negative, it's a value error. */

--- a/Xi/xiproperty.c
+++ b/Xi/xiproperty.c
@@ -272,7 +272,7 @@ get_property(ClientPtr client, DeviceIntPtr dev, Atom property, Atom type,
 
     /* Return type, format, value to client */
     n = (prop_value->format / 8) * prop_value->size;    /* size (bytes) of prop */
-    ind = (unsigned long)offset << 2;
+    ind = offset << 2;
 
     /* If offset is invalid such that it causes "len" to
        be negative, it's a value error. */

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -3515,7 +3515,7 @@ ProcSetFontPath(ClientPtr client)
 
     REQUEST_AT_LEAST_SIZE(xSetFontPathReq);
 
-    nbytes = (client->req_len << 2) - sizeof(xSetFontPathReq);
+    nbytes = ((unsigned long)client->req_len << 2) - sizeof(xSetFontPathReq);
     total = nbytes;
     ptr = (unsigned char *) &stuff[1];
     nfonts = stuff->nFonts;
@@ -3883,7 +3883,7 @@ SendConnSetup(ClientPtr client, const char *reason)
     if (client->swapped) {
         WriteSConnSetupPrefix(client, lconnSetupPrefix);
         WriteSConnectionInfo(client,
-                             (unsigned long) (lconnSetupPrefix->length << 2),
+                             (unsigned long)lconnSetupPrefix->length << 2,
                              lConnectionInfo);
     }
     else {

--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -526,7 +526,7 @@ QueryFont(FontPtr pFont, xQueryFontReply * pReply, int nProtoCCIStructs)
     }
 
     ninfos = 0;
-    ncols = (unsigned long) (pFont->info.lastCol - pFont->info.firstCol + 1);
+    ncols = (unsigned long)pFont->info.lastCol - pFont->info.firstCol + 1;
     prCI = (xCharInfo *) (prFP);
     for (int r = pFont->info.firstRow;
          ninfos < nProtoCCIStructs && r <= (int) pFont->info.lastRow; r++) {

--- a/dix/property.c
+++ b/dix/property.c
@@ -592,7 +592,7 @@ ProcGetProperty(ClientPtr client)
  *  Return type, format, value to client
  */
     n = (pProp->format / 8) * pProp->size;      /* size (bytes) of prop */
-    ind = p.longOffset << 2;
+    ind = (unsigned long)p.longOffset << 2;
 
     /* If longOffset is invalid such that it causes "len" to
        be negative, it's a value error. */

--- a/dix/swapreq.c
+++ b/dix/swapreq.c
@@ -647,7 +647,7 @@ SProcStoreColors(ClientPtr client)
     REQUEST_AT_LEAST_SIZE(xStoreColorsReq);
     swapl(&stuff->cmap);
     pItem = (xColorItem *) &stuff[1];
-    for (long count = ((client->req_len << 2) - sizeof(xStoreColorsReq)) / sizeof(xColorItem); --count >= 0;)
+    for (long count = (((long)client->req_len << 2) - sizeof(xStoreColorsReq)) / sizeof(xColorItem); --count >= 0;)
         SwapColorItem(pItem++);
     return ((*ProcVector[X_StoreColors]) (client));
 }

--- a/hw/xfree86/common/xf86Cursor.c
+++ b/hw/xfree86/common/xf86Cursor.c
@@ -576,7 +576,7 @@ xf86InitOrigins(void)
 
     memset(xf86ScreenLayout, 0, MAXSCREENS * sizeof(xf86ScreenLayoutRec));
 
-    screensLeft = prevScreensLeft = (1 << xf86NumScreens) - 1;
+    screensLeft = prevScreensLeft = (1UL << xf86NumScreens) - 1;
 
     while (1) {
         for (mask = screensLeft, i = 0; mask; mask >>= 1, i++) {
@@ -587,7 +587,7 @@ xf86InitOrigins(void)
 
             if (screen->refscreen != NULL &&
                 screen->refscreen->screennum >= xf86NumScreens) {
-                screensLeft &= ~(1 << i);
+                screensLeft &= ~(1UL << i);
                 LogMessageVerb(X_WARNING, 1,
                                "Not including screen \"%s\" in origins calculation.\n",
                                screen->screen->id);
@@ -649,7 +649,7 @@ xf86InitOrigins(void)
             case PosAbsolute:
                 pScreen->x = screen->x;
                 pScreen->y = screen->y;
-                screensLeft &= ~(1 << i);
+                screensLeft &= ~(1UL << i);
                 break;
             case PosRelative:
                 ref = screen->refscreen->screennum;
@@ -662,7 +662,7 @@ xf86InitOrigins(void)
                 refScreen = xf86Screens[ref]->pScreen;
                 pScreen->x = refScreen->x + screen->x;
                 pScreen->y = refScreen->y + screen->y;
-                screensLeft &= ~(1 << i);
+                screensLeft &= ~(1UL << i);
                 break;
             case PosRightOf:
                 ref = screen->refscreen->screennum;
@@ -675,7 +675,7 @@ xf86InitOrigins(void)
                 refScreen = xf86Screens[ref]->pScreen;
                 pScreen->x = refScreen->x + refScreen->width;
                 pScreen->y = refScreen->y;
-                screensLeft &= ~(1 << i);
+                screensLeft &= ~(1UL << i);
                 break;
             case PosLeftOf:
                 ref = screen->refscreen->screennum;
@@ -688,7 +688,7 @@ xf86InitOrigins(void)
                 refScreen = xf86Screens[ref]->pScreen;
                 pScreen->x = refScreen->x - pScreen->width;
                 pScreen->y = refScreen->y;
-                screensLeft &= ~(1 << i);
+                screensLeft &= ~(1UL << i);
                 break;
             case PosBelow:
                 ref = screen->refscreen->screennum;
@@ -701,7 +701,7 @@ xf86InitOrigins(void)
                 refScreen = xf86Screens[ref]->pScreen;
                 pScreen->x = refScreen->x;
                 pScreen->y = refScreen->y + refScreen->height;
-                screensLeft &= ~(1 << i);
+                screensLeft &= ~(1UL << i);
                 break;
             case PosAbove:
                 ref = screen->refscreen->screennum;
@@ -714,7 +714,7 @@ xf86InitOrigins(void)
                 refScreen = xf86Screens[ref]->pScreen;
                 pScreen->x = refScreen->x;
                 pScreen->y = refScreen->y - pScreen->height;
-                screensLeft &= ~(1 << i);
+                screensLeft &= ~(1UL << i);
                 break;
             default:
                 ErrorF("Illegal placement keyword in Layout!\n");
@@ -736,7 +736,7 @@ xf86InitOrigins(void)
 
             ref = xf86ConfigLayout.screens[i].refscreen->screennum;
             xf86Screens[ref]->pScreen->x = xf86Screens[ref]->pScreen->y = 0;
-            screensLeft &= ~(1 << ref);
+            screensLeft &= ~(1UL << ref);
         }
 
         prevScreensLeft = screensLeft;

--- a/include/servermd.h
+++ b/include/servermd.h
@@ -109,6 +109,6 @@ extern _X_EXPORT PaddingInfo PixmapWidthPaddingInfo[];
     (PixmapWidthInPadUnits(w, d) << PixmapWidthPaddingInfo[d].padBytesLog2)
 
 #define BitmapBytePad(w) \
-    (((int)((w) + BITMAP_SCANLINE_PAD - 1) >> LOG2_BITMAP_PAD) << LOG2_BYTES_PER_SCANLINE_PAD)
+    ((int)((int)((w) + BITMAP_SCANLINE_PAD - 1) >> LOG2_BITMAP_PAD) << LOG2_BYTES_PER_SCANLINE_PAD)
 
 #endif                          /* SERVERMD_H */

--- a/randr/rrproperty.c
+++ b/randr/rrproperty.c
@@ -687,7 +687,7 @@ ProcRRGetOutputProperty(ClientPtr client)
  *  Return type, format, value to client
  */
     n = (prop_value->format / 8) * prop_value->size;    /* size (bytes) of prop */
-    ind = stuff->longOffset << 2;
+    ind = (unsigned long)stuff->longOffset << 2;
 
     /* If longOffset is invalid such that it causes "len" to
        be negative, it's a value error. */

--- a/randr/rrproviderproperty.c
+++ b/randr/rrproviderproperty.c
@@ -608,7 +608,7 @@ ProcRRGetProviderProperty(ClientPtr client)
  *  Return type, format, value to client
  */
     n = (prop_value->format / 8) * prop_value->size;    /* size (bytes) of prop */
-    ind = stuff->longOffset << 2;
+    ind = (unsigned long)stuff->longOffset << 2;
 
     /* If longOffset is invalid such that it causes "len" to
        be negative, it's a value error. */

--- a/randr/rrscreen.c
+++ b/randr/rrscreen.c
@@ -427,7 +427,7 @@ rrGetMultiScreenResources(ClientPtr client, Bool query, ScreenPtr pScreen)
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
-    extraLen = rep.length << 2;
+    extraLen = (unsigned long)rep.length << 2;
     if (extraLen) {
         extra = x_rpcbuf_reserve(&rpcbuf, extraLen);
         if (!extra) {
@@ -543,7 +543,7 @@ rrGetScreenResources(ClientPtr client, Bool query)
                       num_modes * bytes_to_int32(SIZEOF(xRRModeInfo)) +
                       bytes_to_int32(rep.nbytesNames));
 
-        extraLen = rep.length << 2;
+        extraLen = (unsigned long)rep.length << 2;
         if (!extraLen)
             goto finish;
 

--- a/record/set.c
+++ b/record/set.c
@@ -171,7 +171,7 @@ BitVectorIterateSet(RecordSetPtr pSet, RecordSetIteratePtr pIter,
 
     b = BitVectorFindBit(pSet, b, FALSE);
     pInterval->last = (b < 0) ? ((BitVectorSetPtr) pSet)->maxMember : b - 1;
-    return (RecordSetIteratePtr) (long) (pInterval->last + 1);
+    return (RecordSetIteratePtr) (long)pInterval->last + 1;
 }
 
 static RecordSetOperations BitVectorSetOperations = {

--- a/xkb/xkmread.c
+++ b/xkb/xkmread.c
@@ -647,7 +647,7 @@ ReadXkmIndicators(FILE * file, XkbDescPtr xkb, XkbChangesPtr changes)
             xkb->names->indicators[wire.indicator - 1] = name;
             if (changes)
                 changes->names.changed_indicators |=
-                    (1 << (wire.indicator - 1));
+                    (1UL << (wire.indicator - 1));
         }
         map = &xkb->indicators->maps[wire.indicator - 1];
         map->flags = wire.flags;


### PR DESCRIPTION
@metux,
I hope that no one will take advantage any integer overflow with malicious intentions, so it is advisable to close possible vulnerabilities.

References:
- https://cwe.mitre.org/data/definitions/190.html

Example same type real CVE vuln in Linux Kernel with Integer Overflow:
- https://nvd.nist.gov/vuln/detail/CVE-2022-49748
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=08245672cdc6505550d1a5020603b0a8d4a6dcc7