### PR TITLE
drop NullClient macro

### DIFF
--- a/Xext/dpms.c
+++ b/Xext/dpms.c
@@ -75,7 +75,7 @@ DPMSFreeClient(void *data, XID id)
 
     pEvent = (DPMSEventPtr) data;
     dixLookupResourceByType((void *) &pHead, eventResource, DPMSEventType,
-                            NullClient, DixUnknownAccess);
+                            NULL, DixUnknownAccess);
     if (pHead) {
         pPrev = 0;
         for (pCur = *pHead; pCur && pCur != pEvent; pCur = pCur->next)

--- a/Xext/xvmain.c
+++ b/Xext/xvmain.c
@@ -1045,7 +1045,7 @@ XvFillColorKey(DrawablePtr pDraw, CARD32 key, RegionPtr region)
 
     pval[0].val = key;
     pval[1].val = IncludeInferiors;
-    (void) ChangeGC(NullClient, gc, GCForeground | GCSubwindowMode, pval);
+    (void) ChangeGC(NULL, gc, GCForeground | GCSubwindowMode, pval);
     ValidateGC(pDraw, gc);
 
     rects = calloc(nbox, sizeof(xRectangle));

--- a/Xi/exevents.c
+++ b/Xi/exevents.c
@@ -762,7 +762,7 @@ XISendDeviceChangedEvent(DeviceIntPtr device, DeviceChangedEvent *dce)
         return;
     }
 
-    /* we don't actually swap if there's a NullClient, swapping is done
+    /* we don't actually swap if there's a NULL client, swapping is done
      * later when event is delivered. */
     SendEventToAllWindows(device, XI_DeviceChangedMask, (xEvent *) dcce, 1);
     free(dcce);

--- a/composite/compalloc.c
+++ b/composite/compalloc.c
@@ -248,7 +248,7 @@ compRestoreWindow(WindowPtr pWin, PixmapPtr pPixmap)
             ChangeGCVal val;
 
             val.val = IncludeInferiors;
-            ChangeGC(NullClient, pGC, GCSubwindowMode, &val);
+            ChangeGC(NULL, pGC, GCSubwindowMode, &val);
             ValidateGC(&pWin->drawable, pGC);
             (void) (*pGC->ops->CopyArea) (&pPixmap->drawable,
                                    &pWin->drawable, pGC, x, y, w, h, 0, 0);
@@ -552,7 +552,7 @@ compNewPixmap(WindowPtr pWin, int x, int y, int w, int h)
             ChangeGCVal val;
 
             val.val = IncludeInferiors;
-            ChangeGC(NullClient, pGC, GCSubwindowMode, &val);
+            ChangeGC(NULL, pGC, GCSubwindowMode, &val);
             ValidateGC(&pPixmap->drawable, pGC);
             (void) (*pGC->ops->CopyArea) (&pParent->drawable,
                                           &pPixmap->drawable,

--- a/dbe/dbe.c
+++ b/dbe/dbe.c
@@ -1074,7 +1074,7 @@ DbeSetupBackgroundPainter(WindowPtr pWin, GCPtr pGC)
         return FALSE;
     }
 
-    return ChangeGC(NullClient, pGC, gcmask, gcvalues) == 0;
+    return ChangeGC(NULL, pGC, gcmask, gcvalues) == 0;
 }                               /* DbeSetupBackgroundPainter() */
 
 /******************************************************************************

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -3648,8 +3648,8 @@ CloseDownClient(ClientPtr client)
 #endif
         if (client->index < nextFreeClientID)
             nextFreeClientID = client->index;
-        clients[client->index] = NullClient;
-        SmartLastClient = NullClient;
+        clients[client->index] = NULL;
+        SmartLastClient = NULL;
         dixFreeObjectWithPrivates(client, PRIVATE_CLIENT);
 
         while (!clients[currentMaxClients - 1])

--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -686,7 +686,7 @@ static inline ClientPtr dixLookupXIDOwner(XID xid)
     int clientId = dixClientIdForXID(xid);
     if (clientId < currentMaxClients)
         return clients[clientId];
-    return NullClient;
+    return NULL;
 }
 
 #endif /* _XSERVER_DIX_PRIV_H */

--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -1189,7 +1189,7 @@ doPolyText(ClientPtr client, PTclosurePtr c)
                     ChangeGCVal val;
 
                     val.ptr = pFont;
-                    ChangeGC(NullClient, c->pGC, GCFont, &val);
+                    ChangeGC(NULL, c->pGC, GCFont, &val);
                     ValidateGC(c->pDraw, c->pGC);
                 }
 
@@ -1330,7 +1330,7 @@ doPolyText(ClientPtr client, PTclosurePtr c)
             ChangeGCVal val;
 
             val.ptr = pFont;
-            ChangeGC(NullClient, origGC, GCFont, &val);
+            ChangeGC(NULL, origGC, GCFont, &val);
             ValidateGC(c->pDraw, origGC);
         }
 
