### PR TITLE
mi: move miPointerCloseScreen to hookPostClose

### DIFF
--- a/hw/kdrive/ephyr/ephyrinit.c
+++ b/hw/kdrive/ephyr/ephyrinit.c
@@ -370,6 +370,23 @@ ddxProcessArgument(int argc, char **argv, int i)
     return KdProcessArgument(argc, argv, i);
 }
 
+static int
+EphyrInit(void)
+{
+    /*
+     * make sure at least one screen
+     * has been added to the system.
+     */
+    if (!KdCardInfoLast()) {
+        processScreenArg("640x480", NULL);
+    }
+    return hostx_init();
+}
+
+KdOsFuncs EphyrOsFuncs = {
+    .Init = EphyrInit,
+};
+
 void
 OsVendorInit(void)
 {
@@ -381,12 +398,7 @@ OsVendorInit(void)
     if (hostx_want_host_cursor())
         ephyrFuncs.initCursor = &ephyrCursorInit;
 
-    if (serverGeneration == 1) {
-        if (!KdCardInfoLast()) {
-            processScreenArg("640x480", NULL);
-        }
-        hostx_init();
-    }
+    KdOsInit(&EphyrOsFuncs);
 }
 
 KdCardFuncs ephyrFuncs = {

--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -91,6 +91,14 @@ const char *kdGlobalXkbLayout = NULL;
 const char *kdGlobalXkbVariant = NULL;
 const char *kdGlobalXkbOptions = NULL;
 
+
+/*
+ * Carry arguments from InitOutput through driver initialization
+ * to KdScreenInit
+ */
+
+KdOsFuncs *kdOsFuncs = NULL;
+
 void
 KdDisableScreen(ScreenPtr pScreen)
 {
@@ -515,6 +523,19 @@ KdProcessArgument(int argc, char **argv, int i)
     }
 
     return 0;
+}
+
+void
+KdOsInit(KdOsFuncs * pOsFuncs)
+{
+    kdOsFuncs = pOsFuncs;
+    if (pOsFuncs) {
+        if (serverGeneration == 1) {
+            KdDoSwitchCmd("start");
+            if (pOsFuncs->Init)
+                (*pOsFuncs->Init) ();
+        }
+    }
 }
 
 static Bool

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -278,6 +278,16 @@ int KdAddConfigKeyboard(char *pointer);
 int KdAddKeyboard(KdKeyboardInfo * ki);
 void KdRemoveKeyboard(KdKeyboardInfo * ki);
 
+typedef struct _KdOsFuncs {
+    int (*Init) (void); /* Only called when the X server is started, when serverGeneration == 1 */
+    void (*Enable) (void);
+    Bool (*SpecialKey) (KeySym);
+    void (*Disable) (void);
+    void (*Fini) (void);
+    void (*pollEvents) (void);
+    void (*Bell) (int, int, int);
+} KdOsFuncs;
+
 typedef struct _KdPointerMatrix {
     int matrix[2][3];
 } KdPointerMatrix;
@@ -288,6 +298,8 @@ extern DevPrivateKeyRec kdScreenPrivateKeyRec;
 
 extern Bool kdEmulateMiddleButton;
 extern Bool kdDisableZaphod;
+
+extern KdOsFuncs *kdOsFuncs;
 
 #define KdGetScreenPriv(pScreen) ((KdPrivScreenPtr) \
     dixLookupPrivate(&(pScreen)->devPrivates, kdScreenPrivateKey))
@@ -344,6 +356,9 @@ void
 
 int
  KdProcessArgument(int argc, char **argv, int i);
+
+void
+ KdOsInit(KdOsFuncs * pOsFuncs);
 
 void
  KdOsAddInputDrivers(void);

--- a/mi/mipointer.c
+++ b/mi/mipointer.c
@@ -141,7 +141,7 @@ miPointerInitialize(ScreenPtr pScreen,
     pScreenPriv->screenFuncs = screenFuncs;
     pScreenPriv->waitForUpdate = waitForUpdate;
     pScreenPriv->showTransparent = FALSE;
-    dixScreenHookClose(pScreen, miPointerCloseScreen);
+    dixScreenHookPostClose(pScreen, miPointerCloseScreen);
     dixSetPrivate(&pScreen->devPrivates, miPointerScreenKey, pScreenPriv);
     /*
      * set up screen cursor method table
@@ -169,7 +169,7 @@ static void miPointerCloseScreen(CallbackListPtr *pcbl, ScreenPtr pScreen, void 
 {
     SetupScreen(pScreen);
 
-    dixScreenUnhookClose(pScreen, miPointerCloseScreen);
+    dixScreenUnhookPostClose(pScreen, miPointerCloseScreen);
     free((void *) pScreenPriv);
     dixSetPrivate(&pScreen->devPrivates, miPointerScreenKey, NULL);
     FreeEventList(mipointermove_events, GetMaximumEventsNum());


### PR DESCRIPTION
Same as https://github.com/X11Libre/xserver/pull/317

@metux Should we really special-case another hook, or should we just move all of these calls
after pScreen->CloseScreen in dix/screen_hooks.c ?