### PR TITLE
Xnest: fix analyzer warning on uninitialized `DefaultVisual`

### DIFF
--- a/hw/xnest/Screen.c
+++ b/hw/xnest/Screen.c
@@ -164,7 +164,7 @@ Bool
 xnestOpenScreen(ScreenPtr pScreen, int argc, char *argv[])
 {
     unsigned long valuemask;
-    VisualID defaultVisual;
+    VisualID defaultVisual = 0;
     int rootDepth;
     miPointerScreenPtr PointPriv;
 

--- a/meson.build
+++ b/meson.build
@@ -3,10 +3,10 @@ project('xserver', 'c',
             'buildtype=debugoptimized',
             'c_std=gnu99',
         ],
-        version: '25.0.0.1',
+        version: '25.0.0.2',
         meson_version: '>= 0.58.0',
 )
-release_date = '2025-06-21'
+release_date = '2025-06-30'
 
 add_project_arguments('-DHAVE_DIX_CONFIG_H', language: ['c', 'objc'])
 cc = meson.get_compiler('c')


### PR DESCRIPTION
    In xnestOpenScreen(), some compilers/analyzers spitting out a false alarm on
    `defaultVisual` field potentially used uninitialized. This can't practically
    happen, but not all compilers/analyzers really can see that.

    Adding a zero initializer doesn't cost us anything, so silencing that false
    alarm is trivial.
