### PR TITLE
Xi: drop using HAVE_DIX_CONFIG_H

### DIFF
--- a/Xi/allowev.h
+++ b/Xi/allowev.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef ALLOWEV_H
 #define ALLOWEV_H 1
+
+#include <dix-config.h>
 
 int SProcXAllowDeviceEvents(ClientPtr   /* client */
     );

--- a/Xi/chgdctl.h
+++ b/Xi/chgdctl.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef CHGDCTL_H
 #define CHGDCTL_H 1
+
+#include <dix-config.h>
 
 int SProcXChangeDeviceControl(ClientPtr /* client */
     );

--- a/Xi/chgfctl.h
+++ b/Xi/chgfctl.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef CHGFCTL_H
 #define CHGFCTL_H 1
+
+#include <dix-config.h>
 
 int SProcXChangeFeedbackControl(ClientPtr       /* client */
     );

--- a/Xi/chgkbd.h
+++ b/Xi/chgkbd.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef CHGKBD_H
 #define CHGKBD_H 1
+
+#include <dix-config.h>
 
 int ProcXChangeKeyboardDevice(ClientPtr /* client */
     );

--- a/Xi/chgkmap.h
+++ b/Xi/chgkmap.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef CHGKMAP_H
 #define CHGKMAP_H 1
+
+#include <dix-config.h>
 
 int SProcXChangeDeviceKeyMapping(ClientPtr      /* client */
     );

--- a/Xi/chgprop.h
+++ b/Xi/chgprop.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef CHGPROP_H
 #define CHGPROP_H 1
+
+#include <dix-config.h>
 
 int SProcXChangeDeviceDontPropagateList(ClientPtr       /* client */
     );

--- a/Xi/chgptr.h
+++ b/Xi/chgptr.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef CHGPTR_H
 #define CHGPTR_H 1
+
+#include <dix-config.h>
 
 int ProcXChangePointerDevice(ClientPtr  /* client */
     );

--- a/Xi/closedev.h
+++ b/Xi/closedev.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef CLOSEDEV_H
 #define CLOSEDEV_H 1
+
+#include <dix-config.h>
 
 int ProcXCloseDevice(ClientPtr  /* client */
     );

--- a/Xi/devbell.h
+++ b/Xi/devbell.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef DEVBELL_H
 #define DEVBELL_H 1
+
+#include <dix-config.h>
 
 int ProcXDeviceBell(ClientPtr   /* client */
     );

--- a/Xi/exglobals.h
+++ b/Xi/exglobals.h
@@ -28,9 +28,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  * Globals referenced elsewhere in the server.
  *
  */
-#ifdef HAVE_DIX_CONFIG_H
 #include <dix-config.h>
-#endif
+
 #include "privates.h"
 
 #ifndef EXGLOBALS_H

--- a/Xi/getbmap.h
+++ b/Xi/getbmap.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef GETBMAP_H
 #define GETBMAP_H 1
+
+#include <dix-config.h>
 
 int ProcXGetDeviceButtonMapping(ClientPtr       /* client */
     );

--- a/Xi/getdctl.h
+++ b/Xi/getdctl.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef GETDCTL_H
 #define GETDCTL_H 1
+
+#include <dix-config.h>
 
 int SProcXGetDeviceControl(ClientPtr    /* client */
     );

--- a/Xi/getfctl.h
+++ b/Xi/getfctl.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef GETFCTL_H
 #define GETFCTL_H 1
+
+#include <dix-config.h>
 
 int ProcXGetFeedbackControl(ClientPtr   /* client */
     );

--- a/Xi/getfocus.h
+++ b/Xi/getfocus.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef GETFOCUS_H
 #define GETFOCUS_H 1
+
+#include <dix-config.h>
 
 int ProcXGetDeviceFocus(ClientPtr       /* client */
     );

--- a/Xi/getkmap.h
+++ b/Xi/getkmap.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef GETKMAP_H
 #define GETKMAP_H 1
