### PR TITLE
fbdevhw: fix const char arguments

### DIFF
--- a/hw/xfree86/fbdevhw/fbdevhw.c
+++ b/hw/xfree86/fbdevhw/fbdevhw.c
@@ -384,7 +384,7 @@ fbdev_open(int scrnIndex, const char *dev, char **namep)
 /* -------------------------------------------------------------------- */
 
 Bool
-fbdevHWProbe(struct pci_device *pPci, char *device, char **namep)
+fbdevHWProbe(struct pci_device *pPci, const char *device, char **namep)
 {
     int fd;
 

--- a/hw/xfree86/fbdevhw/fbdevhw.c
+++ b/hw/xfree86/fbdevhw/fbdevhw.c
@@ -400,7 +400,7 @@ fbdevHWProbe(struct pci_device *pPci, const char *device, char **namep)
 }
 
 Bool
-fbdevHWInit(ScrnInfoPtr pScrn, struct pci_device *pPci, char *device)
+fbdevHWInit(ScrnInfoPtr pScrn, struct pci_device *pPci, const char *device)
 {
     fbdevHWPtr fPtr;
 

--- a/hw/xfree86/fbdevhw/fbdevhw.h
+++ b/hw/xfree86/fbdevhw/fbdevhw.h
@@ -12,7 +12,7 @@
 extern _X_EXPORT Bool fbdevHWProbe(struct pci_device *pPci, const char *device,
                                    char **namep);
 extern _X_EXPORT Bool fbdevHWInit(ScrnInfoPtr pScrn, struct pci_device *pPci,
-                                  char *device);
+                                  const char *device);
 
 extern _X_EXPORT char *fbdevHWGetName(ScrnInfoPtr pScrn);
 extern _X_EXPORT int fbdevHWGetDepth(ScrnInfoPtr pScrn, int *fbbpp);

--- a/hw/xfree86/fbdevhw/fbdevhw.h
+++ b/hw/xfree86/fbdevhw/fbdevhw.h
@@ -9,7 +9,7 @@
 #define FBDEVHW_TEXT			3       /* Text/attributes      */
 #define FBDEVHW_VGA_PLANES		4       /* EGA/VGA planes       */
 
-extern _X_EXPORT Bool fbdevHWProbe(struct pci_device *pPci, char *device,
+extern _X_EXPORT Bool fbdevHWProbe(struct pci_device *pPci, const char *device,
                                    char **namep);
 extern _X_EXPORT Bool fbdevHWInit(ScrnInfoPtr pScrn, struct pci_device *pPci,
                                   char *device);


### PR DESCRIPTION
when passing in names that may be const or literals, the corresponding function parameters should be `const char*` instead of `char *`.
 