### PR TITLE
xfree86: drm_platform: fix warning on potentially unitialized variable

### DIFF
--- a/hw/xfree86/os-support/shared/drm_platform.c
+++ b/hw/xfree86/os-support/shared/drm_platform.c
@@ -28,7 +28,7 @@ get_drm_info(struct OdevAttributes *attribs, char *path, int delayed_index)
     drmVersionPtr v;
     int fd;
     int err = 0;
-    Bool paused, server_fd = FALSE;
+    Bool paused = FALSE, server_fd = FALSE;
 
     LogMessage(X_INFO, "Platform probe for %s\n", attribs->syspath);
 


### PR DESCRIPTION
 ../hw/xfree86/os-support/shared/drm_platform.c:37:13: warning: variable 'paused' is uninitialized when used here [-Wuninitialized]
     37 |         if (paused) {
        |             ^~~~~~
  ../hw/xfree86/os-support/shared/drm_platform.c:31:16: note: initialize the variable 'paused' to silence this warning
     31 |     Bool paused, server_fd = FALSE;
        |                ^
        |                 = 0
  1 warning generated.