### PR TITLE
composite: more C99 declaration

### DIFF
--- a/composite/compext.c
+++ b/composite/compext.c
@@ -510,19 +510,16 @@ GetCompositeWindowBytes(void *value, XID id, ResourceSizePtr size)
 void
 CompositeExtensionInit(void)
 {
-    ExtensionEntry *extEntry;
-    int s;
-
     /* Assume initialization is going to fail */
     noCompositeExtension = TRUE;
 
-    for (s = 0; s < screenInfo.numScreens; s++) {
+    for (int s = 0; s < screenInfo.numScreens; s++) {
         ScreenPtr pScreen = screenInfo.screens[s];
-        VisualPtr vis;
 
         /* Composite on 8bpp pseudocolor root windows appears to fail, so
          * just disable it on anything pseudocolor for safety.
          */
+        VisualPtr vis;
         for (vis = pScreen->visuals; vis->vid != pScreen->rootVisual; vis++);
         if ((vis->class | DynamicClass) == PseudoColor)
             return;
@@ -556,11 +553,11 @@ CompositeExtensionInit(void)
                                sizeof(CompositeClientRec)))
         return;
 
-    for (s = 0; s < screenInfo.numScreens; s++)
+    for (int s = 0; s < screenInfo.numScreens; s++)
         if (!compScreenInit(screenInfo.screens[s]))
             return;
 
-    extEntry = AddExtension(COMPOSITE_NAME, 0, 0,
+    ExtensionEntry *extEntry = AddExtension(COMPOSITE_NAME, 0, 0,
                             ProcCompositeDispatch, SProcCompositeDispatch,
                             NULL, StandardMinorOpcode);
     if (!extEntry)

--- a/composite/compinit.c
+++ b/composite/compinit.c
@@ -93,9 +93,8 @@ compInstallColormap(ColormapPtr pColormap)
     VisualPtr pVisual = pColormap->pVisual;
     ScreenPtr pScreen = pColormap->pScreen;
     CompScreenPtr cs = GetCompScreen(pScreen);
-    int a;
 
-    for (a = 0; a < cs->numAlternateVisuals; a++)
+    for (int a = 0; a < cs->numAlternateVisuals; a++)
         if (pVisual->vid == cs->alternateVisuals[a])
             return;
     pScreen->InstallColormap = cs->InstallColormap;
@@ -160,9 +159,7 @@ compSourceValidate(DrawablePtr pDrawable,
 static DepthPtr
 compFindVisuallessDepth(ScreenPtr pScreen, int d)
 {
-    int i;
-
-    for (i = 0; i < pScreen->numDepths; i++) {
+    for (int i = 0; i < pScreen->numDepths; i++) {
         DepthPtr depth = &pScreen->allowedDepths[i];
 
         if (depth->depth == d) {
@@ -299,12 +296,12 @@ compAddAlternateVisual(ScreenPtr pScreen, CompScreenPtr cs,
 static Bool
 compAddAlternateVisuals(ScreenPtr pScreen, CompScreenPtr cs)
 {
-    int alt, ret = 0;
+    int ret = 0;
 
-    for (alt = 0; alt < ARRAY_SIZE(altVisuals); alt++)
+    for (int alt = 0; alt < ARRAY_SIZE(altVisuals); alt++)
         ret |= compAddAlternateVisual(pScreen, cs, altVisuals + alt);
 
-    return ! !ret;
+    return ret;
 }
 
 Bool

--- a/composite/compoverlay.c
+++ b/composite/compoverlay.c
@@ -59,9 +59,9 @@ compFreeOverlayClient(CompOverlayClientPtr pOcToDel)
 {
     ScreenPtr pScreen = pOcToDel->pScreen;
     CompScreenPtr cs = GetCompScreen(pScreen);
-    CompOverlayClientPtr *pPrev, pOc;
 
-    for (pPrev = &cs->pOverlayClients; (pOc = *pPrev); pPrev = &pOc->pNext) {
+    for (CompOverlayClientPtr *pPrev = &cs->pOverlayClients, pOc;
+                        (pOc = *pPrev); pPrev = &pOc->pNext) {
         if (pOc == pOcToDel) {
             *pPrev = pOc->pNext;
             free(pOc);
@@ -81,9 +81,9 @@ CompOverlayClientPtr
 compFindOverlayClient(ScreenPtr pScreen, ClientPtr pClient)
 {
     CompScreenPtr cs = GetCompScreen(pScreen);
-    CompOverlayClientPtr pOc;
 
-    for (pOc = cs->pOverlayClients; pOc != NULL; pOc = pOc->pNext)
+    for (CompOverlayClientPtr pOc = cs->pOverlayClients;
+                          pOc != NULL; pOc = pOc->pNext)
         if (pOc->pClient == pClient)
             return pOc;
 

--- a/composite/compwindow.c
+++ b/composite/compwindow.c
@@ -320,9 +320,8 @@ Bool
 compIsAlternateVisual(ScreenPtr pScreen, XID visual)
 {
     CompScreenPtr cs = GetCompScreen(pScreen);
-    int i;
 
-    for (i = 0; cs && i < cs->numAlternateVisuals; i++)
+    for (int i = 0; cs && i < cs->numAlternateVisuals; i++)
         if (cs->alternateVisuals[i] == visual)
             return TRUE;
     return FALSE;
@@ -333,9 +332,8 @@ CompositeIsImplicitRedirectException(ScreenPtr pScreen,
                                      XID parentVisual, XID winVisual)
 {
     CompScreenPtr cs = GetCompScreen(pScreen);
-    int i;
 
-    for (i = 0; i < cs->numImplicitRedirectExceptions; i++)
+    for (int i = 0; i < cs->numImplicitRedirectExceptions; i++)
         if (cs->implicitRedirectExceptions[i].parentVisual == parentVisual &&
             cs->implicitRedirectExceptions[i].winVisual == winVisual)
             return TRUE;
@@ -564,14 +562,13 @@ compCreateWindow(WindowPtr pWin)
     ret = (*pScreen->CreateWindow) (pWin);
     if (pWin->parent && ret) {
         CompSubwindowsPtr csw = GetCompSubwindows(pWin->parent);
-        CompClientWindowPtr ccw;
         PixmapPtr parent_pixmap = (*pScreen->GetWindowPixmap)(pWin->parent);
         PixmapPtr window_pixmap = (*pScreen->GetWindowPixmap)(pWin);
 
         if (window_pixmap != parent_pixmap)
             (*pScreen->SetWindowPixmap) (pWin, parent_pixmap);
         if (csw)
-            for (ccw = csw->clients; ccw; ccw = ccw->next)
+            for (CompClientWindowPtr ccw = csw->clients; ccw; ccw = ccw->next)
                 compRedirectWindow(dixClientForXID(ccw->id),
                                    pWin, ccw->update);
         if (compImplicitRedirect(pWin, pWin->parent))
@@ -726,12 +723,10 @@ compPaintWindowToParent(WindowPtr pWin)
 void
 compPaintChildrenToWindow(WindowPtr pWin)
 {
-    WindowPtr pChild;
-
     if (!pWin->damagedDescendants)
         return;
 
-    for (pChild = pWin->lastChild; pChild; pChild = pChild->prevSib)
+    for (WindowPtr pChild = pWin->lastChild; pChild; pChild = pChild->prevSib)
         compPaintWindowToParent(pChild);
 
     pWin->damagedDescendants = FALSE;


### PR DESCRIPTION
Followup to #443 

`static Bool compAddAlternativeVisuals(ScreenPtr, CompScreenPtr)` has left me a bit perplexed: why does it return `! ! int` instead of just `int`? It's a bool, so it should be the same thing, if the idea is to return a bitmask then why is returning a Bool instead of an unsigned? I've spotted no regressions, both with xcompmgr and picom (all backends), so it should be fine, it's probably been edited out by GCC all this time anyway.