### PR TITLE
dix: drop using HAVE_DIX_CONFIG_H

### DIFF
--- a/dix/generate-atoms
+++ b/dix/generate-atoms
@@ -19,9 +19,7 @@ cat > "$OUTPUT" << __END__
  * Do not change!  Changing this file implies a protocol change!
  */
 
-#ifdef HAVE_DIX_CONFIG_H
 #include <dix-config.h>
-#endif
 
 #include <X11/X.h>
 #include <X11/Xatom.h>

--- a/randr/randrstr.h
+++ b/randr/randrstr.h
@@ -25,11 +25,6 @@
  * Author:  Jim Gettys, Hewlett-Packard Company, Inc.
  *	    Keith Packard, Intel Corporation
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _RANDRSTR_H_
 #define _RANDRSTR_H_
 


### PR DESCRIPTION
This symbol is always defined, and the header is always present, so no need to check for it.