### PR TITLE
Xi: drop including <dix-config.h> from internal headers

### DIFF
--- a/Xi/allowev.h
+++ b/Xi/allowev.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef ALLOWEV_H
 #define ALLOWEV_H 1
 
-#include <dix-config.h>
-
 int SProcXAllowDeviceEvents(ClientPtr   /* client */
     );
 

--- a/Xi/chgdctl.h
+++ b/Xi/chgdctl.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef CHGDCTL_H
 #define CHGDCTL_H 1
 
-#include <dix-config.h>
-
 int SProcXChangeDeviceControl(ClientPtr /* client */
     );
 

--- a/Xi/chgfctl.h
+++ b/Xi/chgfctl.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef CHGFCTL_H
 #define CHGFCTL_H 1
 
-#include <dix-config.h>
-
 int SProcXChangeFeedbackControl(ClientPtr       /* client */
     );
 

--- a/Xi/chgkbd.h
+++ b/Xi/chgkbd.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef CHGKBD_H
 #define CHGKBD_H 1
 
-#include <dix-config.h>
-
 int ProcXChangeKeyboardDevice(ClientPtr /* client */
     );
 

--- a/Xi/chgkmap.h
+++ b/Xi/chgkmap.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef CHGKMAP_H
 #define CHGKMAP_H 1
 
-#include <dix-config.h>
-
 int SProcXChangeDeviceKeyMapping(ClientPtr      /* client */
     );
 

--- a/Xi/closedev.h
+++ b/Xi/closedev.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef CLOSEDEV_H
 #define CLOSEDEV_H 1
 
-#include <dix-config.h>
-
 int ProcXCloseDevice(ClientPtr  /* client */
     );
 

--- a/Xi/devbell.h
+++ b/Xi/devbell.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef DEVBELL_H
 #define DEVBELL_H 1
 
-#include <dix-config.h>
-
 int ProcXDeviceBell(ClientPtr   /* client */
     );
 

--- a/Xi/exglobals.h
+++ b/Xi/exglobals.h
@@ -28,8 +28,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  * Globals referenced elsewhere in the server.
  *
  */
-#include <dix-config.h>
-
 #include "privates.h"
 
 #ifndef EXGLOBALS_H

--- a/Xi/getbmap.h
+++ b/Xi/getbmap.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef GETBMAP_H
 #define GETBMAP_H 1
 
-#include <dix-config.h>
-
 int ProcXGetDeviceButtonMapping(ClientPtr       /* client */
     );
 

--- a/Xi/getdctl.h
+++ b/Xi/getdctl.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef GETDCTL_H
 #define GETDCTL_H 1
 
-#include <dix-config.h>
-
 int SProcXGetDeviceControl(ClientPtr    /* client */
     );
 

--- a/Xi/getfctl.h
+++ b/Xi/getfctl.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef GETFCTL_H
 #define GETFCTL_H 1
 
-#include <dix-config.h>
-
 int ProcXGetFeedbackControl(ClientPtr   /* client */
     );
 

--- a/Xi/getfocus.h
+++ b/Xi/getfocus.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef GETFOCUS_H
 #define GETFOCUS_H 1
 
-#include <dix-config.h>
-
 int ProcXGetDeviceFocus(ClientPtr       /* client */
     );
 

--- a/Xi/getkmap.h
+++ b/Xi/getkmap.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef GETKMAP_H
 #define GETKMAP_H 1
 
-#include <dix-config.h>
-
 int ProcXGetDeviceKeyMapping(ClientPtr  /* client */
     );
 

--- a/Xi/getmmap.h
+++ b/Xi/getmmap.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef GETMMAP_H
 #define GETMMAP_H 1
 
-#include <dix-config.h>
-
 int ProcXGetDeviceModifierMapping(ClientPtr     /* client */
     );
 

--- a/Xi/getprop.h
+++ b/Xi/getprop.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef GETPROP_H
 #define GETPROP_H 1
 
-#include <dix-config.h>
-
 int SProcXGetDeviceDontPropagateList(ClientPtr  /* client */
     );
 

--- a/Xi/getselev.h
+++ b/Xi/getselev.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef GETSELEV_H
 #define GETSELEV_H 1
 
-#include <dix-config.h>
-
 int SProcXGetSelectedExtensionEvents(ClientPtr  /* client */
     );
 

--- a/Xi/getvers.h
+++ b/Xi/getvers.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef GETVERS_H
 #define GETVERS_H 1
 
-#include <dix-config.h>
-
 int SProcXGetExtensionVersion(ClientPtr /* client */
     );
 

--- a/Xi/grabdev.h
+++ b/Xi/grabdev.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef GRABDEV_H
 #define GRABDEV_H 1
 
-#include <dix-config.h>
-
 int SProcXGrabDevice(ClientPtr  /* client */
     );
 

