### PR TITLE
config: drop using HAVE_DIX_CONFIG_H

### DIFF
--- a/config/config-backends.h
+++ b/config/config-backends.h
@@ -26,9 +26,8 @@
 #ifndef XSERVER_CONFIG_BACKENDS_H
 #define XSERVER_CONFIG_BACKENDS_H
 
-#ifdef HAVE_DIX_CONFIG_H
 #include <dix-config.h>
-#endif
+
 #include "input.h"
 #include "list.h"
 

--- a/meson.build
+++ b/meson.build
@@ -3,10 +3,10 @@ project('xserver', 'c',
             'buildtype=debugoptimized',
             'c_std=gnu99',
         ],
-        version: '25.0.0.3',
+        version: '25.0.0.4',
         meson_version: '>= 0.58.0',
 )
-release_date = '2025-07-02'
+release_date = '2025-07-04'
 
 add_project_arguments('-DHAVE_DIX_CONFIG_H', language: ['c', 'objc'])
 cc = meson.get_compiler('c')


### PR DESCRIPTION
    config: drop using HAVE_DIX_CONFIG_H

    This symbol is always defined, and the header is always present,
    so no need to check for it.

