### PR TITLE
modesetting: ignore the drmmode if p->atoms is null

### DIFF
--- a/config/config-backends.h
+++ b/config/config-backends.h
@@ -26,9 +26,8 @@
 #ifndef XSERVER_CONFIG_BACKENDS_H
 #define XSERVER_CONFIG_BACKENDS_H
 
-#ifdef HAVE_DIX_CONFIG_H
 #include <dix-config.h>
-#endif
+
 #include "input.h"
 #include "list.h"
 

--- a/fb/fbbits.h
+++ b/fb/fbbits.h
@@ -24,14 +24,9 @@
  * This file defines functions for drawing some primitives using
  * underlying datatypes instead of masks
  */
+#include "fb/fb_priv.h"
 
 #define isClipped(c,ul,lr)  (((c) | ((c) - (ul)) | ((lr) - (c))) & 0x80008000)
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
-#include "fb/fb_priv.h"
 
 #define __FbMaskBits(x,w,l,n,r) { \
     n = (w); \

--- a/fb/fbpict.h
+++ b/fb/fbpict.h
@@ -20,11 +20,6 @@
  * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  * PERFORMANCE OF THIS SOFTWARE.
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _FBPICT_H_
 #define _FBPICT_H_
 

--- a/glamor/glamor.h
+++ b/glamor/glamor.h
@@ -34,7 +34,6 @@
 #include <gcstruct.h>
 #include <picturestr.h>
 #include <fb.h>
-#include <fbpict.h>
 #ifdef GLAMOR_FOR_XORG
 #include <xf86xv.h>
 #endif

--- a/glamor/glamor_addtraps.c
+++ b/glamor/glamor_addtraps.c
@@ -27,6 +27,8 @@
  */
 #include <dix-config.h>
 
+#include "fb/fbpict.h"
+
 #include "glamor_priv.h"
 
 void

--- a/glx/glxcontext.h
+++ b/glx/glxcontext.h
@@ -1,7 +1,3 @@
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _GLX_context_h_
 #define _GLX_context_h_
 

--- a/glx/glxdrawable.h
+++ b/glx/glxdrawable.h
@@ -1,7 +1,3 @@
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _GLX_drawable_h_
 #define _GLX_drawable_h_
 

--- a/glx/glxext.h
+++ b/glx/glxext.h
@@ -1,7 +1,3 @@
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _glxext_h_
 #define _glxext_h_
 

--- a/glx/glxscreens.h
+++ b/glx/glxscreens.h
@@ -1,7 +1,3 @@
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _GLX_screens_h_
 #define _GLX_screens_h_
 

--- a/glx/glxserver.h
+++ b/glx/glxserver.h
@@ -1,7 +1,3 @@
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _GLX_server_h_
 #define _GLX_server_h_
 

--- a/glx/glxutil.h
+++ b/glx/glxutil.h
@@ -1,7 +1,3 @@
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _glxcmds_h_
 #define _glxcmds_h_
 

--- a/glx/indirect_table.c
+++ b/glx/indirect_table.c
@@ -22,6 +22,7 @@
  * OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+#include <dix-config.h>
 
 #include <inttypes.h>
 #include "glxserver.h"

--- a/glx/singlesize.h
+++ b/glx/singlesize.h
@@ -1,7 +1,3 @@
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _singlesize_h_
 #define _singlesize_h_
 

--- a/glx/unpack.h
+++ b/glx/unpack.h
@@ -1,7 +1,3 @@
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef __GLX_unpack_h__
 #define __GLX_unpack_h__
 

--- a/glx/vndserver_priv.h
+++ b/glx/vndserver_priv.h
@@ -26,11 +26,9 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
  */
-
 #ifndef _XSERVER_VNDSERVER_PRIV_H
 #define _XSERVER_VNDSERVER_PRIV_H
 
-#include <dix-config.h>
 #include "glxvndabi.h"
 #include "vndserver.h"
 

--- a/glx/vndservervendor.h
+++ b/glx/vndservervendor.h
@@ -26,11 +26,8 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
  */
-
 #ifndef VND_SERVER_VENDOR_H
 #define VND_SERVER_VENDOR_H
-
-#include <dix-config.h>
 
 #include "glxvndabi.h"
 #include "list.h"

--- a/hw/kdrive/ephyr/ephyrinit.c
+++ b/hw/kdrive/ephyr/ephyrinit.c
@@ -370,6 +370,23 @@ ddxProcessArgument(int argc, char **argv, int i)
     return KdProcessArgument(argc, argv, i);
 }
 
+static int
+EphyrInit(void)
+{
+    /*
+     * make sure at least one screen
+     * has been added to the system.
+     */
+    if (!KdCardInfoLast()) {
+        processScreenArg("640x480", NULL);
+    }
+    return hostx_init();
+}
+
+KdOsFuncs EphyrOsFuncs = {
+    .Init = EphyrInit,
+};
+
 void
 OsVendorInit(void)
 {
@@ -381,12 +398,7 @@ OsVendorInit(void)
     if (hostx_want_host_cursor())
         ephyrFuncs.initCursor = &ephyrCursorInit;
 
-    if (serverGeneration == 1) {
-        if (!KdCardInfoLast()) {
-            processScreenArg("640x480", NULL);
-        }
-        hostx_init();
-    }
+    KdOsInit(&EphyrOsFuncs);
 }
 
 KdCardFuncs ephyrFuncs = {

--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -96,8 +96,7 @@ const char *kdGlobalXkbOptions = NULL;
  * Carry arguments from InitOutput through driver initialization
  * to KdScreenInit
  */
-
-KdOsFuncs *kdOsFuncs = NULL;
+const KdOsFuncs *kdOsFuncs = NULL;
 
 void
 KdDisableScreen(ScreenPtr pScreen)
@@ -526,7 +525,7 @@ KdProcessArgument(int argc, char **argv, int i)
 }
 
 void
