### PR TITLE
randr: fix prime sync atom not created correctly

### DIFF
--- a/randr/rrprovider.c
+++ b/randr/rrprovider.c
@@ -275,7 +275,7 @@ RRInitPrimeSyncProps(ScreenPtr pScreen)
     rrScrPrivPtr pScrPriv = rrGetScrPriv(pScreen);
 
     const char *syncStr = PRIME_SYNC_PROP;
-    Atom syncProp = dixGetAtomID(syncStr);
+    Atom syncProp = dixAddAtom(syncStr);
 
     int defaultVal = TRUE;
     INT32 validVals[2] = {FALSE, TRUE};


### PR DESCRIPTION
The commit 30cec786e5fe791a2761cdf12a5d5e7fadae6c9e incorrectly changed RRInitPrimeSyncProps to not create the atom if it doesn't exist.