### PR TITLE
Fix missing vesa symbols

### DIFF
--- a/hw/xfree86/common/xf86.h
+++ b/hw/xfree86/common/xf86.h
@@ -245,6 +245,8 @@ xf86GetBppFromDepth(ScrnInfoPtr pScrn, int depth);
 
 /* xf86Mode.c */
 
+extern _X_EXPORT const char *
+xf86ModeStatusToString(ModeStatus status);
 extern _X_EXPORT ModeStatus
 xf86CheckModeForMonitor(DisplayModePtr mode, MonPtr monitor);
 extern _X_EXPORT int

--- a/hw/xfree86/common/xf86.h
+++ b/hw/xfree86/common/xf86.h
@@ -105,6 +105,7 @@ extern _X_EXPORT void xf86SetEntityInstanceForScreen(ScrnInfoPtr pScrn,
 extern _X_EXPORT int xf86GetNumEntityInstances(int entityIndex);
 extern _X_EXPORT GDevPtr xf86GetDevFromEntity(int entityIndex, int instance);
 extern _X_EXPORT EntityInfoPtr xf86GetEntityInfo(int entityIndex);
+extern _X_EXPORT Bool xf86IsEntityPrimary(int entityIndex);
 
 #define xf86SetLastScrnFlag(e, s) do { } while (0)
 

--- a/hw/xfree86/common/xf86.h
+++ b/hw/xfree86/common/xf86.h
@@ -106,6 +106,7 @@ extern _X_EXPORT int xf86GetNumEntityInstances(int entityIndex);
 extern _X_EXPORT GDevPtr xf86GetDevFromEntity(int entityIndex, int instance);
 extern _X_EXPORT EntityInfoPtr xf86GetEntityInfo(int entityIndex);
 extern _X_EXPORT Bool xf86IsEntityPrimary(int entityIndex);
+extern _X_EXPORT ScrnInfoPtr xf86FindScreenForEntity(int entityIndex);
 
 #define xf86SetLastScrnFlag(e, s) do { } while (0)
 

--- a/hw/xfree86/common/xf86Bus.h
+++ b/hw/xfree86/common/xf86Bus.h
@@ -75,7 +75,6 @@ extern int pciSlotClaimed;
 Bool xf86ComparePciBusString(const char *busID, int bus, int device, int func);
 Bool xf86DriverHasEntities(DriverPtr drvp);
 void xf86RemoveEntityFromScreen(ScrnInfoPtr pScrn, int entityIndex);
-ScrnInfoPtr xf86FindScreenForEntity(int entityIndex);
 
 Bool xf86BusConfig(void);
 void xf86PostProbe(void);

--- a/hw/xfree86/common/xf86Bus.h
+++ b/hw/xfree86/common/xf86Bus.h
@@ -75,7 +75,6 @@ extern int pciSlotClaimed;
 Bool xf86ComparePciBusString(const char *busID, int bus, int device, int func);
 Bool xf86DriverHasEntities(DriverPtr drvp);
 void xf86RemoveEntityFromScreen(ScrnInfoPtr pScrn, int entityIndex);
-Bool xf86IsEntityPrimary(int entityIndex);
 ScrnInfoPtr xf86FindScreenForEntity(int entityIndex);
 
 Bool xf86BusConfig(void);

--- a/hw/xfree86/common/xf86Mode.c
+++ b/hw/xfree86/common/xf86Mode.c
@@ -93,6 +93,7 @@
 #include "os.h"
 #include "servermd.h"
 #include "globals.h"
+#include "xf86.h"
 #include "xf86_priv.h"
 #include "xf86Priv.h"
 #include "edid.h"

--- a/hw/xfree86/common/xf86Priv.h
+++ b/hw/xfree86/common/xf86Priv.h
@@ -40,6 +40,7 @@
 
 extern _X_EXPORT int xf86FbBpp;
 extern _X_EXPORT int xf86Depth;
+extern _X_EXPORT Bool xf86FlipPixels;
 
 /* Other parameters */
 

--- a/hw/xfree86/common/xf86_priv.h
+++ b/hw/xfree86/common/xf86_priv.h
@@ -79,7 +79,6 @@ Bool xf86LoadModules(const char **list, void **optlist);
 Bool xf86HasTTYs(void);
 
 /* xf86Mode.c */
-const char * xf86ModeStatusToString(ModeStatus status);
 ModeStatus xf86CheckModeForDriver(ScrnInfoPtr scrp, DisplayModePtr mode, int flags);
 
 /* xf86DefaultModes (auto-generated) */

--- a/hw/xfree86/common/xf86_priv.h
+++ b/hw/xfree86/common/xf86_priv.h
@@ -33,7 +33,6 @@ extern char *xf86PointerName;
 extern char *xf86KeyboardName;
 
 extern rgb xf86Weight;
-extern Bool xf86FlipPixels;
 extern Gamma xf86Gamma;
 
 extern const char *xf86ModulePath;

--- a/hw/xfree86/compat/xf86Helper.c
+++ b/hw/xfree86/compat/xf86Helper.c
@@ -4,7 +4,7 @@
 
 
 #include "xf86Priv.h"
-#include "xf86Bus.h"
+#include "xf86.h"
 
 
 /*

--- a/hw/xfree86/int10/helper_exec.c
+++ b/hw/xfree86/int10/helper_exec.c
@@ -27,7 +27,6 @@
 
 #include "xf86.h"
 #include "xf86_OSproc.h"
-#include "xf86Bus.h"
 #include "compiler.h"
 #define _INT10_PRIVATE
 #include "int10Defines.h"

--- a/hw/xfree86/int10/vbeModes.c
+++ b/hw/xfree86/int10/vbeModes.c
@@ -38,6 +38,7 @@
 
 #include "os/log_priv.h"
 
+#include "xf86.h"
 #include "xf86_priv.h"
 #include "vbe.h"
 #include "vbeModes.h"

--- a/hw/xfree86/vgahw/vgaHW.c
+++ b/hw/xfree86/vgahw/vgaHW.c
@@ -21,7 +21,7 @@
 
 #include "misc.h"
 
-#include "xf86_priv.h"
+#include "xf86.h"
 #include "xf86_OSproc.h"
 #include "xf86Opt_priv.h"
 #include "xf86Priv.h"

--- a/include/os.h
+++ b/include/os.h
@@ -191,10 +191,39 @@ XNFstrdup(const char *s);
 /* Include new X*asprintf API */
 #include "Xprintf.h"
 
+typedef void (*OsSigHandlerPtr) (int /* sig */ );
 typedef int (*OsSigWrapperPtr) (int /* sig */ );
 
+extern _X_EXPORT OsSigHandlerPtr
+OsSignal(int /* sig */ , OsSigHandlerPtr /* handler */ );
 extern _X_EXPORT OsSigWrapperPtr
 OsRegisterSigWrapper(OsSigWrapperPtr newWrap);
+
+extern _X_EXPORT void
+OsInit(void);
+
+extern _X_EXPORT void
+OsCleanup(Bool);
+
+extern _X_EXPORT void
+OsVendorFatalError(const char *f, va_list args)
+_X_ATTRIBUTE_PRINTF(1, 0);
+
+extern _X_EXPORT void
+OsVendorInit(void);
+
+extern _X_EXPORT void
+OsBlockSignals(void);
+
+extern _X_EXPORT void
+OsReleaseSignals(void);
+
+extern void
+OsResetSignals(void);
+
+extern _X_EXPORT void
+OsAbort(void)
+    _X_NORETURN;
 
 extern _X_EXPORT Bool
 PrivsElevated(void);

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -164,19 +164,7 @@ int os_move_fd(int fd);
    depending on whether multithreading is used */
 int xthread_sigmask(int how, const sigset_t *set, sigset_t *oldest);
 
-typedef void (*OsSigHandlerPtr) (int sig);
 
-/* install signal handler */
-OsSigHandlerPtr OsSignal(int sig, OsSigHandlerPtr handler);
-
-void OsInit(void);
-void OsCleanup(Bool);
-void OsVendorFatalError(const char *f, va_list args) _X_ATTRIBUTE_PRINTF(1, 0);
-void OsVendorInit(void);
-void OsBlockSignals(void);
-void OsReleaseSignals(void);
-void OsResetSignals(void);
-void OsAbort(void) _X_NORETURN;
 void AbortServer(void) _X_NORETURN;
 
 void MakeClientGrabPervious(ClientPtr client);


### PR DESCRIPTION
A lot of symbols needed by various internal modules were unexported, which caused them not to load due to unresolved symbols, which caused drivers like vesa to break.

This pr brings them back.

I tested int10, fbdevhw,  vgahw, exa, shadow, shadowfb, glamoregl and wfb,  which seem to be the only internal modules, so this should not happen again.