### PR TITLE
Xext: sync: drop unneeded include of <sys/time.h>

### DIFF
--- a/Xext/sync.c
+++ b/Xext/sync.c
@@ -75,10 +75,6 @@ PERFORMANCE OF THIS SOFTWARE.
 #include "inputstr.h"
 #include "misync_priv.h"
 
-#if !defined(WIN32)
-#include <sys/time.h>
-#endif
-
 /*
  * Local Global Variables
  */


### PR DESCRIPTION
We neither need to guard including <sys/time.h> from mingw, nor do we need that include here at all.