### PR TITLE
[25.0] os: xdmcp: fix missing include of <X11/Xdmcp.h>

### DIFF
--- a/os/osdep.h
+++ b/os/osdep.h
@@ -53,10 +53,6 @@ SOFTWARE.
 
 #include <X11/Xdefs.h>
 
-#if defined(XDMCP) || defined(HASXDMAUTH)
-#include <X11/Xdmcp.h>
-#endif
-
 #include <limits.h>
 #include <stddef.h>
 #include <X11/Xos.h>

--- a/os/xdmcp.h
+++ b/os/xdmcp.h
@@ -1,6 +1,8 @@
 #ifndef _XSERVER_OS_XDMCP_H
 #define _XSERVER_OS_XDMCP_H
 
+#include <X11/Xdmcp.h>
+
 #include "osdep.h"
 
 typedef Bool (*ValidatorFunc) (ARRAY8Ptr Auth, ARRAY8Ptr Data, int packet_type);


### PR DESCRIPTION
xdmcp.h is using types from <X11/Xdmcp.h>, but forgot to include it. This just popped up with building w/ -Dxdmcp=false, because that file was included in the wrong place (osdep.h) and only conditionally.