### PR TITLE
dix: add WriteRpcbufToClient()

### DIFF
--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -19,6 +19,7 @@
 
 #include "dix/input_priv.h"
 #include "dix/resource_priv.h"
+#include "dix/rpcbuf_priv.h"
 
 #include "include/callback.h"
 #include "include/cursor.h"
@@ -687,6 +688,20 @@ static inline ClientPtr dixLookupXIDOwner(XID xid)
     if (clientId < currentMaxClients)
         return clients[clientId];
     return NULL;
+}
+
+/*
+ * @brief write rpc buffer to client and then clear it
+ *
+ * @param pClient the client to write buffer to
+ * @param rpcbuf  the buffer whose contents will be written
+ * @return the result of WriteToClient() call
+ */
+static inline int WriteRpcbufToClient(ClientPtr pClient,
+                                      x_rpcbuf_t *rpcbuf) {
+    int ret = WriteToClient(pClient, rpcbuf->wpos, rpcbuf->buffer);
+    x_rpcbuf_clear(rpcbuf);
+    return ret;
 }
 
 #endif /* _XSERVER_DIX_PRIV_H */


### PR DESCRIPTION
Adding convenience function for writing out rpc buffer contents to client and clear the buffer (free it's memory) afterwards.