### PR TITLE
xfree86: compat: consolidate logging

### DIFF
--- a/hw/xfree86/compat/README
+++ b/hw/xfree86/compat/README
@@ -1,1 +1,5 @@
 special compat code for legacy drivers, namely Nvidia proprietary
+
+NVidia is lacking behind for at least a year and don't actually clean up
+their spaghetti code. That's why we need to keep several special compat
+functions to emulate prehistoric behaviour.

--- a/hw/xfree86/compat/clientexception.c
+++ b/hw/xfree86/compat/clientexception.c
@@ -4,6 +4,8 @@
 
 #include "dix/dix_priv.h"
 
+#include "xf86_compat.h"
+
 /*
  * this is specifically for NVidia proprietary driver: they're again lagging
  * behind a year, doing at least some minimal cleanup of their code base.
@@ -13,12 +15,7 @@ _X_EXPORT void MarkClientException(ClientPtr pClient);
 
 void MarkClientException(ClientPtr pClient)
 {
-    LogMessageVerb(X_WARNING, 0, "Bogus driver calling DIX-internal function MarkClientException() !\n");
-    LogMessageVerb(X_WARNING, 0, "External drivers really should never ever call this function.\n");
-    LogMessageVerb(X_WARNING, 0, "Nor should they ever DIX-internal fields like ClientRec->noClientException\n");
-    LogMessageVerb(X_WARNING, 0, "File a bug report to driver vendor or use a FOSS driver.\n");
-    LogMessageVerb(X_WARNING, 0, "Proprietary drivers are inherently unstable, they just can't be done right.\n");
-    LogMessageVerb(X_WARNING, 0, "And just don't buy Nvidia hardware, ever.\n");
+    xf86NVidiaBugInternalFunc("MarkClientException()");
 
     dixMarkClientException(pClient);
 }

--- a/hw/xfree86/compat/log.c
+++ b/hw/xfree86/compat/log.c
@@ -4,6 +4,8 @@
 
 #include "include/os.h"
 
+#include "xf86_compat.h"
+
 #undef xf86Msg
 #undef xf86MsgVerb
 
@@ -17,9 +19,7 @@ _X_EXPORT void xf86Msg(MessageType type, const char *format, ...)
 
 void xf86Msg(MessageType type, const char *format, ...)
 {
-    LogMessageVerb(X_WARNING, 0, "Outdated driver still using xf86Msg() !\n");
-    LogMessageVerb(X_WARNING, 0, "File a bug report to driver vendor or use a FOSS driver.\n");
-    LogMessageVerb(X_WARNING, 0, "Proprietary drivers are inherently unstable, they just can't be done right.\n");
+    xf86NVidiaBugInternalFunc("xf86Msg()");
 
     va_list ap;
 
@@ -39,9 +39,7 @@ _X_EXPORT void xf86MsgVerb(MessageType type, int verb, const char *format, ...)
 void
 xf86MsgVerb(MessageType type, int verb, const char *format, ...)
 {
-    LogMessageVerb(X_WARNING, 0, "Outdated driver still using xf86MsgVerb() !\n");
-    LogMessageVerb(X_WARNING, 0, "File a bug report to driver vendor or use a FOSS driver.\n");
-    LogMessageVerb(X_WARNING, 0, "Proprietary drivers are inherently unstable, they just can't be done right.\n");
+    xf86NVidiaBugInternalFunc("xf86MsgVerb()");
 
     va_list ap;
     va_start(ap, format);

--- a/hw/xfree86/compat/meson.build
+++ b/hw/xfree86/compat/meson.build
@@ -1,6 +1,7 @@
 srcs_xorg_compat = [
     'clientexception.c',
     'log.c',
+    'nvidiabug.c',
     'ones.c',
     'xf86Helper.c',
 ]

--- a/hw/xfree86/compat/nvidiabug.c
+++ b/hw/xfree86/compat/nvidiabug.c
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#include <dix-config.h>
+
+#include "include/os.h"
+
+#include "xf86_compat.h"
+
+void xf86NVidiaBug(void)
+{
+    LogMessageVerb(X_WARNING, 0, "[DRIVER BUG] file a bug report to driver vendor or use a free Xlibre driver.\n");
+    LogMessageVerb(X_WARNING, 0, "[DRIVER BUG] Proprietary drivers are inherently unstable, they just can't be done right.\n");
+    LogMessageVerb(X_WARNING, 0, "[DRIVER BUG] For NVidia report here: https://forums.developer.nvidia.com/c/gpu-graphics/linux/148\n");
+    LogMessageVerb(X_WARNING, 0, "[DRIVER BUG] And better don't buy NVidia HW until they've fixed their mess.\n");
+}
+
+void xf86NVidiaBugInternalFunc(const char* name)
+{
+    LogMessageVerb(X_WARNING, 0, "[DRIVER BUG] calling internal function: %s\n", name);
+    LogMessageVerb(X_WARNING, 0, "[DRIVER BUG] this function is not supposed to be by drivers ever\n");
+    xf86NVidiaBug();
+}
+
+void xf86NVidiaBugObsoleteFunc(const char* name)
+{
+    LogMessageVerb(X_WARNING, 0, "[DRIVER BUG] calling obsolete function: %s\n", name);
+    LogMessageVerb(X_WARNING, 0, "[DRIVER BUG] this function is not supposed to be by drivers ever\n");
+    xf86NVidiaBug();
+}

--- a/hw/xfree86/compat/xf86_compat.h
+++ b/hw/xfree86/compat/xf86_compat.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef __XFREE86_COMPAT_XF86_COMPAT_H
+#define __XFREE86_COMPAT_XF86_COMPAT_H
+
+void xf86NVidiaBug(void);
+void xf86NVidiaBugInternalFunc(const char* name);
+void xf86NVidiaBugObsoleteFunc(const char* name);
+
+#endif /* __XFREE86_COMPAT_XF86_COMPAT_H */


### PR DESCRIPTION
Consolidate the redundant warnings into generic functions.