### PR TITLE
 dbe: drop using HAVE_DIX_CONFIG_H

### DIFF
--- a/dbe/midbe.h
+++ b/dbe/midbe.h
@@ -28,13 +28,10 @@
  *     Header file for users of machine-independent DBE code
  *
  *****************************************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef MIDBE_H
 #define MIDBE_H
+
+#include <dix-config.h>
 
 #include "dix/screen_hooks_priv.h"
 #include "include/privates.h"


### PR DESCRIPTION
    This symbol is always defined, and the header is always present,
    so no need to check for it.
