### PR TITLE
include: drop obsolete WriteReplyToClient() macro

### DIFF
--- a/doc/Xserver-spec.xml
+++ b/doc/Xserver-spec.xml
@@ -599,7 +599,7 @@ are useful to the extension writer.  Ones of particular interest
 are: REQUEST, REQUEST_SIZE_MATCH, REQUEST_AT_LEAST_SIZE,
 REQUEST_FIXED_SIZE, LEGAL_NEW_RESOURCE, and
 VALIDATE_DRAWABLE_AND_GC. Useful byte swapping macros can be found
-in Xserver/include/dix.h: WriteReplyToClient and WriteSwappedDataToClient; and
+in Xserver/include/dix.h: WriteSwappedDataToClient; and
 in Xserver/include/misc.h: bswap_64, bswap_32, bswap_16, LengthRestS,
 LengthRestL, SwapRestS, SwapRestL, swapl, swaps, cpswapl, and cpswaps.</para>
 </section>

--- a/include/dix.h
+++ b/include/dix.h
@@ -92,15 +92,6 @@ SOFTWARE.
             return(BadLength);                                          \
     } while (0)
 
-#define WriteReplyToClient(pClient, size, pReply)                       \
-    do {                                                                \
-        if ((pClient)->swapped)                                         \
-            (*ReplySwapVector[((xReq *)(pClient)->requestBuffer)->reqType]) \
-                (pClient, (int)(size), pReply);                         \
-        else                                                            \
-            WriteToClient(pClient, (int)(size), (pReply));              \
-    } while (0)
-
 #define WriteSwappedDataToClient(pClient, size, pbuf)                   \
     do {                                                                \
         if ((pClient)->swapped)                                         \


### PR DESCRIPTION
Not used anymore, and not part of ABI, so no need to keep it around any longer.