### PR TITLE
xfree86: fix security and memory issues if calloc is failed

### DIFF
--- a/hw/xfree86/parser/scan.c
+++ b/hw/xfree86/parser/scan.c
@@ -846,8 +846,15 @@ xf86initConfigFiles(void)
     configLineNo = 0;
     pushToken = LOCK_TOKEN;
 
-    configBuf = calloc(1, CONFIG_BUF_LEN);
-    configRBuf = calloc(1, CONFIG_BUF_LEN);
+    if (!(configBuf = calloc(1, CONFIG_BUF_LEN))) {
+        ErrorF("xf86initConfigFiles: cannot allocate configBuf\n");
+        return;
+    }
+    if (!(configRBuf = calloc(1, CONFIG_BUF_LEN))) {
+        free(configBuf);
+        ErrorF("xf86initConfigFiles: cannot allocate configRBuf\n");
+        return;
+    }
     configBuf[0] = '\0';        /* sanity ... */
 }
 


### PR DESCRIPTION
@metux,
using dynamic sanitizers, I found possible issues and leaks.

### Memory reasons for processing realloc result

In addition to properly free memory when returning NULL from function in advance, it solves problems described below.

When there is shortage memory, situation is handled, as well as return from function with future free memory by call stack functions.

### Security reasons for processing realloc result

- Buffer Overflow (The Most Common and Exploitable Case):

If realloc() returns NULL, the original pointer (e.g., my_buffer) still points to the smaller, original memory block.

However, the program, lacking a NULL check, might continue its logic assuming the buffer has been successfully expanded to the desired new_size.

Any subsequent write operations (e.g., using strcpy, memcpy, or a loop writing character by character) that attempt to put more data than the original buffer's capacity will write beyond its allocated boundaries. This is a buffer overflow.

This can overwrite adjacent data on the heap (or sometimes stack, depending on context), leading to data corruption, denial of service, or, in severe cases, arbitrary code execution (by overwriting critical program data like function pointers or return addresses).

- NULL Dereference / Crash (Denial of Service):

If the code immediately assigns the NULL return value from realloc() back to the pointer variable used for the buffer (e.g., buffer = (char*)realloc(buffer, new_size);), and realloc() returned NULL, then buffer itself becomes NULL.

Any subsequent attempt to read from or write to *buffer (i.e., dereferencing a NULL pointer) will typically cause a segmentation fault or access violation, leading to a program crash. This is a denial-of-service (DoS) vulnerability. While serious, it's generally less severe than arbitrary code execution.

### Examples

Buffer Overflow:
```c
#include <stdio.h>
#include <stdlib.string.h>

int main() {
    char *buffer = (char *)malloc(10); // Initial allocation
    if (buffer == NULL) {
        perror("Initial malloc failed");
        return 1;
    }
    strcpy(buffer, "hello");
    printf("Original buffer: %s (address: %p)\n", buffer, (void *)buffer);

    size_t new_size = 1000; // A significantly larger size
    
    // --- VULNERABLE CODE SNIPPET ---
    // Missing NULL check after realloc
    buffer = (char *)realloc(buffer, new_size); 
    // If realloc fails and returns NULL, 'buffer' is now NULL.
    // We are skipping a check like: if (buffer == NULL) { handle_error(); }
    // --- END VULNERABLE CODE SNIPPET ---

    // --- Potential problem due to missing NULL check ---
    // If realloc failed, 'buffer' is NULL.
    // The following strcpy would attempt to write to address 0x0,
    // leading to a segmentation fault (NULL pointer dereference).
    // This is NOT a buffer overflow in the traditional sense, but a critical crash.
    strcpy(buffer, "This is a much longer string that won't fit in the original 10 bytes."); 
    printf("Reallocated buffer: %s (address: %p)\n", buffer, (void *)buffer);

    free(buffer); // This free call might also cause issues if buffer is NULL
                  // depending on the C standard library implementation,
                  // though often free(NULL) is defined to do nothing.

    return 0;
}
```

Denied-of-Service:
```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

int main() {
    char *buffer = NULL;
    size_t current_size = 10; // Initial size

    // Allocate initial buffer
    buffer = (char *)malloc(current_size);
    if (buffer == NULL) {
        perror("Initial malloc failed");
        return 1;
    }
    strcpy(buffer, "Hello");
    printf("Initial buffer: %s (size: %zu)\n", buffer, current_size);

    // --- VULNERABLE CODE START ---
    // Attempt to reallocate to a much larger size without checking for NULL
    // In a real-world scenario, 'new_size' might come from user input
    // and could be an extremely large value.
    size_t new_size = 1024 * 1024 * 1024; // 1 GB - likely to fail on many systems

    printf("\nAttempting to reallocate buffer to %zu bytes...\n", new_size);
    buffer = (char *)realloc(buffer, new_size);
    // !!! MISSING NULL CHECK HERE !!!
    // If realloc fails, 'buffer' will be NULL, but we proceed to use it.
    // --- VULNERABLE CODE END ---

    // This line will cause a crash (segmentation fault) if realloc returned NULL.
    // The program attempts to write to an invalid memory location.
    if (buffer != NULL) { // This check *should* be here, but is omitted in the vulnerable example
        strcpy(buffer, "This will cause a crash if realloc failed and buffer is NULL.");
        printf("Reallocated buffer: %s (size: %zu)\n", buffer, new_size);
    } else {
        printf("Reallocation failed, but the program is designed to crash here in the example.\n");
    }


    // This free will also operate on a NULL pointer if realloc failed,
    // which is generally safe in C (free(NULL) is a no-op), but doesn't
    // fix the earlier use-after-NULL issue.
    free(buffer);

    return 0;
}
```