### PR TITLE
remove "lib" prefix in static_library in meson.build

### DIFF
--- a/Xext/meson.build
+++ b/Xext/meson.build
@@ -58,13 +58,13 @@ if build_xv
     hdrs_xext += ['xvdix.h', 'xvmcext.h']
 endif
 
-libxserver_xext = static_library('libxserver_xext',
+libxserver_xext = static_library('xserver_xext',
     srcs_xext,
     include_directories: inc,
     dependencies: common_dep,
 )
 
-libxserver_xext_vidmode = static_library('libxserver_xext_vidmode',
+libxserver_xext_vidmode = static_library('xserver_xext_vidmode',
     'vidmode.c',
     include_directories: inc,
     dependencies: common_dep,

--- a/Xext/namespace/meson.build
+++ b/Xext/namespace/meson.build
@@ -1,5 +1,5 @@
 libxserver_namespace = static_library(
-	'libxserver_namespace',
+	'xserver_namespace',
 	[
 		'config.c',
 		'hook-client.c',

--- a/Xi/meson.build
+++ b/Xi/meson.build
@@ -53,14 +53,14 @@ srcs_xi = [
     'xiwarppointer.c',
 ]
 
-libxserver_xi = static_library('libxserver_xi',
+libxserver_xi = static_library('xserver_xi',
     srcs_xi,
     include_directories: inc,
     dependencies: common_dep,
 )
 
 srcs_xi_stubs = ['stubs.c']
-libxserver_xi_stubs = static_library('libxserver_xi_stubs',
+libxserver_xi_stubs = static_library('xserver_xi_stubs',
     srcs_xi_stubs,
     include_directories: inc,
     dependencies: common_dep,

--- a/composite/meson.build
+++ b/composite/meson.build
@@ -10,7 +10,7 @@ hdrs_composite = [
 	'compositeext.h',
 ]
 
-libxserver_composite = static_library('libxserver_composite',
+libxserver_composite = static_library('xserver_composite',
 	srcs_composite,
 	include_directories: inc,
 	dependencies: common_dep,

--- a/config/meson.build
+++ b/config/meson.build
@@ -28,7 +28,7 @@ if build_xorg
                  install_dir: join_paths(get_option('datadir'), 'X11/xorg.conf.d'))
 endif
 
-libxserver_config = static_library('libxserver_config',
+libxserver_config = static_library('xserver_config',
     srcs_config,
     include_directories: inc,
     dependencies: config_dep,

--- a/damageext/meson.build
+++ b/damageext/meson.build
@@ -2,7 +2,7 @@ srcs_damageext = [
 	'damageext.c',
 ]
 
-libxserver_damageext = static_library('libxserver_damageext',
+libxserver_damageext = static_library('xserver_damageext',
 	srcs_damageext,
 	include_directories: inc,
 	dependencies: common_dep,

--- a/dbe/meson.build
+++ b/dbe/meson.build
@@ -3,7 +3,7 @@ srcs_dbe = [
 	'midbe.c',
 ]
 
-libxserver_dbe = static_library('libxserver_dbe',
+libxserver_dbe = static_library('xserver_dbe',
 	srcs_dbe,
 	include_directories: inc,
 	dependencies: common_dep,

--- a/dix/meson.build
+++ b/dix/meson.build
@@ -57,13 +57,13 @@ endif
 
 dtrace_dep = declare_dependency(sources: [dtrace_src, dtrace_hdr])
 
-libxserver_dix = static_library('libxserver_dix',
+libxserver_dix = static_library('xserver_dix',
     [ srcs_dix, builtinatoms_src ],
     include_directories: inc,
     dependencies: [ dtrace_dep, common_dep, ]
 )
 
-libxserver_main = static_library('libxserver_main',
+libxserver_main = static_library('xserver_main',
     'stubmain.c',
     include_directories: inc,
     dependencies: common_dep,

--- a/dri3/meson.build
+++ b/dri3/meson.build
@@ -10,7 +10,7 @@ hdrs_dri3 = [
 
 libxserver_dri3 = []
 if build_dri3
-    libxserver_dri3 = static_library('libxserver_dri3',
+    libxserver_dri3 = static_library('xserver_dri3',
         srcs_dri3,
         include_directories: inc,
         dependencies: [ common_dep, libdrm_dep ],

--- a/exa/meson.build
+++ b/exa/meson.build
@@ -12,7 +12,7 @@ srcs_exa = [
     'exa_unaccel.c',
 ]
 
-libxserver_exa = static_library('libxserver_exa',
+libxserver_exa = static_library('xserver_exa',
     srcs_exa,
     include_directories: inc,
     dependencies: common_dep,

--- a/fb/meson.build
+++ b/fb/meson.build
@@ -37,7 +37,7 @@ hdrs_fb = [
 	'wfbrename.h'
 ]
 
-libxserver_fb = static_library('libxserver_fb',
+libxserver_fb = static_library('xserver_fb',
 	srcs_fb,
 	include_directories: inc,
 	dependencies: common_dep,
@@ -46,7 +46,7 @@ libxserver_fb = static_library('libxserver_fb',
 
 wfb_args = '-DFB_ACCESS_WRAPPER'
 
-libxserver_wfb = static_library('libxserver_wfb',
+libxserver_wfb = static_library('xserver_wfb',
 	srcs_fb,
 	c_args: wfb_args,
 	include_directories: inc,

--- a/glx/meson.build
+++ b/glx/meson.build
@@ -32,7 +32,7 @@ srcs_glx = [
 
 libxserver_glx = []
 if build_glx
-    libxserver_glx = static_library('libxserver_glx',
+    libxserver_glx = static_library('xserver_glx',
         srcs_glx,
         include_directories: inc,
         dependencies: [
@@ -68,7 +68,7 @@ hdrs_vnd = [
 
 libglxvnd = []
 if build_glx
-    libglxvnd = static_library('libglxvnd',
+    libglxvnd = static_library('glxvnd',
     srcs_vnd,
     include_directories: inc,
         dependencies: [

--- a/mi/meson.build
+++ b/mi/meson.build
@@ -40,7 +40,7 @@ hdrs_mi = [
   'mizerarc.h',
 ]
 
-libxserver_mi = static_library('libxserver_mi',
+libxserver_mi = static_library('xserver_mi',
     srcs_mi,
     include_directories: inc,
     dependencies: [

--- a/miext/damage/meson.build
+++ b/miext/damage/meson.build
@@ -7,7 +7,7 @@ hdrs_miext_damage = [
 	'damagestr.h',
 ]
 
-libxserver_miext_damage = static_library('libxserver_miext_damage',
+libxserver_miext_damage = static_library('xserver_miext_damage',
 	srcs_miext_damage,
 	include_directories: inc,
 	dependencies: common_dep,

--- a/miext/rootless/meson.build
+++ b/miext/rootless/meson.build
@@ -6,7 +6,7 @@ srcs_miext_rootless = [
         'rootlessWindow.c',
 ]
 
-libxserver_miext_rootless = static_library('libxserver_miext_rootless',
+libxserver_miext_rootless = static_library('xserver_miext_rootless',
         srcs_miext_rootless,
         include_directories: inc,
         dependencies: common_dep,

--- a/miext/shadow/meson.build
+++ b/miext/shadow/meson.build
@@ -29,7 +29,7 @@ hdrs_miext_shadow = [
     'shadow.h',
 ]
 
-libxserver_miext_shadow = static_library('libxserver_miext_shadow',
+libxserver_miext_shadow = static_library('xserver_miext_shadow',
     srcs_miext_shadow,
     include_directories: inc,
     dependencies: common_dep,

--- a/miext/sync/meson.build
+++ b/miext/sync/meson.build
@@ -14,7 +14,7 @@ if build_dri3 or build_xwayland
     srcs_miext_sync += 'misyncshm.c'
 endif
 
-libxserver_miext_sync = static_library('libxserver_miext_sync',
+libxserver_miext_sync = static_library('xserver_miext_sync',
     srcs_miext_sync,
     include_directories: inc,
     dependencies: [

--- a/os/meson.build
+++ b/os/meson.build
@@ -79,7 +79,7 @@ endif
 
 libxlibc = []
 if srcs_libc.length() > 0
-    libxlibc = static_library('libxlibc',
+    libxlibc = static_library('xlibc',
         srcs_libc,
         include_directories: inc,
         dependencies: [
@@ -92,7 +92,7 @@ if enable_input_thread
     os_dep += cc.find_library('pthread')
 endif
 
-libxserver_os = static_library('libxserver_os',
+libxserver_os = static_library('xserver_os',
     srcs_os,
     include_directories: inc,
     dependencies: [

--- a/present/meson.build
+++ b/present/meson.build
@@ -15,7 +15,7 @@ hdrs_present = [
     'present.h',
 ]
 
-libxserver_present = static_library('libxserver_present',
+libxserver_present = static_library('xserver_present',
     srcs_present,
     include_directories: inc,
     dependencies: [

--- a/pseudoramiX/meson.build
+++ b/pseudoramiX/meson.build
@@ -1,4 +1,4 @@
-libxserver_pseudoramix = static_library('libxserver_pseudoramiX',
+libxserver_pseudoramix = static_library('xserver_pseudoramiX',
     'pseudoramiX.c',
     include_directories: inc,
     dependencies: common_dep,

--- a/randr/meson.build
+++ b/randr/meson.build
@@ -25,7 +25,7 @@ if build_xinerama
     srcs_randr += 'rrxinerama.c'
 endif
 
-libxserver_randr = static_library('libxserver_randr',
+libxserver_randr = static_library('xserver_randr',
     srcs_randr,
     include_directories: inc,
     dependencies: common_dep,

--- a/record/meson.build
+++ b/record/meson.build
@@ -3,7 +3,7 @@ srcs_record = [
 	'set.c',
 ]
 
-libxserver_record = static_library('libxserver_record',
+libxserver_record = static_library('xserver_record',
 	srcs_record,
 	include_directories: inc,
 	dependencies: common_dep,

--- a/render/meson.build
+++ b/render/meson.build
@@ -19,7 +19,7 @@ hdrs_render = [
     'picturestr.h',
 ]
 
-libxserver_render = static_library('libxserver_render',
+libxserver_render = static_library('xserver_render',
     srcs_render,
     include_directories: inc,
     dependencies: common_dep,

--- a/xfixes/meson.build
+++ b/xfixes/meson.build
@@ -7,7 +7,7 @@ srcs_xfixes = [
     'xfixes.c',
 ]
 
-libxserver_xfixes = static_library('libxserver_xfixes',
+libxserver_xfixes = static_library('xserver_xfixes',
     srcs_xfixes,
     include_directories: inc,
     dependencies: common_dep,

--- a/xkb/meson.build
+++ b/xkb/meson.build
@@ -23,7 +23,7 @@ srcs_xkb = [
     'XKBMAlloc.c',
 ]
 
-libxserver_xkb = static_library('libxserver_xkb',
+libxserver_xkb = static_library('xserver_xkb',
     srcs_xkb,
     include_directories: inc,
     dependencies: common_dep,
@@ -35,7 +35,7 @@ srcs_xkb_stubs = [
     'ddxVT.c',
 ]
 
-libxserver_xkb_stubs = static_library('libxserver_xkb_stubs',
+libxserver_xkb_stubs = static_library('xserver_xkb_stubs',
     srcs_xkb_stubs,
     include_directories: inc,
     dependencies: common_dep,


### PR DESCRIPTION
this was producing static libraries named "liblibsomething.a"