### PR TITLE
xv: inline SWrite*Reply() functions

### DIFF
--- a/Xext/xvdisp.c
+++ b/Xext/xvdisp.c
@@ -55,18 +55,6 @@ unsigned long XvXRTPort;
 #endif /* XINERAMA */
 
 static int
-SWriteGetPortAttributeReply(ClientPtr client, xvGetPortAttributeReply * rep)
-{
-    swaps(&rep->sequenceNumber);
-    swapl(&rep->length);
-    swapl(&rep->value);
-
-    WriteToClient(client, sz_xvGetPortAttributeReply, rep);
-
-    return Success;
-}
-
-static int
 SWriteQueryBestSizeReply(ClientPtr client, xvQueryBestSizeReply * rep)
 {
     swaps(&rep->sequenceNumber);
@@ -120,10 +108,6 @@ SWriteListImageFormatsReply(ClientPtr client, xvListImageFormatsReply * rep)
 
     return Success;
 }
-
-#define _WriteGetPortAttributeReply(_c,_d) \
-  if ((_c)->swapped) SWriteGetPortAttributeReply(_c, _d); \
-  else WriteToClient(_c, sz_xvGetPortAttributeReply, _d)
 
 #define _WriteQueryBestSizeReply(_c,_d) \
   if ((_c)->swapped) SWriteQueryBestSizeReply(_c, _d); \
@@ -650,8 +634,13 @@ ProcXvGetPortAttribute(ClientPtr client)
         .value = value
     };
 
-    _WriteGetPortAttributeReply(client, &rep);
+    if (client->swapped) {
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.value);
+    }
 
+    WriteToClient(client, sz_xvGetPortAttributeReply, &rep);
     return Success;
 }
 

--- a/Xext/xvdisp.c
+++ b/Xext/xvdisp.c
@@ -55,19 +55,6 @@ unsigned long XvXRTPort;
 #endif /* XINERAMA */
 
 static int
-SWriteQueryBestSizeReply(ClientPtr client, xvQueryBestSizeReply * rep)
-{
-    swaps(&rep->sequenceNumber);
-    swapl(&rep->length);
-    swaps(&rep->actual_width);
-    swaps(&rep->actual_height);
-
-    WriteToClient(client, sz_xvQueryBestSizeReply, rep);
-
-    return Success;
-}
-
-static int
 SWriteQueryPortAttributesReply(ClientPtr client,
                                xvQueryPortAttributesReply * rep)
 {
@@ -108,10 +95,6 @@ SWriteListImageFormatsReply(ClientPtr client, xvListImageFormatsReply * rep)
 
     return Success;
 }
-
-#define _WriteQueryBestSizeReply(_c,_d) \
-  if ((_c)->swapped) SWriteQueryBestSizeReply(_c, _d); \
-  else WriteToClient(_c, sz_xvQueryBestSizeReply, _d)
 
 #define _WriteQueryPortAttributesReply(_c,_d) \
   if ((_c)->swapped) SWriteQueryPortAttributesReply(_c, _d); \
@@ -667,8 +650,14 @@ ProcXvQueryBestSize(ClientPtr client)
         .actual_height = actual_height
     };
 
-    _WriteQueryBestSizeReply(client, &rep);
+    if (client->swapped) {
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swaps(&rep.actual_width);
+        swaps(&rep.actual_height);
+    }
 
+    WriteToClient(client, sz_xvQueryBestSizeReply, &rep);
     return Success;
 }
 

--- a/Xext/xvdisp.c
+++ b/Xext/xvdisp.c
@@ -55,19 +55,6 @@ unsigned long XvXRTPort;
 #endif /* XINERAMA */
 
 static int
