### PR TITLE
dix: rpcbuf: add x_rpcbuf_write_string_0t_pad()

### DIFF
--- a/dix/rpcbuf.c
+++ b/dix/rpcbuf.c
@@ -93,6 +93,23 @@ Bool x_rpcbuf_write_string_pad(struct x_rpcbuf *rpcbuf, const char *str)
     return TRUE;
 }
 
+Bool x_rpcbuf_write_string_0t_pad(struct x_rpcbuf *rpcbuf, const char *str)
+{
+    if (!str)
+        return x_rpcbuf_write_CARD32(rpcbuf, 0);
+
+    size_t slen = strlen(str);
+    if (!slen)
+        return x_rpcbuf_write_CARD32(rpcbuf, 0);
+
+    char *reserved = x_rpcbuf_reserve(rpcbuf, pad_to_int32(slen+1));
+    if (!reserved)
+        return FALSE;
+
+    memcpy(reserved, str, slen+1);
+    return TRUE;
+}
+
 Bool x_rpcbuf_write_CARD8(struct x_rpcbuf *rpcbuf, CARD8 value)
 {
     CARD8 *reserved = x_rpcbuf_reserve(rpcbuf, sizeof(value));

--- a/dix/rpcbuf_priv.h
+++ b/dix/rpcbuf_priv.h
@@ -97,6 +97,19 @@ Bool x_rpcbuf_write_string_pad(struct x_rpcbuf *rpcbuf, const char *str)
     _X_ATTRIBUTE_NONNULL_ARG(1);
 
 /*
+ * write a plain C string with terminating 0 to rpc buffer and pad it.
+ *
+ * allocate a region for the string (padded to 32bits) and copy in the string.
+ * if given string is NULL or zero-size, only a (CARD32)0 is written.
+ *
+ * @param rpcbuf    pointer to struct x_rpcbuf to operate on
+ * @param needed    string to plain C string
+ * @return          TRUE on success, FALSE on allocation failure
+ */
+Bool x_rpcbuf_write_string_0t_pad(struct x_rpcbuf *rpcbuf, const char *str)
+    _X_ATTRIBUTE_NONNULL_ARG(1);
+
+/*
  * write binary data to rpc buffer and pad it.
  *
  * allocate a region for the string (padded to 32bits) and copy in the data.


### PR DESCRIPTION
The existing x_rpcbuf_write_string() function is just writing the string w/o trailing zero. It's for cases where the string length is known by other means (eg. some header field). In cases where we also need the trailing zero written (eg. when sending lists of strings) this isn't sufficient.

Thus introducing another variant of this function, which is always writing a leading zero. Using this one, the string's characters will be followed by 1, 2 or 3 zeros (and also be 32bit aligned)