+
+#include <dix-config.h>
 
 int ProcXGetDeviceKeyMapping(ClientPtr  /* client */
     );

--- a/Xi/getmmap.h
+++ b/Xi/getmmap.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef GETMMAP_H
 #define GETMMAP_H 1
+
+#include <dix-config.h>
 
 int ProcXGetDeviceModifierMapping(ClientPtr     /* client */
     );

--- a/Xi/getprop.h
+++ b/Xi/getprop.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef GETPROP_H
 #define GETPROP_H 1
+
+#include <dix-config.h>
 
 int SProcXGetDeviceDontPropagateList(ClientPtr  /* client */
     );

--- a/Xi/getselev.h
+++ b/Xi/getselev.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef GETSELEV_H
 #define GETSELEV_H 1
+
+#include <dix-config.h>
 
 int SProcXGetSelectedExtensionEvents(ClientPtr  /* client */
     );

--- a/Xi/getvers.h
+++ b/Xi/getvers.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef GETVERS_H
 #define GETVERS_H 1
+
+#include <dix-config.h>
 
 int SProcXGetExtensionVersion(ClientPtr /* client */
     );

--- a/Xi/grabdev.h
+++ b/Xi/grabdev.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef GRABDEV_H
 #define GRABDEV_H 1
+
+#include <dix-config.h>
 
 int SProcXGrabDevice(ClientPtr  /* client */
     );

--- a/Xi/grabdevb.h
+++ b/Xi/grabdevb.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef GRABDEVB_H
 #define GRABDEVB_H 1
+
+#include <dix-config.h>
 
 int SProcXGrabDeviceButton(ClientPtr    /* client */
     );

--- a/Xi/grabdevk.h
+++ b/Xi/grabdevk.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef GRABDEVK_H
 #define GRABDEVK_H 1
+
+#include <dix-config.h>
 
 int SProcXGrabDeviceKey(ClientPtr       /* client */
     );

--- a/Xi/gtmotion.h
+++ b/Xi/gtmotion.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef GTMOTION_H
 #define GTMOTION_H 1
+
+#include <dix-config.h>
 
 int SProcXGetDeviceMotionEvents(ClientPtr       /* client */
     );

--- a/Xi/listdev.h
+++ b/Xi/listdev.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef LISTDEV_H
 #define LISTDEV_H 1
+
+#include <dix-config.h>
 
 #define VPC	20              /* Max # valuators per chunk */
 

--- a/Xi/opendev.h
+++ b/Xi/opendev.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef OPENDEV_H
 #define OPENDEV_H 1
+
+#include <dix-config.h>
 
 int ProcXOpenDevice(ClientPtr   /* client */
     );

--- a/Xi/queryst.h
+++ b/Xi/queryst.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef QUERYST_H
 #define QUERYST_H 1
+
+#include <dix-config.h>
 
 int ProcXQueryDeviceState(ClientPtr     /* client */
     );

--- a/Xi/selectev.h
+++ b/Xi/selectev.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef SELECTEV_H
 #define SELECTEV_H 1
+
+#include <dix-config.h>
 
 int SProcXSelectExtensionEvent(ClientPtr        /* client */
     );

--- a/Xi/sendexev.h
+++ b/Xi/sendexev.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef SENDEXEV_H
 #define SENDEXEV_H 1
+
+#include <dix-config.h>
 
 int SProcXSendExtensionEvent(ClientPtr  /* client */
     );

--- a/Xi/setbmap.h
+++ b/Xi/setbmap.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef SETBMAP_H
 #define SETBMAP_H 1
+
+#include <dix-config.h>
 
 int ProcXSetDeviceButtonMapping(ClientPtr       /* client */
     );

--- a/Xi/setdval.h
+++ b/Xi/setdval.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef SETDVAL_H
 #define SETDVAL_H 1
+
+#include <dix-config.h>
 
 int ProcXSetDeviceValuators(ClientPtr   /* client */
     );