-KdOsInit(KdOsFuncs * pOsFuncs)
+KdOsInit(const KdOsFuncs * pOsFuncs)
 {
     kdOsFuncs = pOsFuncs;
     if (pOsFuncs) {

--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -91,6 +91,14 @@ const char *kdGlobalXkbLayout = NULL;
 const char *kdGlobalXkbVariant = NULL;
 const char *kdGlobalXkbOptions = NULL;
 
+
+/*
+ * Carry arguments from InitOutput through driver initialization
+ * to KdScreenInit
+ */
+
+KdOsFuncs *kdOsFuncs = NULL;
+
 void
 KdDisableScreen(ScreenPtr pScreen)
 {
@@ -515,6 +523,19 @@ KdProcessArgument(int argc, char **argv, int i)
     }
 
     return 0;
+}
+
+void
+KdOsInit(KdOsFuncs * pOsFuncs)
+{
+    kdOsFuncs = pOsFuncs;
+    if (pOsFuncs) {
+        if (serverGeneration == 1) {
+            KdDoSwitchCmd("start");
+            if (pOsFuncs->Init)
+                (*pOsFuncs->Init) ();
+        }
+    }
 }
 
 static Bool

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -299,7 +299,12 @@ extern DevPrivateKeyRec kdScreenPrivateKeyRec;
 extern Bool kdEmulateMiddleButton;
 extern Bool kdDisableZaphod;
 
-extern KdOsFuncs *kdOsFuncs;
+/*
+ * pointer to OS/platform specific callbacks from kdrive core back
+ * into the individual Xserver implementations.
+ * Initialized via KdOSInit()
+ */
+extern const KdOsFuncs *kdOsFuncs;
 
 #define KdGetScreenPriv(pScreen) ((KdPrivScreenPtr) \
     dixLookupPrivate(&(pScreen)->devPrivates, kdScreenPrivateKey))
@@ -357,8 +362,14 @@ void
 int
  KdProcessArgument(int argc, char **argv, int i);
 
-void
- KdOsInit(KdOsFuncs * pOsFuncs);
+/*
+ * Initialize OS/platform specific parts of the Kdrive Xserver.
+ * Also filling kdOsFuncs with the given call vector table.
+ *
+ * @param pOsFuncs pointer to KdOsFuncs structure. Must be valid for the
+ *                 whole lifetime of the Xserver process.
+ */
+void KdOsInit(const KdOsFuncs * pOsFuncs);
 
 void
  KdOsAddInputDrivers(void);

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -278,6 +278,16 @@ int KdAddConfigKeyboard(const char *pointer);
 int KdAddKeyboard(KdKeyboardInfo * ki);
 void KdRemoveKeyboard(KdKeyboardInfo * ki);
 
+typedef struct _KdOsFuncs {
+    int (*Init) (void); /* Only called when the X server is started, when serverGeneration == 1 */
+    void (*Enable) (void);
+    Bool (*SpecialKey) (KeySym);
+    void (*Disable) (void);
+    void (*Fini) (void);
+    void (*pollEvents) (void);
+    void (*Bell) (int, int, int);
+} KdOsFuncs;
+
 typedef struct _KdPointerMatrix {
     int matrix[2][3];
 } KdPointerMatrix;
@@ -288,6 +298,8 @@ extern DevPrivateKeyRec kdScreenPrivateKeyRec;
 
 extern Bool kdEmulateMiddleButton;
 extern Bool kdDisableZaphod;
+
+extern KdOsFuncs *kdOsFuncs;
 
 #define KdGetScreenPriv(pScreen) ((KdPrivScreenPtr) \
     dixLookupPrivate(&(pScreen)->devPrivates, kdScreenPrivateKey))
@@ -344,6 +356,9 @@ void
 
 int
  KdProcessArgument(int argc, char **argv, int i);
+
+void
+ KdOsInit(KdOsFuncs * pOsFuncs);
 
 void
  KdOsAddInputDrivers(void);

--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
@@ -3178,7 +3178,7 @@ drmmode_output_set_property(xf86OutputPtr output, Atom property,
     for (i = 0; i < drmmode_output->num_props; i++) {
         drmmode_prop_ptr p = &drmmode_output->props[i];
 
-        if (p->atoms[0] != property)
+        if (p->atoms && p->atoms[0] != property)
             continue;
 
         if (p->mode_prop->flags & DRM_MODE_PROP_RANGE) {


### PR DESCRIPTION
Some display drivers might cause p->atoms to be null if the display is disabled. This will cause segfault when checking
if p->atoms[0] != property .
Some display drivers owned by qualcomm is known to cause this bug.

Got the segfault during trying to get xlibre working with qualcomm's proprietary display driver in a fork of downstream Android kernel for some device. This is a quick fix and I think it wont do anything and cause any trouble in normal environment.