### PR TITLE
modesetting: Allow enabling atomic mode.

### DIFF
--- a/hw/xfree86/drivers/modesetting/driver.c
+++ b/hw/xfree86/drivers/modesetting/driver.c
@@ -1306,7 +1306,7 @@ PreInit(ScrnInfoPtr pScrn, int flags)
     ms->atomic_modeset_capable = (ret == 0);
 
     if (xf86ReturnOptValBool(ms->drmmode.Options, OPTION_ATOMIC, FALSE)) {
-        ret = drmSetClientCap(ms->fd, DRM_CLIENT_CAP_ATOMIC, 1);
+        ret = drmSetClientCap(ms->fd, DRM_CLIENT_CAP_ATOMIC, 2);
         ms->atomic_modeset = (ret == 0);
         if (!ms->atomic_modeset)
             xf86DrvMsg(pScrn->scrnIndex, X_WARNING, "Atomic modesetting not supported\n");


### PR DESCRIPTION
The Linux kernel has long had code preventing Xorg from using atomic modesetting [1] as a mitigation for it being enabled by default accidentally in older releases due to various bugs in it's implementation, some of these issues have since been fixed but some issues remain, namely with DPMS and other smaller things, so allow users to opt-in by setting `Option "Atomic" "True'`

This shouldn't cause any issues as the feature remains disabled by default.

[1] https://elixir.bootlin.com/linux/v6.15.2/source/drivers/gpu/drm/drm_ioctl.c#L341

(v2: Added the original author of this commit as a co-author)