### PR TITLE
glamor: Enable dmabuf_capable for Zink

### DIFF
--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -1192,6 +1192,8 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
                                                   "dmabuf_capable");
         else if (strstr((const char *)renderer, "Intel"))
             glamor_egl->dmabuf_capable = TRUE;
+        else if (strstr((const char *)renderer, "zink"))
+            glamor_egl->dmabuf_capable = TRUE;
         else
             glamor_egl->dmabuf_capable = FALSE;
     }


### PR DESCRIPTION
This lets Zink take advantage of DRM modifiers on GPUs letting it properly handle the import of tiled buffers.

Should help out NVK users using XLibre.

(This is a copy of the FDO MR)