--- a/Xi/setfocus.h
+++ b/Xi/setfocus.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef SETFOCUS_H
 #define SETFOCUS_H 1
+
+#include <dix-config.h>
 
 int SProcXSetDeviceFocus(ClientPtr      /* client */
     );

--- a/Xi/setmmap.h
+++ b/Xi/setmmap.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef SETMMAP_H
 #define SETMMAP_H 1
+
+#include <dix-config.h>
 
 int ProcXSetDeviceModifierMapping(ClientPtr     /* client */
     );

--- a/Xi/setmode.h
+++ b/Xi/setmode.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef SETMODE_H
 #define SETMODE_H 1
+
+#include <dix-config.h>
 
 int ProcXSetDeviceMode(ClientPtr        /* client */
     );

--- a/Xi/ungrdev.h
+++ b/Xi/ungrdev.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef UNGRDEV_H
 #define UNGRDEV_H 1
+
+#include <dix-config.h>
 
 int SProcXUngrabDevice(ClientPtr        /* client */
     );

--- a/Xi/ungrdevb.h
+++ b/Xi/ungrdevb.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef UNGRDEVB_H
 #define UNGRDEVB_H 1
+
+#include <dix-config.h>
 
 int SProcXUngrabDeviceButton(ClientPtr  /* client */
     );

--- a/Xi/ungrdevk.h
+++ b/Xi/ungrdevk.h
@@ -22,13 +22,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef UNGRDEVK_H
 #define UNGRDEVK_H 1
+
+#include <dix-config.h>
 
 int SProcXUngrabDeviceKey(ClientPtr     /* client */
     );

--- a/Xi/xiallowev.h
+++ b/Xi/xiallowev.h
@@ -22,13 +22,10 @@
  *
  * Author: Peter Hutterer
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef XIALLOWEV_H
 #define XIALLOWEV_H 1
+
+#include <dix-config.h>
 
 int ProcXIAllowEvents(ClientPtr client);
 int SProcXIAllowEvents(ClientPtr client);

--- a/Xi/xibarriers.h
+++ b/Xi/xibarriers.h
@@ -1,10 +1,7 @@
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _XIBARRIERS_H_
 #define _XIBARRIERS_H_
+
+#include <dix-config.h>
 
 #include "resource.h"
 

--- a/Xi/xichangecursor.h
+++ b/Xi/xichangecursor.h
@@ -22,13 +22,10 @@
  *
  * Author: Peter Hutterer, University of South Australia, NICTA
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef CHDEVCUR_H
 #define CHDEVCUR_H 1
+
+#include <dix-config.h>
 
 int SProcXIChangeCursor(ClientPtr /* client */ );
 int ProcXIChangeCursor(ClientPtr /* client */ );

--- a/Xi/xichangehierarchy.h
+++ b/Xi/xichangehierarchy.h
@@ -28,13 +28,10 @@
  * Request change in the device hierarchy.
  *
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef CHDEVHIER_H
 #define CHDEVHIER_H 1
+
+#include <dix-config.h>
 
 int ProcXIChangeHierarchy(ClientPtr /* client */ );
 

--- a/Xi/xigetclientpointer.h
+++ b/Xi/xigetclientpointer.h
@@ -22,13 +22,10 @@
  *
  * Author: Peter Hutterer, University of South Australia, NICTA
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef GETCPTR_H
 #define GETCPTR_H 1
+
+#include <dix-config.h>
 
 int SProcXIGetClientPointer(ClientPtr /* client */ );
 int ProcXIGetClientPointer(ClientPtr /* client */ );

--- a/Xi/xigrabdev.h
+++ b/Xi/xigrabdev.h
@@ -22,13 +22,10 @@
  *
  * Author: Peter Hutterer
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef XIGRABDEV_H
 #define XIGRABDEV_H 1
+
+#include <dix-config.h>
 
 int ProcXIGrabDevice(ClientPtr client);
 int SProcXIGrabDevice(ClientPtr client);

