### PR TITLE
ephyr: fix checking the same expression twice

### DIFF
--- a/hw/kdrive/ephyr/ephyr.c
+++ b/hw/kdrive/ephyr/ephyr.c
@@ -732,7 +732,7 @@ ephyrPrintGrabShortcut(char* const out, size_t const out_size,
             EphyrKeybindToggleHostGrabKey == 0
         ) || (
             EphyrTitleHostGrabKeyComboHint == 0 ||
-            EphyrTitleHostGrabKeyComboHint == 0
+            EphyrTitleHostGrabKeyComboHintLen == 0
         )
     ) {
         /* grabbing disabled */


### PR DESCRIPTION
Probably was a copy-paste error.
Intention is to check if the string is valid
(i.e. not null and length isn't 0).

fixes: #179