### PR TITLE
Make miDCCloseScreen and PictureScreenClose post-hooks 

### DIFF
--- a/mi/midispcur.c
+++ b/mi/midispcur.c
@@ -102,7 +102,7 @@ miDCInitialize(ScreenPtr pScreen, miPointerScreenFuncPtr screenFuncs)
     if (!pScreenPriv)
         return FALSE;
 
-    dixScreenHookClose(pScreen, miDCCloseScreen);
+    dixScreenHookPostClose(pScreen, miDCCloseScreen);
     dixSetPrivate(&pScreen->devPrivates, miDCScreenKey, pScreenPriv);
 
     if (!miSpriteInitialize(pScreen, screenFuncs)) {
@@ -135,7 +135,7 @@ miDCSwitchScreenCursor(ScreenPtr pScreen, CursorPtr pCursor, PixmapPtr sourceBit
 
 static void miDCCloseScreen(CallbackListPtr *pcbl, ScreenPtr pScreen, void *unused)
 {
-    dixScreenUnhookClose(pScreen, miDCCloseScreen);
+    dixScreenUnhookPostClose(pScreen, miDCCloseScreen);
 
     miDCScreenPtr pScreenPriv;
     pScreenPriv = (miDCScreenPtr) dixLookupPrivate(&pScreen->devPrivates,

--- a/render/picture.c
+++ b/render/picture.c
@@ -89,7 +89,7 @@ static void PictureScreenClose(CallbackListPtr *pcbl, ScreenPtr pScreen, void *u
     SetPictureScreen(pScreen, 0);
     free(ps->formats);
     free(ps);
-    dixScreenUnhookClose(pScreen, PictureScreenClose);
+    dixScreenUnhookPostClose(pScreen, PictureScreenClose);
 }
 
 static void
@@ -683,7 +683,7 @@ PictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats)
     pScreen->StoreColors = PictureStoreColors;
 
     dixScreenHookWindowDestroy(pScreen, picture_window_destructor);
-    dixScreenHookClose(pScreen, PictureScreenClose);
+    dixScreenHookPostClose(pScreen, PictureScreenClose);
 
     if (!PictureSetDefaultFilters(pScreen)) {
         PictureResetFilters(pScreen);


### PR DESCRIPTION
This fixes two segfaults at exit for intel driver. At screen closing `sna_late_close_screen` needs to destroy the cursor and the glyphs cache using `FreePicture`, which in turn needs privates that has already been released by `miDCCloseScreen` and `PictureScreenClose` executed earlier because they are in pre hooks.

Closes: https://github.com/X11Libre/xf86-video-intel/issues/7