### PR TITLE
dix: fix security and memory issues if calloc is failed

### DIFF
--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -694,7 +694,11 @@ doListFontsAndAliases(ClientPtr client, struct list_fonts_closure *c)
                 }
                 if (err == FontNameAlias) {
                     free(resolved);
-                    resolved = XNFalloc(resolvedlen + 1);
+                    resolved = calloc(1, resolvedlen + 1);
+                    if (!resolved) {
+                        err = AllocError;
+                        goto bail;
+                    }
                     memcpy(resolved, tmpname, resolvedlen + 1);
                 }
             }
@@ -748,8 +752,11 @@ doListFontsAndAliases(ClientPtr client, struct list_fonts_closure *c)
                     c->haveSaved = TRUE;
                     free(c->savedName);
                     c->savedName = calloc(1, namelen + 1);
-                    if (c->savedName)
-                        memcpy(c->savedName, name, namelen + 1);
+                    if (!c->savedName) {
+                        err = AllocError;
+                        goto bail;
+                    }
+                    memcpy(c->savedName, name, namelen + 1);
                     c->savedNameLen = namelen;
                     aliascount = 20;
                 }
@@ -976,7 +983,11 @@ doListFontsWithInfo(ClientPtr client, struct list_fonts_with_info_closure *c)
                 c->haveSaved = TRUE;
                 c->savedNumFonts = numFonts;
                 free(c->savedName);
-                c->savedName = XNFalloc(namelen + 1);
+                c->savedName = calloc(1, namelen + 1);
+                if (!c->savedName) {
+                    err = AllocError;
+                    goto bail;
+                }
                 memcpy(c->savedName, name, namelen + 1);
                 aliascount = 20;
             }

--- a/dix/getevents.c
+++ b/dix/getevents.c
@@ -382,11 +382,11 @@ AllocateMotionHistory(DeviceIntPtr pDev)
     size += sizeof(Time);
 
     pDev->valuator->motion = calloc(pDev->valuator->numMotionEvents, size);
-    pDev->valuator->first_motion = 0;
-    pDev->valuator->last_motion = 0;
     if (!pDev->valuator->motion)
         ErrorF("[dix] %s: Failed to alloc motion history (%d bytes).\n",
                pDev->name, size * pDev->valuator->numMotionEvents);
+    pDev->valuator->first_motion = 0;
+    pDev->valuator->last_motion = 0;
 }
 
 /**
@@ -1129,6 +1129,8 @@ InternalEvent *
 InitEventList(int num_events)
 {
     InternalEvent *events = calloc(num_events, sizeof(InternalEvent));
+    if (!events)
+        ErrorF("[dix]: Failed to allocate event list (%d num_events).\n", num_events);
 
     return events;
 }

--- a/dix/grabs.c
+++ b/dix/grabs.c
@@ -198,18 +198,18 @@ GrabPtr
 AllocGrab(const GrabPtr src)
 {
     GrabPtr grab = calloc(1, sizeof(GrabRec));
+    if (!grab)
+        return NULL;
 
-    if (grab) {
-        grab->xi2mask = xi2mask_new();
-        if (!grab->xi2mask) {
-            free(grab);
-            grab = NULL;
-        }
-        else if (src && !CopyGrab(grab, src)) {
-            free(grab->xi2mask);
-            free(grab);
-            grab = NULL;
-        }
+    grab->xi2mask = xi2mask_new();
+    if (!grab->xi2mask) {
+        free(grab);
+        grab = NULL;
+    }
+    else if (src && !CopyGrab(grab, src)) {
+        free(grab->xi2mask);
+        free(grab);
+        grab = NULL;
     }
 
     return grab;
@@ -343,15 +343,19 @@ static Mask *
 DeleteDetailFromMask(Mask *pDetailMask, unsigned int detail)
 {
     Mask *mask = calloc(MasksPerDetailMask, sizeof(Mask));
-    if (mask) {
-        if (pDetailMask)
-            for (int i = 0; i < MasksPerDetailMask; i++)
-                mask[i] = pDetailMask[i];
-        else
-            for (int i = 0; i < MasksPerDetailMask; i++)
-                mask[i] = ~0L;
-        BITCLEAR(mask, detail);
-    }
+    int i;
+
+    if (!mask)
+        return NULL;
+
+    if (pDetailMask)
+        for (i = 0; i < MasksPerDetailMask; i++)
+            mask[i] = pDetailMask[i];
+    else
+        for (i = 0; i < MasksPerDetailMask; i++)
+            mask[i] = ~0L;
+    BITCLEAR(mask, detail);
+
     return mask;
 }
 

--- a/dix/inpututils.c
+++ b/dix/inpututils.c
@@ -344,12 +344,12 @@ generate_modkeymap(ClientPtr client, DeviceIntPtr dev,
 InputAttributes *
 DuplicateInputAttributes(InputAttributes * attrs)
 {
+    if (!attrs)
+        return NULL;
+
     InputAttributes *new_attr;
     int ntags = 0;
     char **tags, **new_tags;
-
-    if (!attrs)
-        return NULL;
 
     if (!(new_attr = calloc(1, sizeof(InputAttributes))))
         goto unwind;
@@ -427,8 +427,7 @@ valuator_mask_new(int num_valuators)
      * flying-car future, when we can dynamically alloc the masks and are
      * not constrained by signals, we can start using num_valuators */
     ValuatorMask *mask = calloc(1, sizeof(ValuatorMask));
