### PR TITLE
xserver: os/log.c: ignore alternate forms in log formats

### DIFF
--- a/os/log.c
+++ b/os/log.c
@@ -410,6 +410,10 @@ vpnprintf(char *string, int size_in, const char *f, va_list args)
 
         f_idx++;
 
+        if (f[f_idx] == '#')
+        /* silently ignore alternate form */
+            f_idx++;
+
         /* silently ignore reverse justification */
         if (f[f_idx] == '-')
             f_idx++;


### PR DESCRIPTION
This patch fixes Xserver crashes when evdev or synaptics input drivers are used. These (and maybe other) driver use alternate forms "%#..." in formats for xf86IDrvLogVerb() function, which in turn uses signal-safe vpnprintf(). The last function does not recognize alternate forms and exits abnormally, which causes Xserver to crash. The patch make vpnprintf() to ignore alternate forms.

Closes: https://github.com/X11Libre/xserver/issues/498