### PR TITLE
meson: rename symbol MITSHM to CONFIG_MITSHM

### DIFF
--- a/Xext/xf86bigfont.c
+++ b/Xext/xf86bigfont.c
@@ -42,12 +42,12 @@
 #include <time.h>
 #include <errno.h>
 
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
 #include <sys/sysmacros.h>
 #include <sys/ipc.h>
 #include <sys/shm.h>
 #include <sys/stat.h>
-#endif /* MITSHM */
+#endif /* CONFIG_MITSHM */
 
 #include <X11/X.h>
 #include <X11/Xproto.h>
@@ -71,7 +71,7 @@ Bool noXFree86BigfontExtension = FALSE;
 
 static void XF86BigfontResetProc(ExtensionEntry *extEntry );
 
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
 
 /* A random signature, transmitted to the clients so they can verify that the
    shared memory segment they are attaching to was really established by the
@@ -233,12 +233,12 @@ XF86BigfontCleanup(void)
         shmdealloc(ShmList);
 }
 
-#else /* MITSHM */
+#else /* CONFIG_MITSHM */
 
 void XF86BigfontFreeFontShm(FontPtr pFont) { }
 void XF86BigfontCleanup(void) { }
 
-#endif /* MITSHM */
+#endif /* CONFIG_MITSHM */
 
 /* Called when a server generation dies. */
 static void
@@ -269,11 +269,11 @@ ProcXF86BigfontQueryVersion(ClientPtr client)
         .minorVersion = SERVER_XF86BIGFONT_MINOR_VERSION,
         .uid = geteuid(),
         .gid = getegid(),
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
         .signature = signature,
         .capabilities = (client->local && !client->swapped)
                          ? XF86Bigfont_CAP_LocalShm : 0
-#endif /* MITSHM */
+#endif /* CONFIG_MITSHM */
     };
     if (client->swapped) {
         swaps(&reply.sequenceNumber);
@@ -318,11 +318,11 @@ ProcXF86BigfontQueryFont(ClientPtr client)
     int nCharInfos;
     int shmid;
 
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
     ShmDescPtr pDesc = NULL;
 #else
 #define pDesc 0
-#endif /* MITSHM */
+#endif /* CONFIG_MITSHM */
     xCharInfo *pCI;
     CARD16 *pIndex2UniqIndex;
     CARD16 *pUniqIndex2Index;
@@ -361,7 +361,7 @@ ProcXF86BigfontQueryFont(ClientPtr client)
     nUniqCharInfos = 0;
 
     if (nCharInfos > 0) {
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
         if (!badSysCall)
             pDesc = (ShmDescPtr) FontGetPrivate(pFont, FontShmdescIndex);
         if (pDesc) {
@@ -378,13 +378,13 @@ ProcXF86BigfontQueryFont(ClientPtr client)
                 shmid = pDesc->shmid;
             }
             else {
-#endif /* MITSHM */
+#endif /* CONFIG_MITSHM */
                 pCI = calloc(nCharInfos, sizeof(xCharInfo));
                 if (!pCI)
                     return BadAlloc;
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
             }
-#endif /* MITSHM */
+#endif /* CONFIG_MITSHM */
             /* Fill nCharInfos starting at pCI. */
             {
                 xCharInfo *prCI = pCI;
@@ -414,7 +414,7 @@ ProcXF86BigfontQueryFont(ClientPtr client)
                     }
                 }
             }
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
             if (pDesc && !badSysCall) {
                 *(CARD32 *) (pCI + nCharInfos) = signature;
                 if (!xfont2_font_set_private(pFont, FontShmdescIndex, pDesc)) {
@@ -423,7 +423,7 @@ ProcXF86BigfontQueryFont(ClientPtr client)
                 }
             }
         }
-#endif /* MITSHM */
+#endif /* CONFIG_MITSHM */
         if (shmid == -1) {
             /* Cannot use shared memory, so remove-duplicates the xCharInfos
                using a temporary hash table. */
@@ -679,7 +679,7 @@ XFree86BigfontExtensionInit(void)
                      ProcXF86BigfontDispatch,
                      SProcXF86BigfontDispatch,
                      XF86BigfontResetProc, StandardMinorOpcode)) {
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
 #ifdef MUST_CHECK_FOR_SHM_SYSCALL
         /*
          * Note: Local-clients will not be optimized without shared memory
@@ -710,6 +710,6 @@ XFree86BigfontExtensionInit(void)
         pagesize = getpagesize();
 #endif
 #endif
-#endif /* MITSHM */
+#endif /* CONFIG_MITSHM */
     }
 }

