### PR TITLE
xkb/servermd: fix bit shifting by CWE-190 Integer Overflow or Wraparound

### DIFF
--- a/include/servermd.h
+++ b/include/servermd.h
@@ -90,11 +90,11 @@ extern _X_EXPORT PaddingInfo PixmapWidthPaddingInfo[];
 
 #define PixmapWidthInPadUnits(w, d) \
     (PixmapWidthPaddingInfo[d].notPower2 ? \
-    (((int)(w) * PixmapWidthPaddingInfo[d].bytesPerPixel +  \
+    ((int)((int)(w) * PixmapWidthPaddingInfo[d].bytesPerPixel +  \
 	         PixmapWidthPaddingInfo[d].bytesPerPixel) >> \
-	PixmapWidthPaddingInfo[d].padBytesLog2) : \
-    ((int)((w) + PixmapWidthPaddingInfo[d].padRoundUp) >> \
-	PixmapWidthPaddingInfo[d].padPixelsLog2))
+	(int)PixmapWidthPaddingInfo[d].padBytesLog2) : \
+    ((int)((int)(w) + PixmapWidthPaddingInfo[d].padRoundUp) >> \
+	(int)PixmapWidthPaddingInfo[d].padPixelsLog2))
 
 /*
  *	Return the number of bytes to which a scanline of the given

--- a/xkb/xkbsrv_priv.h
+++ b/xkb/xkbsrv_priv.h
@@ -70,9 +70,9 @@
  * code statement it is. _XkbErrCode2(4, foo) means "this is the 4th error
  * statement in this function". lovely.
  */
-#define _XkbErrCode2(a,b) ((XID)((((unsigned int)(a))<<24)|((b)&0xffffff)))
-#define _XkbErrCode3(a,b,c)     _XkbErrCode2(a,(((unsigned int)(b))<<16)|(c))
-#define _XkbErrCode4(a,b,c,d) _XkbErrCode3(a,b,((((unsigned int)(c))<<8)|(d)))
+#define _XkbErrCode2(a,b) ((XID)(((unsigned int)((unsigned int)(a))<<24)|((b)&0xffffff)))
+#define _XkbErrCode3(a,b,c)     _XkbErrCode2(a,((unsigned int)((unsigned int)(b))<<16)|(c))
+#define _XkbErrCode4(a,b,c,d) _XkbErrCode3(a,b,(((unsigned int)((unsigned int)(c))<<8)|(d)))
 
 #define WRAP_PROCESS_INPUT_PROC(device, oldprocs, proc, unwrapproc) \
         device->public.processInputProc = proc; \


### PR DESCRIPTION
Continue working prev PR here: https://github.com/X11Libre/xserver/pull/22

References:
- https://cwe.mitre.org/data/definitions/190.html

Example real CVE vulns with Integer Overflow:
- https://nvd.nist.gov/vuln/detail/CVE-2022-49748
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=08245672cdc6505550d1a5020603b0a8d4a6dcc7