-SWriteQueryExtensionReply(ClientPtr client, xvQueryExtensionReply * rep)
-{
-    swaps(&rep->sequenceNumber);
-    swapl(&rep->length);
-    swaps(&rep->version);
-    swaps(&rep->revision);
-
-    WriteToClient(client, sz_xvQueryExtensionReply, rep);
-
-    return Success;
-}
-
-static int
 SWriteQueryAdaptorsReply(ClientPtr client, xvQueryAdaptorsReply * rep)
 {
     swaps(&rep->sequenceNumber);
@@ -244,10 +231,6 @@ SWriteListImageFormatsReply(ClientPtr client, xvListImageFormatsReply * rep)
   if ((_c)->swapped) SWriteQueryAdaptorsReply(_c, _d); \
   else WriteToClient(_c, sz_xvQueryAdaptorsReply, _d)
 
-#define _WriteQueryExtensionReply(_c,_d) \
-  if ((_c)->swapped) SWriteQueryExtensionReply(_c, _d); \
-  else WriteToClient(_c, sz_xvQueryExtensionReply, _d)
-
 #define _WriteQueryEncodingsReply(_c,_d) \
   if ((_c)->swapped) SWriteQueryEncodingsReply(_c, _d); \
   else WriteToClient(_c, sz_xvQueryEncodingsReply, _d)
@@ -310,8 +293,14 @@ ProcXvQueryExtension(ClientPtr client)
     /* REQUEST(xvQueryExtensionReq); */
     REQUEST_SIZE_MATCH(xvQueryExtensionReq);
 
-    _WriteQueryExtensionReply(client, &rep);
+    if (client->swapped) {
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swaps(&rep.version);
+        swaps(&rep.revision);
+    }
 
+    WriteToClient(client, sizeof(rep), &rep);
     return Success;
 }
 

--- a/Xext/xvdisp.c
+++ b/Xext/xvdisp.c
@@ -55,22 +55,6 @@ unsigned long XvXRTPort;
 #endif /* XINERAMA */
 
 static int
-SWriteListImageFormatsReply(ClientPtr client, xvListImageFormatsReply * rep)
-{
-    swaps(&rep->sequenceNumber);
-    swapl(&rep->length);
-    swapl(&rep->num_formats);
-
-    WriteToClient(client, sz_xvListImageFormatsReply, rep);
-
-    return Success;
-}
-
-#define _WriteListImageFormatsReply(_c,_d) \
-  if ((_c)->swapped) SWriteListImageFormatsReply(_c, _d); \
-  else WriteToClient(_c, sz_xvListImageFormatsReply, _d)
-
-static int
 ProcXvQueryExtension(ClientPtr client)
 {
     /* REQUEST(xvQueryExtensionReq); */
@@ -946,7 +930,13 @@ ProcXvListImageFormats(ClientPtr client)
             bytes_to_int32(pPort->pAdaptor->nImages * sz_xvImageFormatInfo)
     };
 
-    _WriteListImageFormatsReply(client, &rep);
+    if (client->swapped) {
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+        swapl(&rep.num_formats);
+    }
+
+    WriteToClient(client, sz_xvListImageFormatsReply, &rep);
 
     pImage = pPort->pAdaptor->pImages;
 

--- a/Xext/xvdisp.c
+++ b/Xext/xvdisp.c
@@ -55,17 +55,6 @@ unsigned long XvXRTPort;
 #endif /* XINERAMA */
 
 static int
-SWriteGrabPortReply(ClientPtr client, xvGrabPortReply * rep)
-{
-    swaps(&rep->sequenceNumber);
-    swapl(&rep->length);
-
-    WriteToClient(client, sz_xvGrabPortReply, rep);
-
-    return Success;
-}
-
-static int
 SWriteGetPortAttributeReply(ClientPtr client, xvGetPortAttributeReply * rep)
 {
     swaps(&rep->sequenceNumber);
@@ -131,10 +120,6 @@ SWriteListImageFormatsReply(ClientPtr client, xvListImageFormatsReply * rep)
 
     return Success;
 }
-
-#define _WriteGrabPortReply(_c,_d) \
-  if ((_c)->swapped) SWriteGrabPortReply(_c, _d); \
-  else WriteToClient(_c, sz_xvGrabPortReply, _d)
 
 #define _WriteGetPortAttributeReply(_c,_d) \
   if ((_c)->swapped) SWriteGetPortAttributeReply(_c, _d); \
@@ -543,7 +528,12 @@ ProcXvGrabPort(ClientPtr client)
         .result = result
     };
 
-    _WriteGrabPortReply(client, &rep);
+    if (client->swapped) {
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+    }
+
+    WriteToClient(client, sz_xvGrabPortReply, &rep);
 
     return Success;
 }


### PR DESCRIPTION
Instead of complex macro machinery, just move the conditional swapping directly into request handlers.

Factored out of https://github.com/X11Libre/xserver/pull/386