--- a/Xext/xvdisp.c
+++ b/Xext/xvdisp.c
@@ -43,7 +43,7 @@ SOFTWARE.
 #include "dixstruct.h"
 #include "resource.h"
 #include "opaque.h"
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
 #include <X11/extensions/shmproto.h>
 #include "shmint.h"
 #endif
@@ -737,7 +737,7 @@ ProcXvPutImage(ClientPtr client)
     return SingleXvPutImage(client);
 }
 
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
 
 static int
 SingleXvShmPutImage(ClientPtr client)
@@ -816,12 +816,12 @@ SingleXvShmPutImage(ClientPtr client)
 
 static int XineramaXvShmPutImage(ClientPtr client);
 
-#endif /* MITSHM */
+#endif /* CONFIG_MITSHM */
 
 static int
 ProcXvShmPutImage(ClientPtr client)
 {
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
 #ifdef XINERAMA
     if (xvUseXinerama)
         return XineramaXvShmPutImage(client);
@@ -829,7 +829,7 @@ ProcXvShmPutImage(ClientPtr client)
     return SingleXvShmPutImage(client);
 #else
     return BadImplementation;
-#endif
+#endif /* CONFIG_MITSHM */
 }
 
 #ifdef XvMCExtension
@@ -1178,7 +1178,7 @@ SProcXvPutImage(ClientPtr client)
     return ProcXvPutImage(client);
 }
 
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
 static int _X_COLD
 SProcXvShmPutImage(ClientPtr client)
 {
@@ -1202,9 +1202,9 @@ SProcXvShmPutImage(ClientPtr client)
     swaps(&stuff->height);
     return ProcXvShmPutImage(client);
 }
-#else                           /* MITSHM */
+#else /* CONFIG_MITSHM */
 #define SProcXvShmPutImage ProcXvShmPutImage
-#endif
+#endif /* CONFIG_MITSHM */
 
 static int _X_COLD
 SProcXvSelectVideoNotify(ClientPtr client)
@@ -1405,7 +1405,7 @@ XineramaXvSetPortAttribute(ClientPtr client)
     return result;
 }
 
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
 static int
 XineramaXvShmPutImage(ClientPtr client)
 {
@@ -1457,9 +1457,9 @@ XineramaXvShmPutImage(ClientPtr client)
     }
     return result;
 }
-#else
+#else /* CONFIG_MITSHM */
 #define XineramaXvShmPutImage ProcXvShmPutImage
-#endif /* MITSHM */
+#endif /* CONFIG_MITSHM */
 
 static int
 XineramaXvPutImage(ClientPtr client)

--- a/exa/exa.c
+++ b/exa/exa.c
@@ -39,9 +39,9 @@
 
 DevPrivateKeyRec exaScreenPrivateKeyRec;
 
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
 static ShmFuncs exaShmFuncs = { NULL, NULL };
-#endif
+#endif /* CONFIG_MITSHM */
 
 /**
  * exaGetPixmapOffset() returns the offset (in bytes) within the framebuffer of
@@ -910,12 +910,12 @@ exaDriverInit(ScreenPtr pScreen, ExaDriverPtr pScreenInfo)
         wrap(pExaScr, ps, AddTraps, ExaCheckAddTraps);
     }
 
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
     /*
      * Don't allow shared pixmaps.
      */
     ShmRegisterFuncs(pScreen, &exaShmFuncs);
-#endif
+#endif /* CONFIG_MITSHM */
     /*
      * Hookup offscreen pixmaps
      */

--- a/exa/exa_priv.h
+++ b/exa/exa_priv.h
@@ -32,9 +32,9 @@
 
 #include <X11/X.h>
 #include <X11/Xproto.h>
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
 #include "shmint.h"
-#endif
+#endif /* CONFIG_MITSHM */
 #include "scrnintstr.h"
 #include "pixmapstr.h"
 #include "windowstr.h"

--- a/fb/fboverlay.c
+++ b/fb/fboverlay.c
@@ -285,9 +285,9 @@ fbOverlayFinishScreenInit(ScreenPtr pScreen,
         return FALSE;
     }
     /* MI thinks there's no frame buffer */
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
     ShmRegisterFbFuncs(pScreen);
