### PR TITLE
.github: freebsd: install libudev-devd

### DIFF
--- a/.github/scripts/freebsd/install-pkg.sh
+++ b/.github/scripts/freebsd/install-pkg.sh
@@ -15,6 +15,7 @@ pkg install -y \
     libxcvt \
     libglvnd \
     libepoxy \
+    libudev-devd \
     mesa-dri \
     mesa-libs \
     meson \


### PR DESCRIPTION
Allow building with udev features, eg. XORG_PLATFORM_BUS. Using libudev-devd, which provides a libudev api while speaking to devd.