### PR TITLE
xkb: fix XkbGetKbdByName returning incorrect data

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -6054,7 +6054,7 @@ ProcXkbGetKbdByName(ClientPtr client)
 
     if (reported & (XkbGBN_SymbolsMask | XkbGBN_TypesMask)) {
         char *buf = payload_walk + sizeof(mrep);
-        XkbAssembleMap(client, xkb, mrep, buf);
+        XkbAssembleMap(client, new, mrep, buf);
 
         if (client->swapped) {
             swaps(&mrep.sequenceNumber);


### PR DESCRIPTION
This is a regression first caused by 182404fde6bcacf5e2f05424fde4073c96c2474e that sends back the old xkb data instead of the new one. This causes a mismatch in the data and size calculations between the XkbComputeGetMapReplySize that is called above that calculates the size of the reply and XkbAssembleMap that sets the data for the reply.

Without this fix this error is seen when running setxkbmap fr: "Error loading new keyboard description".

Fixes setxkbmap error described in #180