### PR TITLE
screen: initialize rootDepth to zero to fix uninitialized-variable warning

### DIFF
--- a/hw/xnest/Screen.c
+++ b/hw/xnest/Screen.c
@@ -165,7 +165,7 @@ xnestOpenScreen(ScreenPtr pScreen, int argc, char *argv[])
 {
     unsigned long valuemask;
     VisualID defaultVisual = 0;
-    int rootDepth;
+    int rootDepth = 0;
     miPointerScreenPtr PointPriv;
 
     if (!dixRegisterPrivateKey


### PR DESCRIPTION
This sets rootDepth to 0 to avoid the compiler errors for using uninitialized variables

Rebased from https://github.com/X11Libre/xserver/pull/278