### PR TITLE
damage: drop using HAVE_DIX_CONFIG_H

### DIFF
--- a/damageext/damageextint.h
+++ b/damageext/damageextint.h
@@ -19,13 +19,10 @@
  * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  * PERFORMANCE OF THIS SOFTWARE.
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #ifndef _DAMAGEEXTINT_H_
 #define _DAMAGEEXTINT_H_
+
+#include <dix-config.h>
 
 #include <X11/X.h>
 #include <X11/Xproto.h>


### PR DESCRIPTION
This symbol is always defined, and the header is always present, so no need to check for it.