### PR TITLE
xkb: fix regression in GetDeviceInfo

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -6545,7 +6545,7 @@ ProcXkbGetDeviceInfo(ClientPtr client)
         walk += sizeof(xkbActionWireDesc)*rep.nBtnsRtrn;
     }
 
-    length -= sz;
+    length -= walk - buf;
 
     if (nDeviceLedFBs > 0) {
         status = FillDeviceLedFBs(dev, ledClass, ledID, length, walk, client);
@@ -6559,7 +6559,7 @@ ProcXkbGetDeviceInfo(ClientPtr client)
         return BadLength;
     }
 
-    WriteToClient(client, sizeof(buf), &buf);
+    WriteToClient(client, sz, buf);
     return Success;
 }
 


### PR DESCRIPTION
This fixes a regression in 5499a2999 (xkb: let SendDeviceLedFBs() fill buffer instead of writing directly, 2024-07-16).

We need to write the whole buffer, and the updated length has to take into consideration that `sz` now contains `led_len` so we need to subtract that or properly calculate the remaining size.