### PR TITLE
kdrive: move ephyr build option check into kdrive's meson.build

### DIFF
--- a/hw/kdrive/meson.build
+++ b/hw/kdrive/meson.build
@@ -1,2 +1,10 @@
-subdir('src')
-subdir('ephyr')
+build_xephyr = get_option('xephyr')
+build_kdrive = build_xephyr
+
+if build_kdrive
+    subdir('src')
+endif
+
+if build_xephyr
+    subdir('ephyr')
+endif

--- a/hw/meson.build
+++ b/hw/meson.build
@@ -1,6 +1,4 @@
-if build_xephyr
-    subdir('kdrive')
-endif
+subdir('kdrive')
 
 if build_xvfb
     subdir('vfb')

--- a/meson.build
+++ b/meson.build
@@ -237,7 +237,6 @@ if build_xquartz
     build_rootless = true
 endif
 
-build_xephyr = get_option('xephyr')
 build_xvfb = get_option('xvfb')
 
 summary({


### PR DESCRIPTION
As more kdrive-based servers are coming, it's time to refactor the meson structure a little bit, so all kdrive specific logic is in its own subdir.