### PR TITLE
xquartz: drop using HAVE_DIX_CONFIG_H

### DIFF
--- a/hw/xquartz/X11Controller.h
+++ b/hw/xquartz/X11Controller.h
@@ -31,9 +31,7 @@
 #ifndef X11CONTROLLER_H
 #define X11CONTROLLER_H 1
 
-#ifdef HAVE_DIX_CONFIG_H
 #include <dix-config.h>
-#endif
 
 #if __OBJC__
 


### PR DESCRIPTION
This symbol is always defined, and the header is always present, so no need to check for it.