### PR TITLE
meson.build: Enabled udev for FreeBSD.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -183,7 +183,7 @@ endif
 
 build_udev = get_option('udev')
 build_udev_kms = get_option('udev_kms')
-if ['windows', 'darwin', 'freebsd', 'netbsd', 'openbsd', 'sunos'].contains(host_machine.system())
+if ['windows', 'darwin', 'netbsd', 'openbsd', 'sunos'].contains(host_machine.system())
     build_udev = false
     build_udev_kms = false
 endif


### PR DESCRIPTION
Related to #397.
FreeBSD uses [libudev-devd](https://github.com/wulf7/libudev-devd) as a wrapper specifically intended for X.Org and libinput.
The udev options should be available for it.

Signed-off-by: b-aaz <b-aazbsd.proton.me>