### PR TITLE
Fix xserver build if no recent libdrm found

### DIFF
--- a/glamor/glamor_sync.c
+++ b/glamor/glamor_sync.c
@@ -93,7 +93,7 @@ glamor_sync_init(ScreenPtr screen)
 			return FALSE;
 	}
 
-#ifdef HAVE_XSHMFENCE
+#if defined HAVE_XSHMFENCE && defined DRI3
 	if (!miSyncShmScreenInit(screen))
 		return FALSE;
 #else

--- a/include/meson.build
+++ b/include/meson.build
@@ -100,7 +100,7 @@ conf_data.set('NEED_DBUS', build_systemd_logind or build_hal ? '1' : false)
 conf_data.set('CONFIG_WSCONS', host_machine.system() in ['openbsd', 'netbsd'] ? '1' : false)
 
 conf_data.set('HAVE_XSHMFENCE', xshmfence_dep.found() ? '1' : false)
-conf_data.set('WITH_LIBDRM', libdrm_required ? '1' : false)
+conf_data.set('WITH_LIBDRM', libdrm_required and libdrm_dep.found() ? '1' : false)
 conf_data.set('GLAMOR_HAS_EGL_QUERY_DMABUF',
               epoxy_dep.found() and epoxy_dep.version().version_compare('>= 1.4.4') ? '1' : false)
 conf_data.set('GLAMOR_HAS_EGL_QUERY_DRIVER',


### PR DESCRIPTION
If no recent enough `libdrm` has been found,  `libdrm_required` is set to true anyway, and `WITH_LIBDRM` gets defined although
```
Dependency libdrm found: NO. Found 2.4.107 but need: '>= 2.4.116'
```
which results later in not building `miext/sync/misyncshm.c`. Later we get
```
/usr/bin/ld: glamor/libglamor.a.p/glamor_sync.c.o: у функції «glamor_sync_init»:
/tmp/x11-build/xserver-xlibre-xserver-25.0.0.6rc1/build/../glamor/glamor_sync.c:97: невизначене посилання «miSyncShmScreenInit»
collect2: помилка: ld returned 1 exit status
```
because if there is no `libdrm`, then `dri3` is also not built and the function `miSyncShmScreenInit()` in `glamor_sync.c` in unavailable.

This PR adds a condition `libdrm_dep.found()` to `include/meson.build` that verifies that `libdrm` is present indeed, and a condition `defined DRI3` is check if `miSyncShmScreenInit()` can be called.