### PR TITLE
Fix incorrect power of two operator

### DIFF
--- a/hw/xnest/xcb.c
+++ b/hw/xnest/xcb.c
@@ -167,7 +167,7 @@ void xnest_set_command(
     for (i = 0, nbytes = 0; i < argc; i++)
         nbytes += strlen(argv[i]) + 1;
 
-    if (nbytes >= (2^16) - 1)
+    if (nbytes >= (1<<16) - 1)
         return;
 
     char *buf = calloc(1, nbytes+1);

--- a/os/connection.c
+++ b/os/connection.c
@@ -120,7 +120,7 @@ SOFTWARE.
 #include "probes.h"
 #include "xdmcp.h"
 
-#define MAX_CONNECTIONS (2^16)
+#define MAX_CONNECTIONS (1<<16)
 
 struct ospoll   *server_poll;
 


### PR DESCRIPTION
2^16 is 2 xor 16 which equals 18, not 2 to the power of 16 which is 65536