### PR TITLE
xfree86: i2c: constify I2CBusRec::name

### DIFF
--- a/hw/xfree86/i2c/xf86i2c.h
+++ b/hw/xfree86/i2c/xf86i2c.h
@@ -17,7 +17,7 @@ typedef struct _I2CDevRec *I2CDevPtr;
 /* I2C masters have to register themselves */
 
 typedef struct _I2CBusRec {
-    char *BusName;
+    const char *BusName;
     int scrnIndex;
     ScrnInfoPtr pScrn;
 


### PR DESCRIPTION
The bus name is always assigned to string literals, thus pointing to constant data.