### PR TITLE
Update log.c to Solve High CodeQL alert Time-of-check time-of-use filesystem race condition

### DIFF
--- a/os/log.c
+++ b/os/log.c
@@ -178,7 +178,7 @@ LogFilePrep(const char *fname, const char *backup, const char *idstring)
     if (asprintf(&logFileName, fname, idstring) == -1)
         FatalError("Cannot allocate space for the log file name\n");
 
-        int fd = open(logFileName, O_RDWR | O_NOFOLLOW);Add commentMore actions
+        int fd = open(logFileName, O_RDWR | O_NOFOLLOW);
         if (fd != -1) {
             struct stat buf;
             if (fstat(fd, &buf) == 0 && S_ISREG(buf.st_mode)) {

--- a/os/log.c
+++ b/os/log.c
@@ -178,6 +178,7 @@ LogFilePrep(const char *fname, const char *backup, const char *idstring)
     if (asprintf(&logFileName, fname, idstring) == -1)
         FatalError("Cannot allocate space for the log file name\n");
 
+    if (backup && *backup) {
         int fd = open(logFileName, O_RDWR | O_NOFOLLOW);
         if (fd != -1) {
             struct stat buf;
@@ -197,7 +198,6 @@ LogFilePrep(const char *fname, const char *backup, const char *idstring)
                 }
                 free(oldLog);
             }
-            free(oldLog);
             close(fd);
         }
     }


### PR DESCRIPTION
Fixes a bug found in how log files worked. Feel free to make any changes. It was made with copilot but works fine on my fork after testing for a few days trying to break and overflow the logs. https://github.com/X11Libre/xserver/commit/a713cf7f836fd3b6c5d024d1e1bbda9215c9925b