### PR TITLE
os: xtranssock: undefine before redefining EADDRINUSE

### DIFF
--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -119,6 +119,8 @@ from the copyright holders.
 #include <X11/Xw32defs.h>
 #undef close
 #define close closesocket
+
+#undef EADDRINUSE
 #define EADDRINUSE WSAEADDRINUSE
 #undef EWOULDBLOCK
 #define EWOULDBLOCK WSAEWOULDBLOCK


### PR DESCRIPTION
prevent warning on doubly defined preprocessor symbol.