### PR TITLE
xserver: Update README.md to remove part ragebaiting alt left to avoid flame war

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ That's not enough? Then have a glance on the [good first](https://github.com/X11
     </figure>
 </p>
 
+Together we'll make X great again!
+
 ## Contact
 
 [XLibre Discussions at Github](https://github.com/orgs/X11Libre/discussions) | [XLibre mailing list at FreeLists](https://www.freelists.org/list/xlibre) | [@x11dev channel at Telegram](https://t.me/x11dev) | [#xlibre room at Matrix](https://matrix.to/#/#xlibre:matrix.org) | [XLibre security contact at Github](https://github.com/X11Libre/xserver/security/policy)

--- a/README.md
+++ b/README.md
@@ -108,8 +108,6 @@ That's not enough? Then have a glance on the [good first](https://github.com/X11
     </figure>
 </p>
 
-This is an independent project, not at all affiliated with BigTech or any of their subsidiaries or tax evasion tools, nor any political activists groups, state actors, etc. It's explicitly free of any "DEI" or similar discriminatory policies. Anybody who's treating others nicely is welcomed.
-
 It doesn't matter which country you're coming from, your political views, your race, your sex, your age, your food menu, whether you wear boots or heels, whether you're furry or fairy, Conan or McKay, comic character, a small furry creature from Alpha Centauri, or just a boring average person. Anybody who's interested in bringing X forward is welcome.
 
 Together we'll make X great again!

--- a/README.md
+++ b/README.md
@@ -108,11 +108,6 @@ That's not enough? Then have a glance on the [good first](https://github.com/X11
     </figure>
 </p>
 
-It doesn't matter which country you're coming from, your political views, your race, your sex, your age, your food menu, whether you wear boots or heels, whether you're furry or fairy, Conan or McKay, comic character, a small furry creature from Alpha Centauri, or just a boring average person. Anybody who's interested in bringing X forward is welcome.
-
-Together we'll make X great again!
-
-
 ## Contact
 
 [XLibre Discussions at Github](https://github.com/orgs/X11Libre/discussions) | [XLibre mailing list at FreeLists](https://www.freelists.org/list/xlibre) | [@x11dev channel at Telegram](https://t.me/x11dev) | [#xlibre room at Matrix](https://matrix.to/#/#xlibre:matrix.org) | [XLibre security contact at Github](https://github.com/X11Libre/xserver/security/policy)

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ That's not enough? Then have a glance on the [good first](https://github.com/X11
     </figure>
 </p>
 
-Together we'll make X great again!
+Anybody who's treating others nicely and interested in bringing X forward is welcome.  Together we'll make X great again!
 
 ## Contact
 


### PR DESCRIPTION
I think this section is unnecessary and just creates the flame war we have trouble with. These are trigger words for the alt left its easier to just drop it than constantly have people complaining about it. they aren't ready to accept DEI was another form of discrimination yet, they think that's a conspiracy theory. It's fluff it doesn't add anything good to poke the bear per say.