### PR TITLE
xquartz: fix incomplete prototype of executable_path()

### DIFF
--- a/hw/xquartz/mach-startup/bundle_trampoline.c
+++ b/hw/xquartz/mach-startup/bundle_trampoline.c
@@ -50,7 +50,7 @@
  * needs and simply execs the startup script which then execs the main binary.
  */
 
-static char *executable_path() {
+static char *executable_path(void) {
     uint32_t bufsize = PATH_MAX;
     char *buf = calloc(1, bufsize);
 


### PR DESCRIPTION
> ../hw/xquartz/mach-startup/bundle_trampoline.c:53:29: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
> static char *executable_path() {
>                             ^
>                              void
> 1 warning generated.