### PR TITLE
glamor: handle if GBM_BO_USE_SCANOUT is not supported

### DIFF
--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -391,9 +391,16 @@ glamor_make_pixmap_exportable(PixmapPtr pixmap, Bool modifiers_ok)
 
         glamor_get_modifiers(screen, format, &num_modifiers, &modifiers);
 
-        if (num_modifiers > 0)
+        if (num_modifiers > 0) {
+#ifdef GBM_BO_WITH_MODIFIERS2
+            bo = gbm_bo_create_with_modifiers2(glamor_egl->gbm, width, height,
+                                               format, modifiers, num_modifiers,
+                                               GBM_BO_USE_RENDERING | GBM_BO_USE_SCANOUT);
+#else
             bo = gbm_bo_create_with_modifiers(glamor_egl->gbm, width, height,
                                               format, modifiers, num_modifiers);
+#endif
+        }
         if (bo)
             used_modifiers = TRUE;
         free(modifiers);

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -787,10 +787,12 @@ glamor_get_modifiers(ScreenPtr screen, uint32_t format,
 #ifdef GLAMOR_HAS_EGL_QUERY_DMABUF
     struct glamor_egl_screen_private *glamor_egl;
     EGLint num;
+#endif
 
-    /* Explicitly zero the count as the caller may ignore the return value */
+    /* Explicitly zero the count and modifiers as the caller may ignore the return value */
     *num_modifiers = 0;
-
+    *modifiers = NULL;
+#ifdef GLAMOR_HAS_EGL_QUERY_DMABUF
     glamor_egl = glamor_egl_get_screen_private(xf86ScreenToScrn(screen));
 
     if (!glamor_egl->dmabuf_capable)
@@ -814,11 +816,8 @@ glamor_get_modifiers(ScreenPtr screen, uint32_t format,
     }
 
     *num_modifiers = num;
-    return TRUE;
-#else
-    *num_modifiers = 0;
-    return TRUE;
 #endif
+    return TRUE;
 }
 
 const char *

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -391,8 +391,9 @@ glamor_make_pixmap_exportable(PixmapPtr pixmap, Bool modifiers_ok)
 
         glamor_get_modifiers(screen, format, &num_modifiers, &modifiers);
 
-        bo = gbm_bo_create_with_modifiers(glamor_egl->gbm, width, height,
-                                          format, modifiers, num_modifiers);
+        if (num_modifiers > 0)
+            bo = gbm_bo_create_with_modifiers(glamor_egl->gbm, width, height,
+                                              format, modifiers, num_modifiers);
         if (bo)
             used_modifiers = TRUE;
         free(modifiers);


### PR DESCRIPTION
GBM_BO_USE_SCANOUT is not always supported.
Handle the case when it is unsupported.

@metux @dec05eba @mikedld Please take a look