### PR TITLE
dix: resolved not free after ClientSleep (suspended status)

### DIFF
--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -648,6 +648,7 @@ doListFontsAndAliases(ClientPtr client, struct list_fonts_closure *c)
                 if (!ClientIsAsleep(client))
                     ClientSleep(client,
                                 (ClientSleepProcPtr) doListFontsAndAliases, c);
+                free(resolved);
                 return TRUE;
             }
 
@@ -673,6 +674,7 @@ doListFontsAndAliases(ClientPtr client, struct list_fonts_closure *c)
                         ClientSleep(client,
                                     (ClientSleepProcPtr) doListFontsAndAliases,
                                     c);
+                    free(resolved);
                     return TRUE;
                 }
                 if (err == Successful)
@@ -690,6 +692,7 @@ doListFontsAndAliases(ClientPtr client, struct list_fonts_closure *c)
                         ClientSleep(client,
                                     (ClientSleepProcPtr) doListFontsAndAliases,
                                     c);
+                    free(resolved);
                     return TRUE;
                 }
                 if (err == FontNameAlias) {


### PR DESCRIPTION
However, I'm not sure for sure, only `resolved` needs release memory or other pointers too?