### PR TITLE
vidmode: fix ProcVidModeGetDotClocks() reply size computation

### DIFF
--- a/Xext/vidmode.c
+++ b/Xext/vidmode.c
@@ -1432,7 +1432,7 @@ ProcVidModeGetDotClocks(ClientPtr client)
         .type = X_Reply,
         .sequenceNumber = client->sequence,
         .length = bytes_to_int32(sizeof(xXF86VidModeGetDotClocksReply)
-                                 - sizeof(xGenericReply) + numClocks),
+                                 - sizeof(xGenericReply)) + numClocks,
         .clocks = numClocks,
         .maxclocks = MAXCLOCKS,
         .flags = (ClockProg ? CLKFLAG_PROGRAMABLE : 0),


### PR DESCRIPTION
A clock entry is 32 bits instead of 8 bits long.