### PR TITLE
meson_options: set defaults for systemd and HAL to false

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -295,6 +295,12 @@ else
     endif
 endif
 
+if build_hal
+    message('WARNING: HAL is deprecated and might be removed in near future')
+    message('If you really need it, please file a feature request on keeping it')
+    message('and explain why you need it, what your use case is.')
+endif
+
 if build_udev and build_hal
     error('Hotplugging through both libudev and hal not allowed')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -66,7 +66,7 @@ option('pciaccess', type: 'boolean', value: true,
        description: 'Xorg pciaccess support')
 option('udev', type: 'boolean', value: true)
 option('udev_kms', type: 'boolean', value: true)
-option('hal', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
+option('hal', type: 'combo', choices: ['true', 'false', 'auto'], value: 'false',
        description: 'Enable HAL integration')
 option('systemd_notify', type: 'combo', choices: ['true', 'false', 'auto'], value: 'false',
        description: 'Enable systemd-notify support')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -68,9 +68,9 @@ option('udev', type: 'boolean', value: true)
 option('udev_kms', type: 'boolean', value: true)
 option('hal', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
        description: 'Enable HAL integration')
-option('systemd_notify', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
+option('systemd_notify', type: 'combo', choices: ['true', 'false', 'auto'], value: 'false',
        description: 'Enable systemd-notify support')
-option('systemd_logind', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
+option('systemd_logind', type: 'combo', choices: ['true', 'false', 'auto'], value: 'false',
        description: 'Enable systemd-logind integration')
 option('vgahw', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
        description: 'Xorg VGA access module')


### PR DESCRIPTION
Right now, meson is probing for and trying to enable systemd- as well as HAL-support automatically.
This is flawed in several ways:

a) the probing logic for systemd is broken (doesn't actually check for systemd, but just udev and dbus)
b) this should be deliberate decisions by the user/operator/distro, whether it's actually wanted
    (just the presence of some libraries in the build environment alone doesn't tell it)
c) HAL is pretty much obsolete, so we're considering to drop it entirely 
    --> anybody who still needs it: this is your wakeup call ;-)

