### PR TITLE
add helpers for atom creation and retrieval

### DIFF
--- a/Xext/namespace/hook-selection.c
+++ b/Xext/namespace/hook-selection.c
@@ -4,6 +4,7 @@
 
 #include <stdio.h>
 
+#include "dix/dix_priv.h"
 #include "dix/selection_priv.h"
 
 #include "namespace.h"
@@ -40,7 +41,7 @@ void hookSelectionFilter(CallbackListPtr *pcbl, void *unused, void *calldata)
 
     char selname[PATH_MAX] = { 0 };
     snprintf(selname, sizeof(selname)-1, "<%s>%s", subj->ns->name, origSelectionName);
-    Atom realSelection = MakeAtom(selname, strlen(selname), TRUE);
+    Atom realSelection = dixAddAtom(selname);
 
     switch (param->op) {
         case SELECTION_FILTER_GETOWNER:
@@ -55,7 +56,7 @@ void hookSelectionFilter(CallbackListPtr *pcbl, void *unused, void *calldata)
         {
             // need to translate back, since we're having the ns-prefixed name here
             const char *stripped = stripNS(origSelectionName);
-            param->selection = MakeAtom(stripped, strlen(stripped), TRUE);
+            param->selection = dixAddAtom(stripped);
             break;
         }
 

--- a/Xext/xres.c
+++ b/Xext/xres.c
@@ -11,6 +11,7 @@
 #include <X11/Xproto.h>
 #include <X11/extensions/XResproto.h>
 
+#include "dix/dix_priv.h"
 #include "dix/registry_priv.h"
 #include "dix/resource_priv.h"
 #include "os/client_priv.h"
@@ -272,12 +273,12 @@ resourceTypeAtom(int i)
 
     const char *name = LookupResourceName(i);
     if (strcmp(name, XREGISTRY_UNKNOWN))
-        ret = MakeAtom(name, strlen(name), TRUE);
+        ret = dixAddAtom(name);
     else {
         char buf[40];
 
         snprintf(buf, sizeof(buf), "Unregistered resource %i", i + 1);
-        ret = MakeAtom(buf, strlen(buf), TRUE);
+        ret = dixAddAtom(buf);
     }
 
     return ret;

--- a/Xext/xselinux_hooks.c
+++ b/Xext/xselinux_hooks.c
@@ -32,6 +32,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <X11/Xatom.h>
 #include <X11/Xfuncproto.h>
 
+#include "dix/dix_priv.h"
 #include "dix/input_priv.h"
 #include "dix/registry_priv.h"
 #include "dix/resource_priv.h"
@@ -908,10 +909,10 @@ SELinuxFlaskInit(void)
         FatalError("SELinux: Failed to allocate private storage.\n");
 
     /* Create atoms for doing window labeling */
-    atom_ctx = MakeAtom("_SELINUX_CONTEXT", 16, TRUE);
+    atom_ctx = dixAddAtom("_SELINUX_CONTEXT");
     if (atom_ctx == BAD_RESOURCE)
         FatalError("SELinux: Failed to create atom\n");
-    atom_client_ctx = MakeAtom("_SELINUX_CLIENT_CONTEXT", 23, TRUE);
+    atom_client_ctx = dixAddAtom("_SELINUX_CLIENT_CONTEXT");
     if (atom_client_ctx == BAD_RESOURCE)
         FatalError("SELinux: Failed to create atom\n");
 

--- a/Xext/xvmain.c
+++ b/Xext/xvmain.c
@@ -81,6 +81,7 @@ SOFTWARE.
 #include <X11/extensions/Xv.h>
 #include <X11/extensions/Xvproto.h>
 
+#include "dix/dix_priv.h"
 #include "dix/screen_hooks_priv.h"
 #include "miext/extinit_priv.h"
 #include "Xext/panoramiX.h"
@@ -199,8 +200,7 @@ XvExtensionInit(void)
             (EventSwapPtr) WriteSwappedPortNotifyEvent;
 
         SetResourceTypeErrorValue(XvRTPort, _XvBadPort);
-        (void) MakeAtom(XvName, strlen(XvName), xTrue);
-
+        (void) dixAddAtom(XvName);
     }
 }
 

--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -1245,8 +1245,7 @@ MakeDeviceTypeAtoms(void)
     int i;
 
     for (i = 0; i < NUMTYPES; i++)
