### PR TITLE
os: io: simplify FlushClient() et al

### DIFF
--- a/os/connection.c
+++ b/os/connection.c
@@ -787,7 +787,7 @@ CloseDownConnection(ClientPtr client)
         CallCallbacks(&FlushCallback, client);
 
     if (oc->output)
-	FlushClient(client, oc, (char *) NULL, 0);
+	FlushClient(client, oc);
     CloseDownFileDescriptor(oc);
     FreeOsBuffers(oc);
     free(client->osPrivate);

--- a/os/io.c
+++ b/os/io.c
@@ -883,6 +883,15 @@ FlushClient(ClientPtr who, OsCommPtr oc, const void *__extraBuf, int extraCount)
 
     if (!oco)
 	return 0;
+
+    if (!trans_conn) {
+        /* uh, transport not connected ? can only kill the client :( */
+        AbortClient(who);
+        dixMarkClientException(who);
+        oco->count = 0;
+        return -1;
+    }
+
     written = 0;
     padsize = padding_for_int32(extraCount);
     notWritten = oco->count + extraCount + padsize;
@@ -931,7 +940,7 @@ FlushClient(ClientPtr who, OsCommPtr oc, const void *__extraBuf, int extraCount)
             InsertIOV(padBuffer, padsize)
 
             errno = 0;
-        if (trans_conn && (len = _XSERVTransWritev(trans_conn, iov, i)) >= 0) {
+        if ((len = _XSERVTransWritev(trans_conn, iov, i)) >= 0) {
             written += len;
             notWritten -= len;
             todo = notWritten;

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -95,11 +95,7 @@ typedef struct _osComm {
 #define OS_COMM_GRAB_IMPERVIOUS 1
 #define OS_COMM_IGNORED         2
 
-extern int FlushClient(ClientPtr /*who */ ,
-                       OsCommPtr /*oc */ ,
-                       const void * /*extraBuf */ ,
-                       int      /*extraCount */
-    );
+int FlushClient(ClientPtr who, OsCommPtr oc);
 
 extern void FreeOsBuffers(OsCommPtr     /*oc */
     );


### PR DESCRIPTION
The FlushClient() logic is pretty complicated and not entirely trivial to understand. Part of that coming from the fact that it's not just flushing (writing out client output buffer), but also can optionally send extra data.

It's much simpler if we split off the separate topics (make buffer room, write out the buffer, write more data) into separate functions.

This PR also removes one of the two users of _XSERVTransWritev(). In combination with https://github.com/X11Libre/xserver/pull/519, this functions becomes obsolete, and so allows for more cleanups in xtrans.
