### PR TITLE
dix: delete unused structure

### DIFF
--- a/dix/property.c
+++ b/dix/property.c
@@ -157,11 +157,6 @@ static void
 deliverPropertyNotifyEvent(WindowPtr pWin, int state, PropertyPtr pProp)
 {
     xEvent event;
-    PropertyStateRec rec = {
-        .win = pWin,
-        .prop = pProp,
-        .state = state
-    };
     UpdateCurrentTimeIf();
     event = (xEvent) {
         .u.property.window = pWin->drawable.id,


### PR DESCRIPTION
Does not affect work, but it is better to delete to debloat the codebase.
Compiled several times, no errors occurred.