### PR TITLE
drop unused DarwinHandleGUI()

### DIFF
--- a/hw/vfb/InitOutput.c
+++ b/hw/vfb/InitOutput.c
@@ -259,13 +259,6 @@ ddxGiveUp(enum ExitCode error)
     }
 }
 
-#ifdef __APPLE__
-void
-DarwinHandleGUI(int argc, char *argv[])
-{
-}
-#endif
-
 void
 OsVendorInit(void)
 {

--- a/hw/xnest/Init.c
+++ b/hw/xnest/Init.c
@@ -154,13 +154,6 @@ ddxGiveUp(enum ExitCode error)
     xnestCloseDisplay();
 }
 
-#ifdef __APPLE__
-void
-DarwinHandleGUI(int argc, char *argv[])
-{
-}
-#endif
-
 void
 OsVendorInit(void)
 {


### PR DESCRIPTION
Obsolete since 17 years now, probably just forgotten to clean up.

Fixing compiler warning on missing prototype.
