### PR TITLE
os: xtrans: drop _XSERVTransReadv() et al

### DIFF
--- a/os/Xtrans.c
+++ b/os/Xtrans.c
@@ -762,11 +762,6 @@ int _XSERVTransWrite (XtransConnInfo ciptr, const char *buf, int size)
     return ciptr->transptr->Write (ciptr, buf, size);
 }
 
-int _XSERVTransReadv (XtransConnInfo ciptr, struct iovec *buf, int size)
-{
-    return ciptr->transptr->Readv (ciptr, buf, size);
-}
-
 int _XSERVTransWritev (XtransConnInfo ciptr, struct iovec *buf, int size)
 {
     return ciptr->transptr->Writev (ciptr, buf, size);
@@ -1092,33 +1087,6 @@ int _XSERVTransMakeAllCOTSServerListeners (const char *port, int *partial,
 
 
 #ifdef WIN32
-
-/*
- * emulate readv
- */
-static int _XSERVTransReadV (XtransConnInfo ciptr, struct iovec *iov, int iovcnt)
-{
-    int i, len, total;
-    char *base;
-
-    ESET(0);
-    for (i = 0, total = 0;  i < iovcnt;  i++, iov++) {
-	len = iov->iov_len;
-	base = iov->iov_base;
-	while (len > 0) {
-	    register int nbytes;
-	    nbytes = _XSERVTransRead (ciptr, base, len);
-	    if (nbytes < 0 && total == 0)  return -1;
-	    if (nbytes <= 0)  return total;
-	    ESET(0);
-	    len   -= nbytes;
-	    total += nbytes;
-	    base  += nbytes;
-	}
-    }
-    return total;
-}
-
 
 /*
  * emulate writev

--- a/os/Xtrans.h
+++ b/os/Xtrans.h
@@ -113,7 +113,7 @@ typedef long BytesReadable_t;
 #if defined(WIN32)
 
 /*
- *      _XSERVTransReadv and _XSERVTransWritev use struct iovec, normally found
+ *      _XSERVTransWritev use struct iovec, normally found
  *      in Berkeley systems in <sys/uio.h>.  See the readv(2) and writev(2)
  *      manual pages for details.
  */
@@ -242,12 +242,6 @@ int _XSERVTransRead (
 int _XSERVTransWrite (
     XtransConnInfo,	/* ciptr */
     const char *,	/* buf */
-    int			/* size */
-);
-
-int _XSERVTransReadv (
-    XtransConnInfo,	/* ciptr */
-    struct iovec *,	/* buf */
     int			/* size */
 );
 

--- a/os/Xtransint.h
+++ b/os/Xtransint.h
@@ -187,12 +187,6 @@ typedef struct _Xtransport {
 	int			/* size */
     );
 
-    int	(*Readv)(
-	XtransConnInfo,		/* connection */
-	struct iovec *,		/* buf */
-	int			/* size */
-    );
-
     int	(*Writev)(
 	XtransConnInfo,		/* connection */
 	struct iovec *,		/* buf */
@@ -258,28 +252,6 @@ typedef struct _Xtransport_table {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
 #endif
-
-/*
- * readv() and writev() don't exist or don't work correctly on some
- * systems, so they may be emulated.
- */
-
-#ifdef WIN32
-
-#define READV(ciptr, iov, iovcnt)	_XSERVTransReadV(ciptr, iov, iovcnt)
-
-static	int _XSERVTransReadV(
-    XtransConnInfo,	/* ciptr */
-    struct iovec *,	/* iov */
-    int			/* iovcnt */
-);
-
-#else
-
-#define READV(ciptr, iov, iovcnt)	readv(ciptr->fd, iov, iovcnt)
-
-#endif /* WIN32 */
-
 
 #ifdef WIN32
 

--- a/os/Xtranslcl.c
+++ b/os/Xtranslcl.c
@@ -761,13 +761,6 @@ static int _XSERVTransLocalWrite(XtransConnInfo ciptr, const char *buf, int size
     return write(ciptr->fd,buf,size);
 }
 
-static int _XSERVTransLocalReadv(XtransConnInfo ciptr, struct iovec *buf, int size)
-{
-    prmsg(2,"LocalReadv(%d,%p,%d)\n", ciptr->fd, (void *) buf, size );
-
-    return READV(ciptr,buf,size);
-}
-
 static int _XSERVTransLocalWritev(XtransConnInfo ciptr, struct iovec *buf, int size)
 {
     prmsg(2,"LocalWritev(%d,%p,%d)\n", ciptr->fd, (const void *) buf, size );
@@ -845,7 +838,6 @@ static Xtransport _XSERVTransLocalFuncs = {
 	_XSERVTransLocalBytesReadable,
 	_XSERVTransLocalRead,
 	_XSERVTransLocalWrite,
-	_XSERVTransLocalReadv,
 	_XSERVTransLocalWritev,
 #if XTRANS_SEND_FDS
 	_XSERVTransLocalSendFdInvalid,
@@ -873,7 +865,6 @@ static Xtransport _XSERVTransNAMEDFuncs = {
 	_XSERVTransLocalBytesReadable,
 	_XSERVTransLocalRead,
 	_XSERVTransLocalWrite,
-	_XSERVTransLocalReadv,
 	_XSERVTransLocalWritev,
 #if XTRANS_SEND_FDS
 	_XSERVTransLocalSendFdInvalid,
@@ -898,7 +889,6 @@ static Xtransport _XSERVTransPIPEFuncs = {
 	_XSERVTransLocalBytesReadable,
 	_XSERVTransLocalRead,
 	_XSERVTransLocalWrite,
-	_XSERVTransLocalReadv,
 	_XSERVTransLocalWritev,
 #if XTRANS_SEND_FDS
 	_XSERVTransLocalSendFdInvalid,

--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -1358,45 +1358,6 @@ static int _XSERVTransSocketRead (
 #endif /* WIN32 */
 }
 
-static int _XSERVTransSocketReadv (
-    XtransConnInfo ciptr, struct iovec *buf, int size)
-{
-    prmsg (2,"SocketReadv(%d,%p,%d)\n", ciptr->fd, (void *) buf, size);
-
-#if XTRANS_SEND_FDS
-    {
-        union fd_pass   cmsgbuf;
-        struct msghdr   msg = {
-            .msg_name = NULL,
-            .msg_namelen = 0,
-            .msg_iov = buf,
-            .msg_iovlen = size,
-            .msg_control = cmsgbuf.buf,
-            .msg_controllen = CMSG_LEN(MAX_FDS * sizeof(int))
-        };
-
-        size = recvmsg(ciptr->fd, &msg, 0);
-        if (size >= 0) {
-            struct cmsghdr *hdr;
-
-            for (hdr = CMSG_FIRSTHDR(&msg); hdr; hdr = CMSG_NXTHDR(&msg, hdr)) {
-                if (hdr->cmsg_level == SOL_SOCKET && hdr->cmsg_type == SCM_RIGHTS) {
-                    int nfd = (hdr->cmsg_len - CMSG_LEN(0)) / sizeof (int);
-                    int i;
-                    int *fd = (int *) CMSG_DATA(hdr);
-
-                    for (i = 0; i < nfd; i++)
-                        appendFd(&ciptr->recv_fds, fd[i], 0);
-                }
-            }
-        }
-        return size;
-    }
-#else
-    return READV (ciptr, buf, size);
-#endif
-}
-
 static int _XSERVTransSocketWritev (
     XtransConnInfo ciptr, struct iovec *buf, int size)
 {
@@ -1577,7 +1538,6 @@ static Xtransport _XSERVTransSocketTCPFuncs = {
 	_XSERVTransSocketBytesReadable,
 	_XSERVTransSocketRead,
 	_XSERVTransSocketWrite,
-	_XSERVTransSocketReadv,
 	_XSERVTransSocketWritev,
 #if XTRANS_SEND_FDS
 	_XSERVTransSocketSendFdInvalid,
@@ -1602,7 +1562,6 @@ static Xtransport _XSERVTransSocketINETFuncs = {
 	_XSERVTransSocketBytesReadable,
 	_XSERVTransSocketRead,
 	_XSERVTransSocketWrite,
-	_XSERVTransSocketReadv,
 	_XSERVTransSocketWritev,
 #if XTRANS_SEND_FDS
 	_XSERVTransSocketSendFdInvalid,
@@ -1628,7 +1587,6 @@ static Xtransport _XSERVTransSocketINET6Funcs = {
 	_XSERVTransSocketBytesReadable,
 	_XSERVTransSocketRead,
 	_XSERVTransSocketWrite,
-	_XSERVTransSocketReadv,
 	_XSERVTransSocketWritev,
 #if XTRANS_SEND_FDS
 	_XSERVTransSocketSendFdInvalid,
@@ -1661,7 +1619,6 @@ static Xtransport _XSERVTransSocketLocalFuncs = {
 	_XSERVTransSocketBytesReadable,
 	_XSERVTransSocketRead,
 	_XSERVTransSocketWrite,
-	_XSERVTransSocketReadv,
 	_XSERVTransSocketWritev,
 #if XTRANS_SEND_FDS
 	_XSERVTransSocketSendFd,
@@ -1698,7 +1655,6 @@ static Xtransport _XSERVTransSocketUNIXFuncs = {
 	_XSERVTransSocketBytesReadable,
 	_XSERVTransSocketRead,
 	_XSERVTransSocketWrite,
-	_XSERVTransSocketReadv,
 	_XSERVTransSocketWritev,
 #if XTRANS_SEND_FDS
 	_XSERVTransSocketSendFd,


### PR DESCRIPTION
It's not used anywhere, so no need to keep it around anymore. We can also dispose the corresponding connection driver's procs here.