### PR TITLE
xf86bigfont: restoring build status feeling being deliberately spoiled

### DIFF
--- a/Xext/xf86bigfont.c
+++ b/Xext/xf86bigfont.c
@@ -52,7 +52,11 @@
 
 #include <X11/X.h>
 #include <X11/Xproto.h>
+#ifdef XF86BIGFONT
 #include <X11/extensions/xf86bigfproto.h>
+#include <X11/fonts/fontstruct.h>
+#include <X11/fonts/libxfont2.h>
+#endif
 
 #include "miext/extinit_priv.h"
 
@@ -530,8 +534,8 @@ ProcXF86BigfontQueryFont(ClientPtr client)
                : 0);
 
         xXF86BigfontQueryFontReply rep = {
-            .type = X_Reply;
-            .length = bytes_to_int32(buflength),
+            .type = X_Reply,
+            .length = bytes_to_int32(rlength),
             .sequenceNumber = client->sequence,
             .minBounds = pFont->info.ink_minbounds,
             .maxBounds = pFont->info.ink_maxbounds,

--- a/os/utils.c
+++ b/os/utils.c
@@ -119,6 +119,10 @@ OR PERFORMANCE OF THIS SOFTWARE.
 
 #include <errno.h>
 
+#ifdef XF86BIGFONT
+#include "xf86bigfontsrv.h"
+#endif
+
 Bool CoreDump;
 
 Bool enableIndirectGLX = FALSE;


### PR DESCRIPTION
I wonder if this is broken build xf86bigfont in master Xorg freedesktop.org, or only in metux fork master branch.