### PR TITLE
config: Also read config files from XDG config

### DIFF
--- a/hw/xfree86/common/xf86Config.c
+++ b/hw/xfree86/common/xf86Config.c
@@ -69,6 +69,7 @@
 #include "xf86Xinput.h"
 #include "loaderProcs.h"
 #include "xf86Xinput_priv.h"
+#include "xf86_os_support.h"
 
 #include "picture.h"
 #ifdef DPMSExtension
@@ -2335,6 +2336,21 @@ xf86HandleConfigFile(Bool autoconfig)
                                             PROJECTROOT);
         dirname = xf86openConfigDirFiles(dirsearch, xf86ConfigDir, PROJECTROOT);
         filename = xf86openConfigFile(filesearch, xf86ConfigFile, PROJECTROOT);
+
+        if(xf86UseXDGConfig) {
+            char userdir[PATH_MAX] = {0};
+            GetXDGConfigPath(userdir);
+            if (userdir[0]) {
+                size_t userdirlen = strlen(userdir);
+                Bool endsWithSlash =  userdir[userdirlen] == '/';
+                strncat(userdir, endsWithSlash ? "X11/%X" : "/X11/%X", PATH_MAX-1);
+                userdir[PATH_MAX-1] = '\0';
+                char* userdirname = xf86openConfigDirFiles(userdir, NULL, PROJECTROOT);
+                if (userdirname) {
+                    LogMessageVerb(X_NOTICE, 0, "Using user config dir: \"%s\"\n", userdirname);
+                }
+            }
+        }
         if (filename) {
             LogMessageVerb(filefrom, 0, "Using config file: \"%s\"\n", filename);
             xf86ConfigFile = XNFstrdup(filename);

--- a/hw/xfree86/common/xf86Config.h
+++ b/hw/xfree86/common/xf86Config.h
@@ -72,6 +72,7 @@ void xf86SetLogVerbosity(int verb);
 
 extern confDRIRec xf86ConfigDRI;
 
+extern Bool xf86UseXDGConfig;
 extern const char *xf86ConfigFile;
 extern const char *xf86ConfigDir;
 

--- a/hw/xfree86/common/xf86Globals.c
+++ b/hw/xfree86/common/xf86Globals.c
@@ -190,6 +190,9 @@ Gamma xf86Gamma = { 0.0, 0.0, 0.0 };
 Bool xf86AllowMouseOpenFail = FALSE;
 Bool xf86AutoBindGPUDisabled = FALSE;
 
+Bool xf86UseXDGConfig = TRUE;
+
+
 #ifdef XF86VIDMODE
 Bool xf86VidModeDisabled = FALSE;
 Bool xf86VidModeAllowNonLocal = FALSE;

--- a/hw/xfree86/common/xf86Init.c
+++ b/hw/xfree86/common/xf86Init.c
@@ -931,6 +931,10 @@ ddxProcessArgument(int argc, char **argv, int i)
         xf86LogFileFrom = X_CMDLINE;
         return 2;
     }
+    if (!strcmp(argv[i], "-noXDGconfig")) {
+        xf86UseXDGConfig = FALSE;
+        return 1;
+    }
     if (!strcmp(argv[i], "-config") || !strcmp(argv[i], "-xf86config")) {
         CHECK_FOR_REQUIRED_ARGUMENTS(1);
         xf86CheckPrivs(argv[i], argv[i + 1]);

--- a/hw/xfree86/os-support/meson.build
+++ b/hw/xfree86/os-support/meson.build
@@ -3,6 +3,7 @@ srcs_xorg_os_support = [
     'shared/posix_tty.c',
     'shared/sigio.c',
     'shared/vidmem.c',
+    'shared/xdg.c'
 ]
 
 hdrs_xorg_os_support = [

--- a/hw/xfree86/os-support/shared/xdg.c
+++ b/hw/xfree86/os-support/shared/xdg.c
@@ -1,0 +1,37 @@
+#include <pwd.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <limits.h>
+
+#include "xf86.h"
+#include "xf86Priv.h"
+#include "xf86_os_support.h"
+#include "xf86_OSlib.h"
+
+/*
+ * GetXDGConfigPath: Gets the XDG user config directory
+ * Puts $XDG_CONFIG_HOME, fallbacks to $HOME/.config/ into out_path
+*/
+void GetXDGConfigPath(char* out_path)
+{
+    struct passwd* pw = getpwuid(getuid());
+    if ((!pw) || !pw->pw_dir || pw->pw_dir[0] == '\0') {
+        out_path[0] = '\0';
+        return;
+    }
+    char* XDG_CONFIG_HOME = getenv("XDG_CONFIG_HOME");
+
+    char tmpPath[PATH_MAX] = {0};
+    strncpy(tmpPath, pw->pw_dir, PATH_MAX-1);
+    tmpPath[PATH_MAX-1] = '\0';
+
+    char* base_dir = strcat(tmpPath, "/.config/");
+    if (XDG_CONFIG_HOME != NULL) {
+        strncpy(out_path, XDG_CONFIG_HOME, PATH_MAX-1);
+        out_path[PATH_MAX-1] = '\0';
+        return;
+    }
+    strncpy(out_path, base_dir, PATH_MAX-1);
+    out_path[PATH_MAX-1] = '\0';
+}

--- a/hw/xfree86/os-support/xf86_os_support.h
+++ b/hw/xfree86/os-support/xf86_os_support.h
@@ -71,4 +71,6 @@ void xf86VTAcquire(int);
 void xf86VTRelease(int);
 #endif
 
+void GetXDGConfigPath(char* out_path);
+
 #endif /* _XSERVER_XF86_OS_SUPPORT */


### PR DESCRIPTION
Some users may want to have a different configuration depending on the current user running Xserver, or just to have different config on a ro rootfs.
For example different repeat rates, modes, keyboard layout and mouse sensitivity/acceleration
While the examples above can be set just using a start script, it would be more flexible and streamlined to have it directly in the config to avoid unnecessary mode changes, etc

default path is `$HOME/.config/X11/xorg.conf.d/`

Fixes #201

Im not fairly experienced in the xserver codebase so if theres room for improvement or im missing some edge case like support for BSD or windows, please say
Thanks