### PR TITLE
hw/xnest/Events: fix uninitialized BoxRec

### DIFF
--- a/hw/xnest/Events.c
+++ b/hw/xnest/Events.c
@@ -215,12 +215,11 @@ xnest_handle_event(xcb_generic_event_t *event)
             WindowPtr pWin = xnestWindowPtr(ev->window);
             if (pWin && ev->width && ev->height) {
                 RegionRec Rgn;
-                BoxRec Box = {
-                    .x1 = pWin->drawable.x + wBorderWidth(pWin) + ev->x,
-                    .y1 = pWin->drawable.y + wBorderWidth(pWin) + ev->y,
-                    .x2 = Box.x1 + ev->width,
-                    .y2 = Box.y1 + ev->height,
-                };
+                BoxRec Box;
+                Box.x1 = pWin->drawable.x + wBorderWidth(pWin) + ev->x;
+                Box.y1 = pWin->drawable.y + wBorderWidth(pWin) + ev->y;
+                Box.x2 = Box.x1 + ev->width;
+                Box.y2 = Box.y1 + ev->height;
                 RegionInit(&Rgn, &Box, 1);
                 miSendExposures(pWin, &Rgn, Box.x1, Box.y1);
             }


### PR DESCRIPTION
Box.x2 and Box.y2 depend on Box.x1 and Box.y1. According to the C language, it has no guarantees in which order structures will be initialized, so this can lead to unspecified behavior