### PR TITLE
Fix some applications freezing on startup because of xkb issue

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -6559,7 +6559,7 @@ ProcXkbGetDeviceInfo(ClientPtr client)
         return BadLength;
     }
 
-    WriteToClient(client, sizeof(buf), &buf);
+    WriteToClient(client, sz, buf);
     return Success;
 }
 


### PR DESCRIPTION
Fixes #4 and #8

Issue tracked down by @mikedld https://github.com/X11Libre/xserver/issues/4#issuecomment-2957146780

WriteToClient uses wrong size and uses pointer to buf (which is a pointer itself)