### PR TITLE
glamor: #include <fbpict.h> in glamor.h

### DIFF
--- a/glamor/glamor.h
+++ b/glamor/glamor.h
@@ -34,6 +34,7 @@
 #include <gcstruct.h>
 #include <picturestr.h>
 #include <fb.h>
+#include <fbpict.h>
 #ifdef GLAMOR_FOR_XORG
 #include <xf86xv.h>
 #endif

--- a/glamor/glamor_addtraps.c
+++ b/glamor/glamor_addtraps.c
@@ -27,8 +27,6 @@
  */
 #include <dix-config.h>
 
-#include "fb/fbpict.h"
-
 #include "glamor_priv.h"
 
 void

--- a/glamor/glamor_render.c
+++ b/glamor/glamor_render.c
@@ -39,7 +39,7 @@
 
 #include "glamor_priv.h"
 #include "mipict.h"
-#include "fbpict.h"
+
 #if 0
 //#define DEBUGF(str, ...)  do {} while(0)
 #define DEBUGF(str, ...) ErrorF(str, ##__VA_ARGS__)

--- a/glamor/glamor_trapezoid.c
+++ b/glamor/glamor_trapezoid.c
@@ -34,7 +34,6 @@
 #include "glamor_priv.h"
 
 #include "mipict.h"
-#include "fbpict.h"
 
 /**
  * Creates an appropriate picture for temp mask use.


### PR DESCRIPTION
This header is needed both by glamor and other drivers that use glamor

Fixes: https://github.com/X11Libre/ports-gentoo/issues/50
Fixes: https://github.com/X11Libre/xf86-video-amdgpu/issues/7

@metux @dec05eba @mikedld @ONykyf Thoughts?