### PR TITLE
Xi: drop unused variable and NULL free in ProcXISelectEvents()

### DIFF
--- a/Xi/xiselectev.c
+++ b/Xi/xiselectev.c
@@ -151,7 +151,6 @@ ProcXISelectEvents(ClientPtr client)
     DeviceIntPtr dev;
     DeviceIntRec dummy;
     xXIEventMask *evmask;
-    int *types = NULL;
     int len;
 
     REQUEST(xXISelectEventsReq);
@@ -327,8 +326,6 @@ ProcXISelectEvents(ClientPtr client)
     }
 
     RecalculateDeliverableEvents(win);
-
-    free(types);
     return Success;
 }
 


### PR DESCRIPTION
The `types` variable is never used, just assigned NULL - and that NULL value is passed to free(). This code is really doing nothing, never did so since introduced in 2009.

Fixes: 8b6a370058ad5a20e0a0e49ec9443daf03775de8