### PR TITLE
modesetting: Use IN_FORMATS_ASYNC for async flips 

### DIFF
--- a/Xext/xace.h
+++ b/Xext/xace.h
@@ -78,7 +78,7 @@ int XaceHookPropertyAccess(ClientPtr ptr, WindowPtr pWin, PropertyPtr *ppProp,
                            Mask access_mode);
 int XaceHookSelectionAccess(ClientPtr ptr, Selection ** ppSel, Mask access_mode);
 
-/* needs to be exported for in-tree modsetting, but not part of public API */
+/* needs to be exported for in-tree modesetting, but not part of public API */
 _X_EXPORT int XaceHookResourceAccess(ClientPtr client, XID id, RESTYPE rtype, void *res,
                            RESTYPE ptype, void *parent, Mask access_mode);
 

--- a/hw/xfree86/drivers/modesetting/driver.c
+++ b/hw/xfree86/drivers/modesetting/driver.c
@@ -913,6 +913,51 @@ msSetWindowVRRMode(WindowPtr window, WindowVRRMode mode)
         ms_present_set_screen_vrr(scrn, variable_refresh);
 }
 
+
+Bool
+ms_window_has_async_flip(WindowPtr win)
+{
+    ScrnInfoPtr scrn = xf86ScreenToScrn(win->drawable.pScreen);
+    modesettingPtr ms = modesettingPTR(scrn);
+    struct ms_async_flip_priv *priv = dixLookupPrivate(&win->devPrivates,
+                                                       &ms->drmmode.asyncFlipPrivateKeyRec);
+
+    return priv->async_flip;
+}
+
+void
+ms_window_update_async_flip(WindowPtr win, Bool async_flip)
+{
+    ScrnInfoPtr scrn = xf86ScreenToScrn(win->drawable.pScreen);
+    modesettingPtr ms = modesettingPTR(scrn);
+    struct ms_async_flip_priv *priv = dixLookupPrivate(&win->devPrivates,
+                                                       &ms->drmmode.asyncFlipPrivateKeyRec);
+
+    priv->async_flip = async_flip;
+}
+
+Bool
+ms_window_has_async_flip_modifiers(WindowPtr win)
+{
+    ScrnInfoPtr scrn = xf86ScreenToScrn(win->drawable.pScreen);
+    modesettingPtr ms = modesettingPTR(scrn);
+    struct ms_async_flip_priv *priv = dixLookupPrivate(&win->devPrivates,
+                                                       &ms->drmmode.asyncFlipPrivateKeyRec);
+
+    return priv->async_flip_modifiers;
+}
+
+void
+ms_window_update_async_flip_modifiers(WindowPtr win, Bool async_flip)
+{
+    ScrnInfoPtr scrn = xf86ScreenToScrn(win->drawable.pScreen);
+    modesettingPtr ms = modesettingPTR(scrn);
+    struct ms_async_flip_priv *priv = dixLookupPrivate(&win->devPrivates,
+                                                       &ms->drmmode.asyncFlipPrivateKeyRec);
+
+    priv->async_flip_modifiers = async_flip;
+}
+
 static void
 FreeScreen(ScrnInfoPtr pScrn)
 {
@@ -1709,6 +1754,11 @@ modsetCreateScreenResources(ScreenPtr pScreen)
         !dixRegisterPrivateKey(&ms->drmmode.vrrPrivateKeyRec,
                                PRIVATE_WINDOW,
                                sizeof(struct ms_vrr_priv)))
+            return FALSE;
+
+    if (!dixRegisterPrivateKey(&ms->drmmode.asyncFlipPrivateKeyRec,
+                               PRIVATE_WINDOW,
+                               sizeof(struct ms_async_flip_priv)))
             return FALSE;
 
     return ret;

--- a/hw/xfree86/drivers/modesetting/driver.c
+++ b/hw/xfree86/drivers/modesetting/driver.c
@@ -1676,7 +1676,7 @@ msStopFlippingPixmapTracking(DrawablePtr src,
 }
 
 static Bool
-modsetCreateScreenResources(ScreenPtr pScreen)
+modesetCreateScreenResources(ScreenPtr pScreen)
 {
     ScrnInfoPtr pScrn = xf86ScreenToScrn(pScreen);
     modesettingPtr ms = modesettingPTR(pScrn);
@@ -1991,7 +1991,7 @@ ScreenInit(ScreenPtr pScreen, int argc, char **argv)
         return FALSE;
     }
 
-    pScreen->CreateScreenResources = modsetCreateScreenResources;
+    pScreen->CreateScreenResources = modesetCreateScreenResources;
 
     xf86SetBlackWhitePixels(pScreen);
 

--- a/hw/xfree86/drivers/modesetting/driver.h
+++ b/hw/xfree86/drivers/modesetting/driver.h
@@ -49,6 +49,11 @@ struct ms_vrr_priv {
     Bool variable_refresh;
 };
 
