### PR TITLE
Replace unsecure strcpy() by CWE-676 Use of Potentially Dangerous Function

### DIFF
--- a/Xi/listdev.c
+++ b/Xi/listdev.c
@@ -111,7 +111,7 @@ CopyDeviceName(char **namebuf, const char *name)
 
     if (name) {
         *nameptr++ = strlen(name);
-        strcpy(nameptr, name);
+        strncpy(nameptr, name, strlen(name));
         *namebuf += (strlen(name) + 1);
     }
     else {

--- a/config/hal.c
+++ b/config/hal.c
@@ -109,7 +109,7 @@ get_prop_string_array(LibHalContext * hal_ctx, const char *udi,
 
         str = ret;
         for (i = 0; props[i]; i++) {
-            strcpy(str, props[i]);
+            strncpy(str, props[i], strlen(props[i]));
             str += strlen(props[i]);
             *str++ = ',';
         }

--- a/glx/single2.c
+++ b/glx/single2.c
@@ -275,14 +275,14 @@ __glXcombine_strings(const char *cext_string, const char *sext_string)
         combo_string = (char *) calloc(1, slen + 2);
         s1 = (char *) calloc(1, slen + 2);
         if (s1)
-            strcpy(s1, sext_string);
+            strncpy(s1, sext_string, slen + 2);
         s2 = cext_string;
     }
     else {
         combo_string = (char *) calloc(1, clen + 2);
         s1 = (char *) calloc(1, clen + 2);
         if (s1)
-            strcpy(s1, cext_string);
+            strncpy(s1, cext_string, clen + 2);
         s2 = sext_string;
     }
     if (!combo_string || !s1) {

--- a/hw/kdrive/ephyr/hostx.c
+++ b/hw/kdrive/ephyr/hostx.c
@@ -659,8 +659,8 @@ hostx_init(void)
             class_len = strlen(ephyrResName) + 1 + strlen("Xephyr") + 1;
             char *class_hint = calloc(1, class_len);
             if (class_hint) {
-                strcpy(class_hint, ephyrResName);
-                strcpy(class_hint + strlen(ephyrResName) + 1, "Xephyr");
+                strncpy(class_hint, ephyrResName, strlen(ephyrResName) + 1);
+                strncpy(class_hint + strlen(ephyrResName) + 1, "Xephyr", strlen("Xephyr") + 1);
                 xcb_change_property(HostX.conn,
                                     XCB_PROP_MODE_REPLACE,
                                     scrpriv->win,

--- a/hw/xnest/xcb.c
+++ b/hw/xnest/xcb.c
@@ -178,7 +178,7 @@ void xnest_set_command(
 
     /* copy arguments into single buffer */
     for (i = 0; i < argc; i++) {
-        strcpy(bp, argv[i]);
+        strncpy(bp, argv[i], strlen(argv[i]) + 1);
         bp += strlen(argv[i]) + 1;
     }
 

--- a/os/log.c
+++ b/os/log.c
@@ -218,7 +218,7 @@ static inline void doLogSync(void) {
 static void initSyslog(void) {
 #ifdef CONFIG_SYSLOG
     char buffer[4096];
-    strcpy(buffer, xorgSyslogIdent);
+    strncpy(buffer, xorgSyslogIdent, sizeof(buffer));
 
     snprintf(buffer, sizeof(buffer), "%s :%s", xorgSyslogIdent, (display ? display : "<>"));
 


### PR DESCRIPTION
@metux,

this commit replace unsecure `strcpy()` to `strncpy()` by CWE-676 Use of Potentially Dangerous Function

References: https://cwe.mitre.org/data/definitions/676.html
