### PR TITLE
.github: hold xts at old master revision to fix Mac build

### DIFF
--- a/.github/scripts/install-prereq.sh
+++ b/.github/scripts/install-prereq.sh
@@ -26,7 +26,7 @@ fi
 if [ "$X11_OS" = "Darwin" ]; then
 build_ac      xset              https://gitlab.freedesktop.org/xorg/app/xset             xset-1.2.5
 fi
-build_ac_xts  xts               https://gitlab.freedesktop.org/xorg/test/xts             master # dbbfa96c036e596346147081cbceda136e7c86c1
+build_ac_xts  xts               https://gitlab.freedesktop.org/xorg/test/xts             12a887c2c72c4258962b56ced7b0aec782f1ffed # master @ 2025-02-11
 
 clone_source piglit             https://gitlab.freedesktop.org/mesa/piglit               main # 265896c86f90cb72e8f218ba6a3617fca8b9a1e3
 

--- a/.github/scripts/util.sh
+++ b/.github/scripts/util.sh
@@ -8,7 +8,12 @@ clone_source() {
 
     if [ ! -f $pkgname/.git/config ]; then
         echo "need to clone $pkgname"
-        git clone $url $pkgname --branch=$ref --depth 1
+        # Using multiple commands to support revisions in $ref
+        # TODO: Switch to `git clone --revision=$ref ...` when using Git 2.49+
+        git init $pkgname
+        git -C $pkgname remote add origin $url
+        git -C $pkgname fetch origin $ref --depth 1
+        git -C $pkgname checkout FETCH_HEAD
     else
         echo "already cloned $pkgname"
     fi

--- a/hw/kdrive/ephyr/ephyrinit.c
+++ b/hw/kdrive/ephyr/ephyrinit.c
@@ -370,6 +370,23 @@ ddxProcessArgument(int argc, char **argv, int i)
     return KdProcessArgument(argc, argv, i);
 }
 
+static int
+EphyrInit(void)
+{
+    /*
+     * make sure at least one screen
+     * has been added to the system.
+     */
+    if (!KdCardInfoLast()) {
+        processScreenArg("640x480", NULL);
+    }
+    return hostx_init();
+}
+
+KdOsFuncs EphyrOsFuncs = {
+    .Init = EphyrInit,
+};
+
 void
 OsVendorInit(void)
 {
@@ -381,12 +398,7 @@ OsVendorInit(void)
     if (hostx_want_host_cursor())
         ephyrFuncs.initCursor = &ephyrCursorInit;
 
-    if (serverGeneration == 1) {
-        if (!KdCardInfoLast()) {
-            processScreenArg("640x480", NULL);
-        }
-        hostx_init();
-    }
+    KdOsInit(&EphyrOsFuncs);
 }
 
 KdCardFuncs ephyrFuncs = {

--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -91,6 +91,14 @@ const char *kdGlobalXkbLayout = NULL;
 const char *kdGlobalXkbVariant = NULL;
 const char *kdGlobalXkbOptions = NULL;
 
+
+/*
+ * Carry arguments from InitOutput through driver initialization
+ * to KdScreenInit
+ */
+
+KdOsFuncs *kdOsFuncs = NULL;
+
 void
 KdDisableScreen(ScreenPtr pScreen)
 {
@@ -515,6 +523,19 @@ KdProcessArgument(int argc, char **argv, int i)
     }
 
     return 0;
+}
+
+void
+KdOsInit(KdOsFuncs * pOsFuncs)
+{
+    kdOsFuncs = pOsFuncs;
+    if (pOsFuncs) {
+        if (serverGeneration == 1) {
+            KdDoSwitchCmd("start");
+            if (pOsFuncs->Init)
+                (*pOsFuncs->Init) ();
+        }
+    }
 }
 
 static Bool

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -278,6 +278,16 @@ int KdAddConfigKeyboard(char *pointer);
 int KdAddKeyboard(KdKeyboardInfo * ki);
 void KdRemoveKeyboard(KdKeyboardInfo * ki);
 
+typedef struct _KdOsFuncs {
+    int (*Init) (void); /* Only called when the X server is started, when serverGeneration == 1 */
+    void (*Enable) (void);
+    Bool (*SpecialKey) (KeySym);
+    void (*Disable) (void);
+    void (*Fini) (void);
+    void (*pollEvents) (void);
+    void (*Bell) (int, int, int);
+} KdOsFuncs;
+
 typedef struct _KdPointerMatrix {
     int matrix[2][3];
 } KdPointerMatrix;
@@ -288,6 +298,8 @@ extern DevPrivateKeyRec kdScreenPrivateKeyRec;
 
 extern Bool kdEmulateMiddleButton;
 extern Bool kdDisableZaphod;
+
+extern KdOsFuncs *kdOsFuncs;
 
 #define KdGetScreenPriv(pScreen) ((KdPrivScreenPtr) \
     dixLookupPrivate(&(pScreen)->devPrivates, kdScreenPrivateKey))
@@ -344,6 +356,9 @@ void
 
 int
  KdProcessArgument(int argc, char **argv, int i);
+
+void
+ KdOsInit(KdOsFuncs * pOsFuncs);
 
 void
  KdOsAddInputDrivers(void);


### PR DESCRIPTION
While MRs to fix Mac build are in the process of being reviewed and merged upstream, hold xts at old master revision to avoid build failures. Once/if all upstream MRs are accepted, could revert this back to track master, or bump to a newer revision.