### PR TITLE
os: xtrans: fix trans_mkdir() prototype

### DIFF
--- a/os/Xtransint.h
+++ b/os/Xtransint.h
@@ -297,10 +297,7 @@ static int _XSERVTransWriteV(
 
 #endif /* WIN32 */
 
-static int trans_mkdir (
-    const char *,	/* path */
-    int			/* mode */
-);
+int trans_mkdir (const char *path, int mode);
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/os/Xtransutil.c
+++ b/os/Xtransutil.c
@@ -250,8 +250,7 @@ int _XSERVTransWSAStartup (void)
  * it's not save if the directory has non-root ownership or the sticky
  * bit cannot be set and fail.
  */
-static int
-trans_mkdir(const char *path, int mode)
+int trans_mkdir(const char *path, int mode)
 {
     struct stat buf;
 


### PR DESCRIPTION
Functions used acrossed various .c files cannot be static.