-        dev_type[i].type =
-            MakeAtom(dev_type[i].name, strlen(dev_type[i].name), 1);
+        dev_type[i].type = dixAddAtom(dev_type[i].name);
 }
 
 /*****************************************************************************

--- a/Xi/xiproperty.c
+++ b/Xi/xiproperty.c
@@ -32,6 +32,7 @@
 #include <X11/extensions/XIproto.h>
 #include <X11/extensions/XI2proto.h>
 
+#include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
 #include "dix/extension_priv.h"
 #include "dix/input_priv.h"
@@ -375,12 +376,8 @@ XIGetKnownProperty(const char *name)
 
     for (i = 0; i < ARRAY_SIZE(dev_properties); i++) {
         if (strcmp(name, dev_properties[i].name) == 0) {
-            if (dev_properties[i].type == None) {
-                dev_properties[i].type =
-                    MakeAtom(dev_properties[i].name,
-                             strlen(dev_properties[i].name), TRUE);
-            }
-
+            if (dev_properties[i].type == None)
+                dev_properties[i].type = dixAddAtom(dev_properties[i].name);
             return dev_properties[i].type;
         }
     }

--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -705,6 +705,18 @@ static inline int WriteRpcbufToClient(ClientPtr pClient,
 }
 
 /*
+ * @brief make atom from null-terminated string
+ *
+ * if atom already existing, return the existing Atom ID
+ *
+ * @param name  the atom name
+ * @return atom ID
+ */
+static inline Atom dixAddAtom(const char *name) {
+    return MakeAtom(name, strlen(name), TRUE);
+}
+
+/*
  * @brief retrieve atom ID by name
  *
  * if the atom doesn't exist yet, 0 / NONE is returned

--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -704,4 +704,16 @@ static inline int WriteRpcbufToClient(ClientPtr pClient,
     return ret;
 }
 
+/*
+ * @brief retrieve atom ID by name
+ *
+ * if the atom doesn't exist yet, 0 / NONE is returned
+ *
+ * @param name  the atom name
+ * @return atom ID
+ */
+static inline Atom dixGetAtomID(const char *name) {
+    return MakeAtom(name, strlen(name), FALSE);
+}
+
 #endif /* _XSERVER_DIX_PRIV_H */

--- a/glamor/glamor_xv.c
+++ b/glamor/glamor_xv.c
@@ -35,6 +35,7 @@
 
 #include <assert.h>
 
+#include "dix/dix_priv.h"
 #include "os/bug_priv.h"
 
 #include "glamor_priv.h"
@@ -176,8 +177,6 @@ static const glamor_facet glamor_facet_xv_rgb_raw = {
                 "        frag_color = texture2D(sampler, tcs);\n"
                 ),
 };
-
-#define MAKE_ATOM(a) MakeAtom(a, sizeof(a) - 1, TRUE)
 
 XvAttributeRec glamor_xv_attributes[] = {
     {XvSettable | XvGettable, -1000, 1000, (char *)"XV_BRIGHTNESS"},
@@ -865,10 +864,10 @@ glamor_xv_init_port(glamor_port_private *port_priv)
 void
 glamor_xv_core_init(ScreenPtr screen)
 {
-    glamorBrightness = MAKE_ATOM("XV_BRIGHTNESS");
-    glamorContrast = MAKE_ATOM("XV_CONTRAST");
-    glamorSaturation = MAKE_ATOM("XV_SATURATION");
-    glamorHue = MAKE_ATOM("XV_HUE");
-    glamorGamma = MAKE_ATOM("XV_GAMMA");
-    glamorColorspace = MAKE_ATOM("XV_COLORSPACE");
+    glamorBrightness = dixAddAtom("XV_BRIGHTNESS");
+    glamorContrast = dixAddAtom("XV_CONTRAST");
+    glamorSaturation = dixAddAtom("XV_SATURATION");
+    glamorHue = dixAddAtom("XV_HUE");
+    glamorGamma = dixAddAtom("XV_GAMMA");
+    glamorColorspace = dixAddAtom("XV_COLORSPACE");
 }

--- a/hw/vfb/InitInput.c
+++ b/hw/vfb/InitInput.c
@@ -33,6 +33,7 @@ from The Open Group.
 #include <X11/Xos.h>
 #include <X11/keysym.h>
 
+#include "dix/dix_priv.h"
 #include "dix/input_priv.h"
 #include "mi/mi_priv.h"
 
@@ -142,9 +143,9 @@ InitInput(int argc, char *argv[])
 
     p = AddInputDevice(serverClient, vfbMouseProc, TRUE);
     k = AddInputDevice(serverClient, vfbKeybdProc, TRUE);
-    xiclass = MakeAtom(XI_MOUSE, sizeof(XI_MOUSE) - 1, TRUE);
+    xiclass = dixAddAtom(XI_MOUSE);
     AssignTypeAndName(p, xiclass, "Xvfb mouse");
-    xiclass = MakeAtom(XI_KEYBOARD, sizeof(XI_KEYBOARD) - 1, TRUE);
+    xiclass = dixAddAtom(XI_KEYBOARD);
     AssignTypeAndName(k, xiclass, "Xvfb keyboard");
     (void) mieqInit();
 }

