### PR TITLE
.github: 01-bug-report: use 25.0.0.X instead of listing all minor rel…

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -14,8 +14,7 @@ body:
     attributes:
       label: Select the version
       options:
-        - 25.0.0.0
-        - 25.0.0.1
+        - 25.0.0.X
         - Git master branch
         - other or don't know
       default: 1


### PR DESCRIPTION
…eases

Listing all patchlevels in the ticket form would quickly explode it.

Users are expected to always run the latest patchlevel (4th digit), because they're only receiving urgent bug and security fixes, not getting anything new, that could break other things.