### PR TITLE
.gitlab-ci: only look for files when validating man pages

### DIFF
--- a/.gitlab-ci/manpages-check
+++ b/.gitlab-ci/manpages-check
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-find build/ -regex ".*\.[1-9]$" -exec grep -E \
+find build/ -type f -regex ".*\.[1-9]$" -exec grep -E \
 @vendorversion@\|\
 @xorgversion@\|\
 @xservername@\|\


### PR DESCRIPTION
Build directory may sometimes contain directories ending with a period and a digit, e.g. in my case

* `./meson-private/cmake_xshmfence/CMakeFiles/4.0.3`
* `./meson-private/__CMake_compiler_info__/CMakeFiles/4.0.3`

Since man pages are files, filter out the rest.