### PR TITLE
.github: don't override env vars set externally

### DIFF
--- a/.github/scripts/conf.sh
+++ b/.github/scripts/conf.sh
@@ -1,6 +1,8 @@
-export X11_PREFIX=/home/runner/x11
+export X11_PREFIX="${X11_PREFIX:-$HOME/x11}"
+export X11_BUILD_DIR="${X11_BUILD_DIR:-$HOME/build-deps}"
+export DRV_BUILD_DIR="${DRV_BUILD_DIR:-$HOME/build-drivers}"
+
+export FDO_CI_CONCURRENT=`nproc`
+
 export PATH="$X11_PREFIX/bin:$PATH"
 export PKG_CONFIG_PATH="$X11_PREFIX/lib/x86_64-linux-gnu/pkgconfig:$X11_PREFIX/lib/pkgconfig:$X11_PREFIX/share/pkgconfig:$PKG_CONFIG_PATH"
-export FDO_CI_CONCURRENT=`nproc`
-export X11_BUILD_DIR=/home/runner/build-deps
-export DRV_BUILD_DIR=/home/runner/build-drivers


### PR DESCRIPTION
Helpful for CI builds where we could be setting different paths on different runners (due to OS or something else).