### PR TITLE
Fix xf86-input-wacom compilation

### DIFF
--- a/hw/xfree86/common/xf86Xinput.h
+++ b/hw/xfree86/common/xf86Xinput.h
@@ -134,6 +134,9 @@ extern _X_EXPORT void xf86PostButtonEventP(DeviceIntPtr device, int is_absolute,
                                            int first_valuator,
                                            int num_valuators,
                                            const int *valuators);
+extern _X_EXPORT void xf86PostButtonEventM(DeviceIntPtr device, int is_absolute,
+                                           int button, int is_down,
+                                           const ValuatorMask *mask);
 extern _X_EXPORT void xf86PostKeyboardEvent(DeviceIntPtr device,
                                             unsigned int key_code, int is_down);
 extern _X_EXPORT void xf86PostTouchEvent(DeviceIntPtr dev, uint32_t touchid,

--- a/hw/xfree86/common/xf86Xinput_priv.h
+++ b/hw/xfree86/common/xf86Xinput_priv.h
@@ -12,9 +12,6 @@ extern InputInfoPtr xf86InputDevs;
 int xf86NewInputDevice(InputInfoPtr pInfo, DeviceIntPtr *pdev, BOOL is_auto);
 InputInfoPtr xf86AllocateInput(void);
 
-void xf86PostButtonEventM(DeviceIntPtr device, int is_absolute, int button,
-                          int is_down, const ValuatorMask *mask);
-
 void xf86InputEnableVTProbe(void);
 
 InputDriverPtr xf86LookupInputDriver(const char *name);


### PR DESCRIPTION
Export `xf86PostButtonEventM()` to allow [`xf86-input-wacom`](https://github.com/linuxwacom/xf86-input-wacom) to build against XLibre. Tested with a Wacom One S tablet.

The upstream driver also depends on `xf86VIDrvMsgVerb()`, however removing usage of that function was trivial unlike this one.