### PR TITLE
Xnamespace: fix possible memleak

### DIFF
--- a/Xext/namespace/config.c
+++ b/Xext/namespace/config.c
@@ -115,6 +115,7 @@ static void parseLine(char *line, struct Xnamespace **walk_ns)
         new_token->authTokenLen = strlen(token)/2;
         new_token->authTokenData = calloc(1, new_token->authTokenLen);
         if (!new_token->authTokenData) {
+            free(new_token->authProto);
             free(new_token);
             return;
         }


### PR DESCRIPTION
In an OOM error path, we've forgotten an free() call.