### PR TITLE
Add a convenient way to IgnoreABI for certain drivers by default using OutputClass

### DIFF
--- a/config/10-nvidia.conf
+++ b/config/10-nvidia.conf
@@ -1,0 +1,15 @@
+# This xorg.conf.d configuration snippet configures the X server to
+# automatically load the nvidia X driver when it detects a device driven by the
+# nvidia-drm.ko kernel module and ignores nvidia_drv.so ABI version.
+# Please note that this works on Linux kernels version 6.12 or higher
+# with CONFIG_DRM enabled, and only if the nvidia-drm.ko kernel module
+# is loaded before the X server is started.
+
+Section "OutputClass"
+	Identifier "NVidia"
+	MatchDriver "nvidia-drm"
+	Driver "nvidia"
+        Option "AllowEmptyInitialConfiguration"
+	Option "IgnoreABI" /* Add this to ServerFlags if your xserver
+			      does not recognize this in OutputClass */
+EndSection

--- a/config/meson.build
+++ b/config/meson.build
@@ -26,6 +26,8 @@ endif
 if build_xorg
     install_data('10-quirks.conf',
                  install_dir: join_paths(get_option('datadir'), 'X11/xorg.conf.d'))
+    install_data('10-nvidia.conf',
+                 install_dir: join_paths(get_option('datadir'), 'X11/xorg.conf.d'))
 endif
 
 libxserver_config = static_library('xserver_config',

--- a/hw/xfree86/common/xf86Init.c
+++ b/hw/xfree86/common/xf86Init.c
@@ -332,7 +332,7 @@ InitOutput(ScreenInfo * pScreenInfo, int argc, char **argv)
         LoaderSetPath(xf86ModulePath);
 
         if (xf86Info.ignoreABI) {
-            LoaderSetIgnoreAbi();
+            LoaderSetOptions(LDR_OPT_ABI_MISMATCH_NONFATAL);
         }
 
         if (xf86DoShowOptions)
@@ -962,7 +962,7 @@ ddxProcessArgument(int argc, char **argv, int i)
         return 1;
     }
     if (!strcmp(argv[i], "-ignoreABI")) {
-        LoaderSetIgnoreAbi();
+        LoaderSetOptions(LDR_OPT_ABI_MISMATCH_NONFATAL);
         return 1;
     }
     if (!strcmp(argv[i], "-verbose")) {

--- a/hw/xfree86/common/xf86Init.c
+++ b/hw/xfree86/common/xf86Init.c
@@ -749,6 +749,8 @@ CloseInput(void)
 {
     config_fini();
     mieqFini();
+    /* strictly speaking the below is not related to input, but ... */
+    LoaderClose();
 }
 
 /*

--- a/hw/xfree86/common/xf86Init.c
+++ b/hw/xfree86/common/xf86Init.c
@@ -331,9 +331,8 @@ InitOutput(ScreenInfo * pScreenInfo, int argc, char **argv)
         /* Tell the loader the default module search path */
         LoaderSetPath(xf86ModulePath);
 
-        if (xf86Info.ignoreABI) {
-            LoaderSetOptions(LDR_OPT_ABI_MISMATCH_NONFATAL);
-        }
+        if (xf86Info.ignoreABI)
+            LoaderSetIgnoreAllABI();
 
         if (xf86DoShowOptions)
             DoShowOptions();
@@ -962,7 +961,7 @@ ddxProcessArgument(int argc, char **argv, int i)
         return 1;
     }
     if (!strcmp(argv[i], "-ignoreABI")) {
-        LoaderSetOptions(LDR_OPT_ABI_MISMATCH_NONFATAL);
+        LoaderSetIgnoreAllABI();
         return 1;
     }
     if (!strcmp(argv[i], "-verbose")) {

--- a/hw/xfree86/common/xf86platformBus.c
+++ b/hw/xfree86/common/xf86platformBus.c
@@ -309,6 +309,7 @@ xf86platformProbe(void)
     }
 
     for (i = 0; i < xf86_num_platform_devices; i++) {
+        struct xf86_platform_device *dev = &xf86_platform_devices[i];
         char *busid = xf86_platform_odev_attributes(i)->busid;
 
         if (pci && busid && (strncmp(busid, "pci:", 4) == 0)) {
@@ -331,6 +332,18 @@ xf86platformProbe(void)
                 LogMessageVerb(X_CONFIG, 1, "OutputClass \"%s\" ModulePath extended to \"%s\"\n",
                                cl->identifier, path);
                 LoaderSetPath(path);
+            }
+
+            if (xf86CheckBoolOption(cl->option_lst, "IgnoreABI", FALSE)) {
+                if (cl->driver) {
+                    LogMessageVerb(X_CONFIG, 1, "OutputClass \"%s\" sets %s to ignore ABI for \"%s\" managed by %s\n",
+                               cl->identifier, cl->driver, dev->attribs->path, dev->attribs->driver);
+                    LoaderSetIgnoreABI(cl->driver);
+                } else {
+                    LogMessageVerb(X_CONFIG, 1, "OutputClass \"%s\" requires to ignore ABI for \"%s\" managed by %s\n"
+                            "   but Option \"Driver\" is not set\n",
+                            cl->identifier, dev->attribs->path, dev->attribs->driver);
+                }
             }
         }
     }

