### PR TITLE
Xi: fix wrong assertion in RetrieveTouchDeliveryData()

### DIFF
--- a/Xi/exevents.c
+++ b/Xi/exevents.c
@@ -1364,7 +1364,6 @@ RetrieveTouchDeliveryData(DeviceIntPtr dev, TouchPointInfoPtr ti,
                           XI2Mask **mask)
 {
     int rc;
-    InputClients *iclients = NULL;
     *mask = NULL;
 
     if (listener->type == TOUCH_LISTENER_GRAB ||
@@ -1393,8 +1392,9 @@ RetrieveTouchDeliveryData(DeviceIntPtr dev, TouchPointInfoPtr ti,
             else
                 evtype = GetXI2Type(ev->any.type);
 
-            assert(iclients);
             assert(wOtherInputMasks(*win));
+
+            InputClients *iclients = NULL;
             nt_list_for_each_entry(iclients,
                                    wOtherInputMasks(*win)->inputClients, next)
                 if (xi2mask_isset(iclients->xi2mask, dev, evtype))
@@ -1410,6 +1410,8 @@ RetrieveTouchDeliveryData(DeviceIntPtr dev, TouchPointInfoPtr ti,
             Mask xi_filter = event_get_filter_from_type(dev, xi_type);
 
             assert(wOtherInputMasks(*win));
+
+            InputClients *iclients = NULL;
             nt_list_for_each_entry(iclients,
                                    wOtherInputMasks(*win)->inputClients, next)
                 if (iclients->mask[dev->id] & xi_filter)


### PR DESCRIPTION
The assert(iclients) was in a place where the iclients variable could not have been initialized ever - the first assignment is done *after* that. Since we already have a BUG_RETURN_VAL() right be before it's actually dereferenced, there's no need for that assert() at all - so drop it.

See https://github.com/X11Libre/xserver/issues/330