### PR TITLE
Fix punctuation error in Manpage.

### DIFF
--- a/man/Xserver.man
+++ b/man/Xserver.man
@@ -189,7 +189,7 @@ sets beep (bell) volume (allowable range: 0\(en100).
 sets fake presenter screen default fps (allowable range: 1\(en600).
 .TP 8
 .B \-fp \fIfontPath\fP
-sets the search path for fonts.  This path is a comma separated list
+sets the search path for fonts.  This path is a comma-separated list
 of directories which the X server searches for font databases.
 See the FONTS section of this manual page for more information and the default
 list.


### PR DESCRIPTION
Change "comma separated" to "comma-separated" in man/Xserver.man @ line 192, description of `-fp fontPath` option.