### PR TITLE
os: ospoll: use realloc() instead of reallocarray()

### DIFF
--- a/os/ospoll.c
+++ b/os/ospoll.c
@@ -284,7 +284,7 @@ ospoll_add(struct ospoll *ospoll, int fd,
             struct ospollfd *new_fds;
             int new_size = ospoll->size ? ospoll->size * 2 : MAXCLIENTS * 2;
 
-            new_fds = reallocarray(ospoll->fds, new_size, sizeof (ospoll->fds[0]));
+            new_fds = realloc(ospoll->fds, new_size * sizeof (ospoll->fds[0]));
             if (!new_fds)
                 return FALSE;
             ospoll->fds = new_fds;
@@ -314,7 +314,7 @@ ospoll_add(struct ospoll *ospoll, int fd,
             struct ospollfd **new_fds;
             int new_size = ospoll->size ? ospoll->size * 2 : MAXCLIENTS * 2;
 
-            new_fds = reallocarray(ospoll->fds, new_size, sizeof (ospoll->fds[0]));
+            new_fds = realloc(ospoll->fds, new_size * sizeof (ospoll->fds[0]));
             if (!new_fds) {
                 free (osfd);
                 return FALSE;
@@ -352,7 +352,7 @@ ospoll_add(struct ospoll *ospoll, int fd,
             struct ospollfd **new_fds;
             int new_size = ospoll->size ? ospoll->size * 2 : MAXCLIENTS * 2;
 
-            new_fds = reallocarray(ospoll->fds, new_size, sizeof (ospoll->fds[0]));
+            new_fds = realloc(ospoll->fds, new_size * sizeof (ospoll->fds[0]));
             if (!new_fds) {
                 free (osfd);
                 return FALSE;
@@ -390,11 +390,11 @@ ospoll_add(struct ospoll *ospoll, int fd,
             struct ospollfd *new_osfds;
             int             new_size = ospoll->size ? ospoll->size * 2 : MAXCLIENTS * 2;
 
-            new_fds = reallocarray(ospoll->fds, new_size, sizeof (ospoll->fds[0]));
+            new_fds = realloc(ospoll->fds, new_size * sizeof (ospoll->fds[0]));
             if (!new_fds)
                 return FALSE;
             ospoll->fds = new_fds;
-            new_osfds = reallocarray(ospoll->osfds, new_size, sizeof (ospoll->osfds[0]));
+            new_osfds = realloc(ospoll->osfds, new_size * sizeof (ospoll->osfds[0]));
             if (!new_osfds)
                 return FALSE;
             ospoll->osfds = new_osfds;


### PR DESCRIPTION
MacOS doesn't support reallocarray(), and we can't include os.h here on win32/mingw.