### PR TITLE
dix/exa/glx/hw/xkb/dmgext: fix warnings uninit vars maybe be used

### DIFF
--- a/damageext/damageext.c
+++ b/damageext/damageext.c
@@ -643,7 +643,7 @@ PanoramiXDamageCreate(ClientPtr client, xDamageCreateReq *stuff)
         unsigned int walkScreenIdx;
         FOR_NSCREENS_FORWARD(walkScreenIdx) {
             ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
-            DrawablePtr pDrawable;
+            DrawablePtr pDrawable = NULL;
             DamagePtr pDamage = DamageCreate(PanoramiXDamageReport,
                                              PanoramiXDamageExtDestroy,
                                              DamageReportRawRegion,

--- a/dix/window.c
+++ b/dix/window.c
@@ -215,7 +215,7 @@ get_window_name(WindowPtr pWin)
 static void
 log_window_info(WindowPtr pWin, int depth)
 {
-    const char *win_name, *visibility;
+    const char *win_name, *visibility = NULL;
     BoxPtr rects;
 
     for (int i = 0; i < (depth << 2); i++)

--- a/exa/exa_render.c
+++ b/exa/exa_render.c
@@ -635,7 +635,7 @@ exaTryDriverComposite(CARD8 op,
     RegionRec region;
     BoxPtr pbox;
     int nbox;
-    int src_off_x, src_off_y, mask_off_x = 0, mask_off_y = 0, dst_off_x, dst_off_y;
+    int src_off_x = 0, src_off_y = 0, mask_off_x = 0, mask_off_y = 0, dst_off_x, dst_off_y;
     PixmapPtr pSrcPix = NULL, pMaskPix = NULL, pDstPix;
     ExaPixmapPrivPtr pSrcExaPix = NULL, pMaskExaPix = NULL, pDstExaPix;
 

--- a/glx/glxdri2.c
+++ b/glx/glxdri2.c
@@ -448,7 +448,7 @@ create_driver_context(__GLXDRIcontext * context,
     context->driContext = NULL;
 
     if (screen->dri2->base.version >= 3) {
-        uint32_t ctx_attribs[4 * 2];
+        uint32_t ctx_attribs[4 * 2] = { NULL };
         unsigned num_ctx_attribs = 0;
         unsigned dri_err = 0;
         unsigned major_ver;

--- a/glx/glxdri2.c
+++ b/glx/glxdri2.c
@@ -448,7 +448,7 @@ create_driver_context(__GLXDRIcontext * context,
     context->driContext = NULL;
 
     if (screen->dri2->base.version >= 3) {
-        uint32_t ctx_attribs[4 * 2] = { NULL };
+        uint32_t ctx_attribs[4 * 2] = { 0 };
         unsigned num_ctx_attribs = 0;
         unsigned dri_err = 0;
         unsigned major_ver;

--- a/hw/xfree86/x86emu/ops2.c
+++ b/hw/xfree86/x86emu/ops2.c
@@ -1893,9 +1893,9 @@ x86emuOp2_movzx_word_R_RM(u8 X86EMU_UNUSED(op2))
 {
     int mod, rl, rh;
     uint srcoffset;
-    u32 *destreg;
+    u32 *destreg = NULL;
     u32 srcval;
-    u16 *srcreg;
+    u16 *srcreg = NULL;
 
     START_OF_INSTR();
     DECODE_PRINTF("MOVZX\t");

--- a/xkb/xkbtext.c
+++ b/xkb/xkbtext.c
@@ -1261,7 +1261,7 @@ XkbActionText(XkbDescPtr xkb, XkbAction *action, unsigned format)
 char *
 XkbBehaviorText(XkbDescPtr xkb, XkbBehavior * behavior, unsigned format)
 {
-    char buf[256] = { NULL };
+    char buf[256] = { 0 };
 
     if (format == XkbCFile) {
         if (behavior->type == XkbKB_Default)

--- a/xkb/xkbtext.c
+++ b/xkb/xkbtext.c
@@ -1261,7 +1261,7 @@ XkbActionText(XkbDescPtr xkb, XkbAction *action, unsigned format)
 char *
 XkbBehaviorText(XkbDescPtr xkb, XkbBehavior * behavior, unsigned format)
 {
-    char buf[256];
+    char buf[256] = { NULL };
 
     if (format == XkbCFile) {
         if (behavior->type == XkbKB_Default)


### PR DESCRIPTION
Detected on latest Clang 19