### PR TITLE
os: encapsulate OS specific aspects of hostname retrieval into xhostname() function 

### DIFF
--- a/hw/vfb/InitOutput.c
+++ b/hw/vfb/InitOutput.c
@@ -44,6 +44,7 @@ from The Open Group.
 #include "os/cmdline.h"
 #include "os/ddx_priv.h"
 #include "os/osdep.h"
+#include "os/xhostname.h"
 
 #include "scrnintstr.h"
 #include "servermd.h"
@@ -701,7 +702,6 @@ vfbWriteXWDFileHeader(ScreenPtr pScreen)
 {
     vfbScreenInfoPtr pvfb = &vfbScreens[pScreen->myNum];
     XWDFileHeader *pXWDHeader = pvfb->pXWDHeader;
-    char hostname[XWD_WINDOW_NAME_LEN];
     unsigned long swaptest = 1;
     int i;
 
@@ -736,12 +736,10 @@ vfbWriteXWDFileHeader(ScreenPtr pScreen)
     pXWDHeader->window_bdrwidth = 0;
 
     /* write xwd "window" name: Xvfb hostname:server.screen */
-
-    if (-1 == gethostname(hostname, sizeof(hostname)))
-        hostname[0] = 0;
-    else
-        hostname[XWD_WINDOW_NAME_LEN - 1] = 0;
-    sprintf((char *) (pXWDHeader + 1), "Xvfb %s:%s.%d", hostname, display,
+    struct xhostname hn;
+    xhostname(&hn);
+    hn.name[XWD_WINDOW_NAME_LEN - 1] = 0;
+    sprintf((char *) (pXWDHeader + 1), "Xvfb %s:%s.%d", hn.name, display,
             pScreen->myNum);
 
     /* write colormap pixel slot values */

--- a/hw/xfree86/parser/scan.c
+++ b/hw/xfree86/parser/scan.c
@@ -66,11 +66,10 @@
 #include <X11/Xdefs.h>
 #include <X11/Xfuncproto.h>
 #include <limits.h>
-#include "xf86Parser_priv.h"
 
-#if !defined(MAXHOSTNAMELEN)
-#define MAXHOSTNAMELEN 32
-#endif                          /* !MAXHOSTNAMELEN */
+#include "os/xhostname.h"
+
+#include "xf86Parser_priv.h"
 
 /* For PATH_MAX */
 #include "misc.h"
@@ -625,15 +624,9 @@ DoSubstitution(const char *template, const char *cmdline, const char *projroot,
                 break;
             case 'H':
                 if (!hostname) {
-                    if ((hostname = calloc(1, MAXHOSTNAMELEN + 1))) {
-                        if (gethostname(hostname, MAXHOSTNAMELEN) == 0) {
-                            hostname[MAXHOSTNAMELEN] = '\0';
-                        }
-                        else {
-                            free(hostname);
-                            hostname = NULL;
-                        }
-                    }
+                    struct xhostname hn;
+                    if (xhostname(&hn))
+                        hostname = strdup(hn.name);
                 }
                 if (hostname)
                     APPEND_STR(hostname);

--- a/os/Xtrans.c
+++ b/os/Xtrans.c
@@ -56,6 +56,7 @@ from The Open Group.
 #endif
 
 #include "os/ossock.h"
+#include "os/xhostname.h"
 
 /*
  * The transport table contains a definition for every transport (protocol)
@@ -201,7 +202,6 @@ _XSERVTransParseAddress (const char *address,
     char	*mybuf, *tmpptr = NULL;
     const char	*_protocol = NULL;
     const char	*_host, *_port;
-    char	hostnamebuf[256];
     char	*_host_buf;
     int		_host_len;
 
@@ -305,10 +305,12 @@ _XSERVTransParseAddress (const char *address,
     *mybuf ++= '\0';
 
     _host_len = strlen(_host);
+
+    struct xhostname hn;
     if (_host_len == 0)
     {
-	_XSERVTransGetHostname (hostnamebuf, sizeof (hostnamebuf));
-	_host = hostnamebuf;
+        xhostname(&hn);
+        _host = hn.name;
     }
 #ifdef IPv6
     /* hostname in IPv6 [numeric_addr]:0 form? */
@@ -1058,36 +1060,6 @@ static int _XSERVTransWriteV (XtransConnInfo ciptr, struct iovec *iov, int iovcn
 	}
     }
     return total;
-}
-
-/*
- * _XSERVTransGetHostname - similar to gethostname but allows special processing.
- */
-int _XSERVTransGetHostname (char *buf, int maxlen)
-{
-    buf[0] = '\0';
-    (void) gethostname (buf, maxlen);
-    buf [maxlen - 1] = '\0';
-    return strlen(buf);
-}
-
-#else /* WIN32 */
-
-#include <sys/utsname.h>
-
-/*
- * _XSERVTransGetHostname - similar to gethostname but allows special processing.
- */
-int _XSERVTransGetHostname (char *buf, int maxlen)
-{
-    struct utsname name;
-    uname (&name);
-
-    int len = strlen (name.nodename);
-    if (len >= maxlen) len = maxlen - 1;
-    memcpy (buf, name.nodename, len);
-    buf[len] = '\0';
-    return len;
 }
 
 #endif /* WIN32 */

--- a/os/Xtrans.h
+++ b/os/Xtrans.h
@@ -292,9 +292,4 @@ int _XSERVTransConvertAddress (
     Xtransaddr **	/* addrp */
 );
 
-int _XSERVTransGetHostname (
-    char *	/* buf */,
-    int 	/* maxlen */
-);
-
 #endif /* _XTRANS_H_ */

--- a/os/Xtransutil.c
+++ b/os/Xtransutil.c
@@ -62,6 +62,8 @@ from The Open Group.
 #include <X11/Xwinsock.h>
 #endif
 
+#include "os/xhostname.h"
+
 #if defined(IPv6) && !defined(AF_INET6)
 #error "Cannot build IPv6 support without AF_INET6"
 #endif
@@ -189,8 +191,9 @@ int _XSERVTransConvertAddress(int *familyp, int *addrlenp, Xtransaddr **addrp)
 	 * host name for authentication.
 	 */
 
-	char hostnamebuf[256];
-	int len = _XSERVTransGetHostname (hostnamebuf, sizeof hostnamebuf);
+        struct xhostname hn;
+        xhostname(&hn);
+        int len = strlen(hn.name);
 
 	if (len > 0) {
 	    if (*addrp && *addrlenp < (len + 1))
@@ -201,7 +204,7 @@ int _XSERVTransConvertAddress(int *familyp, int *addrlenp, Xtransaddr **addrp)
 	    if (!*addrp)
 		*addrp = malloc (len + 1);
 	    if (*addrp) {
-		strcpy ((char *) *addrp, hostnamebuf);
+		strcpy ((char *) *addrp, hn.name);
 		*addrlenp = len;
 	    } else {
 		*addrlenp = 0;

--- a/os/access.c
+++ b/os/access.c
@@ -91,6 +91,9 @@ SOFTWARE.
 #include "misc.h"
 #include <errno.h>
 #include <sys/types.h>
+
+#include "os/xhostname.h"
+
 #ifndef WIN32
 #include <sys/socket.h>
 #include <sys/ioctl.h>
@@ -403,7 +406,6 @@ DefineSelf(int fd)
     caddr_t addr;
     int family;
     register HOST *host;
-    struct utsname name;
     register struct hostent *hp;
 
     union {
@@ -429,9 +431,10 @@ DefineSelf(int fd)
      * uname() lets me access to the whole string (it smashes release, you
      * see), whereas gethostname() kindly truncates it for me.
      */
-    uname(&name);
+    struct xhostname hn;
+    xhostname(&hn);
 
-    hp = _XGethostbyname(name.nodename, hparams);
+    hp = _XGethostbyname(hn.name, hparams);
     if (hp != NULL) {
         saddr.sa.sa_family = hp->h_addrtype;
         switch (hp->h_addrtype) {

--- a/os/meson.build
+++ b/os/meson.build
@@ -18,6 +18,7 @@ srcs_os = [
     'string.c',
     'utils.c',
     'xdmauth.c',
+    'xhostname.c',
     'xsha1.c',
     'xstrans.c',
     'xprintf.c',

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -122,13 +122,6 @@ Bool TimerForce(OsTimerPtr timer);
 
 #ifdef WIN32
 #include <X11/Xwinsock.h>
-struct utsname {
-    char nodename[512];
-};
-
-static inline void uname(struct utsname *uts) {
-    gethostname(uts->nodename, sizeof(uts->nodename));
-}
 
 const char *Win32TempDir(void);
 

--- a/os/utils.c
+++ b/os/utils.c
@@ -102,6 +102,7 @@ OR PERFORMANCE OF THIS SOFTWARE.
 #include "os/log_priv.h"
 #include "os/osdep.h"
 #include "os/serverlock.h"
+#include "os/xhostname.h"
 #include "Xext/xf86bigfontsrv.h" /* XF86BigfontCleanup() */
 #include "xkb/xkbsrv_priv.h"
 #include "dixstruct.h"
@@ -796,7 +797,6 @@ set_font_authorizations(char **authorizations, int *authlen, void *client)
     static char *p = NULL;
 
     if (p == NULL) {
-        char hname[1024], *hnameptr;
         unsigned int len;
 
 #if defined(HAVE_GETADDRINFO)
@@ -809,20 +809,23 @@ set_font_authorizations(char **authorizations, int *authlen, void *client)
 #endif
 #endif
 
-        gethostname(hname, 1024);
+        struct xhostname hn;
+        xhostname(&hn);
+
+        char *hnameptr = NULL;
 #if defined(HAVE_GETADDRINFO)
         memset(&hints, 0, sizeof(hints));
         hints.ai_flags = AI_CANONNAME;
-        if (getaddrinfo(hname, NULL, &hints, &ai) == 0) {
+        if (getaddrinfo(hn.name, NULL, &hints, &ai) == 0) {
             hnameptr = ai->ai_canonname;
         }
         else {
-            hnameptr = hname;
+            hnameptr = hn.name;
         }
 #else
-        host = _XGethostbyname(hname, hparams);
+        host = _XGethostbyname(hn.name, hparams);
         if (host == NULL)
-            hnameptr = hname;
+            hnameptr = hn.name;
         else
             hnameptr = host->h_name;
 #endif

--- a/os/xhostname.c
+++ b/os/xhostname.c
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#include <dix-config.h>
+
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+
+#if WIN32
+#include <winsock.h>
+#endif
+
+#include "os/xhostname.h"
+
+int xhostname(struct xhostname* hn)
+{
+    /* being extra-paranoid here */
+    memset(hn, 0, sizeof(struct xhostname));
+    int ret = gethostname(hn->name, sizeof(hn->name));
+
+    if (ret == -1) {
+        hn->name[0] = 0;
+        return errno;
+    }
+
+    hn->name[sizeof(hn->name)-1] = 0;
+    return ret;
+}

--- a/os/xhostname.h
+++ b/os/xhostname.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef _XSERVER_OS_XHOSTNAME_H_
+#define _XSERVER_OS_XHOSTNAME_H_
+
+#define XHOSTNAME_MAX 2048
+
+struct xhostname {
+    char name[XHOSTNAME_MAX];
+};
+
+/*
+ * retrieve host's nodename. basically a safer way of gethostname() / uname()
+ * making sure that the nodename is always zero-terminated.
+ *
+ * @hn pointer to struct xhostname that will be filled
+ * @return 0 on success
+ */
+int xhostname(struct xhostname* hn);
+
+#endif /* _XSERVER_OS_XHOSTNAME_H_ */


### PR DESCRIPTION
* os layer: add a function for safe hostname retrieval using a fixed-size buffer struct 
* this buffer is carefully cleared and the name string always zero-terminated
* simplify callers of gethostname() by using this function
