### PR TITLE
os: ospoll: drop not needed including of X11 headers

### DIFF
--- a/os/ospoll.c
+++ b/os/ospoll.c
@@ -24,8 +24,6 @@
 
 #include <stdlib.h>
 #include <unistd.h>
-#include <X11/X.h>
-#include <X11/Xproto.h>
 
 #include "os/xserver_poll.h"
 


### PR DESCRIPTION
Those just conflicting with win32/mingw headers on type `BOOL`.