### PR TITLE
xfree86: meson.bulid: move driver specific build logic to drivers/ su…

### DIFF
--- a/hw/xfree86/drivers/meson.build
+++ b/hw/xfree86/drivers/meson.build
@@ -1,0 +1,7 @@
+if build_modesetting
+   subdir('modesetting')
+endif
+
+if get_option('xf86-input-inputtest')
+    subdir('inputtest')
+endif

--- a/hw/xfree86/meson.build
+++ b/hw/xfree86/meson.build
@@ -137,12 +137,8 @@ subdir('shadowfb')
 if build_vgahw
     subdir('vgahw')
 endif
-if build_modesetting
-   subdir('drivers/modesetting')
-endif
-if get_option('xf86-input-inputtest')
-    subdir('drivers/inputtest')
-endif
+
+subdir('drivers')
 
 meson.add_install_script(
     'sh', '-c',


### PR DESCRIPTION
…bdir

For better code structuring, move the meson logic for drivers into the drivers/ subdir.