### PR TITLE
Rebrand 'X.Org X Server' to 'XLibre X Server'

### DIFF
--- a/hw/xfree86/common/xf86Init.c
+++ b/hw/xfree86/common/xf86Init.c
@@ -122,7 +122,7 @@ static Bool formatsDone = FALSE;
 static void
 xf86PrintBanner(void)
 {
-    xf86ErrorFVerb(0, "\nX.Org X Server %d.%d.%d",
+    xf86ErrorFVerb(0, "\nXLibre X Server %d.%d.%d",
                    XORG_VERSION_MAJOR, XORG_VERSION_MINOR, XORG_VERSION_PATCH);
 #if XORG_VERSION_SNAP > 0
     xf86ErrorFVerb(0, ".%d", XORG_VERSION_SNAP);

--- a/hw/xquartz/darwin.c
+++ b/hw/xquartz/darwin.c
@@ -173,7 +173,7 @@ void
 DarwinPrintBanner(void)
 {
     ErrorF("Xquartz starting:\n");
-    ErrorF("X.Org X Server %s\n", XSERVER_VERSION);
+    ErrorF("XLibre X Server %s\n", XSERVER_VERSION);
 }
 
 /*

--- a/hw/xquartz/mach-startup/bundle-main.c
+++ b/hw/xquartz/mach-startup/bundle-main.c
@@ -92,7 +92,7 @@ static const char *__crashreporter_info__ __attribute__((__used__)) =
 asm (".desc ___crashreporter_info__, 0x10");
 
 static const char *__crashreporter_info__base =
-    "X.Org X Server " XSERVER_VERSION;
+    "XLibre X Server " XSERVER_VERSION;
 
 char *bundle_id_prefix = NULL;
 static char *server_bootstrap_name = NULL;


### PR DESCRIPTION
Might cause issues in some programs that check for the "X.Org X Server" string, but I'm not aware of any atm.