### PR TITLE
xquartz: drop unused field declarations in request handlers

### DIFF
--- a/hw/xquartz/applewm.c
+++ b/hw/xquartz/applewm.c
@@ -690,7 +690,6 @@ SNotifyEvent(xAppleWMNotifyEvent *from, xAppleWMNotifyEvent *to)
 static int
 SProcAppleWMQueryVersion(register ClientPtr client)
 {
-    REQUEST(xAppleWMQueryVersionReq);
     return ProcAppleWMQueryVersion(client);
 }
 

--- a/hw/xquartz/xpr/appledri.c
+++ b/hw/xquartz/xpr/appledri.c
@@ -394,7 +394,6 @@ SNotifyEvent(xAppleDRINotifyEvent *from,
 static int
 SProcAppleDRIQueryVersion(register ClientPtr client)
 {
-    REQUEST(xAppleDRIQueryVersionReq);
     return ProcAppleDRIQueryVersion(client);
 }
 


### PR DESCRIPTION
Silence compiler warning on unused fields, eg.:

> ../hw/xquartz/applewm.c:692:5: warning: unused variable 'stuff' [-Wunused-variable]
>     REQUEST(xAppleWMQueryVersionReq);
>     ^
> ../include/dix.h:65:12: note: expanded from macro 'REQUEST'
>     type * stuff = (type *)client->requestBuffer;
>            ^