### PR TITLE
rootless: fix missing include of dix/screen_hooks_priv.h

### DIFF
--- a/miext/rootless/rootlessWindow.h
+++ b/miext/rootless/rootlessWindow.h
@@ -34,6 +34,8 @@
 #ifndef _ROOTLESSWINDOW_H
 #define _ROOTLESSWINDOW_H
 
+#include "dix/screen_hooks_priv.h"
+
 #include "rootlessCommon.h"
 
 Bool RootlessCreateWindow(WindowPtr pWin);


### PR DESCRIPTION
We're using XorgScreenWindowPositionParamRec here, so need to include that header.