### PR TITLE
namespace: drop unused winIsRoot()

### DIFF
--- a/Xext/namespace/hook-windowproperty.c
+++ b/Xext/namespace/hook-windowproperty.c
@@ -11,14 +11,6 @@
 #include "namespace.h"
 #include "hooks.h"
 
-static inline Bool winIsRoot(WindowPtr pWin) {
-    if (!pWin)
-        return FALSE;
-    if (pWin->drawable.pScreen->root == pWin)
-        return TRUE;
-    return FALSE;
-}
-
 void hookWindowProperty(CallbackListPtr *pcbl, void *unused, void *calldata)
 {
     XNS_HOOK_HEAD(PropertyFilterParam);


### PR DESCRIPTION
Not used in this file, so no need to keep it around anymore.