### PR TITLE
glx: drop including dix-config.h from internal includes

### DIFF
--- a/glx/glxcontext.h
+++ b/glx/glxcontext.h
@@ -1,7 +1,3 @@
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _GLX_context_h_
 #define _GLX_context_h_
 

--- a/glx/glxdrawable.h
+++ b/glx/glxdrawable.h
@@ -1,7 +1,3 @@
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _GLX_drawable_h_
 #define _GLX_drawable_h_
 

--- a/glx/glxext.h
+++ b/glx/glxext.h
@@ -1,7 +1,3 @@
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _glxext_h_
 #define _glxext_h_
 

--- a/glx/glxscreens.h
+++ b/glx/glxscreens.h
@@ -1,7 +1,3 @@
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _GLX_screens_h_
 #define _GLX_screens_h_
 

--- a/glx/glxserver.h
+++ b/glx/glxserver.h
@@ -1,7 +1,3 @@
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _GLX_server_h_
 #define _GLX_server_h_
 

--- a/glx/glxutil.h
+++ b/glx/glxutil.h
@@ -1,7 +1,3 @@
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _glxcmds_h_
 #define _glxcmds_h_
 

--- a/glx/indirect_table.c
+++ b/glx/indirect_table.c
@@ -22,6 +22,7 @@
  * OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+#include <dix-config.h>
 
 #include <inttypes.h>
 #include "glxserver.h"

--- a/glx/singlesize.h
+++ b/glx/singlesize.h
@@ -1,7 +1,3 @@
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _singlesize_h_
 #define _singlesize_h_
 

--- a/glx/unpack.h
+++ b/glx/unpack.h
@@ -1,7 +1,3 @@
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef __GLX_unpack_h__
 #define __GLX_unpack_h__
 

--- a/glx/vndserver_priv.h
+++ b/glx/vndserver_priv.h
@@ -26,11 +26,9 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
  */
-
 #ifndef _XSERVER_VNDSERVER_PRIV_H
 #define _XSERVER_VNDSERVER_PRIV_H
 
-#include <dix-config.h>
 #include "glxvndabi.h"
 #include "vndserver.h"
 

--- a/glx/vndservervendor.h
+++ b/glx/vndservervendor.h
@@ -26,11 +26,8 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
  */
-
 #ifndef VND_SERVER_VENDOR_H
 #define VND_SERVER_VENDOR_H
-
-#include <dix-config.h>
 
 #include "glxvndabi.h"
 #include "list.h"


### PR DESCRIPTION
The consumers always need to include <dix-config.h> at the very top
anyways, so no need to also include it (with extra guards) from
internal headers.
