### PR TITLE
Add Contribution Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contribution Guidelines
+
+1. All commits need a sign-off by the author (except for drafts)
+   If additional reviewers gave their ack, a proper attribution
+   header may be added.
+
+2. Commit messages should explain what's really done here and their
+   headlines need a short an precise subject. See history for examples.
+
+   Keep in mind that history is also a piece of documentation.
+
+3. Once release is out, bugfixes should be submitted separately, against
+   the affected release branch(es) as well as master (so multiple MRs)
+
+4. If new functions or types are introduced, these should be documented
+   in-code, so we can generate docs directly from the code :)
+
+5. Use MR tags if you can - if we need some more, just ask.


### PR DESCRIPTION
The guidelines come from metux's heads up mail:
https://www.freelists.org/post/xlibre/Heads-up-branch-changes-and-MR-policies