### PR TITLE
dix: fix fuzzing issue when `pScreen` is `NULL`

### DIFF
--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -1901,6 +1901,9 @@ get_client_resolutions(int *num)
     static struct _FontResolution res;
     ScreenPtr masterScreen = dixGetMasterScreen();
 
+    if (!masterScreen)
+        return NULL;
+
     res.x_resolution = (masterScreen->width * 25.4) / masterScreen->mmWidth;
     /*
      * XXX - we'll want this as long as bitmap instances are prevalent

--- a/dix/glyphcurs.c
+++ b/dix/glyphcurs.c
@@ -86,6 +86,10 @@ ServerBitsFromGlyph(FontPtr pfont, unsigned ch, CursorMetricPtr cm,
     char2b[1] = (unsigned char) (ch & 0xff);
 
     ScreenPtr masterScreen = dixGetMasterScreen();
+
+    if (!masterScreen)
+        return BadDrawable;
+
     pbits = calloc(BitmapBytePad(cm->width), cm->height);
     if (!pbits)
         return BadAlloc;


### PR DESCRIPTION
Reference: https://github.com/X11Libre/xserver/issues/115