### PR TITLE
Fix XFree86-Vidmode extension

### DIFF
--- a/Xext/vidmode.c
+++ b/Xext/vidmode.c
@@ -44,6 +44,7 @@ from Kaleb S. KEITHLEY
 #include "extnsionst.h"
 #include "scrnintstr.h"
 #include "servermd.h"
+#include "swaprep.h"
 #include "vidmodestr.h"
 #include "globals.h"
 #include "protocol-versions.h"
@@ -1308,12 +1309,11 @@ ProcVidModeGetMonitor(ClientPtr client)
     if (client->swapped) {
         swaps(&rep.sequenceNumber);
         swapl(&rep.length);
-        SwapLongs(hsyncdata, sizeof(hsyncdata));
-        SwapLongs(vsyncdata, sizeof(vsyncdata));
     }
     WriteToClient(client, SIZEOF(xXF86VidModeGetMonitorReply), &rep);
-    WriteToClient(client, sizeof(hsyncdata), hsyncdata);
-    WriteToClient(client, sizeof(vsyncdata), vsyncdata);
+    client->pSwapReplyFunc = (ReplySwapPtr) Swap32Write;
+    WriteSwappedDataToClient(client, nHsync * sizeof(CARD32), hsyncdata);
+    WriteSwappedDataToClient(client, nVrefresh * sizeof(CARD32), vsyncdata);
     if (rep.vendorLength)
         WriteToClient(client, rep.vendorLength,
                  (pVidMode->GetMonitorValue(pScreen, VIDMODE_MON_VENDOR, 0)).ptr);


### PR DESCRIPTION
This pr makes `xdpyinfo -ext all` not crash the X server, and makes it return good data for the XFree86-Vidmode extension.

I don't know if this extension is broken in other ways, as I'm not sure how to check for that.