### PR TITLE
xwin: win.h: missing include of dix/dix_priv.h

### DIFF
--- a/hw/xwin/win.h
+++ b/hw/xwin/win.h
@@ -145,6 +145,7 @@
 #include <X11/Xprotostr.h>
 
 #include "dix/colormap_priv.h"
+#include "dix/dix_priv.h"
 
 #include "scrnintstr.h"
 #include "pixmapstr.h"


### PR DESCRIPTION
Needed for dixAddAtom()