+struct ms_async_flip_priv {
+    Bool async_flip;
+    Bool async_flip_modifiers;
+};
+
 typedef enum {
     OPTION_SW_CURSOR,
     OPTION_DEVICE_PATH,
@@ -261,3 +266,7 @@ void ms_drain_drm_events(ScreenPtr screen);
 Bool ms_window_has_variable_refresh(modesettingPtr ms, WindowPtr win);
 void ms_present_set_screen_vrr(ScrnInfoPtr scrn, Bool vrr_enabled);
 Bool ms_tearfree_is_active_on_crtc(xf86CrtcPtr crtc);
+Bool ms_window_has_async_flip(WindowPtr win);
+void ms_window_update_async_flip(WindowPtr win, Bool async_flip);
+Bool ms_window_has_async_flip_modifiers(WindowPtr win);
+void ms_window_update_async_flip_modifiers(WindowPtr win, Bool async_flip);

--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
@@ -2400,6 +2400,7 @@ drmmode_crtc_create_planes(xf86CrtcPtr crtc, int num)
         return;
     }
 
+    drmSetClientCap(drmmode->fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
     kplane_res = drmModeGetPlaneResources(drmmode->fd);
     if (!kplane_res) {
         xf86DrvMsg(drmmode->scrn->scrnIndex, X_ERROR,

--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
@@ -1114,10 +1114,6 @@ drmmode_create_bo(drmmode_ptr drmmode, drmmode_bo *bo,
 
 #ifdef GLAMOR_HAS_GBM
     if (drmmode->glamor) {
-#ifdef GBM_BO_WITH_MODIFIERS
-        uint32_t num_modifiers;
-        uint64_t *modifiers = NULL;
-#endif
         uint32_t format;
 
         switch (drmmode->scrn->depth) {
@@ -1134,22 +1130,6 @@ drmmode_create_bo(drmmode_ptr drmmode, drmmode_bo *bo,
             format = GBM_FORMAT_ARGB8888;
             break;
         }
-
-#ifdef GBM_BO_WITH_MODIFIERS
-        num_modifiers = get_modifiers_set(drmmode->scrn, format, &modifiers,
-                                          FALSE, TRUE);
-        if (num_modifiers > 0 &&
-            !(num_modifiers == 1 && modifiers[0] == DRM_FORMAT_MOD_INVALID)) {
-            bo->gbm = gbm_bo_create_with_modifiers(drmmode->gbm, width, height,
-                                                   format, modifiers,
-                                                   num_modifiers);
-            free(modifiers);
-            if (bo->gbm) {
-                bo->used_modifiers = TRUE;
-                return TRUE;
-            }
-        }
-#endif
 
         bo->gbm = gbm_bo_create(drmmode->gbm, width, height, format,
                                 GBM_BO_USE_RENDERING | GBM_BO_USE_SCANOUT);

--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
@@ -243,6 +243,7 @@ get_drawable_modifiers(DrawablePtr draw, uint32_t format,
 {
     ScrnInfoPtr scrn = xf86ScreenToScrn(draw->pScreen);
     modesettingPtr ms = modesettingPTR(scrn);
+    Bool async_flip;
 
     if (!present_can_window_flip((WindowPtr) draw) ||
         !ms->drmmode.pageflip || ms->drmmode.dri2_flipping || !scrn->vtSema) {
@@ -251,8 +252,11 @@ get_drawable_modifiers(DrawablePtr draw, uint32_t format,
         return TRUE;
     }
 
+    async_flip = ms_window_has_async_flip((WindowPtr)draw);
+    ms_window_update_async_flip_modifiers((WindowPtr)draw, async_flip);
+
     *num_modifiers = get_modifiers_set(scrn, format, modifiers,
-                                       TRUE, FALSE, FALSE);
+                                       TRUE, FALSE, async_flip);
     return TRUE;
 }
 #endif

--- a/hw/xfree86/drivers/modesetting/drmmode_display.h
+++ b/hw/xfree86/drivers/modesetting/drmmode_display.h
@@ -119,6 +119,7 @@ typedef struct {
     DevPrivateKeyRec pixmapPrivateKeyRec;
     DevScreenPrivateKeyRec spritePrivateKeyRec;
     DevPrivateKeyRec vrrPrivateKeyRec;
+    DevPrivateKeyRec asyncFlipPrivateKeyRec;
     /* Number of SW cursors currently visible on this screen */
     int sprites_visible;
 

--- a/hw/xfree86/drivers/modesetting/drmmode_display.h
+++ b/hw/xfree86/drivers/modesetting/drmmode_display.h
@@ -42,6 +42,7 @@ enum drmmode_plane_property {
     DRMMODE_PLANE_TYPE = 0,
     DRMMODE_PLANE_FB_ID,
     DRMMODE_PLANE_IN_FORMATS,
+    DRMMODE_PLANE_IN_FORMATS_ASYNC,
     DRMMODE_PLANE_CRTC_ID,
     DRMMODE_PLANE_SRC_X,
     DRMMODE_PLANE_SRC_Y,
@@ -198,6 +199,7 @@ typedef struct {
     drmmode_mode_ptr current_mode;
     uint32_t num_formats;
     drmmode_format_rec *formats;
+    drmmode_format_rec *formats_async;
 
     drmmode_bo rotate_bo;
     unsigned rotate_fb_id;
@@ -293,7 +295,7 @@ typedef struct _msSpritePriv {
 extern miPointerSpriteFuncRec drmmode_sprite_funcs;
 
 Bool drmmode_is_format_supported(ScrnInfoPtr scrn, uint32_t format,
-                                 uint64_t modifier);
+                                 uint64_t modifier, Bool async_flip);
 int drmmode_bo_import(drmmode_ptr drmmode, drmmode_bo *bo,
                       uint32_t *fb_id);
 int drmmode_bo_destroy(drmmode_ptr drmmode, drmmode_bo *bo);

--- a/hw/xfree86/drivers/modesetting/present.c
+++ b/hw/xfree86/drivers/modesetting/present.c
@@ -294,7 +294,7 @@ ms_present_check_unflip(RRCrtcPtr crtc,
         modifier = gbm_bo_get_modifier(gbm);
         gbm_bo_destroy(gbm);
 
-        if (!drmmode_is_format_supported(scrn, format, modifier)) {
+        if (!drmmode_is_format_supported(scrn, format, modifier, FALSE)) {
             if (reason)
                 *reason = PRESENT_FLIP_REASON_BUFFER_FORMAT;
             return FALSE;

--- a/present/present.c
+++ b/present/present.c
@@ -120,9 +120,14 @@ present_set_tree_pixmap_visit(WindowPtr window, void *data)
     struct pixmap_visit *visit = data;
     ScreenPtr           screen = window->drawable.pScreen;
 
-    if ((*screen->GetWindowPixmap)(window) != visit->old)
-        return WT_DONTWALKCHILDREN;
-    (*screen->SetWindowPixmap)(window, visit->new);
+    if ((*screen->GetWindowPixmap)(window) == visit->old)
+        (*screen->SetWindowPixmap)(window, visit->new);
+
+    /*
+     * Walk the entire tree in case windows using the
+     * the old pixmap have been reparented to newly
+     * created windows using the screen pixmap instead.
+     */
     return WT_WALKCHILDREN;
 }
 

--- a/present/present_vblank.c
+++ b/present/present_vblank.c
@@ -40,6 +40,20 @@ present_vblank_notify(present_vblank_ptr vblank, CARD8 kind, CARD8 mode, uint64_
     }
 }
 
+static Bool
+present_want_async_flip(uint32_t options, uint32_t capabilities)
+{
+	if (options & PresentOptionAsync &&
+	    capabilities & PresentCapabilityAsync)
+		return TRUE;
+
+	if (options & PresentOptionAsyncMayTear &&
+	    capabilities & PresentCapabilityAsyncMayTear)
+		return TRUE;
+
+	return FALSE;
+}
+
 /* The memory vblank points to must be 0-initialized before calling this function.
  *
  * If this function returns FALSE, present_vblank_destroy must be called to clean
@@ -118,15 +132,14 @@ present_vblank_init(present_vblank_ptr vblank,
     if (pixmap != NULL &&
         !(options & PresentOptionCopy) &&
         screen_priv->check_flip) {
-        if (msc_is_after(target_msc, crtc_msc) &&
-            screen_priv->check_flip (target_crtc, window, pixmap, TRUE, valid, x_off, y_off, &reason))
+
+        Bool sync_flip = !present_want_async_flip(options, capabilities);
+
+        if (screen_priv->check_flip (target_crtc, window, pixmap,
+                                     sync_flip, valid, x_off, y_off, &reason))
         {
             vblank->flip = TRUE;
-            vblank->sync_flip = TRUE;
-        } else if ((capabilities & PresentAllAsyncCapabilities) &&
-            screen_priv->check_flip (target_crtc, window, pixmap, FALSE, valid, x_off, y_off, &reason))
-        {
-            vblank->flip = TRUE;
+            vblank->sync_flip = sync_flip;
         }
     }
     vblank->reason = reason;


### PR DESCRIPTION
Linux 6.16 will be shipping the `IN_FORMATS_ASYNC` DRM property [1] which is Intel's fix for their hardware being unique, turns out that older Intel hardware can't scanout linear modifiers asynchronously and can't handle compressed buffers correctly. Users of those hardware will be stuck with horrible performance when using PRIME as modesetting will enter a flip retry loop until the end of time.

Also fixes what I assume is a typo.

Draft until I've tested this, taken from FDO.

[1] https://github.com/torvalds/linux/commit/9cd5cc9da7ff650f1e9818dbfd54232c00ec47ed