### PR TITLE
Github Workflow: Add a check for pull request commits to be signed off

### DIFF
--- a/.github/workflows/pr-signoff-check.yml
+++ b/.github/workflows/pr-signoff-check.yml
@@ -1,0 +1,15 @@
+name: Check PR Sign-off
+
+on: [pull_request]
+
+jobs:
+  check-sign-off:
+    name: Write comment if unsigned commits found
+    env:
+      FORCE_COLOR: 1
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: live627/check-pr-signoff-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added a new Github workflow to automate PR sign off checks as requested in issue #496.

A new token will need to be generated for this repository giving the workflow permission to post PR comments.
For my test repository, I created the token from: https://github.com/settings/personal-access-tokens
Then in the repository Settings > Secrets and variables > Actions, a new repository secret name PR_SIGNOFF_TOKEN needs to be created and given the token generated earlier.

Resolves #496 