### PR TITLE
os: xtranssock: win32: use separate symbol for socket close

### DIFF
--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -110,6 +110,8 @@ from the copyright holders.
 #include <sys/filio.h>
 #endif
 
+#define socket_close close
+
 #include <unistd.h>
 
 #else /* !WIN32 */
@@ -117,8 +119,8 @@ from the copyright holders.
 #include <X11/Xwinsock.h>
 #include <X11/Xwindows.h>
 #include <X11/Xw32defs.h>
-#undef close
-#define close closesocket
+
+#define socket_close closesocket
 
 #undef EADDRINUSE
 #define EADDRINUSE WSAEADDRINUSE
@@ -383,7 +385,7 @@ static XtransConnInfo _XSERVTransSocketOpen (int i, int type)
     {
 	prmsg (2, "SocketOpen: socket() returned out of range fd %d\n",
 	       ciptr->fd);
-	close (ciptr->fd);
+	socket_close (ciptr->fd);
 	ciptr->fd = -1;
     }
 #endif
@@ -688,7 +690,7 @@ static int _XSERVTransSocketCreateListener (XtransConnInfo ciptr,
 
 	if (retry-- == 0) {
 	    prmsg (1, "SocketCreateListener: failed to bind listener\n");
-	    close (fd);
+	    socket_close (fd);
 	    return TRANS_CREATE_LISTENER_FAILED;
 	}
 #ifdef SO_REUSEADDR
@@ -719,7 +721,7 @@ static int _XSERVTransSocketCreateListener (XtransConnInfo ciptr,
     if (listen (fd, BACKLOG) < 0)
     {
 	prmsg (1, "SocketCreateListener: listen() failed\n");
-	close (fd);
+	socket_close (fd);
 	return TRANS_CREATE_LISTENER_FAILED;
     }
 
@@ -999,7 +1001,7 @@ static int _XSERVTransSocketUNIXResetListener (XtransConnInfo ciptr)
         }
 #endif
 
-	close (ciptr->fd);
+	socket_close (ciptr->fd);
 	unlink (unsock->sun_path);
 
 	if ((ciptr->fd = socket (AF_UNIX, SOCK_STREAM, 0)) < 0)
@@ -1011,14 +1013,14 @@ static int _XSERVTransSocketUNIXResetListener (XtransConnInfo ciptr)
 
 	if (bind (ciptr->fd, (struct sockaddr *) unsock, ciptr->addrlen) < 0)
 	{
-	    close (ciptr->fd);
+	    socket_close (ciptr->fd);
 	    _XSERVTransFreeConnInfo (ciptr);
 	    return TRANS_RESET_FAILURE;
 	}
 
 	if (listen (ciptr->fd, BACKLOG) < 0)
 	{
-	    close (ciptr->fd);
+	    socket_close (ciptr->fd);
 	    _XSERVTransFreeConnInfo (ciptr);
 	    (void) umask (oldUmask);
 	    return TRANS_RESET_FAILURE;
@@ -1086,7 +1088,7 @@ static XtransConnInfo _XSERVTransSocketINETAccept (
     {
 	prmsg (1,
 	    "SocketINETAccept: ...SocketINETGetAddr() failed:\n");
-	close (newciptr->fd);
+	socket_close (newciptr->fd);
 	free (newciptr);
 	*status = TRANS_ACCEPT_MISC_ERROR;
         return NULL;
@@ -1096,7 +1098,7 @@ static XtransConnInfo _XSERVTransSocketINETAccept (
     {
 	prmsg (1,
 	  "SocketINETAccept: ...SocketINETGetPeerAddr() failed:\n");
-	close (newciptr->fd);
+	socket_close (newciptr->fd);
 	if (newciptr->addr) free (newciptr->addr);
 	free (newciptr);
 	*status = TRANS_ACCEPT_MISC_ERROR;
@@ -1147,7 +1149,7 @@ static XtransConnInfo _XSERVTransSocketUNIXAccept (
     {
         prmsg (1,
         "SocketUNIXAccept: Can't allocate space for the addr\n");
-	close (newciptr->fd);
+	socket_close (newciptr->fd);
 	free (newciptr);
 	*status = TRANS_ACCEPT_BAD_MALLOC;
         return NULL;
@@ -1165,7 +1167,7 @@ static XtransConnInfo _XSERVTransSocketUNIXAccept (
     {
         prmsg (1,
 	      "SocketUNIXAccept: Can't allocate space for the addr\n");
-	close (newciptr->fd);
+	socket_close (newciptr->fd);
 	if (newciptr->addr) free (newciptr->addr);
 	free (newciptr);
 	*status = TRANS_ACCEPT_BAD_MALLOC;
@@ -1210,7 +1212,7 @@ appendFd(struct _XtransConnFd **prev, int fd, int do_close)
     new = malloc (sizeof (struct _XtransConnFd));
     if (!new) {
         /* XXX mark connection as broken */
-        close(fd);
+        socket_close(fd);
         return;
     }
     new->next = 0;
@@ -1244,7 +1246,7 @@ discardFd(struct _XtransConnFd **prev, struct _XtransConnFd *upto, int do_close)
     for (cf = *prev; cf != upto; cf = next) {
         next = cf->next;
         if (do_close || cf->do_close)
-            close(cf->fd);
+            socket_close(cf->fd);
         free(cf);
     }
     *prev = upto;
@@ -1488,15 +1490,11 @@ static int _XSERVTransSocketINETClose (XtransConnInfo ciptr)
 {
     prmsg (2,"SocketINETClose(%p,%d)\n", (void *) ciptr, ciptr->fd);
 
+    int ret = socket_close (ciptr->fd);
 #ifdef WIN32
-    {
-	int ret = close (ciptr->fd);
-	if (ret == SOCKET_ERROR) errno = WSAGetLastError();
-	return ret;
-    }
-#else
-    return close (ciptr->fd);
+    if (ret == SOCKET_ERROR) errno = WSAGetLastError();
 #endif
+    return ret;
 }
 
 #endif /* TCPCONN */
@@ -1517,7 +1515,7 @@ static int _XSERVTransSocketUNIXClose (XtransConnInfo ciptr)
 #if XTRANS_SEND_FDS
     cleanupFds(ciptr);
 #endif
-    ret = close(ciptr->fd);
+    ret = socket_close(ciptr->fd);
 
     if (ciptr->flags
        && sockname
@@ -1537,18 +1535,13 @@ static int _XSERVTransSocketUNIXCloseForCloning (XtransConnInfo ciptr)
     /*
      * Don't unlink path.
      */
-
-    int ret;
-
     prmsg (2,"SocketUNIXCloseForCloning(%p,%d)\n",
 	(void *) ciptr, ciptr->fd);
 
 #if XTRANS_SEND_FDS
     cleanupFds(ciptr);
 #endif
-    ret = close(ciptr->fd);
-
-    return ret;
+    return socket_close(ciptr->fd);
 }
 
 #endif /* UNIXCONN */


### PR DESCRIPTION
Instead of redefining existing standard libc symbols, pick another symbol that's mapped to the corresponding platform specific function.