-#endif
+#endif /* CONFIG_MITSHM */
     pScreen->minInstalledCmaps = 1;
     pScreen->maxInstalledCmaps = 2;
 

--- a/hw/vfb/InitOutput.c
+++ b/hw/vfb/InitOutput.c
@@ -66,10 +66,10 @@ from The Open Group.
 #include <sys/param.h>
 #endif
 #include <X11/XWDFile.h>
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
 #include <sys/ipc.h>
 #include <sys/shm.h>
-#endif                          /* MITSHM */
+#endif /* CONFIG-MITSHM */
 #include "dix.h"
 #include "miline.h"
 #include "glx_extinit.h"
@@ -116,9 +116,9 @@ typedef struct {
     char mmap_file[MAXPATHLEN];
 #endif
 
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
     int shmid;
-#endif
+#endif /* CONFIG_MITSHM */
 } vfbScreenInfo, *vfbScreenInfoPtr;
 
 static int vfbNumScreens;
@@ -228,17 +228,17 @@ freeScreenInfo(vfbScreenInfoPtr pvfb)
         break;
 #endif                          /* HAVE_MMAP */
 
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
     case SHARED_MEMORY_FB:
         if (-1 == shmdt((char *) pvfb->pXWDHeader)) {
             perror("shmdt");
             ErrorF("shmdt failed, %s", strerror(errno));
         }
         break;
-#else                           /* MITSHM */
+#else /* CONFIG_MITSHM */
     case SHARED_MEMORY_FB:
         break;
-#endif                          /* MITSHM */
+#endif /* CONFIG_MITSHM */
 
     case NORMAL_MEMORY_FB:
         free(pvfb->pXWDHeader);
@@ -294,9 +294,9 @@ ddxUseMsg(void)
         ("-fbdir directory       put framebuffers in mmap'ed files in directory\n");
 #endif
 
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
     ErrorF("-shmem                 put framebuffers in shared memory\n");
-#endif
+#endif /* CONFIG_MITSHM */
 
     ErrorF("-crtcs n               number of CRTCs per screen (default: %d)\n",
            VFB_DEFAULT_NUM_CRTCS);
@@ -411,12 +411,12 @@ ddxProcessArgument(int argc, char *argv[], int i)
     }
 #endif                          /* HAVE_MMAP */
 
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
     if (strcmp(argv[i], "-shmem") == 0) {       /* -shmem */
         fbmemtype = SHARED_MEMORY_FB;
         return 1;
     }
-#endif
+#endif /* CONFIG_MITSHM */
 
     if (strcmp(argv[i], "-crtcs") == 0) {       /* -crtcs n */
         int numCrtcs;
@@ -601,7 +601,7 @@ vfbAllocateMmappedFramebuffer(vfbScreenInfoPtr pvfb)
 }
 #endif                          /* HAVE_MMAP */
 
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
 static void
 vfbAllocateSharedMemoryFramebuffer(vfbScreenInfoPtr pvfb)
 {
@@ -627,7 +627,7 @@ vfbAllocateSharedMemoryFramebuffer(vfbScreenInfoPtr pvfb)
 
     ErrorF("screen %d shmid %d\n", (int) (pvfb - vfbScreens), pvfb->shmid);
 }
-#endif                          /* MITSHM */
+#endif /* CONFIG_MITSHM */
 
 static char *
 vfbAllocateFramebufferMemory(vfbScreenInfoPtr pvfb)
@@ -670,14 +670,14 @@ vfbAllocateFramebufferMemory(vfbScreenInfoPtr pvfb)
         break;
 #endif
 
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
     case SHARED_MEMORY_FB:
         vfbAllocateSharedMemoryFramebuffer(pvfb);
         break;
-#else
+#else /* CONFIG_MITSHM */
     case SHARED_MEMORY_FB:
         break;
-#endif
+#endif /* CONFIG_MITSHM */
 
     case NORMAL_MEMORY_FB:
         pvfb->pXWDHeader = (XWDFileHeader *) calloc(1, pvfb->sizeInBytes);

--- a/hw/xfree86/sdksyms.sh
+++ b/hw/xfree86/sdksyms.sh
@@ -53,9 +53,9 @@ cat > sdksyms.c << EOF
 #include "xvdix.h"
 #include "xvmcext.h"
 #endif
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
 #include "shmint.h"
