### PR TITLE
Remove libselinux1-dev

### DIFF
--- a/.github/scripts/ubuntu/install-pkg.sh
+++ b/.github/scripts/ubuntu/install-pkg.sh
@@ -41,7 +41,6 @@ apt-get install -y \
 	libnvidia-egl-wayland-dev \
 	libpciaccess-dev \
 	libpixman-1-dev \
-	libselinux1-dev \
 	libspice-protocol-dev \
 	libsystemd-dev \
 	libudev-dev \


### PR DESCRIPTION
Should hopefully build without it; if not, we should fix that