### PR TITLE
static asserts for protocol struct sizes

### DIFF
--- a/Xext/panoramiX.c
+++ b/Xext/panoramiX.c
@@ -1299,3 +1299,20 @@ XineramaGetImageData(DrawablePtr *pDrawables,
     RegionUninit(&SrcRegion);
     RegionUninit(&GrabRegion);
 }
+
+// work around broken X11 proto headers
+#define sz_xXineramaQueryScreensReply sz_XineramaQueryScreensReply
+#define sz_xXineramaIsActiveReply sz_XineramaIsActiveReply
+#define sz_xPanoramiXGetScreenSizeReply sz_panoramiXGetScreenSizeReply
+#define sz_xPanoramiXGetScreenCountReply sz_panoramiXGetScreenCountReply
+#define sz_xPanoramiXGetStateReply sz_panoramiXGetStateReply
+
+XTYPE_SIZE_ASSERT(xPanoramiXQueryVersionReply);
+XTYPE_SIZE_ASSERT(xPanoramiXGetStateReply);
+XTYPE_SIZE_ASSERT(xPanoramiXGetScreenCountReply);
+XTYPE_SIZE_ASSERT(xPanoramiXGetScreenSizeReply);
+XTYPE_SIZE_ASSERT(xXineramaIsActiveReply);
+XTYPE_SIZE_ASSERT(xTranslateCoordsReply);
+XTYPE_SIZE_ASSERT(xXineramaQueryScreensReply);
+XTYPE_SIZE_ASSERT(xGetGeometryReply);
+XTYPE_SIZE_ASSERT(xGetImageReply);

--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -39,6 +39,13 @@
         }                                       \
     } while (0)
 
+/* static assert for protocol structure sizes */
+#ifndef __size_assert
+#define __size_assert(what, howmuch) \
+  typedef char what##_size_wrong_[( !!(sizeof(what) == howmuch) )*2-1 ]
+#endif
+#define XTYPE_SIZE_ASSERT(typename) __size_assert(typename,SIZEOF(typename))
+
 /* server setting: maximum size for big requests */
 #define MAX_BIG_REQUEST_SIZE 4194303
 extern long maxBigRequestSize;


### PR DESCRIPTION
Theoretically, sizeof() on protocol structs should always give the actual network size. But in order to make sure, that some compiler doens't do anything else - or some header's not entirely correct, adding some static asserts.