-#endif
+#endif /* CONFIG_MITSHM */
 #include "syncsdk.h"
 
 /* glx/Makefile.am */

--- a/hw/xnest/Args.c
+++ b/hw/xnest/Args.c
@@ -52,9 +52,9 @@ int
 ddxProcessArgument(int argc, char *argv[], int i)
 {
     /* disable some extensions we currently don't support yet */
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
     noMITShmExtension = TRUE;
-#endif
+#endif /* CONFIG_MITSHM */
 
     noCompositeExtension = TRUE;
 

--- a/hw/xquartz/darwin.c
+++ b/hw/xquartz/darwin.c
@@ -75,9 +75,9 @@
 #include "input_priv.h"
 #include "screenint_priv.h"
 
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
 #include "shmint.h"
-#endif
+#endif /* CONFIG_MITSHM */
 
 #include "darwin.h"
 #include "darwinEvents.h"
@@ -259,9 +259,9 @@ DarwinScreenInit(ScreenPtr pScreen, int argc, char **argv)
         return FALSE;
     }
 
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
     ShmRegisterFbFuncs(pScreen);
-#endif
+#endif /* CONFIG_MITSHM */
 
     // finish mode dependent screen setup including cursor support
     if (!QuartzSetupScreen(pScreen->myNum, pScreen)) {

--- a/include/meson.build
+++ b/include/meson.build
@@ -223,6 +223,7 @@ if build_glx
     conf_data.set_quoted('DRI_DRIVER_PATH', dri_dep.get_variable(pkgconfig : 'dridriverdir'))
 endif
 conf_data.set('MITSHM', build_mitshm ? '1' : false)
+conf_data.set('CONFIG_MITSHM', build_mitshm ? '1' : false)
 
 # for backwards compat with drivers, still setting the old PANORAMIX symbol
 conf_data.set('PANORAMIX', build_xinerama ? '1' : false)

--- a/include/xorg-server.h.meson.in
+++ b/include/xorg-server.h.meson.in
@@ -58,6 +58,7 @@
 
 /* Support MIT-SHM Extension */
 #mesondefine MITSHM
+#mesondefine CONFIG_MITSHM
 
 /* Internal define for Xinerama */
 #mesondefine PANORAMIX

--- a/mi/miinitext.c
+++ b/mi/miinitext.c
@@ -85,6 +85,7 @@ SOFTWARE.
 
 #ifdef DISABLE_EXT_MITSHM
 #undef MITSHM
+#undef CONFIG_MITSHM
 #endif
 
 #include "miext/extinit_priv.h"
@@ -101,9 +102,9 @@ SOFTWARE.
 static const ExtensionModule staticExtensions[] = {
     {GEExtensionInit, "Generic Event Extension", NULL},
     {ShapeExtensionInit, "SHAPE", &noShapeExtension},
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
     {ShmExtensionInit, "MIT-SHM", &noMITShmExtension},
-#endif
+#endif /* CONFIG_MITSHM */
     {XInputExtensionInit, "XInputExtension", NULL},
 #ifdef XTEST
     {XTestExtensionInit, "XTEST", &noTestExtensions},

--- a/mi/miscrinit.c
+++ b/mi/miscrinit.c
@@ -38,10 +38,10 @@ from The Open Group.
 #include "pixmapstr.h"
 #include "dix.h"
 #include "miline.h"
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
 #include <X11/extensions/shm.h>
 #include "shmint.h"
-#endif
+#endif /* CONFIG_MITSHM */
 
 /* We use this structure to propagate some information from miScreenInit to
  * miCreateScreenResources.  miScreenInit allocates the structure, fills it
@@ -254,9 +254,9 @@ miScreenInit(ScreenPtr pScreen, void *pbits,  /* pointer to screen bits */
     pScreen->numVisuals = numVisuals;
     pScreen->visuals = visuals;
     if (width) {
-#ifdef MITSHM
+#ifdef CONFIG_MITSHM
         ShmRegisterFbFuncs(pScreen);
-#endif
+#endif /* CONFIG_MITSHM */
         pScreen->CloseScreen = miCloseScreen;
     }
     /* else CloseScreen */


### PR DESCRIPTION
some bit better naming for config symbols.
Yet leaving the old one defined, until all drivers have kept up.
