### PR TITLE
dmgext/dix: additional checks pointers where they may be uninitialized

### DIFF
--- a/damageext/damageext.c
+++ b/damageext/damageext.c
@@ -660,6 +660,8 @@ PanoramiXDamageCreate(ClientPtr client, xDamageCreateReq *stuff)
             }
             if (rc != Success)
                 break;
+            if (!pDrawable)
+                break;
 
             DamageExtRegister(pDrawable, pDamage, walkScreenIdx != 0);
         }

--- a/dix/window.c
+++ b/dix/window.c
@@ -251,7 +251,10 @@ log_window_info(WindowPtr pWin, int depth)
         visibility = "unviewable";
         break;
     }
-    ErrorF(", %s", visibility);
+    if (visibility)
+        ErrorF(", %s", visibility);
+    else
+        ErrorF(", visibility not set!");
 
     if (RegionNotEmpty(&pWin->clipList)) {
         ErrorF(", clip list:");


### PR DESCRIPTION
`window visibility` check after switch block affects fixes this my PR:
https://github.com/X11Libre/xserver/pull/20

after added switch case default, it is necessary to add conclusion that user has not set visibility to window.