### PR TITLE
README.md: Remove example of discriminatory policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ requests, etc, and so fired the shot that the whole world heard.
 
 This is an independent project, not at all affiliated with BigTech or any
 of their subsidiaries or tax evasion tools, nor any political activists
-groups, state actors, etc. It's explicitly free of any "DEI" or similar
-discriminatory policies. Anybody who's treating others nicely is welcomed.
+groups, state actors, etc. It's explicitly free of any discriminatory policies.
+Anybody who's treating others nicely is welcomed.
 
 It doesn't matter which country you're coming from, your political views,
 your race, your sex, your age, your food menu, whether you wear boots or


### PR DESCRIPTION
Some journalists are trying to spread misinformation and manipulate their readers by only focusing on the wordings of this single sentence among all the paragraphs in this README.md, distorting the viewpoint of the maintainer, promoting hate of their readers towards this project and damaging its reputation. 

Example from _The Register_:

> Xlibre is both a conservative, and Conservative, fork. Technologically small-c conservative, inasmuch as its proponents don't want Wayland and prefer the existing, well-established X11 tools, but also capital-C Conservative. Its GitHub README [states](https://github.com/X11Libre/xserver) that it is "explicitly free of any 'DEI' or similar discriminatory policies" and intentionally has an [empty Code of Conduct file](https://github.com/X11Libre/xserver/commit/e0dd3c9c452d43cbfb179cfc9c16ed9107c03445). Weigelt is understood to align himself with extremely right-wing politics.

I found this particular author post 6 articles about xlibre so far, 4 of them use the same tactic to only quote this single sentence in README. They will just keep doing it until they accomplish what they want.

This situation can be mitigated by this PR. Basically the whole idea of the paragraph does not change.