--- a/Xi/grabdevb.h
+++ b/Xi/grabdevb.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef GRABDEVB_H
 #define GRABDEVB_H 1
 
-#include <dix-config.h>
-
 int SProcXGrabDeviceButton(ClientPtr    /* client */
     );
 

--- a/Xi/grabdevk.h
+++ b/Xi/grabdevk.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef GRABDEVK_H
 #define GRABDEVK_H 1
 
-#include <dix-config.h>
-
 int SProcXGrabDeviceKey(ClientPtr       /* client */
     );
 

--- a/Xi/gtmotion.h
+++ b/Xi/gtmotion.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef GTMOTION_H
 #define GTMOTION_H 1
 
-#include <dix-config.h>
-
 int SProcXGetDeviceMotionEvents(ClientPtr       /* client */
     );
 

--- a/Xi/listdev.h
+++ b/Xi/listdev.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef LISTDEV_H
 #define LISTDEV_H 1
 
-#include <dix-config.h>
-
 #define VPC	20              /* Max # valuators per chunk */
 
 int ProcXListInputDevices(ClientPtr     /* client */

--- a/Xi/opendev.h
+++ b/Xi/opendev.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef OPENDEV_H
 #define OPENDEV_H 1
 
-#include <dix-config.h>
-
 int ProcXOpenDevice(ClientPtr   /* client */
     );
 

--- a/Xi/queryst.h
+++ b/Xi/queryst.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef QUERYST_H
 #define QUERYST_H 1
 
-#include <dix-config.h>
-
 int ProcXQueryDeviceState(ClientPtr     /* client */
     );
 

--- a/Xi/selectev.h
+++ b/Xi/selectev.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef SELECTEV_H
 #define SELECTEV_H 1
 
-#include <dix-config.h>
-
 int SProcXSelectExtensionEvent(ClientPtr        /* client */
     );
 

--- a/Xi/sendexev.h
+++ b/Xi/sendexev.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef SENDEXEV_H
 #define SENDEXEV_H 1
 
-#include <dix-config.h>
-
 int SProcXSendExtensionEvent(ClientPtr  /* client */
     );
 

--- a/Xi/setbmap.h
+++ b/Xi/setbmap.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef SETBMAP_H
 #define SETBMAP_H 1
 
-#include <dix-config.h>
-
 int ProcXSetDeviceButtonMapping(ClientPtr       /* client */
     );
 

--- a/Xi/setdval.h
+++ b/Xi/setdval.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef SETDVAL_H
 #define SETDVAL_H 1
 
-#include <dix-config.h>
-
 int ProcXSetDeviceValuators(ClientPtr   /* client */
     );
 

--- a/Xi/setfocus.h
+++ b/Xi/setfocus.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef SETFOCUS_H
 #define SETFOCUS_H 1
 
-#include <dix-config.h>
-
 int SProcXSetDeviceFocus(ClientPtr      /* client */
     );
 

--- a/Xi/setmmap.h
+++ b/Xi/setmmap.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef SETMMAP_H
 #define SETMMAP_H 1
 
-#include <dix-config.h>
-
 int ProcXSetDeviceModifierMapping(ClientPtr     /* client */
     );
 

--- a/Xi/setmode.h
+++ b/Xi/setmode.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef SETMODE_H
 #define SETMODE_H 1
 
-#include <dix-config.h>
-
 int ProcXSetDeviceMode(ClientPtr        /* client */
     );
 

--- a/Xi/ungrdev.h
+++ b/Xi/ungrdev.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef UNGRDEV_H
 #define UNGRDEV_H 1
 
-#include <dix-config.h>
-
 int SProcXUngrabDevice(ClientPtr        /* client */
     );
 

--- a/Xi/ungrdevb.h
+++ b/Xi/ungrdevb.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef UNGRDEVB_H
 #define UNGRDEVB_H 1
 
-#include <dix-config.h>
-
 int SProcXUngrabDeviceButton(ClientPtr  /* client */
     );
 

--- a/Xi/ungrdevk.h
+++ b/Xi/ungrdevk.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef UNGRDEVK_H
 #define UNGRDEVK_H 1
 
-#include <dix-config.h>
-
 int SProcXUngrabDeviceKey(ClientPtr     /* client */
     );
 

--- a/Xi/xiallowev.h
+++ b/Xi/xiallowev.h
@@ -25,8 +25,6 @@
 #ifndef XIALLOWEV_H
 #define XIALLOWEV_H 1
 
-#include <dix-config.h>
-
 int ProcXIAllowEvents(ClientPtr client);
 int SProcXIAllowEvents(ClientPtr client);
 

--- a/Xi/xibarriers.h
+++ b/Xi/xibarriers.h
@@ -1,8 +1,6 @@
 #ifndef _XIBARRIERS_H_
 #define _XIBARRIERS_H_
 
-#include <dix-config.h>
-
 #include "resource.h"
 
 extern RESTYPE PointerBarrierType;

--- a/Xi/xichangecursor.h
+++ b/Xi/xichangecursor.h
@@ -25,8 +25,6 @@
 #ifndef CHDEVCUR_H
 #define CHDEVCUR_H 1
 
-#include <dix-config.h>
-
 int SProcXIChangeCursor(ClientPtr /* client */ );
 int ProcXIChangeCursor(ClientPtr /* client */ );
 

--- a/Xi/xichangehierarchy.h
+++ b/Xi/xichangehierarchy.h
@@ -31,8 +31,6 @@
 #ifndef CHDEVHIER_H
 #define CHDEVHIER_H 1
 
-#include <dix-config.h>
-
 int ProcXIChangeHierarchy(ClientPtr /* client */ );
 
 void XISendDeviceHierarchyEvent(int flags[MAXDEVICES]);

--- a/Xi/xigetclientpointer.h
+++ b/Xi/xigetclientpointer.h
@@ -25,8 +25,6 @@
 #ifndef GETCPTR_H
 #define GETCPTR_H 1
 
-#include <dix-config.h>
-
 int SProcXIGetClientPointer(ClientPtr /* client */ );
 int ProcXIGetClientPointer(ClientPtr /* client */ );
 

--- a/Xi/xipassivegrab.h
+++ b/Xi/xipassivegrab.h
@@ -25,8 +25,6 @@
 #ifndef XIPASSIVEGRAB_H
 #define XIPASSIVEGRAB_H 1
 
-#include <dix-config.h>
-
 int SProcXIPassiveUngrabDevice(ClientPtr client);
 int ProcXIPassiveUngrabDevice(ClientPtr client);
 int ProcXIPassiveGrabDevice(ClientPtr client);

--- a/Xi/xiproperty.h
+++ b/Xi/xiproperty.h
@@ -25,8 +25,6 @@
 #ifndef XIPROPERTY_H
 #define XIPROPERTY_H 1
 
-#include <dix-config.h>
-
 int ProcXListDeviceProperties(ClientPtr client);
 int ProcXChangeDeviceProperty(ClientPtr client);
 int ProcXDeleteDeviceProperty(ClientPtr client);

--- a/Xi/xiquerydevice.h
+++ b/Xi/xiquerydevice.h
@@ -26,8 +26,6 @@
 #ifndef QUERYDEV_H
 #define QUERYDEV_H 1
 
-#include <dix-config.h>
-
 #include <X11/extensions/XI2proto.h>
 
 int SProcXIQueryDevice(ClientPtr client);

--- a/Xi/xiquerypointer.h
+++ b/Xi/xiquerypointer.h
@@ -25,8 +25,6 @@
 #ifndef QUERYDP_H
 #define QUERYDP_H 1
 
-#include <dix-config.h>
-
 int SProcXIQueryPointer(ClientPtr /* client */ );
 int ProcXIQueryPointer(ClientPtr /* client */ );
 

--- a/Xi/xiqueryversion.h
+++ b/Xi/xiqueryversion.h
@@ -26,8 +26,6 @@
 #ifndef QUERYVERSION_H
 #define QUERYVERSION_H 1
 
-#include <dix-config.h>
-
 #include <X11/extensions/XI2proto.h>
 
 int SProcXIQueryVersion(ClientPtr client);

--- a/Xi/xiselectev.h
+++ b/Xi/xiselectev.h
@@ -25,8 +25,6 @@
 #ifndef XISELECTEVENTS_H
 #define XISELECTEVENTS_H 1
 
-#include <dix-config.h>
-
 int SProcXISelectEvents(ClientPtr client);
 int ProcXISelectEvents(ClientPtr client);
 int SProcXIGetSelectedEvents(ClientPtr client);

--- a/Xi/xisetclientpointer.h
+++ b/Xi/xisetclientpointer.h
@@ -25,8 +25,6 @@
 #ifndef SETCPTR_H
 #define SETCPTR_H 1
 
-#include <dix-config.h>
-
 int SProcXISetClientPointer(ClientPtr /* client */ );
 int ProcXISetClientPointer(ClientPtr /* client */ );
 

--- a/Xi/xisetdevfocus.h
+++ b/Xi/xisetdevfocus.h
@@ -25,8 +25,6 @@
 #ifndef XISETDEVFOCUS_H
 #define XISETDEVFOCUS_H 1
 
-#include <dix-config.h>
-
 int SProcXISetFocus(ClientPtr client);
 int ProcXISetFocus(ClientPtr client);
 

--- a/Xi/xiwarppointer.h
+++ b/Xi/xiwarppointer.h
@@ -25,8 +25,6 @@
 #ifndef WARPDEVP_H
 #define WARPDEVP_H 1
 
-#include <dix-config.h>
-
 int SProcXIWarpPointer(ClientPtr /* client */ );
 int ProcXIWarpPointer(ClientPtr /* client */ );
 


### PR DESCRIPTION
All their consumers need to include <dix-config.h> at the very top anyways.