### PR TITLE
os: move X_NOTIFY_* defines to separate header

### DIFF
--- a/include/fd_notify.h
+++ b/include/fd_notify.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ *
+ * @brief: defines needed for SetNotifyFd() as well as ospoll
+ */
+#ifndef _XSERVER_INCLUDE_FDNOTIFY_H
+#define _XSERVER_INCLUDE_FDNOTIFY_H
+
+#define X_NOTIFY_NONE   0x0
+#define X_NOTIFY_READ   0x1
+#define X_NOTIFY_WRITE  0x2
+#define X_NOTIFY_ERROR  0x4     /* don't need to select for, always reported */
+
+#endif /* _XSERVER_INCLUDE_FDNOTIFY_H */

--- a/include/meson.build
+++ b/include/meson.build
@@ -440,6 +440,7 @@ if build_xorg
             'extension.h',
             'extinit.h',
             'extnsionst.h',
+            'fd_notify.h',
             'fourcc.h',
             'gc.h',
             'gcstruct.h',

--- a/include/os.h
+++ b/include/os.h
@@ -98,10 +98,7 @@ extern _X_EXPORT int WriteToClient(ClientPtr /*who */ , int /*count */ ,
 
 typedef void (*NotifyFdProcPtr)(int fd, int ready, void *data);
 
-#define X_NOTIFY_NONE   0x0
-#define X_NOTIFY_READ   0x1
-#define X_NOTIFY_WRITE  0x2
-#define X_NOTIFY_ERROR  0x4     /* don't need to select for, always reported */
+#include "fd_notify.h"
 
 extern _X_EXPORT Bool SetNotifyFd(int fd, NotifyFdProcPtr notify_fd, int mask, void *data);
 

--- a/os/ospoll.c
+++ b/os/ospoll.c
@@ -27,6 +27,7 @@
 #include <X11/X.h>
 #include <X11/Xproto.h>
 
+#include "include/fd_notify.h"
 #include "os/xserver_poll.h"
 
 #include "misc.h"               /* for typedef of pointer */


### PR DESCRIPTION
These defines are already public, used by consumers of SetNotifyFd(), but also needed in places where os.h cannot be included.