### PR TITLE
os: osdep.h: drop using HAVE_DIX_CONFIG_H

### DIFF
--- a/os/osdep.h
+++ b/os/osdep.h
@@ -43,13 +43,10 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
 SOFTWARE.
 
 ******************************************************************/
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _OSDEP_H_
 #define _OSDEP_H_ 1
+
+#include <dix-config.h>
 
 #include <X11/Xdefs.h>
 


### PR DESCRIPTION
This symbol is always defined, and the header is always present, so no need to check for it.