--- a/hw/xfree86/loader/loader.c
+++ b/hw/xfree86/loader/loader.c
@@ -52,6 +52,7 @@
 
 #include <string.h>
 #include "os.h"
+#include "list.h"
 #include "loader.h"
 #include "loaderProcs.h"
 
@@ -68,8 +69,19 @@
 extern void *xorg_symbols[];
 #endif
 
+/* ABI versions for all modules are ignored */
 Bool LoaderIgnoresAllABI;
+/* ABI version for a currently loaded module is ignored */
 Bool LoaderIgnoresABI;
+
+/* ABI for a module with this canonical name is ignored */
+typedef struct {
+    struct xorg_list entry;
+    const char * name;
+} LoaderIgnoreABIItem;
+
+/* List of such modules */
+struct xorg_list LoaderIgnoreABIList;
 
 void
 LoaderInit(void)
@@ -92,6 +104,18 @@ LoaderInit(void)
                    GET_ABI_MINOR(LoaderVersionInfo.extensionVersion));
     LoaderIgnoresAllABI = FALSE;
     LoaderIgnoresABI = FALSE;
+    xorg_list_init(&LoaderIgnoreABIList);
+}
+
+void
+LoaderClose(void)
+{
+    LoaderIgnoreABIItem *item, *next;
+    xorg_list_for_each_entry_safe(item, next, &LoaderIgnoreABIList, entry) {
+        xorg_list_del(&item->entry);
+        free(item->name);
+        free(item);
+    }
 }
 
 /* Public Interface to the loader. */
@@ -151,25 +175,70 @@ LoaderUnload(const char *name, void *handle)
         dlclose(handle);
 }
 
+/*
+ * The functions below are necessary to load some modules, e.g., nvidia proprietary drivers,
+ * regardless of their ABI versions
+ */
+
+
+/* ABI versions for all modules will be ignored */
 void
 LoaderSetIgnoreAllABI(void)
 {
     LoaderIgnoresAllABI = TRUE;
 }
 
+/* Check whether ABI for a currently loaded module is ignored and set the flag respectively */
 Bool
 LoaderGetAndFlagIgnoreABI(const char *name)
 {
-    if (LoaderIgnoresAllABI)
+    LoaderIgnoreABIItem *item;
+
+    if (LoaderIgnoresAllABI) {
         LoaderIgnoresABI = TRUE;
-    return LoaderIgnoresABI;
+        return TRUE;
+    }
+
+    xorg_list_for_each_entry(item, &LoaderIgnoreABIList, entry) {
+        if (!strcmp(item->name, name)) {
+            LoaderIgnoresABI = TRUE;
+            return TRUE;
+        }
+    }
+
+    LoaderIgnoresABI = FALSE;
+    return FALSE;
 }
 
