### PR TITLE
randr: set initial DPI property to a default value for all outputs

### DIFF
--- a/randr/rroutput.c
+++ b/randr/rroutput.c
@@ -71,6 +71,7 @@ RROutputCreate(ScreenPtr pScreen,
     RROutputPtr *outputs;
     rrScrPrivPtr pScrPriv;
     Atom nonDesktopAtom;
+    Atom DPIAtom;
 
     if (!RRInit())
         return NULL;
@@ -109,6 +110,18 @@ RROutputCreate(ScreenPtr pScreen,
                                             2, values);
     }
     RROutputSetNonDesktop(output, FALSE);
+
+    /* Initialize DPI property for all outputs. */
+    DPIAtom = MakeAtom("DPI", 3, TRUE);
+    if (DPIAtom != BAD_RESOURCE) {
+        static const INT32 values[2] = { 0, 960 }; // arbitrary range
+        (void) RRConfigureOutputProperty(output, DPIAtom, FALSE, TRUE, FALSE,
+                                         2, values);
+        INT32 value = monitorResolution ? monitorResolution : 96;
+        (void) RRChangeOutputProperty(output, DPIAtom, XA_INTEGER, 32,
+                                      PropModeReplace, 1, &value, FALSE, FALSE);
+    }
+
     RRResourcesChanged(pScreen);
 
     return output;


### PR DESCRIPTION
X has various ways to deal with DPI but all of the current methods have some drawback (single global value, manually calculating from physical dimensions, etc.) What is lacking is a simple value per output that users and applications can use to communicate desired scaling values. Fortunately, a generic output property mechanism already exists. And they already send events whenever there is a change. So all we have to do is make an "official" property for people to agree on and enshrine it. In that case, all outputs can just always have the DPI property set to something. In most cases, this will be 96 (the default), but one could use the -dpi argument when launching or and that value will be used instead. The intention is that 96 is the base that is equivalent to 1x scaling. i.e. 192 would be 2x, 144 would be 1.5x and so on. xrandr or any other utility can modify this property at any time and applications can choose to use the number in a way that makes sense.

Closes #208. Credit to @dec05eba for essentially coming up with the idea of using output properties.