### PR TITLE
kdrive: constitfy kdOsFuncs & document KdOsInit()

### DIFF
--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -96,8 +96,7 @@ const char *kdGlobalXkbOptions = NULL;
  * Carry arguments from InitOutput through driver initialization
  * to KdScreenInit
  */
-
-KdOsFuncs *kdOsFuncs = NULL;
+const KdOsFuncs *kdOsFuncs = NULL;
 
 void
 KdDisableScreen(ScreenPtr pScreen)
@@ -526,7 +525,7 @@ KdProcessArgument(int argc, char **argv, int i)
 }
 
 void
-KdOsInit(KdOsFuncs * pOsFuncs)
+KdOsInit(const KdOsFuncs * pOsFuncs)
 {
     kdOsFuncs = pOsFuncs;
     if (pOsFuncs) {

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -299,7 +299,12 @@ extern DevPrivateKeyRec kdScreenPrivateKeyRec;
 extern Bool kdEmulateMiddleButton;
 extern Bool kdDisableZaphod;
 
-extern KdOsFuncs *kdOsFuncs;
+/*
+ * pointer to OS/platform specific callbacks from kdrive core back
+ * into the individual Xserver implementations.
+ * Initialized via KdOSInit()
+ */
+extern const KdOsFuncs *kdOsFuncs;
 
 #define KdGetScreenPriv(pScreen) ((KdPrivScreenPtr) \
     dixLookupPrivate(&(pScreen)->devPrivates, kdScreenPrivateKey))
@@ -357,8 +362,14 @@ void
 int
  KdProcessArgument(int argc, char **argv, int i);
 
-void
- KdOsInit(KdOsFuncs * pOsFuncs);
+/*
+ * Initialize OS/platform specific parts of the Kdrive Xserver.
+ * Also filling kdOsFuncs with the given call vector table.
+ *
+ * @param pOsFuncs pointer to KdOsFuncs structure. Must be valid for the
+ *                 whole lifetime of the Xserver process.
+ */
+void KdOsInit(const KdOsFuncs * pOsFuncs);
 
 void
  KdOsAddInputDrivers(void);


### PR DESCRIPTION
Not supposed to be written to (once the pointer is assigned), so should be marked const. Also document KdOsInit()