### PR TITLE
scan: add safety wrapper for builtinConfig access

### DIFF
--- a/hw/xfree86/parser/scan.c
+++ b/hw/xfree86/parser/scan.c
@@ -107,6 +107,18 @@ LexRec xf86_lex_val;
  *  newline; we need to grow configBuf and configRBuf as needed to
  *  support that.
  */
+static char *SafeCopyBuiltinConfig(const char *src, char *dest, int index) {
+    if (!src) {
+        xf86Msg(X_WARNING, "builtinConfig[%d] is NULL\n", index);
+        return NULL;
+    }
+    if (!dest) {
+        xf86Msg(X_WARNING, "configBuf is NULL while copying builtinConfig[%d]\n", index);
+        return NULL;
+    }
+    strlcpy(dest, src, CONFIG_BUF_LEN);
+    return dest;
+}
 
 static char *
 xf86getNextLine(void)
@@ -285,11 +297,10 @@ xf86getToken(const xf86ConfigSymTabRec * tab)
                 if (builtinConfig[builtinIndex] == NULL)
                     ret = NULL;
                 else {
-                    strlcpy(configBuf,
-                            builtinConfig[builtinIndex], CONFIG_BUF_LEN);
-                    ret = configBuf;
+                ret = SafeCopyBuiltinConfig(builtinConfig[builtinIndex], configBuf, builtinIndex);
+                if (ret != NULL) {
                     builtinIndex++;
-                }
+            	}
             }
             if (ret == NULL) {
                 /*


### PR DESCRIPTION
This PR guards against potential regressions when configBuf is uninitialized or builtinConfig[builtinIndex] is unexpectedly NULL. I incorporated ideas from @dec05eba and Tautvis Nesvarbu from Telegram chat. this is a work in progress I added the features and will also try to incorporate some code cleanup also.