### PR TITLE
Update OutputClass.c to Fix Double Free found in CodeQL

### DIFF
--- a/hw/xfree86/parser/OutputClass.c
+++ b/hw/xfree86/parser/OutputClass.c
@@ -123,16 +123,21 @@ xf86parseOutputClassSection(void)
                 ptr->driver = xf86_lex_val.str;
             break;
         case MODULEPATH:
-            if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
+            if (xf86getSubToken(&ptr->comment) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "ModulePath");
+            {
+                char *newpath;
             if (ptr->modulepath) {
-                char *path;
-                XNFasprintf(&path, "%s,%s", ptr->modulepath, xf86_lex_val.str);
-                free(xf86_lex_val.str);
-                free(ptr->modulepath);
-                ptr->modulepath = path;
-            } else {
-                ptr->modulepath = xf86_lex_val.str;
+                    XNFasprintf(&newpath, "%s,%s",
+                                ptr->modulepath,
+                                xf86_lex_val.str);
+                    free(ptr->modulepath);
+                }
+            else {
+                    newpath = strdup(xf86_lex_val.str);
+                }
+            free(xf86_lex_val.str);
+            ptr->modulepath = newpath;
             }
             break;
         case OPTION:

--- a/hw/xfree86/parser/OutputClass.c
+++ b/hw/xfree86/parser/OutputClass.c
@@ -123,16 +123,21 @@ xf86parseOutputClassSection(void)
                 ptr->driver = xf86_lex_val.str;
             break;
         case MODULEPATH:
-            if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
+            if (xf86getSubToken(&ptr->comment) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "ModulePath");
+            {
+                char *newpath;
             if (ptr->modulepath) {
-                char *path;
-                XNFasprintf(&path, "%s,%s", ptr->modulepath, xf86_lex_val.str);
-                free(xf86_lex_val.str);
-                (ptr->modulepath == xf86_lex_val.str) || free(ptr->modulepath);
-                ptr->modulepath = path;
-            } else {
-                ptr->modulepath = xf86_lex_val.str;
+                    XNFasprintf(&newpath, "%s,%s",
+                                ptr->modulepath,
+                                xf86_lex_val.str);
+                    free(ptr->modulepath);
+                }
+            else {
+                    newpath = strdup(xf86_lex_val.str);
+                }
+            free(xf86_lex_val.str);
+            ptr->modulepath = newpath;
             }
             break;
         case OPTION:

--- a/hw/xfree86/parser/OutputClass.c
+++ b/hw/xfree86/parser/OutputClass.c
@@ -123,21 +123,16 @@ xf86parseOutputClassSection(void)
                 ptr->driver = xf86_lex_val.str;
             break;
         case MODULEPATH:
-            if (xf86getSubToken(&ptr->comment) != XF86_TOKEN_STRING)
+            if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "ModulePath");
-            {
-                char *newpath;
             if (ptr->modulepath) {
-                    XNFasprintf(&newpath, "%s,%s",
-                                ptr->modulepath,
-                                xf86_lex_val.str);
-                    free(ptr->modulepath);
-                }
-            else {
-                    newpath = strdup(xf86_lex_val.str);
-                }
-            free(xf86_lex_val.str);
-            ptr->modulepath = newpath;
+                char *path;
+                XNFasprintf(&path, "%s,%s", ptr->modulepath, xf86_lex_val.str);
+                free(xf86_lex_val.str);
+                (ptr->modulepath == xf86_lex_val.str) || free(ptr->modulepath);
+                ptr->modulepath = path;
+            } else {
+                ptr->modulepath = xf86_lex_val.str;
             }
             break;
         case OPTION:


### PR DESCRIPTION
Moved the newpath variable and restructured if else loop with a strdup(xf86_lex_val.str); to populate newpath separately to avoid bug. This is the first security patch I wrote fully by myself please audit this accordingly need good feedback to improve future changes. https://github.com/HaplessIdiot/xserver/security/code-scanning/3