+/* Add the module with this name to the list of modules with ignored ABI */
 void
 LoaderSetIgnoreABI(const char *name)
 {
+    LoaderIgnoreABIItem *item;
+
+    if (LoaderIgnoresAllABI)
+        return;
+
+    xorg_list_for_each_entry(item, &LoaderIgnoreABIList, entry) {
+        if (!strcmp(item->name, name))
+            goto out;
+    }
+
+    item = malloc(sizeof(LoaderIgnoreABIItem));
+    if (item)
+        item->name = strdup(name);
+    if (item && item->name)
+        xorg_list_add(&item->entry, &LoaderIgnoreABIList);
+    else {
+        LogMessage(X_ERROR, "Failed to allocate memory to store ignore ABI for module %s\n", name);
+        if (item)
+            free(item);
+    }
+
+  out:
 }
 
+/* These two functions are called by legacy nvidia drivers */
 Bool
 LoaderShouldIgnoreABI(void)
 {

--- a/hw/xfree86/loader/loader.c
+++ b/hw/xfree86/loader/loader.c
@@ -68,6 +68,9 @@
 extern void *xorg_symbols[];
 #endif
 
+Bool LoaderIgnoresAllABI;
+Bool LoaderIgnoresABI;
+
 void
 LoaderInit(void)
 {
@@ -87,6 +90,8 @@ LoaderInit(void)
     LogMessageVerb(X_NONE, 2, "\t%s : %d.%d\n", ABI_CLASS_EXTENSION,
                    GET_ABI_MAJOR(LoaderVersionInfo.extensionVersion),
                    GET_ABI_MINOR(LoaderVersionInfo.extensionVersion));
+    LoaderIgnoresAllABI = FALSE;
+    LoaderIgnoresABI = FALSE;
 }
 
 /* Public Interface to the loader. */
@@ -146,18 +151,29 @@ LoaderUnload(const char *name, void *handle)
         dlclose(handle);
 }
 
-unsigned long LoaderOptions = 0;
+void
+LoaderSetIgnoreAllABI(void)
+{
+    LoaderIgnoresAllABI = TRUE;
+}
+
+Bool
+LoaderGetAndFlagIgnoreABI(const char *name)
+{
+    if (LoaderIgnoresAllABI)
+        LoaderIgnoresABI = TRUE;
+    return LoaderIgnoresABI;
+}
 
 void
-LoaderSetOptions(unsigned long opts)
+LoaderSetIgnoreABI(const char *name)
 {
-    LoaderOptions |= opts;
 }
 
 Bool
 LoaderShouldIgnoreABI(void)
 {
-    return (LoaderOptions & LDR_OPT_ABI_MISMATCH_NONFATAL) != 0;
+    return LoaderIgnoresABI;
 }
 
 int

--- a/hw/xfree86/loader/loader.c
+++ b/hw/xfree86/loader/loader.c
@@ -146,22 +146,18 @@ LoaderUnload(const char *name, void *handle)
         dlclose(handle);
 }
 
-Bool LoaderIgnoreAbi = FALSE;
-Bool is_nvidia_proprietary = FALSE;
+unsigned long LoaderOptions = 0;
 
 void
-LoaderSetIgnoreAbi(void)
+LoaderSetOptions(unsigned long opts)
 {
-    /* Only used to keep consistency with the loader api */
-    /* This really doesn't have to be a proc */
-    LoaderIgnoreAbi = TRUE;
+    LoaderOptions |= opts;
 }
 
 Bool
 LoaderShouldIgnoreABI(void)
 {
-    /* The nvidia proprietary DDX driver calls this deprecated function */
-    return is_nvidia_proprietary || LoaderIgnoreAbi;
+    return (LoaderOptions & LDR_OPT_ABI_MISMATCH_NONFATAL) != 0;
 }
 
 int

--- a/hw/xfree86/loader/loader.h
+++ b/hw/xfree86/loader/loader.h
@@ -68,7 +68,8 @@ typedef struct {
 } ModuleVersions;
 extern const ModuleVersions LoaderVersionInfo;
 
-extern unsigned long LoaderOptions;
+extern Bool LoaderIgnoresAllABI;
+extern Bool LoaderIgnoresABI;
 
 /* Internal Functions */
 void *LoaderOpen(const char *, int *);

--- a/hw/xfree86/loader/loader.h
+++ b/hw/xfree86/loader/loader.h
@@ -68,9 +68,7 @@ typedef struct {
 } ModuleVersions;
 extern const ModuleVersions LoaderVersionInfo;
 