--- a/Xi/xipassivegrab.h
+++ b/Xi/xipassivegrab.h
@@ -22,13 +22,10 @@
  *
  * Author: Peter Hutterer
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef XIPASSIVEGRAB_H
 #define XIPASSIVEGRAB_H 1
+
+#include <dix-config.h>
 
 int SProcXIPassiveUngrabDevice(ClientPtr client);
 int ProcXIPassiveUngrabDevice(ClientPtr client);

--- a/Xi/xiproperty.h
+++ b/Xi/xiproperty.h
@@ -22,13 +22,10 @@
  *
  * Author: Peter Hutterer
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef XIPROPERTY_H
 #define XIPROPERTY_H 1
+
+#include <dix-config.h>
 
 int ProcXListDeviceProperties(ClientPtr client);
 int ProcXChangeDeviceProperty(ClientPtr client);

--- a/Xi/xiquerydevice.h
+++ b/Xi/xiquerydevice.h
@@ -23,13 +23,10 @@
  * Authors: Peter Hutterer
  *
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef QUERYDEV_H
 #define QUERYDEV_H 1
+
+#include <dix-config.h>
 
 #include <X11/extensions/XI2proto.h>
 

--- a/Xi/xiquerypointer.h
+++ b/Xi/xiquerypointer.h
@@ -22,13 +22,10 @@
  *
  * Author: Peter Hutterer, University of South Australia, NICTA
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef QUERYDP_H
 #define QUERYDP_H 1
+
+#include <dix-config.h>
 
 int SProcXIQueryPointer(ClientPtr /* client */ );
 int ProcXIQueryPointer(ClientPtr /* client */ );

--- a/Xi/xiqueryversion.h
+++ b/Xi/xiqueryversion.h
@@ -23,15 +23,12 @@
  * Authors: Peter Hutterer
  *
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
-#include <X11/extensions/XI2proto.h>
-
 #ifndef QUERYVERSION_H
 #define QUERYVERSION_H 1
+
+#include <dix-config.h>
+
+#include <X11/extensions/XI2proto.h>
 
 int SProcXIQueryVersion(ClientPtr client);
 int ProcXIQueryVersion(ClientPtr client);

--- a/Xi/xiselectev.h
+++ b/Xi/xiselectev.h
@@ -22,13 +22,10 @@
  *
  * Author: Peter Hutterer
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef XISELECTEVENTS_H
 #define XISELECTEVENTS_H 1
+
+#include <dix-config.h>
 
 int SProcXISelectEvents(ClientPtr client);
 int ProcXISelectEvents(ClientPtr client);

--- a/Xi/xisetclientpointer.h
+++ b/Xi/xisetclientpointer.h
@@ -22,13 +22,10 @@
  *
  * Author: Peter Hutterer, University of South Australia, NICTA
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef SETCPTR_H
 #define SETCPTR_H 1
+
+#include <dix-config.h>
 
 int SProcXISetClientPointer(ClientPtr /* client */ );
 int ProcXISetClientPointer(ClientPtr /* client */ );

--- a/Xi/xisetdevfocus.h
+++ b/Xi/xisetdevfocus.h
@@ -22,13 +22,10 @@
  *
  * Author: Peter Hutterer
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef XISETDEVFOCUS_H
 #define XISETDEVFOCUS_H 1
+
+#include <dix-config.h>
 
 int SProcXISetFocus(ClientPtr client);
 int ProcXISetFocus(ClientPtr client);

--- a/Xi/xiwarppointer.h
+++ b/Xi/xiwarppointer.h
@@ -22,13 +22,10 @@
  *
  * Author: Peter Hutterer, University of South Australia, NICTA
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef WARPDEVP_H
 #define WARPDEVP_H 1
+
+#include <dix-config.h>
 
 int SProcXIWarpPointer(ClientPtr /* client */ );
 int ProcXIWarpPointer(ClientPtr /* client */ );


### PR DESCRIPTION
This symbol is always defined, and the header is always present,
so no need to check for it.
