### PR TITLE
Screen.c resolve compiler warning

### DIFF
--- a/hw/xnest/Screen.c
+++ b/hw/xnest/Screen.c
@@ -164,8 +164,8 @@ Bool
 xnestOpenScreen(ScreenPtr pScreen, int argc, char *argv[])
 {
     unsigned long valuemask;
-    VisualID defaultVisual;
-    int rootDepth;
+    VisualID defaultVisual = 0;
+    int rootDepth = 0;
     miPointerScreenPtr PointPriv;
 
     if (!dixRegisterPrivateKey


### PR DESCRIPTION
A super simple 2 line edit.
```
VisualID defaultVisual = 0;
int rootDepth = 0;
```
This makes certain that the variables are not undefined so it can silence a compiler warning I noticed when building the x11libre xserver.