### PR TITLE
meson.build: Check for libudev directly, instead of our flimsy os-speciffic guessing

### DIFF
--- a/config/config.c
+++ b/config/config.c
@@ -74,7 +74,7 @@ config_fini(void)
 void
 config_odev_probe(config_odev_probe_proc_ptr probe_callback)
 {
-#if defined(CONFIG_UDEV_KMS)
+#if defined(CONFIG_UDEV) && defined(CONFIG_UDEV_KMS)
     config_udev_odev_probe(probe_callback);
 #endif
 }

--- a/meson.build
+++ b/meson.build
@@ -183,27 +183,13 @@ endif
 
 udev_option = get_option('udev')
 udev_kms_option = get_option('udev_kms')
-if ['windows', 'darwin', 'netbsd', 'openbsd', 'sunos'].contains(host_machine.system())
-    if udev_option == 'auto'
-        udev_option = 'false'
-    endif
-    if udev_kms_option == 'auto'
-        udev_kms_option = 'false'
-    endif
-    if udev_option == 'true' or  udev_kms_option == 'true'
-        message('WARNING: udev is not supported on your platform')
-    endif
-else
-    if udev_option == 'auto'
-        udev_option = 'true'
-    endif
-    if udev_kms_option == 'auto'
-        udev_kms_option = 'true'
-    endif
+if not dependency('libudev', required: (udev_option == 'true' or udev_kms_option == 'true')).found()
+    udev_option = 'false'
+    udev_kms_option = 'false'
 endif
 
-build_udev = (udev_option == 'true')
-build_udev_kms = (udev_kms_option == 'true')
+build_udev = (udev_option != 'false')
+build_udev_kms = (udev_kms_option != 'false')
 
 if get_option('systemd_logind') == 'auto'
     build_systemd_logind = build_udev_kms and dbus_dep.found()


### PR DESCRIPTION
Implement what was discussed in https://github.com/X11Libre/xserver/issues/478

Use dependency() instead of cc.check_header(), as the former is the intended way to check for dependencies.

cc.check_headers would turn udev on on systems where libudev.h is present, but libudev.pc isn't.

Thos would do the wrong thing on systems where the admin wants to have that header for some reason, but doesn't want programs to use libudev.

We also keep udev and udev_kms a tristate, so we try to do the right thing when the user doesn't explicitly pass values for udev and udev_kms.

@metux @callmetango @b-aaz @dec05eba Thoughts?