### PR TITLE
.github: limit pipeline permissions to read-only

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -1,5 +1,8 @@
 name: Build X servers
 
+permissions:
+    contents: read
+
 env:
     MESON_BUILDDIR:  "build"
     X11_PREFIX:      /home/runner/x11


### PR DESCRIPTION
https://github.com/HaplessIdiot/xserver/security/code-scanning/16
This change adds permissions to build in read only to support ubuntu package standards. Fixes 2 CodeQL alerts with 2 lines.