### PR TITLE
os: osdep: add macro for compile-time type size assert

### DIFF
--- a/os/osdep.h
+++ b/os/osdep.h
@@ -222,4 +222,10 @@ Ones(unsigned long mask)
 
 #define LIMITCLIENTS     256     /* Must be a power of 2 and <= MAXCLIENTS */
 
+/* static assert for protocol structure sizes */
+#ifndef __size_assert
+#define __size_assert(what, howmuch) \
+  typedef char what##_size_wrong_[( !!(sizeof(what) == howmuch) )*2-1 ]
+#endif
+
 #endif                          /* _OSDEP_H_ */


### PR DESCRIPTION
usage:

   __size_assert(typename, size);

if the type's size (calculated by sizeof) doesn't match the asserted size, an illegal dummy type will be constructed, thus compilation fails.