--- a/hw/xfree86/common/xf86Events.c
+++ b/hw/xfree86/common/xf86Events.c
@@ -324,14 +324,10 @@ xf86EnableInputDeviceForVTSwitch(InputInfoPtr pInfo)
 static void
 xf86UpdateHasVTProperty(Bool hasVT)
 {
-    Atom property_name;
     int32_t value = hasVT ? 1 : 0;
     int i;
 
-    property_name = MakeAtom(HAS_VT_ATOM_NAME, sizeof(HAS_VT_ATOM_NAME) - 1,
-                             FALSE);
-    if (property_name == BAD_RESOURCE)
-        FatalError("Failed to retrieve \"HAS_VT\" atom\n");
+    Atom property_name = MakeAtom(HAS_VT_ATOM_NAME, sizeof(HAS_VT_ATOM_NAME)-1, TRUE);
     for (i = 0; i < xf86NumScreens; i++) {
         dixChangeWindowProperty(serverClient,
                                 xf86ScrnToScreen(xf86Screens[i])->root,

--- a/hw/xfree86/common/xf86Events.c
+++ b/hw/xfree86/common/xf86Events.c
@@ -327,7 +327,7 @@ xf86UpdateHasVTProperty(Bool hasVT)
     int32_t value = hasVT ? 1 : 0;
     int i;
 
-    Atom property_name = MakeAtom(HAS_VT_ATOM_NAME, sizeof(HAS_VT_ATOM_NAME)-1, TRUE);
+    Atom property_name = dixAddAtom(HAS_VT_ATOM_NAME);
     for (i = 0; i < xf86NumScreens; i++) {
         dixChangeWindowProperty(serverClient,
                                 xf86ScrnToScreen(xf86Screens[i])->root,

--- a/hw/xfree86/common/xf86Init.c
+++ b/hw/xfree86/common/xf86Init.c
@@ -224,7 +224,7 @@ static void
 AddSeatId(CallbackListPtr *pcbl, void *data, void *screen)
 {
     ScreenPtr pScreen = screen;
-    Atom SeatAtom = MakeAtom(SEAT_ATOM_NAME, sizeof(SEAT_ATOM_NAME) - 1, TRUE);
+    Atom SeatAtom = dixAddAtom(SEAT_ATOM_NAME);
     int err;
 
     err = dixChangeWindowProperty(serverClient, pScreen->root, SeatAtom,
@@ -242,9 +242,8 @@ AddVTAtoms(CallbackListPtr *pcbl, void *data, void *screen)
 #define VT_ATOM_NAME         "XFree86_VT"
     int err, HasVT = 1;
     ScreenPtr pScreen = screen;
-    Atom VTAtom = MakeAtom(VT_ATOM_NAME, sizeof(VT_ATOM_NAME) - 1, TRUE);
-    Atom HasVTAtom = MakeAtom(HAS_VT_ATOM_NAME, sizeof(HAS_VT_ATOM_NAME) - 1,
-                              TRUE);
+    Atom VTAtom = dixAddAtom(VT_ATOM_NAME);
+    Atom HasVTAtom = dixAddAtom(HAS_VT_ATOM_NAME);
 
     err = dixChangeWindowProperty(serverClient, pScreen->root, VTAtom,
                                   XA_INTEGER, 32, PropModeReplace, 1,

--- a/hw/xfree86/common/xf86Xinput.c
+++ b/hw/xfree86/common/xf86Xinput.c
@@ -393,7 +393,6 @@ static DeviceIntPtr
 xf86ActivateDevice(InputInfoPtr pInfo)
 {
     DeviceIntPtr dev;
-    Atom atom;
 
     dev = AddInputDevice(serverClient, pInfo->device_control, TRUE);
 
@@ -403,7 +402,7 @@ xf86ActivateDevice(InputInfoPtr pInfo)
         return NULL;
     }
 
-    atom = MakeAtom(pInfo->type_name, strlen(pInfo->type_name), TRUE);
+    Atom atom = dixAddAtom(pInfo->type_name);
     AssignTypeAndName(dev, atom, pInfo->name);
     dev->public.devicePrivate = pInfo;
     pInfo->dev = dev;

--- a/hw/xfree86/ddc/ddcProperty.c
+++ b/hw/xfree86/ddc/ddcProperty.c
@@ -51,8 +51,7 @@ edidSize(const xf86MonPtr DDC)
 static void
 setRootWindowEDID(ScreenPtr pScreen, xf86MonPtr DDC)
 {
-    Atom atom = MakeAtom(EDID1_ATOM_NAME, strlen(EDID1_ATOM_NAME), TRUE);
-
+    Atom atom = dixAddAtom(EDID1_ATOM_NAME);
     dixChangeWindowProperty(serverClient, pScreen->root, atom, XA_INTEGER,
                             8, PropModeReplace, edidSize(DDC), DDC->rawData,
                             FALSE);

--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
@@ -34,6 +34,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#include "dix/dix_priv.h"
 #include "os/fmt.h"
 
 #include "dumb_bo.h"
@@ -3050,7 +3051,7 @@ drmmode_output_create_resources(xf86OutputPtr output)
 
     /* Create CONNECTOR_ID property */
     {
-        Atom    name = MakeAtom("CONNECTOR_ID", 12, TRUE);
+        Atom    name = dixAddAtom("CONNECTOR_ID");
         INT32   value = mode_output->connector_id;
 
         if (name != BAD_RESOURCE) {
@@ -3072,7 +3073,7 @@ drmmode_output_create_resources(xf86OutputPtr output)
     }
 
     if (drmmode->use_ctm) {
-        Atom name = MakeAtom("CTM", 3, TRUE);
+        Atom name = dixAddAtom("CTM");
 
         if (name != BAD_RESOURCE) {
             drmmode_output->ctm_atom = name;
@@ -3109,8 +3110,7 @@ drmmode_output_create_resources(xf86OutputPtr output)
             p->atoms = calloc(p->num_atoms, sizeof(Atom));
             if (!p->atoms)
                 continue;
-            p->atoms[0] =
-                MakeAtom(drmmode_prop->name, strlen(drmmode_prop->name), TRUE);
+            p->atoms[0] = dixAddAtom(drmmode_prop->name);
             prop_range[0] = drmmode_prop->values[0];
             prop_range[1] = drmmode_prop->values[1];
             err = RRConfigureOutputProperty(output->randr_output, p->atoms[0],
@@ -3135,12 +3135,10 @@ drmmode_output_create_resources(xf86OutputPtr output)
             p->atoms = calloc(p->num_atoms, sizeof(Atom));
             if (!p->atoms)
                 continue;
-            p->atoms[0] =
-                MakeAtom(drmmode_prop->name, strlen(drmmode_prop->name), TRUE);
+            p->atoms[0] = dixAddAtom(drmmode_prop->name);
             for (j = 1; j <= drmmode_prop->count_enums; j++) {
                 struct drm_mode_property_enum *e = &drmmode_prop->enums[j - 1];
-
-                p->atoms[j] = MakeAtom(e->name, strlen(e->name), TRUE);
+                p->atoms[j] = dixAddAtom(e->name);
             }
             err = RRConfigureOutputProperty(output->randr_output, p->atoms[0],
                                             FALSE, FALSE,

--- a/hw/xfree86/modes/xf86Crtc.c
+++ b/hw/xfree86/modes/xf86Crtc.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <stdio.h>
 
+#include "dix/dix_priv.h"
 #include "dix/screen_hooks_priv.h"
 #include "randr/randrstr_priv.h"
 
@@ -3111,7 +3112,7 @@ xf86DisableUnusedFunctions(ScrnInfoPtr pScrn)
 static void
 xf86OutputSetEDIDProperty(xf86OutputPtr output, void *data, int data_len)
 {
-    Atom edid_atom = MakeAtom(EDID_ATOM_NAME, sizeof(EDID_ATOM_NAME) - 1, TRUE);
+    Atom edid_atom = dixAddAtom(EDID_ATOM_NAME);
 
     /* This may get called before the RandR resources have been created */
     if (output->randr_output == NULL)
@@ -3132,7 +3133,7 @@ xf86OutputSetEDIDProperty(xf86OutputPtr output, void *data, int data_len)
 static void
 xf86OutputSetTileProperty(xf86OutputPtr output)
 {
-    Atom tile_atom = MakeAtom(TILE_ATOM_NAME, sizeof(TILE_ATOM_NAME) - 1, TRUE);
+    Atom tile_atom = dixAddAtom(TILE_ATOM_NAME);
 
     /* This may get called before the RandR resources have been created */
     if (output->randr_output == NULL)

--- a/hw/xfree86/modes/xf86RandR12.c
+++ b/hw/xfree86/modes/xf86RandR12.c
@@ -26,6 +26,7 @@
 
 #include <X11/extensions/render.h>
 
+#include "dix/dix_priv.h"
 #include "dix/input_priv.h"
 #include "dix/screenint_priv.h"
 
@@ -1803,7 +1804,7 @@ xf86RandR12CreateMonitors(ScreenPtr pScreen)
             return;
         monitor->pScreen = pScreen;
         snprintf(buf, 25, "Auto-Monitor-%d", tile_info->group_id);
-        monitor->name = MakeAtom(buf, strlen(buf), TRUE);
+        monitor->name = dixAddAtom(buf);
         monitor->primary = 0;
         monitor->automatic = TRUE;
         memset(&monitor->geometry.box, 0, sizeof(monitor->geometry.box));

--- a/hw/xnest/Font.c
+++ b/hw/xnest/Font.c
@@ -22,6 +22,8 @@ is" without express or implied warranty.
 #include <X11/fonts/fontstruct.h>
 #include <X11/fonts/libxfont2.h>
 
+#include "dix/dix_priv.h"
+
 #include "misc.h"
 #include "regionstr.h"
 #include "dixfontstr.h"
@@ -37,7 +39,6 @@ int xnestFontPrivateIndex;
 Bool
 xnestRealizeFont(ScreenPtr pScreen, FontPtr pFont)
 {
-    Atom name_atom, value_atom;
     int nprops;
     FontPropPtr props;
     int i;
@@ -45,8 +46,8 @@ xnestRealizeFont(ScreenPtr pScreen, FontPtr pFont)
 
     xfont2_font_set_private(pFont, xnestFontPrivateIndex, NULL);
 
-    name_atom = MakeAtom("FONT", 4, TRUE);
-    value_atom = 0L;
+    Atom name_atom = dixAddAtom("FONT");
+    Atom value_atom = 0L;
 
     nprops = pFont->info.nprops;
     props = pFont->info.props;

--- a/hw/xquartz/applewm.c
+++ b/hw/xquartz/applewm.c
@@ -34,6 +34,7 @@
 
 #include <errno.h>
 
+#include "dix/dix_priv.h"
 #include "dix/property_priv.h"
 
 #include "quartz.h"
@@ -62,7 +63,7 @@
         static Atom atom;                                           \
         if (generation != serverGeneration) {                       \
             generation = serverGeneration;                          \
-            atom = MakeAtom(atom_name, strlen(atom_name), TRUE);  \
+            atom = dixAddAtom(atom_name);                           \
         }                                                           \
         return atom;                                                \
     }

--- a/hw/xquartz/xpr/xprFrame.c
+++ b/hw/xquartz/xpr/xprFrame.c
@@ -29,6 +29,8 @@
 
 #include <dix-config.h>
 
+#include "dix/dix_priv.h"
+
 #include "xpr.h"
 #include "rootlessCommon.h"
 #include <Xplugin.h>
@@ -49,7 +51,7 @@
         static Atom atom;                                           \
         if (generation != serverGeneration) {                       \
             generation = serverGeneration;                          \
-            atom = MakeAtom(atom_name, strlen(atom_name), TRUE);  \
+            atom = dixAddAtom(atom_name);                           \
         }                                                           \
         return atom;                                                \
     }

--- a/hw/xwin/win.h
+++ b/hw/xwin/win.h
@@ -242,7 +242,7 @@ static Atom func (void) {					\
     static Atom atom;						\
     if (generation != serverGeneration) {			\
 	generation = serverGeneration;				\
-	atom = MakeAtom (atom_name, strlen (atom_name), TRUE);	\
+	atom = dixAddAtom(atom_name);				\
     }								\
     return atom;						\
 }

--- a/miext/rootless/rootlessWindow.c
+++ b/miext/rootless/rootlessWindow.c
@@ -64,7 +64,7 @@ extern Bool no_configure_window;
     static Atom atom;                                           \
     if (generation != serverGeneration) {                       \
       generation = serverGeneration;                          \
-      atom = MakeAtom (atom_name, strlen (atom_name), TRUE);  \
+      atom = dixAddAtom(atom_name);                             \
     }                                                           \
     return atom;                                                \
   }

--- a/randr/rrcrtc.c
+++ b/randr/rrcrtc.c
@@ -24,6 +24,7 @@
 
 #include <X11/Xatom.h>
 
+#include "dix/dix_priv.h"
 #include "randr/randrstr_priv.h"
 #include "randr/rrdispatch_priv.h"
 #include "os/bug_priv.h"
@@ -453,7 +454,7 @@ rrGetPixmapSharingSyncProp(int numOutputs, RROutputPtr * outputs)
     /* Determine if the user wants prime syncing */
     int o;
     const char *syncStr = PRIME_SYNC_PROP;
-    Atom syncProp = MakeAtom(syncStr, strlen(syncStr), FALSE);
+    Atom syncProp = dixGetAtomID(syncStr);
     if (syncProp == None)
         return TRUE;
 
@@ -477,7 +478,7 @@ rrSetPixmapSharingSyncProp(char val, int numOutputs, RROutputPtr * outputs)
 {
     int o;
     const char *syncStr = PRIME_SYNC_PROP;
-    Atom syncProp = MakeAtom(syncStr, strlen(syncStr), FALSE);
+    Atom syncProp = dixGetAtomID(syncStr);
     if (syncProp == None)
         return;
 
@@ -714,10 +715,9 @@ static Bool
 rrCheckEmulated(RROutputPtr output)
 {
     const char *emulStr = XRANDR_EMULATION_PROP;
-    Atom emulProp;
     RRPropertyValuePtr val;
 
-    emulProp = MakeAtom(emulStr, strlen(emulStr), FALSE);
+    Atom emulProp = dixGetAtomID(emulStr);
     if (emulProp == None)
         return FALSE;
 

--- a/randr/rrmonitor.c
+++ b/randr/rrmonitor.c
@@ -37,7 +37,7 @@ RRMonitorCrtcName(RRCrtcPtr crtc)
         return MakeAtom(output->name, output->nameLength, TRUE);
     }
     sprintf(name, "Monitor-%08lx", (unsigned long int)crtc->id);
-    return MakeAtom(name, strlen(name), TRUE);
+    return dixAddAtom(name);
 }
 
 static Bool

--- a/randr/rroutput.c
+++ b/randr/rroutput.c
@@ -70,7 +70,6 @@ RROutputCreate(ScreenPtr pScreen,
     RROutputPtr output;
     RROutputPtr *outputs;
     rrScrPrivPtr pScrPriv;
-    Atom nonDesktopAtom;
     Atom DPIAtom;
 
     if (!RRInit())
@@ -103,7 +102,7 @@ RROutputCreate(ScreenPtr pScreen,
 
     pScrPriv->outputs[pScrPriv->numOutputs++] = output;
 
-    nonDesktopAtom = MakeAtom(RR_PROPERTY_NON_DESKTOP, strlen(RR_PROPERTY_NON_DESKTOP), TRUE);
+    Atom nonDesktopAtom = dixAddAtom(RR_PROPERTY_NON_DESKTOP);
     if (nonDesktopAtom != BAD_RESOURCE) {
         static const INT32 values[2] = { 0, 1 };
         (void) RRConfigureOutputProperty(output, nonDesktopAtom, FALSE, FALSE, FALSE,
@@ -112,7 +111,7 @@ RROutputCreate(ScreenPtr pScreen,
     RROutputSetNonDesktop(output, FALSE);
 
     /* Initialize DPI property for all outputs. */
-    DPIAtom = MakeAtom("DPI", 3, TRUE);
+    DPIAtom = dixAddAtom("DPI");
     if (DPIAtom != BAD_RESOURCE) {
         static const INT32 values[2] = { 0, 960 }; // arbitrary range
         (void) RRConfigureOutputProperty(output, DPIAtom, FALSE, TRUE, FALSE,
@@ -323,7 +322,7 @@ Bool
 RROutputSetNonDesktop(RROutputPtr output, Bool nonDesktop)
 {
     const char *nonDesktopStr = RR_PROPERTY_NON_DESKTOP;
-    Atom nonDesktopProp = MakeAtom(nonDesktopStr, strlen(nonDesktopStr), TRUE);
+    Atom nonDesktopProp = dixAddAtom(nonDesktopStr);
     uint32_t value = nonDesktop ? 1 : 0;
 
     if (nonDesktopProp == None || nonDesktopProp == BAD_RESOURCE)

--- a/randr/rrproperty.c
+++ b/randr/rrproperty.c
@@ -140,7 +140,7 @@ static void
 RRNoticePropertyChange(RROutputPtr output, Atom property, RRPropertyValuePtr value)
 {
     const char *non_desktop_str = RR_PROPERTY_NON_DESKTOP;
-    Atom non_desktop_prop = MakeAtom(non_desktop_str, strlen(non_desktop_str), FALSE);
+    Atom non_desktop_prop = dixGetAtomID(non_desktop_str);
 
     if (property == non_desktop_prop) {
         if (value->type == XA_INTEGER && value->format == 32 && value->size >= 1) {

--- a/randr/rrprovider.c
+++ b/randr/rrprovider.c
@@ -275,7 +275,7 @@ RRInitPrimeSyncProps(ScreenPtr pScreen)
     rrScrPrivPtr pScrPriv = rrGetScrPriv(pScreen);
 
     const char *syncStr = PRIME_SYNC_PROP;
-    Atom syncProp = MakeAtom(syncStr, strlen(syncStr), TRUE);
+    Atom syncProp = dixGetAtomID(syncStr);
 
     int defaultVal = TRUE;
     INT32 validVals[2] = {FALSE, TRUE};
@@ -306,7 +306,7 @@ RRFiniPrimeSyncProps(ScreenPtr pScreen)
     int i;
 
     const char *syncStr = PRIME_SYNC_PROP;
-    Atom syncProp = MakeAtom(syncStr, strlen(syncStr), FALSE);
+    Atom syncProp = dixGetAtomID(syncStr);
     if (syncProp == None)
         return;
 

--- a/xfixes/cursor.c
+++ b/xfixes/cursor.c
@@ -413,12 +413,12 @@ ProcXFixesSetCursorName(ClientPtr client)
     char *tchar;
 
     REQUEST(xXFixesSetCursorNameReq);
-    Atom atom;
 
     REQUEST_FIXED_SIZE(xXFixesSetCursorNameReq, stuff->nbytes);
     VERIFY_CURSOR(pCursor, stuff->cursor, client, DixSetAttrAccess);
     tchar = (char *) &stuff[1];
-    atom = MakeAtom(tchar, stuff->nbytes, TRUE);
+    tchar[stuff->nbytes] = 0;
+    Atom atom = dixGetAtomID(tchar);
     if (atom == BAD_RESOURCE)
         return BadAlloc;
 
@@ -692,7 +692,6 @@ int
 ProcXFixesChangeCursorByName(ClientPtr client)
 {
     CursorPtr pSource;
-    Atom name;
     char *tchar;
 
     REQUEST(xXFixesChangeCursorByNameReq);
@@ -701,7 +700,8 @@ ProcXFixesChangeCursorByName(ClientPtr client)
     VERIFY_CURSOR(pSource, stuff->source, client,
                   DixReadAccess | DixGetAttrAccess);
     tchar = (char *) &stuff[1];
-    name = MakeAtom(tchar, stuff->nbytes, FALSE);
+    tchar[stuff->nbytes] = 0;
+    Atom name = dixGetAtomID(tchar);
     if (name)
         ReplaceCursor(pSource, TestForCursorName, &name);
     return Success;

--- a/xkb/ddxBeep.c
+++ b/xkb/ddxBeep.c
@@ -32,6 +32,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <X11/keysym.h>
 #include <X11/extensions/XI.h>
 
+#include "dix/dix_priv.h"
 #include "xkb/xkbsrv_priv.h"
 
 #include "inputstr.h"
@@ -90,26 +91,24 @@ static char doesPitch = 1;
 #define	STICKY_UNLOCK	"AX_StickyUnlock"
 #define	BOUNCE_REJECT	"AX_BounceKeyReject"
 
-#define	MAKE_ATOM(a)	MakeAtom(a,sizeof(a)-1,TRUE)
-
 static void
 _XkbDDXBeepInitAtoms(void)
 {
-    featureOn = MAKE_ATOM(FEATURE_ON);
-    featureOff = MAKE_ATOM(FEATURE_OFF);
-    featureChange = MAKE_ATOM(FEATURE_CHANGE);
-    ledOn = MAKE_ATOM(LED_ON);
-    ledOff = MAKE_ATOM(LED_OFF);
-    ledChange = MAKE_ATOM(LED_CHANGE);
-    slowWarn = MAKE_ATOM(SLOW_WARN);
-    slowPress = MAKE_ATOM(SLOW_PRESS);
-    slowReject = MAKE_ATOM(SLOW_REJECT);
-    slowAccept = MAKE_ATOM(SLOW_ACCEPT);
-    slowRelease = MAKE_ATOM(SLOW_RELEASE);
-    stickyLatch = MAKE_ATOM(STICKY_LATCH);
-    stickyLock = MAKE_ATOM(STICKY_LOCK);
-    stickyUnlock = MAKE_ATOM(STICKY_UNLOCK);
-    bounceReject = MAKE_ATOM(BOUNCE_REJECT);
+    featureOn = dixAddAtom(FEATURE_ON);
+    featureOff = dixAddAtom(FEATURE_OFF);
+    featureChange = dixAddAtom(FEATURE_CHANGE);
+    ledOn = dixAddAtom(LED_ON);
+    ledOff = dixAddAtom(LED_OFF);
+    ledChange = dixAddAtom(LED_CHANGE);
+    slowWarn = dixAddAtom(SLOW_WARN);
+    slowPress = dixAddAtom(SLOW_PRESS);
+    slowReject = dixAddAtom(SLOW_REJECT);
+    slowAccept = dixAddAtom(SLOW_ACCEPT);
+    slowRelease = dixAddAtom(SLOW_RELEASE);
+    stickyLatch = dixAddAtom(STICKY_LATCH);
+    stickyLock = dixAddAtom(STICKY_LOCK);
+    stickyUnlock = dixAddAtom(STICKY_UNLOCK);
+    bounceReject = dixAddAtom(BOUNCE_REJECT);
     return;
 }
 

--- a/xkb/xkbDflts.h
+++ b/xkb/xkbDflts.h
@@ -1,13 +1,12 @@
-/* This file generated automatically by xkbcomp */
-/* DO  NOT EDIT */
 #ifdef HAVE_DIX_CONFIG_H
 #include <dix-config.h>
 #endif
 
+#include "dix/dix_priv.h"
+
 #ifndef DEFAULT_H
 #define DEFAULT_H 1
 
-#define GET_ATOM(d,s)	MakeAtom(s,strlen(s),1)
 #define DPYTYPE	char *
 #define NUM_KEYS	1
 
@@ -136,33 +135,33 @@ static XkbKeyTypeRec dflt_types[] = {
 static void
 initTypeNames(DPYTYPE dpy)
 {
-    dflt_types[0].name = GET_ATOM(dpy, "ONE_LEVEL");
-    lnames_ONE_LEVEL[0] = GET_ATOM(dpy, "Any");
-    dflt_types[1].name = GET_ATOM(dpy, "TWO_LEVEL");
-    lnames_TWO_LEVEL[0] = GET_ATOM(dpy, "Base");
-    lnames_TWO_LEVEL[1] = GET_ATOM(dpy, "Shift");
-    dflt_types[2].name = GET_ATOM(dpy, "ALPHABETIC");
-    lnames_ALPHABETIC[0] = GET_ATOM(dpy, "Base");
-    lnames_ALPHABETIC[1] = GET_ATOM(dpy, "Caps");
-    dflt_types[3].name = GET_ATOM(dpy, "KEYPAD");
-    lnames_KEYPAD[0] = GET_ATOM(dpy, "Base");
-    lnames_KEYPAD[1] = GET_ATOM(dpy, "Number");
-    dflt_types[4].name = GET_ATOM(dpy, "PC_BREAK");
-    lnames_PC_BREAK[0] = GET_ATOM(dpy, "Base");
-    lnames_PC_BREAK[1] = GET_ATOM(dpy, "Control");
-    dflt_types[5].name = GET_ATOM(dpy, "PC_SYSRQ");
-    lnames_PC_SYSRQ[0] = GET_ATOM(dpy, "Base");
-    lnames_PC_SYSRQ[1] = GET_ATOM(dpy, "Alt");
-    dflt_types[6].name = GET_ATOM(dpy, "CTRL+ALT");
-    lnames_CTRL_ALT[0] = GET_ATOM(dpy, "Base");
-    lnames_CTRL_ALT[1] = GET_ATOM(dpy, "Ctrl+Alt");
-    dflt_types[7].name = GET_ATOM(dpy, "THREE_LEVEL");
-    lnames_THREE_LEVEL[0] = GET_ATOM(dpy, "Base");
-    lnames_THREE_LEVEL[1] = GET_ATOM(dpy, "Shift");
-    lnames_THREE_LEVEL[2] = GET_ATOM(dpy, "Level3");
-    dflt_types[8].name = GET_ATOM(dpy, "SHIFT+ALT");
-    lnames_SHIFT_ALT[0] = GET_ATOM(dpy, "Base");
-    lnames_SHIFT_ALT[1] = GET_ATOM(dpy, "Shift+Alt");
+    dflt_types[0].name = dixAddAtom("ONE_LEVEL");
+    lnames_ONE_LEVEL[0] = dixAddAtom("Any");
+    dflt_types[1].name = dixAddAtom("TWO_LEVEL");
+    lnames_TWO_LEVEL[0] = dixAddAtom("Base");
+    lnames_TWO_LEVEL[1] = dixAddAtom("Shift");
+    dflt_types[2].name = dixAddAtom("ALPHABETIC");
+    lnames_ALPHABETIC[0] = dixAddAtom("Base");
+    lnames_ALPHABETIC[1] = dixAddAtom("Caps");
+    dflt_types[3].name = dixAddAtom("KEYPAD");
+    lnames_KEYPAD[0] = dixAddAtom("Base");
+    lnames_KEYPAD[1] = dixAddAtom("Number");
+    dflt_types[4].name = dixAddAtom("PC_BREAK");
+    lnames_PC_BREAK[0] = dixAddAtom("Base");
+    lnames_PC_BREAK[1] = dixAddAtom("Control");
+    dflt_types[5].name = dixAddAtom("PC_SYSRQ");
+    lnames_PC_SYSRQ[0] = dixAddAtom("Base");
+    lnames_PC_SYSRQ[1] = dixAddAtom("Alt");
+    dflt_types[6].name = dixAddAtom("CTRL+ALT");
+    lnames_CTRL_ALT[0] = dixAddAtom("Base");
+    lnames_CTRL_ALT[1] = dixAddAtom("Ctrl+Alt");
+    dflt_types[7].name = dixAddAtom("THREE_LEVEL");
+    lnames_THREE_LEVEL[0] = dixAddAtom("Base");
+    lnames_THREE_LEVEL[1] = dixAddAtom("Shift");
+    lnames_THREE_LEVEL[2] = dixAddAtom("Level3");
+    dflt_types[8].name = dixAddAtom("SHIFT+ALT");
+    lnames_SHIFT_ALT[0] = dixAddAtom("Base");
+    lnames_SHIFT_ALT[1] = dixAddAtom("Shift+Alt");
 }
 
 /* compat name is "default" */
@@ -461,11 +460,11 @@ static XkbCompatMapRec compatMap = {
 static void
 initIndicatorNames(DPYTYPE dpy, XkbDescPtr xkb)
 {
-    xkb->names->indicators[0] = GET_ATOM(dpy, "Caps Lock");
-    xkb->names->indicators[1] = GET_ATOM(dpy, "Num Lock");
-    xkb->names->indicators[2] = GET_ATOM(dpy, "Shift Lock");
-    xkb->names->indicators[3] = GET_ATOM(dpy, "Mouse Keys");
-    xkb->names->indicators[4] = GET_ATOM(dpy, "Scroll Lock");
-    xkb->names->indicators[5] = GET_ATOM(dpy, "Group 2");
+    xkb->names->indicators[0] = dixAddAtom("Caps Lock");
+    xkb->names->indicators[1] = dixAddAtom("Num Lock");
+    xkb->names->indicators[2] = dixAddAtom("Shift Lock");
+    xkb->names->indicators[3] = dixAddAtom("Mouse Keys");
+    xkb->names->indicators[4] = dixAddAtom("Scroll Lock");
+    xkb->names->indicators[5] = dixAddAtom("Group 2");
 }
 #endif                          /* DEFAULT_H */

--- a/xkb/xkbInit.c
+++ b/xkb/xkbInit.c
@@ -53,8 +53,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #define      _XKB_RF_NAMES_PROP_ATOM         "_XKB_RULES_NAMES"
 
-#define	CREATE_ATOM(s)	MakeAtom(s,sizeof(s)-1,1)
-
 #if defined(__alpha) || defined(__alpha__)
 #define	LED_COMPOSE	2
 #define LED_CAPS	3
@@ -387,7 +385,7 @@ XkbInitNames(XkbSrvInfoPtr xkbi)
     xkb = xkbi->desc;
     if ((rtrn = XkbAllocNames(xkb, XkbAllNamesMask, 0, 0)) != Success)
         return rtrn;
-    unknown = CREATE_ATOM("unknown");
+    unknown = dixAddAtom("unknown");
     names = xkb->names;
     if (names->keycodes == None)
         names->keycodes = unknown;
@@ -403,25 +401,25 @@ XkbInitNames(XkbSrvInfoPtr xkbi)
         names->compat = unknown;
     if (!(xkb->defined & XkmVirtualModsMask)) {
         if (names->vmods[vmod_NumLock] == None)
-            names->vmods[vmod_NumLock] = CREATE_ATOM("NumLock");
+            names->vmods[vmod_NumLock] = dixAddAtom("NumLock");
         if (names->vmods[vmod_Alt] == None)
-            names->vmods[vmod_Alt] = CREATE_ATOM("Alt");
+            names->vmods[vmod_Alt] = dixAddAtom("Alt");
         if (names->vmods[vmod_AltGr] == None)
-            names->vmods[vmod_AltGr] = CREATE_ATOM("ModeSwitch");
+            names->vmods[vmod_AltGr] = dixAddAtom("ModeSwitch");
     }
 
     if (!(xkb->defined & XkmIndicatorsMask) ||
         !(xkb->defined & XkmGeometryMask)) {
         initIndicatorNames(NULL, xkb);
         if (names->indicators[LED_CAPS - 1] == None)
-            names->indicators[LED_CAPS - 1] = CREATE_ATOM("Caps Lock");
+            names->indicators[LED_CAPS - 1] = dixAddAtom("Caps Lock");
         if (names->indicators[LED_NUM - 1] == None)
-            names->indicators[LED_NUM - 1] = CREATE_ATOM("Num Lock");
+            names->indicators[LED_NUM - 1] = dixAddAtom("Num Lock");
         if (names->indicators[LED_SCROLL - 1] == None)
-            names->indicators[LED_SCROLL - 1] = CREATE_ATOM("Scroll Lock");
+            names->indicators[LED_SCROLL - 1] = dixAddAtom("Scroll Lock");
 #ifdef LED_COMPOSE
         if (names->indicators[LED_COMPOSE - 1] == None)
-            names->indicators[LED_COMPOSE - 1] = CREATE_ATOM("Compose");
+            names->indicators[LED_COMPOSE - 1] = dixAddAtom("Compose");
 #endif
     }
 


### PR DESCRIPTION
add helpers dixGetAtomID() and dixAddAtom() and use them instead of directly calling MakeAtom() or extra local macros.
 