### PR TITLE
xfree86: fix build because of missing include

### DIFF
--- a/hw/xfree86/common/xf86pciBus.h
+++ b/hw/xfree86/common/xf86pciBus.h
@@ -33,7 +33,11 @@
 #ifndef _XF86_PCI_BUS_H
 #define _XF86_PCI_BUS_H
 
+#include <pciaccess.h>
+#include <X11/Xdefs.h>
+
 #include "xf86MatchDrivers.h"
+#include "xf86str.h"
 
 void xf86PciProbe(void);
 Bool xf86PciAddMatchingDev(DriverPtr drvp);


### PR DESCRIPTION
c7f94be5f703487a22ffd8bc2fa14454292d3f29 added xf86Helper.c which includes xf86Bus.h which includes xf86pciBus.h which has missing symbols.
This works fine in other files that include xf86Bus.h because they seem to include xf86str.h indirectly in other includes.

Add required includes directly in xf86pciBus.h to not rely on indirect includes.