-
-    if (mask == NULL)
+    if (!mask)
         return NULL;
 
     mask->last_bit = -1;
@@ -1061,7 +1060,6 @@ xi2mask_new_with_size(size_t nmasks, size_t size)
 	       + nmasks * size;
 
     mask = calloc(1, alloc_size);
-
     if (!mask)
         return NULL;
 

--- a/dix/property.c
+++ b/dix/property.c
@@ -365,13 +365,11 @@ dixChangeWindowProperty(ClientPtr pClient, WindowPtr pWin, Atom property,
         if (!pProp)
             return BadAlloc;
         unsigned char *data = calloc(1, totalSize);
-        if (totalSize) {
-            if (!data) {
-                dixFreeObjectWithPrivates(pProp, PRIVATE_PROPERTY);
-                return BadAlloc;
-            }
-            memcpy(data, value, totalSize);
+        if (!data) {
+            dixFreeObjectWithPrivates(pProp, PRIVATE_PROPERTY);
+            return BadAlloc;
         }
+        memcpy(data, value, totalSize);
         pProp->propertyName = property;
         pProp->type = type;
         pProp->format = format;
@@ -404,11 +402,9 @@ dixChangeWindowProperty(ClientPtr pClient, WindowPtr pWin, Atom property,
 
         if (mode == PropModeReplace) {
             unsigned char *data = calloc(1, totalSize);
-            if (totalSize) {
-                if (!data)
-                    return BadAlloc;
-                memcpy(data, value, totalSize);
-            }
+            if (!data)
+                return BadAlloc;
+            memcpy(data, value, totalSize);
             pProp->data = data;
             pProp->size = len;
             pProp->type = type;

--- a/dix/ptrveloc.c
+++ b/dix/ptrveloc.c
@@ -428,11 +428,15 @@ void
 InitTrackers(DeviceVelocityPtr vel, int ntracker)
 {
     if (ntracker < 1) {
-        ErrorF("invalid number of trackers\n");
+        ErrorF("[dix] invalid number of trackers\n");
         return;
     }
     free(vel->tracker);
     vel->tracker = (MotionTrackerPtr) calloc(ntracker, sizeof(MotionTracker));
+    if (!vel->tracker) {
+        ErrorF("[dix] out of memory number of trackers (%d ntracker).\n", ntracker);
+        return;
+    }
     vel->num_tracker = ntracker;
 }
 

--- a/dix/touch.c
+++ b/dix/touch.c
@@ -384,10 +384,12 @@ TouchEventHistoryAllocate(TouchPointInfoPtr ti)
         return TRUE;
 
     ti->history = calloc(TOUCH_HISTORY_SIZE, sizeof(*ti->history));
+    if (!ti->history)
+        return FALSE;
+
     ti->history_elements = 0;
-    if (ti->history)
-        ti->history_size = TOUCH_HISTORY_SIZE;
-    return ti->history != NULL;
+    ti->history_size = TOUCH_HISTORY_SIZE;
+    return TRUE;
 }
 
 void


### PR DESCRIPTION
@metux, I think you'll like using pointer checking style, and there's a lot test ptr coverage `calloc()` function's returned pointers.
Using dynamic sanitizers, I found possible `calloc()` fails leaks.

Duplicate description PR: https://github.com/X11Libre/xserver/pull/79