@@ -1349,7 +1349,7 @@ doPolyText(ClientPtr client, PTclosurePtr c)
     }
     if (ClientIsAsleep(client)) {
         ClientWakeup(c->client);
-        ChangeGC(NullClient, c->pGC, clearGCmask, clearGC);
+        ChangeGC(NULL, c->pGC, clearGCmask, clearGC);
 
         /* Unreference the font from the scratch GC */
         CloseFont(c->pGC->font, (Font) 0);
@@ -1498,7 +1498,7 @@ doImageText(ClientPtr client, ITclosurePtr c)
     }
     if (ClientIsAsleep(client)) {
         ClientWakeup(c->client);
-        ChangeGC(NullClient, c->pGC, clearGCmask, clearGC);
+        ChangeGC(NULL, c->pGC, clearGCmask, clearGC);
 
         /* Unreference the font from the scratch GC */
         CloseFont(c->pGC->font, (Font) 0);

--- a/dix/events.c
+++ b/dix/events.c
@@ -2359,7 +2359,7 @@ DeliverEventsToWindow(DeviceIntPtr pDev, WindowPtr pWin, xEvent
                       *pEvents, size_t count, Mask filter, GrabPtr grab)
 {
     int deliveries = 0, nondeliveries = 0;
-    ClientPtr client = NullClient;
+    ClientPtr client = NULL;
     Mask deliveryMask = 0;      /* If a grab occurs due to a button press, then
                                    this mask is the mask of the grab. */
     int type = pEvents->u.u.type;
@@ -2812,7 +2812,7 @@ DeliverEvent(DeviceIntPtr dev, xEvent *xE, int count,
     Mask filter;
     int deliveries = 0;
 
-    if (XaceHookSendAccess(NullClient, dev, win, xE, count) == Success) {
+    if (XaceHookSendAccess(NULL, dev, win, xE, count) == Success) {
         filter = GetEventFilter(dev, xE);
         FixUpEventFromWindow(pSprite, xE, win, child, FALSE);
         deliveries = DeliverEventsToWindow(dev, win, xE, count, filter, grab);
@@ -4240,7 +4240,7 @@ DeliverFocusedEvent(DeviceIntPtr keybd, InternalEvent *event, WindowPtr window)
 
     rc = EventToXI(event, &xE, &count);
     if (rc == Success &&
-        XaceHookSendAccess(NullClient, keybd, focus, xE, count) == Success) {
+        XaceHookSendAccess(NULL, keybd, focus, xE, count) == Success) {
         FixUpEventFromWindow(ptr->spriteInfo->sprite, xE, focus, None, FALSE);
         deliveries = DeliverEventsToWindow(keybd, focus, xE, count,
                                            GetEventFilter(keybd, xE), NullGrab);
@@ -4256,7 +4256,7 @@ DeliverFocusedEvent(DeviceIntPtr keybd, InternalEvent *event, WindowPtr window)
     if (sendCore) {
         rc = EventToCore(event, &core, &count);
         if (rc == Success) {
-            if (XaceHookSendAccess(NullClient, keybd, focus, core, count) ==
+            if (XaceHookSendAccess(NULL, keybd, focus, core, count) ==
                 Success) {
                 FixUpEventFromWindow(keybd->spriteInfo->sprite, core, focus,
                                      None, FALSE);
@@ -4329,7 +4329,7 @@ DeliverOneGrabbedEvent(InternalEvent *event, DeviceIntPtr dev,
 
     if (rc == Success) {
         FixUpEventFromWindow(pSprite, xE, grab->window, None, TRUE);
-        if (XaceHookSendAccess(NullClient, dev, grab->window, xE, count) ||
+        if (XaceHookSendAccess(NULL, dev, grab->window, xE, count) ||
             XaceHookReceiveAccess(dixClientForGrab(grab), grab->window, xE, count))
             deliveries = 1;     /* don't send, but pretend we did */
         else if (level != CORE || !IsInterferingGrab(dixClientForGrab(grab), dev, xE)) {

--- a/dix/gc.c
+++ b/dix/gc.c
@@ -86,7 +86,7 @@ ValidateGC(DrawablePtr pDraw, GCPtr pGC)
  * The client performing the gc change must be passed so that access
  * checks can be performed on any tiles, stipples, or fonts that are
  * specified.  ddxen can call this too; they should normally pass
- * NullClient for the client since any access checking should have
+ * NULL for the client since any access checking should have
  * already been done at a higher level.
  *
  * If you have any XIDs, you must use ChangeGCXIDs:
@@ -594,7 +594,7 @@ CreateDefaultTile(GCPtr pGC)
     tmpval[0].val = GXcopy;
     tmpval[1].val = pGC->tile.pixel;
     tmpval[2].val = FillSolid;
-    (void) ChangeGC(NullClient, pgcScratch,
+    (void) ChangeGC(NULL, pgcScratch,
                     GCFunction | GCForeground | GCFillStyle, tmpval);
     ValidateGC((DrawablePtr) pTile, pgcScratch);
     rect.x = 0;
@@ -886,7 +886,7 @@ CreateDefaultStipple(int screenNum)
         dixDestroyPixmap(pScreen->defaultStipple, 0);
         return FALSE;
     }
-    (void) ChangeGC(NullClient, pgcScratch,
+    (void) ChangeGC(NULL, pgcScratch,
                     GCFunction | GCForeground | GCFillStyle, tmpval);
     ValidateGC((DrawablePtr) pScreen->defaultStipple, pgcScratch);
     rect.x = 0;

--- a/dix/glyphcurs.c
+++ b/dix/glyphcurs.c
@@ -112,13 +112,13 @@ ServerBitsFromGlyph(FontPtr pfont, unsigned ch, CursorMetricPtr cm,
     gcval[0].val = GXcopy;
     gcval[1].val = 0;
     gcval[2].ptr = (void *) pfont;
-    ChangeGC(NullClient, pGC, GCFunction | GCForeground | GCFont, gcval);
+    ChangeGC(NULL, pGC, GCFunction | GCForeground | GCFont, gcval);
     ValidateGC((DrawablePtr) ppix, pGC);
     (*pGC->ops->PolyFillRect) ((DrawablePtr) ppix, pGC, 1, &rect);
 
     /* draw the glyph */
     gcval[0].val = 1;
-    ChangeGC(NullClient, pGC, GCForeground, gcval);
+    ChangeGC(NULL, pGC, GCForeground, gcval);
     ValidateGC((DrawablePtr) ppix, pGC);
     (*pGC->ops->PolyText16) ((DrawablePtr) ppix, pGC, cm->xhot, cm->yhot,
                              1, (unsigned short *) char2b);

--- a/dix/lookup.c
+++ b/dix/lookup.c
@@ -14,28 +14,28 @@
 
 ClientPtr dixClientForWindow(WindowPtr pWin) {
     if (!pWin)
-        return NullClient;
+        return NULL;
 
     return dixClientForXID(pWin->drawable.id);
 }
 
 ClientPtr dixClientForGrab(GrabPtr pGrab) {
     if (!pGrab)
-        return NullClient;
+        return NULL;
 
     return dixClientForXID(pGrab->resource);
 }
 
 ClientPtr dixClientForInputClients(InputClientsPtr pInputClients) {
     if (!pInputClients)
-        return NullClient;
+        return NULL;
 
     return dixClientForXID(pInputClients->resource);
 }
 
 ClientPtr dixClientForOtherClients(OtherClientsPtr pOtherClients) {
     if (!pOtherClients)
-        return NullClient;
+        return NULL;
 
     return dixClientForXID(pOtherClients->resource);
 }

--- a/dix/main.c
+++ b/dix/main.c
@@ -158,7 +158,7 @@ dix_main(int argc, char *argv[], char *envp[])
         if (serverGeneration == 1) {
             CreateWellKnownSockets();
             for (i = 1; i < LimitClients; i++)
-                clients[i] = NullClient;
+                clients[i] = NULL;
             serverClient = calloc(1, sizeof(ClientRec));
             if (!serverClient)
                 FatalError("couldn't create server client");

--- a/dix/pixmap.c
+++ b/dix/pixmap.c
@@ -265,7 +265,7 @@ PixmapDirtyCopyArea(PixmapPtr dst, DrawablePtr src,
         ChangeGCVal subWindowMode;
 
         subWindowMode.val = IncludeInferiors;
-        ChangeGC(NullClient, pGC, GCSubwindowMode, &subWindowMode);
+        ChangeGC(NULL, pGC, GCSubwindowMode, &subWindowMode);
     }
     ValidateGC(&dst->drawable, pGC);
 

--- a/dix/resource_priv.h
+++ b/dix/resource_priv.h
@@ -39,7 +39,7 @@
  * (every client so is assigned a range of XIDs it may use for resource creation)
  *
  * @param WindowPtr to the window whose client shall be retrieved
- * @return pointer to ClientRec structure or NullClient (NULL)
+ * @return pointer to ClientRec structure or NULL
  */
 ClientPtr dixClientForWindow(WindowPtr pWin);
 
@@ -50,7 +50,7 @@ ClientPtr dixClientForWindow(WindowPtr pWin);
  * (every client so is assigned a range of XIDs it may use for resource creation)
  *
  * @param GrabPtr to the grab whose owning client shall be retrieved
- * @return pointer to ClientRec structure or NullClient (NULL)
+ * @return pointer to ClientRec structure or NULL
  */
 ClientPtr dixClientForGrab(GrabPtr pGrab);
 
@@ -61,7 +61,7 @@ ClientPtr dixClientForGrab(GrabPtr pGrab);
  * (every client so is assigned a range of XIDs it may use for resource creation)
  *
  * @param GrabPtr to the InputClients whose owning client shall be retrieved
- * @return pointer to ClientRec structure or NullClient (NULL)
+ * @return pointer to ClientRec structure or NULL
  */
 ClientPtr dixClientForInputClients(InputClientsPtr pInputClients);
 
@@ -72,7 +72,7 @@ ClientPtr dixClientForInputClients(InputClientsPtr pInputClients);
  * (every client so is assigned a range of XIDs it may use for resource creation)
  *
  * @param GrabPtr to the OtherClients whose owning client shall be retrieved
- * @return pointer to ClientRec structure or NullClient (NULL)
+ * @return pointer to ClientRec structure or NULL
  */
 ClientPtr dixClientForOtherClients(OtherClientsPtr pOtherClients);
 
@@ -98,13 +98,13 @@ static inline int dixClientIdForXID(XID xid) {
  * (every client so is assigned a range of XIDs it may use for resource creation)
  *
  * @param XID the ID of the resource whose client is retrieved
- * @return pointer to ClientRec structure or NullClient (NULL)
+ * @return pointer to ClientRec structure or NULL
  */
 static inline ClientPtr dixClientForXID(XID xid) {
     const int idx = dixClientIdForXID(xid);
     if (idx < MAXCLIENTS)
         return clients[idx];
-    return NullClient;
+    return NULL;
 }
 
 /*

--- a/dix/selection.c
+++ b/dix/selection.c
@@ -134,7 +134,7 @@ DeleteWindowFromAnySelections(WindowPtr pWin)
 
             pSel->pWin = (WindowPtr) NULL;
             pSel->window = None;
-            pSel->client = NullClient;
+            pSel->client = NULL;
         }
 }
 
@@ -149,7 +149,7 @@ DeleteClientFromAnySelections(ClientPtr client)
 
             pSel->pWin = (WindowPtr) NULL;
             pSel->window = None;
-            pSel->client = NullClient;
+            pSel->client = NULL;
         }
 }
 
@@ -235,7 +235,7 @@ ProcSetSelectionOwner(ClientPtr client)
     pSel->lastTimeChanged = time;
     pSel->window = param.owner;
     pSel->pWin = pWin;
-    pSel->client = (pWin ? client : NullClient);
+    pSel->client = (pWin ? client : NULL);
 
     CallSelectionCallback(pSel, client, SelectionSetOwner);
     return Success;

--- a/dix/window.c
+++ b/dix/window.c
@@ -525,7 +525,7 @@ MakeRootTile(WindowPtr pWin)
         attributes[0].val = pScreen->whitePixel;
         attributes[1].val = pScreen->blackPixel;
 
-        (void) ChangeGC(NullClient, pGC, GCForeground | GCBackground,
+        (void) ChangeGC(NULL, pGC, GCForeground | GCBackground,
                         attributes);
     }
 

--- a/fb/fbseg.c
+++ b/fb/fbseg.c
@@ -213,7 +213,7 @@ fbSetFg(DrawablePtr pDrawable, GCPtr pGC, Pixel fg)
         ChangeGCVal val;
 
         val.val = fg;
-        ChangeGC(NullClient, pGC, GCForeground, &val);
+        ChangeGC(NULL, pGC, GCForeground, &val);
         ValidateGC(pDrawable, pGC);
     }
 }

--- a/glamor/glamor_composite_glyphs.c
+++ b/glamor/glamor_composite_glyphs.c
@@ -97,7 +97,7 @@ glamor_copy_glyph(PixmapPtr     glyph_pixmap,
         }
         changes[0].val = 0xff;
         changes[1].val = 0x00;
-        if (ChangeGC(NullClient, scratch_gc,
+        if (ChangeGC(NULL, scratch_gc,
                      GCForeground|GCBackground, changes) != Success) {
             glamor_destroy_pixmap(upload_pixmap);
             FreeScratchGC(scratch_gc);

--- a/glamor/glamor_dash.c
+++ b/glamor/glamor_dash.c
@@ -110,8 +110,7 @@ glamor_get_dash_pixmap(GCPtr gc)
         ChangeGCVal     changes;
 
         changes.val = pixel;
-        (void) ChangeGC(NullClient, scratch_gc,
-                        GCForeground, &changes);
+        (void) ChangeGC(NULL, scratch_gc, GCForeground, &changes);
         ValidateGC(&pixmap->drawable, scratch_gc);
         rect.x = offset;
         rect.y = 0;

--- a/glamor/glamor_transform.c
+++ b/glamor/glamor_transform.c
@@ -254,7 +254,7 @@ glamor_get_stipple_pixmap(GCPtr gc)
 
     changes[0].val = 0xff;
     changes[1].val = 0x00;
-    if (ChangeGC(NullClient, scratch_gc,
+    if (ChangeGC(NULL, scratch_gc,
                  GCForeground|GCBackground, changes) != Success)
         goto bail_gc;
     ValidateGC(&pixmap->drawable, scratch_gc);

--- a/glamor/glamor_utils.c
+++ b/glamor/glamor_utils.c
@@ -46,7 +46,7 @@ glamor_solid_boxes(DrawablePtr drawable,
         ChangeGCVal vals[1];
 
         vals[0].val = fg_pixel;
-        ChangeGC(NullClient, gc, GCForeground, vals);
+        ChangeGC(NULL, gc, GCForeground, vals);
         ValidateGC(drawable, gc);
         gc->ops->PolyFillRect(drawable, gc, nbox, rect);
         FreeScratchGC(gc);
@@ -67,7 +67,7 @@ glamor_solid(PixmapPtr pixmap, int x, int y, int width, int height,
     gc = GetScratchGC(drawable->depth, drawable->pScreen);
     if (!gc)
         return;
-    ChangeGC(NullClient, gc, GCForeground, vals);
+    ChangeGC(NULL, gc, GCForeground, vals);
     ValidateGC(drawable, gc);
     rect.x = x;
     rect.y = y;

--- a/hw/kdrive/ephyr/ephyr_draw.c
+++ b/hw/kdrive/ephyr/ephyr_draw.c
@@ -106,9 +106,8 @@ ephyrPrepareSolid(PixmapPtr pPix, int alu, Pixel pm, Pixel fg)
     tmpval[0].val = alu;
     tmpval[1].val = pm;
     tmpval[2].val = fg;
-    ChangeGC(NullClient, fakexa->pGC, GCFunction | GCPlaneMask | GCForeground,
-             tmpval);
 
+    ChangeGC(NULL, fakexa->pGC, GCFunction | GCPlaneMask | GCForeground, tmpval);
     ValidateGC(&pPix->drawable, fakexa->pGC);
 
     TRACE_DRAW();
@@ -175,8 +174,8 @@ ephyrPrepareCopy(PixmapPtr pSrc, PixmapPtr pDst, int dx, int dy, int alu,
 
     tmpval[0].val = alu;
     tmpval[1].val = pm;
-    ChangeGC(NullClient, fakexa->pGC, GCFunction | GCPlaneMask, tmpval);
 
+    ChangeGC(NULL, fakexa->pGC, GCFunction | GCPlaneMask, tmpval);
     ValidateGC(&pDst->drawable, fakexa->pGC);
 
     TRACE_DRAW();

--- a/hw/xwin/glx/indirect.c
+++ b/hw/xwin/glx/indirect.c
@@ -734,7 +734,7 @@ glxWinCopyWindow(WindowPtr pWindow, DDXPointRec ptOldOrg, RegionPtr prgnSrc)
     GLWIN_TRACE_MSG("glxWinCopyWindow pWindow %p", pWindow);
 
     dixLookupResourceByType((void *) &pGlxDraw, pWindow->drawable.id,
-                            __glXDrawableRes, NullClient, DixUnknownAccess);
+                            __glXDrawableRes, NULL, DixUnknownAccess);
 
     /*
        Discard any CopyWindow requests if a GL drawing context is pointing at the window

--- a/hw/xwin/wincmap.c
+++ b/hw/xwin/wincmap.c
@@ -180,7 +180,7 @@ winUninstallColormap(ColormapPtr pmap)
     /* Install the default cmap in place of the cmap to be uninstalled */
     if (pmap->mid != pmap->pScreen->defColormap) {
         dixLookupResourceByType((void *) &curpmap, pmap->pScreen->defColormap,
-                                X11_RESTYPE_COLORMAP, NullClient, DixUnknownAccess);
+                                X11_RESTYPE_COLORMAP, NULL, DixUnknownAccess);
         (*pmap->pScreen->InstallColormap) (curpmap);
     }
 }

--- a/hw/xwin/windialogs.c
+++ b/hw/xwin/windialogs.c
@@ -230,7 +230,7 @@ winDisplayExitDialog(winPrivScreenPtr pScreenPriv)
 
     /* Count up running clients (clients[0] is serverClient) */
     for (i = 1; i < currentMaxClients; i++)
-        if (clients[i] != NullClient)
+        if (clients[i] != NULL)
             liveClients++;
     /* Count down server internal clients */
     if (pScreenPriv->pScreenInfo->fMultiWindow)

--- a/include/dix.h
+++ b/include/dix.h
@@ -59,8 +59,6 @@ SOFTWARE.
 #define SAMETIME 0
 #define LATER 1
 
-#define NullClient ((ClientPtr) 0)
-
 #define REQUEST(type)                                                   \
     type * stuff = (type *)client->requestBuffer;
 

--- a/mi/miarc.c
+++ b/mi/miarc.c
@@ -986,7 +986,7 @@ miWideArc(DrawablePtr pDraw, GCPtr pGC, int narcs, xArc * parcs)
             gcvals[3].val = pGC->lineWidth;
             gcvals[4].val = pGC->capStyle;
             gcvals[5].val = pGC->joinStyle;
-            ChangeGC(NullClient, pGCTo, GCFunction |
+            ChangeGC(NULL, pGCTo, GCFunction |
                      GCForeground | GCBackground | GCLineWidth |
                      GCCapStyle | GCJoinStyle, gcvals);
         }
@@ -1024,12 +1024,12 @@ miWideArc(DrawablePtr pDraw, GCPtr pGC, int narcs, xArc * parcs)
 
         if (iphase == 1) {
             gcval.val = bg;
-            ChangeGC(NullClient, pGC, GCForeground, &gcval);
+            ChangeGC(NULL, pGC, GCForeground, &gcval);
             ValidateGC(pDraw, pGC);
         }
         else if (pGC->lineStyle == LineDoubleDash) {
             gcval.val = fg;
-            ChangeGC(NullClient, pGC, GCForeground, &gcval);
+            ChangeGC(NULL, pGC, GCForeground, &gcval);
             ValidateGC(pDraw, pGC);
         }
         for (i = 0; i < polyArcs[iphase].narcs; i++) {

--- a/mi/midispcur.c
+++ b/mi/midispcur.c
@@ -245,7 +245,7 @@ miDCRealize(ScreenPtr pScreen, CursorPtr pCursor)
                            0, 0, pCursor->bits->width, pCursor->bits->height,
                            0, XYPixmap, (char *) pCursor->bits->source);
     gcvals.val = GXand;
-    ChangeGC(NullClient, pGC, GCFunction, &gcvals);
+    ChangeGC(NULL, pGC, GCFunction, &gcvals);
     ValidateGC((DrawablePtr) sourceBits, pGC);
     (*pGC->ops->PutImage) ((DrawablePtr) sourceBits, pGC, 1,
                            0, 0, pCursor->bits->width, pCursor->bits->height,
@@ -253,13 +253,13 @@ miDCRealize(ScreenPtr pScreen, CursorPtr pCursor)
 
     /* mask bits -- pCursor->mask & ~pCursor->source */
     gcvals.val = GXcopy;
-    ChangeGC(NullClient, pGC, GCFunction, &gcvals);
+    ChangeGC(NULL, pGC, GCFunction, &gcvals);
     ValidateGC((DrawablePtr) maskBits, pGC);
     (*pGC->ops->PutImage) ((DrawablePtr) maskBits, pGC, 1,
                            0, 0, pCursor->bits->width, pCursor->bits->height,
                            0, XYPixmap, (char *) pCursor->bits->mask);
     gcvals.val = GXandInverted;
-    ChangeGC(NullClient, pGC, GCFunction, &gcvals);
+    ChangeGC(NULL, pGC, GCFunction, &gcvals);
     ValidateGC((DrawablePtr) maskBits, pGC);
     (*pGC->ops->PutImage) ((DrawablePtr) maskBits, pGC, 1,
                            0, 0, pCursor->bits->width, pCursor->bits->height,
@@ -294,7 +294,7 @@ miDCPutBits(DrawablePtr pDrawable,
 
     if (sourceGC->fgPixel != source) {
         gcval.val = source;
-        ChangeGC(NullClient, sourceGC, GCForeground, &gcval);
+        ChangeGC(NULL, sourceGC, GCForeground, &gcval);
     }
     if (sourceGC->serialNumber != pDrawable->serialNumber)
         ValidateGC(pDrawable, sourceGC);
@@ -312,7 +312,7 @@ miDCPutBits(DrawablePtr pDrawable,
                                   x, y);
     if (maskGC->fgPixel != mask) {
         gcval.val = mask;
-        ChangeGC(NullClient, maskGC, GCForeground, &gcval);
+        ChangeGC(NULL, maskGC, GCForeground, &gcval);
     }
     if (maskGC->serialNumber != pDrawable->serialNumber)
         ValidateGC(pDrawable, maskGC);

--- a/mi/miexpose.c
+++ b/mi/miexpose.c
@@ -529,7 +529,7 @@ miPaintWindow(WindowPtr pWin, RegionPtr prgn, int what)
         return;
     }
 
-    ChangeGC(NullClient, pGC, gcmask, gcval);
+    ChangeGC(NULL, pGC, gcmask, gcval);
     ValidateGC(drawable, pGC);
 
     numRects = RegionNumRects(prgn);
@@ -562,9 +562,9 @@ miClearDrawable(DrawablePtr pDraw, GCPtr pGC)
     rect.y = 0;
     rect.width = pDraw->width;
     rect.height = pDraw->height;
-    ChangeGC(NullClient, pGC, GCForeground, &bg);
+    ChangeGC(NULL, pGC, GCForeground, &bg);
     ValidateGC(pDraw, pGC);
     (*pGC->ops->PolyFillRect) (pDraw, pGC, 1, &rect);
-    ChangeGC(NullClient, pGC, GCForeground, &fg);
+    ChangeGC(NULL, pGC, GCForeground, &fg);
     ValidateGC(pDraw, pGC);
 }

--- a/mi/miglblt.c
+++ b/mi/miglblt.c
@@ -126,8 +126,7 @@ miPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int ngly
     gcvals[1].val = 1;
     gcvals[2].val = 0;
 
-    ChangeGC(NullClient, pGCtmp, GCFunction | GCForeground | GCBackground,
-             gcvals);
+    ChangeGC(NULL, pGCtmp, GCFunction | GCForeground | GCBackground, gcvals);
 
     nbyLine = BitmapBytePad(width);
     pbits = calloc(height, nbyLine);
@@ -211,13 +210,13 @@ miImageGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int ngl
     gcvals[0].val = GXcopy;
     gcvals[1].val = pGC->bgPixel;
     gcvals[2].val = FillSolid;
-    ChangeGC(NullClient, pGC, GCFunction | GCForeground | GCFillStyle, gcvals);
+    ChangeGC(NULL, pGC, GCFunction | GCForeground | GCFillStyle, gcvals);
     ValidateGC(pDrawable, pGC);
     (*pGC->ops->PolyFillRect) (pDrawable, pGC, 1, &backrect);
 
     /* put down the glyphs */
     gcvals[0].val = oldFG;
-    ChangeGC(NullClient, pGC, GCForeground, gcvals);
+    ChangeGC(NULL, pGC, GCForeground, gcvals);
     ValidateGC(pDrawable, pGC);
     (*pGC->ops->PolyGlyphBlt) (pDrawable, pGC, x, y, nglyph, ppci, pglyphBase);
 
@@ -225,7 +224,7 @@ miImageGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int ngl
     gcvals[0].val = oldAlu;
     gcvals[1].val = oldFG;
     gcvals[2].val = oldFS;
-    ChangeGC(NullClient, pGC, GCFunction | GCForeground | GCFillStyle, gcvals);
+    ChangeGC(NULL, pGC, GCFunction | GCForeground | GCFillStyle, gcvals);
     ValidateGC(pDrawable, pGC);
 
 }

--- a/mi/mipolypnt.c
+++ b/mi/mipolypnt.c
@@ -94,7 +94,7 @@ miPolyPoint(DrawablePtr pDrawable, GCPtr pGC, int mode, /* Origin or Previous */
     fsOld.val = pGC->fillStyle;
     fsNew.val = FillSolid;
     if (pGC->fillStyle != FillSolid) {
-        ChangeGC(NullClient, pGC, GCFillStyle, &fsNew);
+        ChangeGC(NULL, pGC, GCFillStyle, &fsNew);
         ValidateGC(pDrawable, pGC);
     }
     pwidth = pwidthInit;
@@ -103,7 +103,7 @@ miPolyPoint(DrawablePtr pDrawable, GCPtr pGC, int mode, /* Origin or Previous */
     (*pGC->ops->FillSpans) (pDrawable, pGC, npt, pptInit, pwidthInit, FALSE);
 
     if (fsOld.val != FillSolid) {
-        ChangeGC(NullClient, pGC, GCFillStyle, &fsOld);
+        ChangeGC(NULL, pGC, GCFillStyle, &fsOld);
         ValidateGC(pDrawable, pGC);
     }
     free(pwidthInit);

--- a/mi/miwideline.c
+++ b/mi/miwideline.c
@@ -616,7 +616,7 @@ fillSpans(DrawablePtr pDrawable, GCPtr pGC, unsigned long pixel, Spans * spans,
         oldPixel.val = pGC->fgPixel;
         if (pixel != oldPixel.val) {
             tmpPixel.val = (XID) pixel;
-            ChangeGC(NullClient, pGC, GCForeground, &tmpPixel);
+            ChangeGC(NULL, pGC, GCForeground, &tmpPixel);
             ValidateGC(pDrawable, pGC);
         }
         (*pGC->ops->FillSpans) (pDrawable, pGC, spans->count, spans->points,
@@ -624,7 +624,7 @@ fillSpans(DrawablePtr pDrawable, GCPtr pGC, unsigned long pixel, Spans * spans,
         free(spans->widths);
         free(spans->points);
         if (pixel != oldPixel.val) {
-            ChangeGC(NullClient, pGC, GCForeground, &oldPixel);
+            ChangeGC(NULL, pGC, GCForeground, &oldPixel);
             ValidateGC(pDrawable, pGC);
         }
     }
@@ -746,12 +746,12 @@ miFillRectPolyHelper(DrawablePtr pDrawable,
         oldPixel.val = pGC->fgPixel;
         if (pixel != oldPixel.val) {
             tmpPixel.val = (XID) pixel;
-            ChangeGC(NullClient, pGC, GCForeground, &tmpPixel);
+            ChangeGC(NULL, pGC, GCForeground, &tmpPixel);
             ValidateGC(pDrawable, pGC);
         }
         (*pGC->ops->PolyFillRect) (pDrawable, pGC, 1, &rect);
         if (pixel != oldPixel.val) {
-            ChangeGC(NullClient, pGC, GCForeground, &oldPixel);
+            ChangeGC(NULL, pGC, GCForeground, &oldPixel);
             ValidateGC(pDrawable, pGC);
         }
     }
@@ -1870,13 +1870,13 @@ miCleanupSpanData(DrawablePtr pDrawable, GCPtr pGC, SpanDataPtr spanData)
         pixel.val = pGC->bgPixel;
         oldPixel.val = pGC->fgPixel;
         if (pixel.val != oldPixel.val) {
-            ChangeGC(NullClient, pGC, GCForeground, &pixel);
+            ChangeGC(NULL, pGC, GCForeground, &pixel);
             ValidateGC(pDrawable, pGC);
         }
         miFillUniqueSpanGroup(pDrawable, pGC, &spanData->bgGroup);
         miFreeSpanGroup(&spanData->bgGroup);
         if (pixel.val != oldPixel.val) {
-            ChangeGC(NullClient, pGC, GCForeground, &oldPixel);
+            ChangeGC(NULL, pGC, GCForeground, &oldPixel);
             ValidateGC(pDrawable, pGC);
         }
     }

--- a/mi/miwideline.h
+++ b/mi/miwideline.h
@@ -82,7 +82,7 @@ typedef struct _LineFace {
     if (pixel != oldPixel) { \
 	ChangeGCVal gcval; \
 	gcval.val = pixel; \
-	ChangeGC (NullClient, pGC, GCForeground, &gcval); \
+	ChangeGC (NULL, pGC, GCForeground, &gcval); \
 	ValidateGC (pDrawable, pGC); \
     } \
 }
@@ -90,7 +90,7 @@ typedef struct _LineFace {
     if (pixel != oldPixel) { \
 	ChangeGCVal gcval; \
 	gcval.val = oldPixel; \
-	ChangeGC (NullClient, pGC, GCForeground, &gcval); \
+	ChangeGC (NULL, pGC, GCForeground, &gcval); \
 	ValidateGC (pDrawable, pGC); \
     } \
 }

--- a/mi/mizerarc.c
+++ b/mi/mizerarc.c
@@ -729,7 +729,7 @@ miZeroPolyArc(DrawablePtr pDraw, GCPtr pGC, int narcs, xArc * parcs)
                 ChangeGCVal gcval;
 
                 gcval.val = pGC->bgPixel;
-                ChangeGC(NullClient, pGC, GCForeground, &gcval);
+                ChangeGC(NULL, pGC, GCForeground, &gcval);
                 ValidateGC(pDraw, pGC);
             }
             pts = &points[numPts >> 1];
@@ -755,7 +755,7 @@ miZeroPolyArc(DrawablePtr pDraw, GCPtr pGC, int narcs, xArc * parcs)
                 ChangeGCVal gcval;
 
                 gcval.val = fgPixel;
-                ChangeGC(NullClient, pGC, GCForeground, &gcval);
+                ChangeGC(NULL, pGC, GCForeground, &gcval);
                 ValidateGC(pDraw, pGC);
             }
         }

--- a/os/client.c
+++ b/os/client.c
@@ -107,7 +107,7 @@ DetermineClientPid(struct _Client * client)
     LocalClientCredRec *lcc = NULL;
     pid_t pid = -1;
 
-    if (client == NullClient)
+    if (client == NULL)
         return pid;
 
     if (client == serverClient)
@@ -451,7 +451,7 @@ void
 ReserveClientIds(struct _Client *client)
 {
 #ifdef CLIENTIDS
-    if (client == NullClient)
+    if (client == NULL)
         return;
 
     assert(!client->clientIds);
@@ -483,7 +483,7 @@ void
 ReleaseClientIds(struct _Client *client)
 {
 #ifdef CLIENTIDS
-    if (client == NullClient)
+    if (client == NULL)
         return;
 
     if (!client->clientIds)
@@ -518,7 +518,7 @@ ReleaseClientIds(struct _Client *client)
 pid_t
 GetClientPid(struct _Client *client)
 {
-    if (client == NullClient)
+    if (client == NULL)
         return -1;
 
     if (!client->clientIds)
@@ -544,7 +544,7 @@ GetClientPid(struct _Client *client)
 const char *
 GetClientCmdName(struct _Client *client)
 {
-    if (client == NullClient)
+    if (client == NULL)
         return NULL;
 
     if (!client->clientIds)
@@ -570,7 +570,7 @@ GetClientCmdName(struct _Client *client)
 const char *
 GetClientCmdArgs(struct _Client *client)
 {
-    if (client == NullClient)
+    if (client == NULL)
         return NULL;
 
     if (!client->clientIds)

--- a/os/connection.c
+++ b/os/connection.c
@@ -626,7 +626,7 @@ AllocNewConnection(XtransConnInfo trans_conn, int fd, CARD32 conn_time)
 
     OsCommPtr oc = calloc(1, sizeof(OsCommRec));
     if (!oc)
-        return NullClient;
+        return NULL;
     oc->trans_conn = trans_conn;
     oc->fd = fd;
     oc->input = (ConnectionInputPtr) NULL;
@@ -636,7 +636,7 @@ AllocNewConnection(XtransConnInfo trans_conn, int fd, CARD32 conn_time)
     oc->flags = 0;
     if (!(client = NextAvailableClient((void *) oc))) {
         free(oc);
-        return NullClient;
+        return NULL;
     }
     client->local = ComputeLocalClient(client);
     ospoll_add(server_poll, fd,

--- a/record/record.c
+++ b/record/record.c
@@ -1226,7 +1226,7 @@ RecordCanonicalizeClientSpecifiers(XID *pClientspecs, int *pNumClientspecs,
             for (nc = 0, j = 1; j < currentMaxClients; j++) {
                 ClientPtr client = clients[j];
 
-                if (client != NullClient &&
+                if (client != NULL &&
                     client->clientState == ClientStateRunning &&
                     client->clientAsMask != excludespec) {
                     pCanon[nc++] = client->clientAsMask;

--- a/render/mirect.c
+++ b/render/mirect.c
@@ -62,7 +62,7 @@ miColorRects(PicturePtr pDst,
         (*pGC->funcs->ChangeClip) (pGC, CT_REGION, pClip, 0);
     }
 
-    ChangeGC(NullClient, pGC, mask, tmpval);
+    ChangeGC(NULL, pGC, mask, tmpval);
     ValidateGC(pDst->pDrawable, pGC);
     if (xoff || yoff) {
         int i;

--- a/xfixes/region.c
+++ b/xfixes/region.c
@@ -609,7 +609,7 @@ SingleXFixesSetGCClipRegion(ClientPtr client, xXFixesSetGCClipRegionReq *stuff)
 
     vals[0].val = stuff->xOrigin;
     vals[1].val = stuff->yOrigin;
-    ChangeGC(NullClient, pGC, GCClipXOrigin | GCClipYOrigin, vals);
+    ChangeGC(NULL, pGC, GCClipXOrigin | GCClipYOrigin, vals);
     (*pGC->funcs->ChangeClip) (pGC, pRegion ? CT_REGION : CT_NONE,
                                (void *) pRegion, 0);
 


### PR DESCRIPTION
this is just the same as NULL, so we don't actually need it anymore.