### PR TITLE
cleanup remaining users of request length field

### DIFF
--- a/Xext/geext.c
+++ b/Xext/geext.c
@@ -136,7 +136,6 @@ static int _X_COLD
 SProcGEDispatch(ClientPtr client)
 {
     REQUEST(xReq);
-    swaps(&stuff->length);
 
     switch (stuff->data) {
     case X_GEQueryVersion:

--- a/randr/rrsdispatch.c
+++ b/randr/rrsdispatch.c
@@ -116,7 +116,6 @@ SProcRRGetScreenResourcesCurrent(ClientPtr client)
     REQUEST(xRRGetScreenResourcesCurrentReq);
 
     REQUEST_SIZE_MATCH(xRRGetScreenResourcesCurrentReq);
-    swaps(&stuff->length);
     swapl(&stuff->window);
     return ProcRRGetScreenResourcesCurrent(client);
 }

--- a/record/record.c
+++ b/record/record.c
@@ -518,7 +518,7 @@ RecordARequest(ClientPtr client)
             RecordIsMemberOfSet(pRCAP->pRequestMajorOpSet, majorop)) {
             if (majorop <= 127) {       /* core request */
 
-                if (stuff->length == 0)
+                if (client->req_len == 0)
                     RecordABigRequest(pContext, client, stuff);
                 else
                     RecordAProtocolElement(pContext, client, XRecordFromClient,
@@ -540,7 +540,7 @@ RecordARequest(ClientPtr client)
                         majorop <= pMinorOpInfo->major.last &&
                         RecordIsMemberOfSet(pMinorOpInfo->major.pMinOpSet,
                                             minorop)) {
-                        if (stuff->length == 0)
+                        if (client->req_len == 0)
                             RecordABigRequest(pContext, client, stuff);
                         else
                             RecordAProtocolElement(pContext, client,


### PR DESCRIPTION
The length field in requests shouldn't be directly used anymore, because it's not compatible with big requests.
Instead everybody should use client->req_len.

(the only remaining user is within connection setup)