### PR TITLE
.github: export MACHINE the right way

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -20,7 +20,8 @@ jobs:
 
             - name: prepare build environment
               run: |
-                export MACHINE=`gcc -dumpmachine`
+                MACHINE=`gcc -dumpmachine`
+                echo "MACHINE=$MACHINE" >> "$GITHUB_ENV"
                 echo "PKG_CONFIG_PATH=$X11_PREFIX/share/pkgconfig:$X11_PREFIX/lib/$MACHINE/pkgconfig:$X11_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
                 sudo chown root /bin/tar && sudo chmod u+s /bin/tar
 
@@ -78,7 +79,8 @@ jobs:
 
             - name: prepare build environment
               run: |
-                export MACHINE=`gcc -dumpmachine`
+                MACHINE=`gcc -dumpmachine`
+                echo "MACHINE=$MACHINE" >> "$GITHUB_ENV"
                 echo "PKG_CONFIG_PATH=$X11_PREFIX/share/pkgconfig:$X11_PREFIX/lib/$MACHINE/pkgconfig:$X11_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
                 sudo chown root /bin/tar && sudo chmod u+s /bin/tar
 


### PR DESCRIPTION
Otherwise, paths constructed on "build xserver sdk" step aren't valid.