### PR TITLE
damage: allow driver hooks to be NULL

### DIFF
--- a/miext/damage/damage.c
+++ b/miext/damage/damage.c
@@ -1714,7 +1714,8 @@ DamageCreate(DamageReportFunc damageReport,
     pDamage->damageDestroy = damageDestroy;
     pDamage->pScreen = pScreen;
 
-    (*pScrPriv->funcs.Create) (pDamage);
+    if (pScrPriv->funcs.Create)
+        pScrPriv->funcs.Create (pDamage);
 
     return pDamage;
 }
@@ -1755,7 +1756,8 @@ DamageRegister(DrawablePtr pDrawable, DamagePtr pDamage)
         pDamage->isWindow = FALSE;
     pDamage->pDrawable = pDrawable;
     damageInsertDamage(getDrawableDamageRef(pDrawable), pDamage);
-    (*pScrPriv->funcs.Register) (pDrawable, pDamage);
+    if (pScrPriv->funcs.Register)
+        pScrPriv->funcs.Register (pDrawable, pDamage);
 }
 
 void
@@ -1774,7 +1776,8 @@ DamageUnregister(DamagePtr pDamage)
 
     damageScrPriv(pScreen);
 
-    (*pScrPriv->funcs.Unregister) (pDrawable, pDamage);
+    if (pScrPriv->funcs.Unregister)
+        pScrPriv->funcs.Unregister (pDrawable, pDamage);
 
     if (pDrawable->type == DRAWABLE_WINDOW) {
         WindowPtr pWindow = (WindowPtr) pDrawable;
@@ -1817,7 +1820,10 @@ DamageDestroy(DamagePtr pDamage)
 
     if (pDamage->damageDestroy)
         (*pDamage->damageDestroy) (pDamage, pDamage->closure);
-    (*pScrPriv->funcs.Destroy) (pDamage);
+
+    if (pScrPriv->funcs.Destroy)
+        pScrPriv->funcs.Destroy (pDamage);
+
     RegionUninit(&pDamage->damage);
     RegionUninit(&pDamage->pendingDamage);
     free(pDamage);

--- a/miext/damage/damage.h
+++ b/miext/damage/damage.h
@@ -54,6 +54,9 @@ typedef void (*DamageScreenDestroyFunc) (DamagePtr);
  * Drivers can inject themselves here, in order to get notified on
  * DamageCreate(), DamageRegister(), DamageUnregister(), DamageDestroy().
  *
+ * The fields may be assigned to NULL, if no action at all is wanted.
+ * (by default assigned to default implementations)
+ *
  * This should ONLY be touched by video drivers, nobody else.
  *
  * So far the only one using it is the proprietary NVidia driver.


### PR DESCRIPTION
This is the second half of https://github.com/X11Libre/xserver/pull/329:

allow damage driver hooks to be NULL, if driver wants no neither default nor its own implementation.