-extern Bool LoaderIgnoreAbi;
-
-extern Bool is_nvidia_proprietary;
+extern unsigned long LoaderOptions;
 
 /* Internal Functions */
 void *LoaderOpen(const char *, int *);

--- a/hw/xfree86/loader/loaderProcs.h
+++ b/hw/xfree86/loader/loaderProcs.h
@@ -78,12 +78,10 @@ void LoaderSetPath(const char *path);
 void LoaderUnload(const char *, void *);
 unsigned long LoaderGetModuleVersion(ModuleDescPtr mod);
 
-void LoaderResetOptions(void);
-void LoaderSetOptions(unsigned long);
+void LoaderSetIgnoreAllABI(void);
+Bool LoaderGetAndFlagIgnoreABI(const char *);
+void LoaderSetIgnoreABI(const char *);
 
 const char **LoaderListDir(const char *, const char **);
-
-/* Options for LoaderSetOptions */
-#define LDR_OPT_ABI_MISMATCH_NONFATAL		0x0001
 
 #endif                          /* _LOADERPROCS_H */

--- a/hw/xfree86/loader/loaderProcs.h
+++ b/hw/xfree86/loader/loaderProcs.h
@@ -69,6 +69,7 @@ typedef struct module_desc {
 /* External API for the loader */
 
 void LoaderInit(void);
+void LoaderClose(void);
 
 ModuleDescPtr LoadModule(const char *, void *, const XF86ModReqInfo *, int *);
 ModuleDescPtr DuplicateModule(ModuleDescPtr mod, ModuleDescPtr parent);

--- a/hw/xfree86/loader/loaderProcs.h
+++ b/hw/xfree86/loader/loaderProcs.h
@@ -79,9 +79,11 @@ void LoaderUnload(const char *, void *);
 unsigned long LoaderGetModuleVersion(ModuleDescPtr mod);
 
 void LoaderResetOptions(void);
-
-void LoaderSetIgnoreAbi(void);
+void LoaderSetOptions(unsigned long);
 
 const char **LoaderListDir(const char *, const char **);
+
+/* Options for LoaderSetOptions */
+#define LDR_OPT_ABI_MISMATCH_NONFATAL		0x0001
 
 #endif                          /* _LOADERPROCS_H */

--- a/hw/xfree86/loader/loadmod.c
+++ b/hw/xfree86/loader/loadmod.c
@@ -457,19 +457,27 @@ CheckVersion(const char *module, XF86ModuleVersionInfo * data,
             vermaj = GET_ABI_MAJOR(ver);
             vermin = GET_ABI_MINOR(ver);
             if (abimaj != vermaj) {
-                LogMessageVerb(LoaderIgnoreAbi ? X_WARNING : X_ERROR, 0,
-                               "%s: module ABI major version (%d) "
+                MessageType errtype;
+                if (LoaderOptions & LDR_OPT_ABI_MISMATCH_NONFATAL)
+                    errtype = X_WARNING;
+                else
+                    errtype = X_ERROR;
+                LogMessageVerb(errtype, 0, "%s: module ABI major version (%d) "
                                "doesn't match the server's version (%d)\n",
                                module, abimaj, vermaj);
-                if (!LoaderIgnoreAbi)
+                if (!(LoaderOptions & LDR_OPT_ABI_MISMATCH_NONFATAL))
                     return FALSE;
             }
             else if (abimin > vermin) {
-                LogMessageVerb(LoaderIgnoreAbi ? X_WARNING : X_ERROR, 0,
-                               "%s: module ABI minor version (%d) "
+                MessageType errtype;
+                if (LoaderOptions & LDR_OPT_ABI_MISMATCH_NONFATAL)
+                    errtype = X_WARNING;
+                else
+                    errtype = X_ERROR;
+                LogMessageVerb(errtype, 0, "%s: module ABI minor version (%d) "
                                "is newer than the server's version (%d)\n",
                                module, abimin, vermin);
-                if (!LoaderIgnoreAbi)
+                if (!(LoaderOptions & LDR_OPT_ABI_MISMATCH_NONFATAL))
                     return FALSE;
             }
         }
@@ -664,9 +672,6 @@ LoadModule(const char *module, void *options, const XF86ModReqInfo *modreq,
 
     LogMessageVerb(X_INFO, 3, "LoadModule: \"%s\"", module);
 
-    /* Ignore abi check for the nvidia proprietary DDX driver */
-    is_nvidia_proprietary = !memcmp(module, "nvidia", sizeof("nvidia"));
-
     patterns = InitPatterns(NULL);
     name = LoaderGetCanonicalName(module, patterns);
     noncanonical = (name && strcmp(module, name) != 0);
@@ -680,12 +685,6 @@ LoadModule(const char *module, void *options, const XF86ModReqInfo *modreq,
     else {
         LogMessageVerb(X_NONE, 3, "\n");
         m = (char *) module;
-    }
-
-    if (is_nvidia_proprietary && !LoaderIgnoreAbi) {
-        /* warn every time this is hit */
-        LogMessage(X_WARNING, "LoadModule: Implicitly ignoring abi mismatch "
-                   "for the nvidia proprierary DDX driver\n");
     }
 
     /* Backward compatibility, vbe and int10 are merged into int10 now */

--- a/hw/xfree86/loader/loadmod.c
+++ b/hw/xfree86/loader/loadmod.c
@@ -458,26 +458,26 @@ CheckVersion(const char *module, XF86ModuleVersionInfo * data,
             vermin = GET_ABI_MINOR(ver);
             if (abimaj != vermaj) {
                 MessageType errtype;
-                if (LoaderOptions & LDR_OPT_ABI_MISMATCH_NONFATAL)
+                if (LoaderIgnoresABI)
                     errtype = X_WARNING;
                 else
                     errtype = X_ERROR;
                 LogMessageVerb(errtype, 0, "%s: module ABI major version (%d) "
                                "doesn't match the server's version (%d)\n",
                                module, abimaj, vermaj);
-                if (!(LoaderOptions & LDR_OPT_ABI_MISMATCH_NONFATAL))
+                if (!LoaderIgnoresABI)
                     return FALSE;
             }
             else if (abimin > vermin) {
                 MessageType errtype;
-                if (LoaderOptions & LDR_OPT_ABI_MISMATCH_NONFATAL)
+                if (LoaderIgnoresABI)
                     errtype = X_WARNING;
                 else
                     errtype = X_ERROR;
                 LogMessageVerb(errtype, 0, "%s: module ABI minor version (%d) "
                                "is newer than the server's version (%d)\n",
                                module, abimin, vermin);
-                if (!(LoaderOptions & LDR_OPT_ABI_MISMATCH_NONFATAL))
+                if (!LoaderIgnoresABI)
                     return FALSE;
             }
         }
@@ -777,6 +777,9 @@ LoadModule(const char *module, void *options, const XF86ModReqInfo *modreq,
         vers = initdata->vers;
         setup = initdata->setup;
         teardown = initdata->teardown;
+
+        if (LoaderGetAndFlagIgnoreABI(name))
+            LogMessageVerb(X_INFO, 3, "ABI ignored for module \"%s\"\n", name);
 
         if (vers) {
             if (!CheckVersion(module, vers, modreq)) {

--- a/hw/xfree86/man/xorg.conf.man
+++ b/hw/xfree86/man/xorg.conf.man
@@ -1292,11 +1292,11 @@ When an output device has been matched to the
 .B OutputClass
 section, any
 .B Option
-entries are applied to the device. One
+entries are applied to the device. Three
 .B OutputClass
-specific
+specific kinds of
 .B Option
-is recognized. See the
+are recognized. See the
 .B Device
 section below for a description of the remaining
 .B Option
@@ -1321,7 +1321,7 @@ If multiple output devices match an
 section with the
 .B HotplugDriver
 option, the first one enumerated becomes the hotplug driver.
-A
+An
 .B OutputClass
 Section may contain
 .B ModulePath
@@ -1336,6 +1336,31 @@ are pre-pended to the search path for loadable Xorg server modules. See
 in the
 .B Files
 section for more info.
+.TP 7
+.BI "Option \*qIgnoreABI\*q \*q" boolean \*q
+If set, this option makes driver loader ignore module ABI, which may be necessary
+to use legacy proprietary NVidia drivers. If
+.PP
+.RS 7
+.nf
+.B  "Section \*qOutputClass\*q"
+.BI  "    Identifier  \*q" AnyName \*q
+.BI  "    MatchDriver  \*q" drm_driver \*q
+.BI  "    Driver  \*q" X_driver \*q
+.BI  "    Option  \*q" IgnoreABI \*q
+.B  "EndSection
+.fi
+.RE
+.PP
+.RS 7
+appears, and a DRM device with a kernel
+.I drm_driver
+is found, then
+.I X_driver
+for it will be loaded regardless of its ABI version. Please note that this has
+no effect if DRM for a GPU is not enabled. See
+.IR /usr/share/X11/xorg.conf.d/10-nvidia.conf
+for an example.
 .SH "DEVICE SECTION"
 The config file may have multiple
 .B Device


### PR DESCRIPTION
I propose a non-hackish way to handle automatic application of `IgnoreABI` options only to certain drivers. I have no nvidia hw accessible at the moment, so modified `/usr/share/X11/xorg.conf.d/10-radeon.conf` to
```
Section "OutputClass"
        Identifier "Radeon"
        MatchDriver "radeon"
        Driver "radeon"
        Option "IgnoreABI"
EndSection

```
and see in X.0.log
```
[2025-07-31 12:46:02] 
XLibre X Server 1.25.0
X Protocol Version 11, Revision 0
...
[2025-07-31 12:46:02] (==) ModulePath set to "/usr/lib64/xorg/modules"
[2025-07-31 12:46:02] (II) The server relies on udev to provide the list of input devices.
        If no devices become available, reconfigure udev or disable AutoAddDevices.
[2025-07-31 12:46:02] (II) Module ABI versions:
[2025-07-31 12:46:02]   X.Org ANSI C Emulation: 1.4
[2025-07-31 12:46:02]   X.Org Video Driver: 28.0
[2025-07-31 12:46:02]   X.Org XInput driver : 26.0
[2025-07-31 12:46:02]   X.Org Server Extension : 11.0
[2025-07-31 12:46:02] (II) xfree86: Adding drm device (/dev/dri/card0)
[2025-07-31 12:46:02] (II) Platform probe for /sys/devices/pci0000:00/0000:00:01.0/0000:01:00.0/drm/card0
[2025-07-31 12:46:02] (**) OutputClass "Radeon" setting radeon to ignore ABI for "/dev/dri/card0"
[2025-07-31 12:46:02] (--) PCI:*(1@0:0:0) 1002:68b8:1682:2990 rev 0, Mem @ 0xd0000000/268435456, 0xfe9c0000/131072, I/O @ 0xc000/256, BIOS @ 0x????????/131072
[2025-07-31 12:46:02] (II) Open ACPI successful (/var/run/acpid.socket)
[2025-07-31 12:46:02] (II) LoadModule: "glx"
[2025-07-31 12:46:02] (II) Loading /usr/lib64/xorg/modules/xlibre-25.0/extensions/libglx.so
[2025-07-31 12:46:02] (II) Module glx: vendor="X.Org Foundation"
[2025-07-31 12:46:02]   compiled for 1.25.0, module version = 1.0.0
[2025-07-31 12:46:02]   ABI class: X.Org Server Extension, version 11.0
[2025-07-31 12:46:02] (II) Applying OutputClass "Radeon" to /dev/dri/card0
[2025-07-31 12:46:02]   loading driver: radeon
...

```
that ignore ABI is applied to radeon (clearly with no consequences because radeon does not call `LoaderShouldIgnoreABI()` ). With  `/usr/share/X11/xorg.conf.d/10-nvidia.conf` installed 
```
 Make nvidia driver ignore ABI by default

Section "OutputClass"
        Identifier "NVidia"
        MatchDriver "nvidia"
        Driver "nvidia"
        Option "IgnoreABI"
EndSection

```
nvidia driver will get the correct return value to this function. No user action is required.

This is motivated by https://github.com/X11Libre/xserver/issues/447

@metux @cepelinas9000 @callmetango @chankongus Please review.