### PR TITLE
os: ospoll: use stdbool instead of X11's Bool

### DIFF
--- a/os/ospoll.c
+++ b/os/ospoll.c
@@ -115,7 +115,7 @@ struct ospoll {
     struct ospollfd     *osfds;
     int                 num;
     int                 size;
-    Bool                changed;
+    bool                changed;
 };
 
 #endif
@@ -269,7 +269,7 @@ ospoll_destroy(struct ospoll *ospoll)
 #endif
 }
 
-Bool
+bool
 ospoll_add(struct ospoll *ospoll, int fd,
            enum ospoll_trigger trigger,
            void (*callback)(int fd, int xevents, void *data),
@@ -284,7 +284,7 @@ ospoll_add(struct ospoll *ospoll, int fd,
 
             new_fds = reallocarray(ospoll->fds, new_size, sizeof (ospoll->fds[0]));
             if (!new_fds)
-                return FALSE;
+                return false;
             ospoll->fds = new_fds;
             ospoll->size = new_size;
         }
@@ -306,7 +306,7 @@ ospoll_add(struct ospoll *ospoll, int fd,
     if (pos < 0) {
         osfd = calloc(1, sizeof (struct ospollfd));
         if (!osfd)
-            return FALSE;
+            return false;
 
         if (ospoll->num >= ospoll->size) {
             struct ospollfd **new_fds;
@@ -315,7 +315,7 @@ ospoll_add(struct ospoll *ospoll, int fd,
             new_fds = reallocarray(ospoll->fds, new_size, sizeof (ospoll->fds[0]));
             if (!new_fds) {
                 free (osfd);
-                return FALSE;
+                return false;
             }
             ospoll->fds = new_fds;
             ospoll->size = new_size;
@@ -344,7 +344,7 @@ ospoll_add(struct ospoll *ospoll, int fd,
 
         osfd = calloc(1, sizeof (struct ospollfd));
         if (!osfd)
-            return FALSE;
+            return false;
 
         if (ospoll->num >= ospoll->size) {
             struct ospollfd **new_fds;
@@ -353,7 +353,7 @@ ospoll_add(struct ospoll *ospoll, int fd,
             new_fds = reallocarray(ospoll->fds, new_size, sizeof (ospoll->fds[0]));
             if (!new_fds) {
                 free (osfd);
-                return FALSE;
+                return false;
             }
             ospoll->fds = new_fds;
             ospoll->size = new_size;
@@ -365,7 +365,7 @@ ospoll_add(struct ospoll *ospoll, int fd,
             ev.events |= EPOLLET;
         if (epoll_ctl(ospoll->epoll_fd, EPOLL_CTL_ADD, fd, &ev) == -1) {
             free(osfd);
-            return FALSE;
+            return false;
         }
         osfd->fd = fd;
         osfd->xevents = 0;
@@ -390,11 +390,11 @@ ospoll_add(struct ospoll *ospoll, int fd,
 
             new_fds = reallocarray(ospoll->fds, new_size, sizeof (ospoll->fds[0]));
             if (!new_fds)
-                return FALSE;
+                return false;
             ospoll->fds = new_fds;
             new_osfds = reallocarray(ospoll->osfds, new_size, sizeof (ospoll->osfds[0]));
             if (!new_osfds)
-                return FALSE;
+                return false;
             ospoll->osfds = new_osfds;
             ospoll->size = new_size;
         }
@@ -402,7 +402,7 @@ ospoll_add(struct ospoll *ospoll, int fd,
         array_insert(ospoll->fds, ospoll->num, sizeof (ospoll->fds[0]), pos);
         array_insert(ospoll->osfds, ospoll->num, sizeof (ospoll->osfds[0]), pos);
         ospoll->num++;
-        ospoll->changed = TRUE;
+        ospoll->changed = true;
 
         ospoll->fds[pos].fd = fd;
         ospoll->fds[pos].events = 0;
@@ -413,7 +413,7 @@ ospoll_add(struct ospoll *ospoll, int fd,
     ospoll->osfds[pos].callback = callback;
     ospoll->osfds[pos].data = data;
 #endif
-    return TRUE;
+    return true;
 }
 
 void
@@ -458,7 +458,7 @@ ospoll_remove(struct ospoll *ospoll, int fd)
         array_delete(ospoll->fds, ospoll->num, sizeof (ospoll->fds[0]), pos);
         array_delete(ospoll->osfds, ospoll->num, sizeof (ospoll->osfds[0]), pos);
         ospoll->num--;
-        ospoll->changed = TRUE;
+        ospoll->changed = true;
 #endif
     }
 }
@@ -661,7 +661,7 @@ ospoll_wait(struct ospoll *ospoll, int timeout)
 #endif
 #if POLL
     nready = xserver_poll(ospoll->fds, ospoll->num, timeout);
-    ospoll->changed = FALSE;
+    ospoll->changed = false;
     if (nready > 0) {
         int f;
         for (f = 0; f < ospoll->num; f++) {

--- a/os/ospoll.h
+++ b/os/ospoll.h
@@ -23,6 +23,8 @@
 #ifndef _OSPOLL_H_
 #define _OSPOLL_H_
 
+#include <stdbool.h>
+
 /* Forward declaration */
 struct ospoll;
 
@@ -64,7 +66,7 @@ ospoll_destroy(struct ospoll *ospoll);
  * @param       callback        Function to call when triggered
  * @param       data            Extra data to pass callback
  */
-Bool
+bool
 ospoll_add(struct ospoll *ospoll, int fd,
            enum ospoll_trigger trigger,
            void (*callback)(int fd, int xevents, void *data),


### PR DESCRIPTION
Low level OS specific code should not depend on higher level protocol headers. This also removes yet another conflict with win32/mingw headers.