### PR TITLE
hw/xfree86/parser: Refactor InputClass/OutputClass matching code and allow regular expressions (Enhancement)

### DIFF
--- a/hw/xfree86/common/xf86Xinput_priv.h
+++ b/hw/xfree86/common/xf86Xinput_priv.h
@@ -22,4 +22,6 @@ void xf86AddInputEventDrainCallback(CallbackProcPtr callback, void *param);
 
 void xf86RemoveInputEventDrainCallback(CallbackProcPtr callback, void *param);
 
+Bool MatchAttrToken(const char *attr, struct xorg_list *groups);
+
 #endif /* _XSERVER__XF86XINPUT_H */

--- a/hw/xfree86/common/xf86platformBus.c
+++ b/hw/xfree86/common/xf86platformBus.c
@@ -54,6 +54,7 @@
 #include "xf86Bus.h"
 #include "Pci.h"
 #include "xf86platformBus.h"
+#include "xf86Xinput_priv.h"
 #include "xf86Config.h"
 #include "xf86Crtc.h"
 
@@ -177,49 +178,12 @@ xf86_check_platform_slot(const struct xf86_platform_device *pd)
 }
 
 static Bool
-MatchToken(const char *value, struct xorg_list *patterns,
-           int (*compare)(const char *, const char *))
-{
-    const xf86MatchGroup *group;
-
-    /* If there are no patterns, accept the match */
-    if (xorg_list_is_empty(patterns))
-        return TRUE;
-
-    /* If there are patterns but no attribute, reject the match */
-    if (!value)
-        return FALSE;
-
-    /*
-     * Otherwise, iterate the list of patterns ensuring each entry has a
-     * match. Each list entry is a separate Match line of the same type.
-     */
-    xorg_list_for_each_entry(group, patterns, entry) {
-        Bool match = FALSE;
-        char *const *cur;
-
-        for (cur = group->values; *cur; cur++) {
-            if ((*compare)(value, *cur) == 0) {
-                match = TRUE;
-                break;
-            }
-        }
-
-        if (!match)
-            return FALSE;
-    }
-
-    /* All the entries in the list matched the attribute */
-    return TRUE;
-}
-
-static Bool
 OutputClassMatches(const XF86ConfOutputClassPtr oclass,
                    struct xf86_platform_device *dev)
 {
     char *driver = dev->attribs->driver;
 
-    if (!MatchToken(driver, &oclass->match_driver, strcmp))
+    if (!MatchAttrToken(driver, &oclass->match_driver))
         return FALSE;
 
     return TRUE;

--- a/hw/xfree86/man/xorg.conf.man
+++ b/hw/xfree86/man/xorg.conf.man
@@ -1079,18 +1079,21 @@ There are two types of match entries used in
 .B InputClass
 sections. The first allows various tokens to be matched against attributes
 of the device. An entry can be constructed to match attributes from different
-devices by separating arguments with a '|' character. Multiple entries of the
-same type may be supplied to add multiple matching conditions on the same
-attribute. For example:
+devices by separating arguments with a '|' character. If an argument is prepended
+with '!', then it should NOT be contained in an attribute. If one or more '&'
+characters are present in an argument, they split it into parts that ALL must
+be disjoint substrings of an attribute in exactly the same order. Multiple
+entries of the same type may be supplied to add multiple matching conditions
+on the same attribute. For example:
 .PP
 .RS 4
 .nf
 .B  "Section \*qInputClass\*q"
 .B  "    Identifier   \*qMy Class\*q"
-.B  "    # product string must contain example and"
-.B  "    # either gizmo or gadget"
-.B  "    MatchProduct \*qexample\*q"
-.B  "    MatchProduct \*qgizmo\^|\^gadget\*q"
+.B  "    # product string may not contain example and must"
+.B  "    # either contain gizmo and then gremlin, or contain gadget"
+.B  "    MatchProduct \*q!example\*q"
+.B  "    MatchProduct \*qgizmo\^&\^gremlin\^|\^gadget\*q"
 .B  "    NoMatchDriver \*qdrivername\*q"
 .I  "    \&.\|.\|.\&"
 .B  EndSection
@@ -1173,6 +1176,38 @@ and
 .B NoMatchLayout
 directives. These NoMatch directives match if the subsequent match is not
 met by the device.
+.PP
+To apply more sophicticated conditions, an entire attribute can be matched
+against an extended regular expression (see
+.BR regex (7)
+or
+.BR re_format (7)
+):
+.PP
+.RS 4
+.nf
+.B  "    # product string must start with Experimental
+.B  "    # and end with Device
+.B  "    MatchProduct \*q~_^Experimental.*Device$_\*q"
+.fi
+.RE
+.PP
+Such a pattern is prefixed with '~', and the next character, which
+may be arbitrary, is used as a two-side delimiter, i.e. the regular
+expression starts after it and lasts until its next occurrence, or to
+the end of the argument, if the delimiting character has not been found
+again.
+.PP
+Negated and non-negated patterns, strings and regular expressions can be mixed
+in one line, e.g.,
+.PP
+.RS 4
+.nf
+.B  "    # accept product names that either do not end with \*qMouse\*q"
+.B  "    # or contain \*qUSB\*q" and \*qReceiver\*q"
+.B  "    MatchProduct \*q!~@Mouse$@|USB&Receiver\*q"
+.fi
+.RE
 .PP
 The second type of entry is used to match device types. These entries take a
 boolean argument similar to

--- a/hw/xfree86/parser/InputClass.c
+++ b/hw/xfree86/parser/InputClass.c
@@ -100,30 +100,13 @@ xf86freeInputClassList(XF86ConfInputClassPtr ptr)
 
 #define CLEANUP xf86freeInputClassList
 
-#define TOKEN_SEP "|"
-
-enum MatchType {
-    MATCH_NORMAL,
-    MATCH_NEGATED,
-};
-
-static void
-add_group_entry(struct xorg_list *head, char **values, enum MatchType type)
-{
-    xf86MatchGroup *group = calloc(1, sizeof(xf86MatchGroup));
-    if (group) {
-        group->is_negated = (type == MATCH_NEGATED);
-        group->values = values;
-        xorg_list_add(&group->entry, head);
-    }
-}
-
 XF86ConfInputClassPtr
 xf86parseInputClassSection(void)
 {
     int has_ident = FALSE;
     int token;
-    enum MatchType matchtype;
+    Bool negated;
+    xf86MatchGroup *group;
 
     parsePrologue(XF86ConfInputClassPtr, XF86ConfInputClassRec)
 
@@ -139,7 +122,7 @@ xf86parseInputClassSection(void)
     xorg_list_init(&ptr->match_layout);
 
     while ((token = xf86getToken(InputClassTab)) != ENDSECTION) {
-        matchtype = MATCH_NORMAL;
+        negated = FALSE;
 
         switch (token) {
         case COMMENT:
@@ -169,103 +152,121 @@ xf86parseInputClassSection(void)
             ptr->option_lst = xf86parseOption(ptr->option_lst);
             break;
         case NOMATCH_PRODUCT:
-            matchtype = MATCH_NEGATED;
+            negated = TRUE;
             /* fallthrough */
         case MATCH_PRODUCT:
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchProduct");
-            add_group_entry(&ptr->match_product,
-                            xstrtokenize(xf86_lex_val.str, TOKEN_SEP),
-                            matchtype);
-            free(xf86_lex_val.str);
+            else {
+                group = xf86createMatchGroup(xf86_lex_val.str, MATCH_AS_SUBSTRING, negated);
+                if (group)
+                    xorg_list_add(&group->entry, &ptr->match_product);
+                free(xf86_lex_val.str);
+            }
             break;
         case NOMATCH_VENDOR:
-            matchtype = MATCH_NEGATED;
+            negated = TRUE;
             /* fallthrough */
         case MATCH_VENDOR:
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchVendor");
-            add_group_entry(&ptr->match_vendor,
-                            xstrtokenize(xf86_lex_val.str, TOKEN_SEP),
-                            matchtype);
-            free(xf86_lex_val.str);
+            else {
+                group = xf86createMatchGroup(xf86_lex_val.str, MATCH_AS_SUBSTRING, negated);
+                if (group)
+                    xorg_list_add(&group->entry, &ptr->match_vendor);
+                free(xf86_lex_val.str);
+            }
             break;
         case NOMATCH_DEVICE_PATH:
-            matchtype = MATCH_NEGATED;
+            negated = TRUE;
             /* fallthrough */
         case MATCH_DEVICE_PATH:
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchDevicePath");
-            add_group_entry(&ptr->match_device,
-                            xstrtokenize(xf86_lex_val.str, TOKEN_SEP),
-                            matchtype);
-            free(xf86_lex_val.str);
+            else {
+                group = xf86createMatchGroup(xf86_lex_val.str, MATCH_AS_PATHNAME, negated);
+                if (group)
+                    xorg_list_add(&group->entry, &ptr->match_device);
+                free(xf86_lex_val.str);
+            }
             break;
         case NOMATCH_OS:
-            matchtype = MATCH_NEGATED;
+            negated = TRUE;
             /* fallthrough */
         case MATCH_OS:
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchOS");
-            add_group_entry(&ptr->match_os, xstrtokenize(xf86_lex_val.str,
-                                                         TOKEN_SEP),
-                            matchtype);
-            free(xf86_lex_val.str);
+            else {
+                group = xf86createMatchGroup(xf86_lex_val.str, MATCH_EXACT_NOCASE, negated);
+                if (group)
+                    xorg_list_add(&group->entry, &ptr->match_os);
+                free(xf86_lex_val.str);
+            }
             break;
         case NOMATCH_PNPID:
-            matchtype = MATCH_NEGATED;
+            negated = TRUE;
             /* fallthrough */
         case MATCH_PNPID:
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchPnPID");
-            add_group_entry(&ptr->match_pnpid,
-                            xstrtokenize(xf86_lex_val.str, TOKEN_SEP),
-                            matchtype);
-            free(xf86_lex_val.str);
+            else {
+                group = xf86createMatchGroup(xf86_lex_val.str, MATCH_AS_FILENAME, negated);
+                if (group)
+                    xorg_list_add(&group->entry, &ptr->match_pnpid);
+                free(xf86_lex_val.str);
+            }
             break;
         case NOMATCH_USBID:
-            matchtype = MATCH_NEGATED;
+            negated = TRUE;
             /* fallthrough */
         case MATCH_USBID:
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchUSBID");
-            add_group_entry(&ptr->match_usbid,
-                            xstrtokenize(xf86_lex_val.str, TOKEN_SEP),
-                            matchtype);
-            free(xf86_lex_val.str);
+            else {
+                group = xf86createMatchGroup(xf86_lex_val.str, MATCH_AS_FILENAME, negated);
+                if (group)
+                    xorg_list_add(&group->entry, &ptr->match_usbid);
+                free(xf86_lex_val.str);
+            }
             break;
         case NOMATCH_DRIVER:
-            matchtype = MATCH_NEGATED;
+            negated = TRUE;
             /* fallthrough */
         case MATCH_DRIVER:
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchDriver");
-            add_group_entry(&ptr->match_driver,
-                            xstrtokenize(xf86_lex_val.str, TOKEN_SEP),
-                            matchtype);
-            free(xf86_lex_val.str);
+            else {
+                group = xf86createMatchGroup(xf86_lex_val.str, MATCH_EXACT, negated);
+                if (group)
+                    xorg_list_add(&group->entry, &ptr->match_driver);
+                free(xf86_lex_val.str);
+            }
             break;
         case NOMATCH_TAG:
-            matchtype = MATCH_NEGATED;
+            negated = TRUE;
             /* fallthrough */
         case MATCH_TAG:
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchTag");
-            add_group_entry(&ptr->match_tag, xstrtokenize(xf86_lex_val.str,
-                                                          TOKEN_SEP),
-                            matchtype);
-            free(xf86_lex_val.str);
+            else {
+                group = xf86createMatchGroup(xf86_lex_val.str, MATCH_EXACT, negated);
+                if (group)
+                    xorg_list_add(&group->entry, &ptr->match_tag);
+                free(xf86_lex_val.str);
+            }
             break;
         case NOMATCH_LAYOUT:
-            matchtype = MATCH_NEGATED;
+            negated = TRUE;
             /* fallthrough */
         case MATCH_LAYOUT:
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchLayout");
-            add_group_entry(&ptr->match_layout,
-                            xstrtokenize(xf86_lex_val.str, TOKEN_SEP),
-                            matchtype);
-            free(xf86_lex_val.str);
+            else {
+                group = xf86createMatchGroup(xf86_lex_val.str, MATCH_EXACT, negated);
+                if (group)
+                    xorg_list_add(&group->entry, &ptr->match_layout);
+                free(xf86_lex_val.str);
+            }
             break;
         case MATCH_IS_KEYBOARD:
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
@@ -348,10 +349,11 @@ xf86parseInputClassSection(void)
 }
 
 void
-xf86printInputClassSection(FILE * cf, XF86ConfInputClassPtr ptr)
+xf86printInputClassSection (FILE * cf, XF86ConfInputClassPtr ptr)
 {
     const xf86MatchGroup *group;
-    char *const *cur;
+    const xf86MatchPattern *pattern;
+    Bool not_first;
 
     while (ptr) {
         fprintf(cf, "Section \"InputClass\"\n");
@@ -363,69 +365,95 @@ xf86printInputClassSection(FILE * cf, XF86ConfInputClassPtr ptr)
             fprintf(cf, "\tDriver          \"%s\"\n", ptr->driver);
 
         xorg_list_for_each_entry(group, &ptr->match_product, entry) {
-            fprintf(cf, "\tMatchProduct    \"");
-            for (cur = group->values; *cur; cur++)
-                fprintf(cf, "%s%s", cur == group->values ? "" : TOKEN_SEP,
-                        *cur);
+            if (group->is_negated) fprintf(cf, "\tNoMatchProduct  \"");
+            else                   fprintf(cf, "\tMatchProduct    \"");
+            not_first = FALSE;
+            xorg_list_for_each_entry(pattern, &group->patterns, entry) {
+                xf86printMatchPattern(cf, pattern, not_first);
+                not_first = TRUE;
+            }
             fprintf(cf, "\"\n");
         }
         xorg_list_for_each_entry(group, &ptr->match_vendor, entry) {
-            fprintf(cf, "\tMatchVendor     \"");
-            for (cur = group->values; *cur; cur++)
-                fprintf(cf, "%s%s", cur == group->values ? "" : TOKEN_SEP,
-                        *cur);
+            if (group->is_negated) fprintf(cf, "\tNoMatchVendor   \"");
+            else                   fprintf(cf, "\tMatchVendor     \"");
+            not_first = FALSE;
+            xorg_list_for_each_entry(pattern, &group->patterns, entry) {
+                xf86printMatchPattern(cf, pattern, not_first);
+                not_first = TRUE;
+            }
             fprintf(cf, "\"\n");
         }
         xorg_list_for_each_entry(group, &ptr->match_device, entry) {
-            fprintf(cf, "\tMatchDevicePath \"");
-            for (cur = group->values; *cur; cur++)
-                fprintf(cf, "%s%s", cur == group->values ? "" : TOKEN_SEP,
-                        *cur);
+            if (group->is_negated) fprintf(cf, "\tNoMatchDevicePath \"");
+            else                   fprintf(cf, "\tMatchDevicePath   \"");
+            not_first = FALSE;
+            xorg_list_for_each_entry(pattern, &group->patterns, entry) {
+                xf86printMatchPattern(cf, pattern, not_first);
+                not_first = TRUE;
+            }
             fprintf(cf, "\"\n");
         }
         xorg_list_for_each_entry(group, &ptr->match_os, entry) {
-            fprintf(cf, "\tMatchOS         \"");
-            for (cur = group->values; *cur; cur++)
-                fprintf(cf, "%s%s", cur == group->values ? "" : TOKEN_SEP,
-                        *cur);
+            if (group->is_negated) fprintf(cf, "\tNoMatchOS       \"");
+            else                   fprintf(cf, "\tMatchOS         \"");
+            not_first = FALSE;
+            xorg_list_for_each_entry(pattern, &group->patterns, entry) {
+                xf86printMatchPattern(cf, pattern, not_first);
+                not_first = TRUE;
+            }
             fprintf(cf, "\"\n");
         }
         xorg_list_for_each_entry(group, &ptr->match_pnpid, entry) {
-            fprintf(cf, "\tMatchPnPID      \"");
-            for (cur = group->values; *cur; cur++)
-                fprintf(cf, "%s%s", cur == group->values ? "" : TOKEN_SEP,
-                        *cur);
+            if (group->is_negated) fprintf(cf, "\tNoMatchPnPID    \"");
+            else                   fprintf(cf, "\tMatchPnPID      \"");
+            not_first = FALSE;
+            xorg_list_for_each_entry(pattern, &group->patterns, entry) {
+                xf86printMatchPattern(cf, pattern, not_first);
+                not_first = TRUE;
+            }
             fprintf(cf, "\"\n");
         }
         xorg_list_for_each_entry(group, &ptr->match_usbid, entry) {
-            fprintf(cf, "\tMatchUSBID      \"");
-            for (cur = group->values; *cur; cur++)
-                fprintf(cf, "%s%s", cur == group->values ? "" : TOKEN_SEP,
-                        *cur);
+            if (group->is_negated) fprintf(cf, "\tNoMatchUSBID    \"");
+            else                   fprintf(cf, "\tMatchUSBID      \"");
+            not_first = FALSE;
+            xorg_list_for_each_entry(pattern, &group->patterns, entry) {
+                xf86printMatchPattern(cf, pattern, not_first);
+                not_first = TRUE;
+            }
             fprintf(cf, "\"\n");
         }
         xorg_list_for_each_entry(group, &ptr->match_driver, entry) {
-            fprintf(cf, "\tMatchDriver     \"");
-            for (cur = group->values; *cur; cur++)
-                fprintf(cf, "%s%s", cur == group->values ? "" : TOKEN_SEP,
-                        *cur);
+            if (group->is_negated) fprintf(cf, "\tNoMatchDriver   \"");
+            else                   fprintf(cf, "\tMatchDriver     \"");
+            not_first = FALSE;
+            xorg_list_for_each_entry(pattern, &group->patterns, entry) {
+                xf86printMatchPattern(cf, pattern, not_first);
+                not_first = TRUE;
+            }
             fprintf(cf, "\"\n");
         }
         xorg_list_for_each_entry(group, &ptr->match_tag, entry) {
-            fprintf(cf, "\tMatchTag        \"");
-            for (cur = group->values; *cur; cur++)
-                fprintf(cf, "%s%s", cur == group->values ? "" : TOKEN_SEP,
-                        *cur);
+            if (group->is_negated) fprintf(cf, "\tNoMatchTAG      \"");
+            else                   fprintf(cf, "\tMatchTAG        \"");
+            not_first = FALSE;
+            xorg_list_for_each_entry(pattern, &group->patterns, entry) {
+                xf86printMatchPattern(cf, pattern, not_first);
+                not_first = TRUE;
+            }
             fprintf(cf, "\"\n");
         }
         xorg_list_for_each_entry(group, &ptr->match_layout, entry) {
-            fprintf(cf, "\tMatchLayout     \"");
-            for (cur = group->values; *cur; cur++)
-                fprintf(cf, "%s%s", cur == group->values ? "" : TOKEN_SEP,
-                        *cur);
+            if (group->is_negated) fprintf(cf, "\tNoMatchLayout   \"");
+            else                   fprintf(cf, "\tMatchLayout     \"");
+            not_first = FALSE;
+            xorg_list_for_each_entry(pattern, &group->patterns, entry) {
+                xf86printMatchPattern(cf, pattern, not_first);
+                not_first = TRUE;
+            }
             fprintf(cf, "\"\n");
         }
-
         if (ptr->is_keyboard.set)
             fprintf(cf, "\tIsKeyboard      \"%s\"\n",
                     ptr->is_keyboard.val ? "yes" : "no");

--- a/hw/xfree86/parser/OutputClass.c
+++ b/hw/xfree86/parser/OutputClass.c
@@ -66,23 +66,12 @@ xf86freeOutputClassList(XF86ConfOutputClassPtr ptr)
 
 #define CLEANUP xf86freeOutputClassList
 
-#define TOKEN_SEP "|"
-
-static void
-add_group_entry(struct xorg_list *head, char **values)
-{
-    xf86MatchGroup *group = calloc(1, sizeof(xf86MatchGroup));
-    if (group) {
-        group->values = values;
-        xorg_list_add(&group->entry, head);
-    }
-}
-
 XF86ConfOutputClassPtr
 xf86parseOutputClassSection(void)
 {
     int has_ident = FALSE;
     int token;
+    xf86MatchGroup *group;
 
     parsePrologue(XF86ConfOutputClassPtr, XF86ConfOutputClassRec)
 
@@ -129,9 +118,12 @@ xf86parseOutputClassSection(void)
         case MATCH_DRIVER:
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchDriver");
-            add_group_entry(&ptr->match_driver,
-                            xstrtokenize(xf86_lex_val.str, TOKEN_SEP));
-            free(xf86_lex_val.str);
+            else {
+                group = xf86createMatchGroup(xf86_lex_val.str, MATCH_EXACT, FALSE);
+                if (group)
+                    xorg_list_add(&group->entry, &ptr->match_driver);
+                free(xf86_lex_val.str);
+            }
             break;
         case EOF_TOKEN:
             Error(UNEXPECTED_EOF_MSG);
@@ -151,11 +143,13 @@ xf86parseOutputClassSection(void)
 
     return ptr;
 }
+
 void
 xf86printOutputClassSection(FILE * cf, XF86ConfOutputClassPtr ptr)
 {
     const xf86MatchGroup *group;
-    char *const *cur;
+    const xf86MatchPattern *pattern;
+    Bool not_first;
 
     while (ptr) {
         fprintf(cf, "Section \"OutputClass\"\n");
@@ -168,9 +162,11 @@ xf86printOutputClassSection(FILE * cf, XF86ConfOutputClassPtr ptr)
 
         xorg_list_for_each_entry(group, &ptr->match_driver, entry) {
             fprintf(cf, "\tMatchDriver     \"");
-            for (cur = group->values; *cur; cur++)
-                fprintf(cf, "%s%s", cur == group->values ? "" : TOKEN_SEP,
-                        *cur);
+            not_first = FALSE;
+            xorg_list_for_each_entry(pattern, &group->patterns, entry) {
+                xf86printMatchPattern(cf, pattern, not_first);
+                not_first = TRUE;
+            }
             fprintf(cf, "\"\n");
         }
 

--- a/hw/xfree86/parser/configProcs.h
+++ b/hw/xfree86/parser/configProcs.h
@@ -140,6 +140,14 @@ xf86printExtensionsSection(FILE * cf, XF86ConfExtensionsPtr ptr);
 void
 xf86freeExtensions(XF86ConfExtensionsPtr ptr);
 
+/* pattern.c */
+xf86MatchGroup* xf86createMatchGroup(const char *arg,
+                                     xf86MatchMode pref_mode,
+                                     Bool negated);
+void xf86printMatchPattern(FILE * cf,
+                           const xf86MatchPattern *pattern,
+                           Bool not_first);
+
 #ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
 #endif

--- a/hw/xfree86/parser/meson.build
+++ b/hw/xfree86/parser/meson.build
@@ -12,6 +12,7 @@ srcs_xorg_parser = [
     'Pointer.c',
     'Screen.c',
     'Vendor.c',
+    'patterns.c',
     'read.c',
     'scan.c',
     'write.c',

--- a/hw/xfree86/parser/patterns.c
+++ b/hw/xfree86/parser/patterns.c
@@ -1,0 +1,178 @@
+/* SPDX-License-Identifier: MIT or X11
+ *
+ * Copyright (c) 2025 Oleh Nykyforchyn <oleh.nyk@gmail.com>
+ *
+ */
+
+#ifdef HAVE_XORG_CONFIG_H
+#include <xorg-config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "misc.h"
+#include "xf86Parser_priv.h"
+#include "configProcs.h"
+#include "os.h"
+
+/*
+ *  Utilities used by InputClass.c and OutputClass.c
+ */
+
+/* A group (which is a struct xf86MatchGroup) represents a complex condition
+ * that should be satisfied if is_negated_is true or should not be satisfied
+ * otherwise, for an input or output device to be accepted. A group contains
+ * an xorg_list patterns.
+ *
+ * Each pattern (a struct xf86MatchPattern) is a subcondition. The logical value
+ * of a group is true if and only if at least one subcondition is true, i.e.,
+ * the patterns are combined by logical 'OR', which is represented by '|' in
+ * the string that defines a group.
+ *
+ * If a string that defines a pattern is preceded by '!', then the logical
+ * value of the pattern is negated. Note that a second '!' does not cancel
+ * the first one, so '!!' does not make sense.
+ *
+ * A string correponding to a pattern (after an eventual '!') can be treated
+ * either as a regular expression, if it is prepended with '~', or otherwise
+ * as a string with which an attribute of a device is compared.
+ * The mode of comparison is of the type enum xf86MatchMode and depends on
+ * the type of the attribute.
+ *
+ * If a string is not a regular expression but contains one or more '&'s, then
+ * it is treated as a sequence of &'-separated substrings that should ALL be
+ * present in an attribute (in arbitrary places and order) for the logical value
+ * to be positive (so empty substrings are inessential and dropped).
+ * They are kept in pattern.str '\0'-separated, with a final second '\0'.
+ */
+
+#define LOG_OR '|'
+#define LOG_AND '&'
+
+#define NEG_FLAG '!'
+
+
+xf86MatchGroup*
+xf86createMatchGroup(const char *arg, xf86MatchMode pref_mode,
+             Bool negated)
+ {
+    xf86MatchPattern *pattern;
+    xf86MatchGroup *group;
+    const char *str = arg;
+    unsigned n;
+    static const char sep_or[2]  = { LOG_OR,  '\0' };
+    static const char sep_and[2] = { LOG_AND, '\0' };
+
+    if (!str)
+        return NULL;
+
+    group = malloc(sizeof(*group));
+    if (!group) return NULL;
+    xorg_list_init(&group->patterns);
+    xorg_list_init(&group->entry);
+    group->is_negated = negated;
+
+  again:
+    /* start new pattern */
+    if ((pattern = malloc(sizeof(*pattern))) == NULL)
+        goto fail;
+
+    xorg_list_add(&pattern->entry, &group->patterns);
+
+    /* Pattern starting with '!' should NOT be matched */
+    if (*str == NEG_FLAG) {
+        pattern->is_negated = TRUE;
+        str++;
+    }
+    else
+        pattern->is_negated = FALSE;
+
+    pattern->str = NULL;
+
+        n = strcspn(str, sep_or);
+        if (n > strcspn(str, sep_and)) {
+            pattern->mode = MATCH_SUBSTRINGS_SEQUENCE;
+            pattern->str = malloc(n+2);
+            if (pattern->str) {
+                char *s, *d;
+                strncpy(pattern->str, str, n);
+                str += n;
+                *(pattern->str+n) = '\0';
+                s = d = pattern->str;
+                n = 0;
+              next_chunk:
+                while ((*s) && (*s != LOG_AND)) {
+                    if (n == -1) {
+                        *(d++) = '\0';
+                        n = 0;
+                    }
+                    *(d++) = *(s++);
+                    n++;
+                }
+                while ((*s) == LOG_AND) s++;
+                if (*s) {
+                    n = -1;
+                    goto next_chunk;
+                }
+                if (d == pattern->str) {
+                /* All chunks are empty */
+                    pattern->mode = MATCH_IS_INVALID;
+                    LogMessageVerb(X_ERROR, 1,
+                        "No non-empty substrings supplied in the alternative \"%s\" of \"%s\", ignoring\n",
+                        pattern->str, arg);
+                }
+                *(++d) = '\0';
+            }
+            else
+                goto fail;
+        }
+        else {
+            pattern->mode = pref_mode;
+            pattern->str = strndup(str, n);
+            if (pattern->str == NULL)
+                goto fail;
+            *(pattern->str+n) = '\0'; /* should already be, but to be sure */
+            str += n;
+        }
+
+    while (*str == LOG_OR)
+        str++;
+
+    if (*str)
+        goto again;
+
+    return group;
+
+  fail:
+    xf86freeMatchGroup(group);
+    return NULL;
+}
+
+void
+xf86printMatchPattern(FILE * cf, const xf86MatchPattern *pattern, Bool not_first)
+{
+    if (!pattern) return;
+    if (not_first)
+        fprintf(cf, "%c", LOG_OR);
+    if (pattern->is_negated)
+        fprintf(cf, "%c", NEG_FLAG);
+    if (pattern->mode == MATCH_IS_INVALID)
+        fprintf(cf, "invalid:%s",
+            pattern->str ? pattern->str : "(none)");
+    else
+    if (pattern->mode == MATCH_SUBSTRINGS_SEQUENCE) {
+        Bool after = FALSE;
+        char *str = pattern->str;
+        while (*str) {
+            if (after)
+                fprintf(cf, "%c", LOG_AND);
+            fprintf(cf, "%s", str);
+            str += strlen(str);
+            str++;
+            after = TRUE;
+        }
+    }
+    else
+        fprintf(cf, "%s",
+            pattern->str ? pattern->str : "(none)");
+}

--- a/hw/xfree86/parser/xf86Parser.h
+++ b/hw/xfree86/parser/xf86Parser.h
@@ -67,6 +67,9 @@
 #include "xf86Optrec.h"
 #include "list.h"
 
+#include <sys/types.h>
+#include <regex.h>
+
 #define HAVE_PARSER_DECLS
 
 typedef struct {
@@ -317,6 +320,7 @@ typedef enum {
     MATCH_AS_FILENAME,
     MATCH_AS_PATHNAME,
     MATCH_SUBSTRINGS_SEQUENCE,
+    MATCH_REGEX
 } xf86MatchMode;
 
 typedef struct {
@@ -324,6 +328,7 @@ typedef struct {
     xf86MatchMode mode;
     Bool is_negated;
     char *str;
+    regex_t *regex;
 } xf86MatchPattern;
 
 typedef struct {

--- a/hw/xfree86/parser/xf86Parser.h
+++ b/hw/xfree86/parser/xf86Parser.h
@@ -304,7 +304,6 @@ typedef struct {
 
 typedef struct {
     struct xorg_list entry;
-    char **values;
     struct xorg_list patterns;
     Bool is_negated;
 } xf86MatchGroup;

--- a/hw/xfree86/parser/xf86Parser.h
+++ b/hw/xfree86/parser/xf86Parser.h
@@ -305,8 +305,27 @@ typedef struct {
 typedef struct {
     struct xorg_list entry;
     char **values;
+    struct xorg_list patterns;
     Bool is_negated;
 } xf86MatchGroup;
+
+typedef enum {
+    MATCH_IS_INVALID,
+    MATCH_EXACT,
+    MATCH_EXACT_NOCASE,
+    MATCH_AS_SUBSTRING,
+    MATCH_AS_SUBSTRING_NOCASE,
+    MATCH_AS_FILENAME,
+    MATCH_AS_PATHNAME,
+    MATCH_SUBSTRINGS_SEQUENCE,
+} xf86MatchMode;
+
+typedef struct {
+    struct xorg_list entry;
+    xf86MatchMode mode;
+    Bool is_negated;
+    char *str;
+} xf86MatchPattern;
 
 typedef struct {
     GenericListRec list;

--- a/hw/xfree86/parser/xf86Parser_priv.h
+++ b/hw/xfree86/parser/xf86Parser_priv.h
@@ -28,12 +28,12 @@ int xf86layoutAddInputDevices(XF86ConfigPtr config, XF86ConfLayoutPtr layout);
 static inline void xf86freeMatchGroup(xf86MatchGroup *group)
 {
     xorg_list_del(&group->entry);
-    if (group->values) {
-        for (char **list = group->values; *list; list++) {
-            free(*list);
-            *list = NULL;
-        }
-        group->values = NULL;
+    xf86MatchPattern *pattern, *next_pattern;
+    xorg_list_for_each_entry_safe(pattern, next_pattern, &group->patterns, entry) {
+        xorg_list_del(&pattern->entry);
+        if (pattern->str)
+            free(pattern->str);
+        free(pattern);
     }
     free(group);
 }


### PR DESCRIPTION
The code that matches devices against input/output classes is tangled and difficult to track and extend, in particular, because there are different matching modes for different device attributes: case (in)sensitive, pathnames etc.  Sometimes it is convenient to set parameters for a specific device (in old days I used this to create multiseat configurations). In this case more complicated conditions, in particular, REs, come in handy. For example, this is a (slightly modified) excerpt from a real config (**updated with a new version of the PR**):
```
Section "InputClass"
    Identifier     "Keyboard-at-seat"
    MatchProduct   "~/(Translated|Raw) Set 2 keyboard$"
    MatchIsKeyboard "on"
    MatchLayout    "!Seat0"
    Driver         "evdev"
    Option         "Ignore" "on"
    Option         "XkbRules" "evdev"
    Option         "XkbModel" "evdev"
    Option         "XkbLayout" "us_pl,ua_ru_by"
    Option         "XkbOptions" "overlay,terminate:ctrl_alt_bksp"
    Option         "AutoRepeat" "500 3"
EndSection

Section "InputClass"
    Identifier     "Mouse-in-set"
    MatchProduct   "USB Receiver&Mouse"
    MatchIsPointer "on"
    Driver         "evdev"
    Option         "Ignore" "on"
    Option         "Buttons" "5"
    Option         "ZAxisMapping" "4 5"
    Option         "Emulate3Buttons"
EndSection
```
The class Keyboard-at-seat is applied only to devices with product names that end in "Translated Set 2 keyboard" or "Raw Set 2 keyboard" (this happens if You have more than one keyboard attached) and for all seats but 0.  The class Mouse-in-set applies only to devices that have both "USB Receiver" and "Mouse" in product names. Sometimes it helped to configure devices that present themselves in weird way.

Although most users will not need this (and will not even notice because handling of simple arguments has not been changed), it costs nothing and may be useful sometimes. I have been using this extension for years in many settings.
