### PR TITLE
[25.0] fix macos build

### DIFF
--- a/.github/scripts/install-prereq.sh
+++ b/.github/scripts/install-prereq.sh
@@ -9,18 +9,18 @@ cd $X11_BUILD_DIR
 
 build_meson   rendercheck       https://gitlab.freedesktop.org/xorg/test/rendercheck     rendercheck-1.6
 if [ "$X11_OS" = "Linux" ]; then
-build_meson   drm               https://gitlab.freedesktop.org/mesa/drm                  libdrm-2.4.121 \
+build_meson   drm               https://gitlab.freedesktop.org/mesa/drm                  libdrm-2.4.121   "" \
     -Domap=enabled
 fi
 build_meson   libxcvt           https://gitlab.freedesktop.org/xorg/lib/libxcvt          libxcvt-0.1.0
 build_ac      xorgproto         https://gitlab.freedesktop.org/xorg/proto/xorgproto      xorgproto-2024.1
 if [ "$X11_OS" = "Linux" ]; then
-build_meson   wayland           https://gitlab.freedesktop.org/wayland/wayland           1.21.0 \
+build_meson   wayland           https://gitlab.freedesktop.org/wayland/wayland           1.21.0           "" \
     -Dtests=false -Ddocumentation=false -Ddtd_validation=false
 build_meson   wayland-protocols https://gitlab.freedesktop.org/wayland/wayland-protocols 1.38
-build_meson   libdecor          https://gitlab.freedesktop.org/libdecor/libdecor         0.1.1 \
+build_meson   libdecor          https://gitlab.freedesktop.org/libdecor/libdecor         0.1.1            "" \
     -D{demo,install_demo}=false
-build_meson   libei             https://gitlab.freedesktop.org/libinput/libei            1.0.0 \
+build_meson   libei             https://gitlab.freedesktop.org/libinput/libei            1.0.0            "" \
     -Dtests=disabled -Ddocumentation=[] -Dliboeffis=enabled
 fi
 if [ "$X11_OS" = "Darwin" ]; then

--- a/.github/scripts/install-prereq.sh
+++ b/.github/scripts/install-prereq.sh
@@ -26,7 +26,7 @@ fi
 if [ "$X11_OS" = "Darwin" ]; then
 build_ac      xset              https://gitlab.freedesktop.org/xorg/app/xset             xset-1.2.5
 fi
-build_ac_xts  xts               https://gitlab.freedesktop.org/xorg/test/xts             master # dbbfa96c036e596346147081cbceda136e7c86c1
+build_ac_xts  xts               https://gitlab.freedesktop.org/xorg/test/xts             master     12a887c2c72c4258962b56ced7b0aec782f1ffed
 
 clone_source piglit             https://gitlab.freedesktop.org/mesa/piglit               main # 265896c86f90cb72e8f218ba6a3617fca8b9a1e3
 

--- a/.github/scripts/install-prereq.sh
+++ b/.github/scripts/install-prereq.sh
@@ -28,7 +28,7 @@ build_ac      xset              https://gitlab.freedesktop.org/xorg/app/xset    
 fi
 build_ac_xts  xts               https://gitlab.freedesktop.org/xorg/test/xts             master     12a887c2c72c4258962b56ced7b0aec782f1ffed
 
-clone_source piglit             https://gitlab.freedesktop.org/mesa/piglit               main # 265896c86f90cb72e8f218ba6a3617fca8b9a1e3
+clone_source piglit             https://gitlab.freedesktop.org/mesa/piglit               main       265896c86f90cb72e8f218ba6a3617fca8b9a1e3
 
 echo '[xts]' > piglit/piglit.conf
 echo "path=$X11_BUILD_DIR/xts" >> piglit/piglit.conf

--- a/.github/scripts/util.sh
+++ b/.github/scripts/util.sh
@@ -5,12 +5,21 @@ clone_source() {
     local pkgname="$1"
     local url="$2"
     local ref="$3"
+    local commit="$4"
 
     if [ ! -f $pkgname/.git/config ]; then
         echo "need to clone $pkgname"
-        git clone $url $pkgname --branch=$ref --depth 1
+        if [ "$commit" ]; then
+            git clone $url $pkgname --branch=$ref
+        else
+            git clone $url $pkgname --branch=$ref --depth 1
+        fi
     else
         echo "already cloned $pkgname"
+    fi
+
+    if [ "$commit" ]; then
+        ( cd $pkgname && git checkout -f "$commit" )
     fi
 }
 
@@ -18,13 +27,15 @@ build_meson() {
     local pkgname="$1"
     local url="$2"
     local ref="$3"
+    local commit="$4"
     shift
     shift
     shift
+    shift || true
     if [ -f $X11_PREFIX/$pkgname.DONE ]; then
         echo "package $pkgname already built"
     else
-        clone_source "$pkgname" "$url" "$ref"
+        clone_source "$pkgname" "$url" "$ref" "$commit"
         (
             cd $pkgname
             meson "$@" build -Dprefix=$X11_PREFIX
@@ -38,13 +49,15 @@ build_ac() {
     local pkgname="$1"
     local url="$2"
     local ref="$3"
+    local commit="$4"
     shift
     shift
     shift
+    shift || true
     if [ -f $X11_PREFIX/$pkgname.DONE ]; then
         echo "package $pkgname already built"
     else
-        clone_source "$pkgname" "$url" "$ref"
+        clone_source "$pkgname" "$url" "$ref" "$commit"
         (
             cd $pkgname
             ./autogen.sh --prefix=$X11_PREFIX
@@ -58,10 +71,12 @@ build_drv_ac() {
     local pkgname="$1"
     local url="$2"
     local ref="$3"
+    local commit="$4"
     shift
     shift
     shift
-    clone_source "$pkgname" "$url" "$ref"
+    shift || true
+    clone_source "$pkgname" "$url" "$ref" "$commit"
     (
         cd $pkgname
         ./autogen.sh # --prefix=$X11_PREFIX
@@ -73,13 +88,15 @@ build_ac_xts() {
     local pkgname="$1"
     local url="$2"
     local ref="$3"
+    local commit="$4"
     shift
     shift
     shift
+    shift || true
     if [ -f $X11_PREFIX/$pkgname.DONE ]; then
         echo "package $pkgname already built"
     else
-        clone_source "$pkgname" "$url" "$ref"
+        clone_source "$pkgname" "$url" "$ref" "$commit"
         (
             cd $pkgname
             CFLAGS='-fcommon'


### PR DESCRIPTION
macos build broke due changes in 3rdparty repos (xts, etc). we shouldn't use master branches, but specific commits instead. 