### PR TITLE
include: meson.build: Fixed broken dependency on epoll-shim on FreeBSD.

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -141,7 +141,7 @@ conf_data.set('HAVE_SYS_SYSMACROS_H', cc.has_header('sys/sysmacros.h') ? '1' : f
 conf_data.set('HAVE_ARC4RANDOM_BUF', cc.has_function('arc4random_buf', dependencies: libbsd_dep) ? '1' : false)
 conf_data.set('HAVE_BACKTRACE', cc.has_function('backtrace') ? '1' : false)
 conf_data.set('HAVE_CBRT', cc.has_function('cbrt') ? '1' : false)
-conf_data.set('HAVE_EPOLL_CREATE1', cc.has_function('epoll_create1') ? '1' : false)
+conf_data.set('HAVE_EPOLL_CREATE1', cc.has_function('epoll_create1',dependencies:epoll_dep, prefix:'#include<sys/epoll.h>') ? '1' : false)
 conf_data.set('HAVE_GETUID', cc.has_function('getuid') ? '1' : false)
 conf_data.set('HAVE_GETEUID', cc.has_function('geteuid') ? '1' : false)
 conf_data.set('HAVE_ISASTREAM', cc.has_function('isastream') ? '1' : false)

--- a/meson.build
+++ b/meson.build
@@ -457,8 +457,10 @@ endif
 
 if host_machine.system() in ['freebsd', 'openbsd']
    epoll_dep = dependency('epoll-shim')
+   epoll_inc = join_paths(get_option('prefix'), get_option('includedir'), 'libepoll-shim')
 else
    epoll_dep = []
+   epoll_inc = ''
 endif
 
 have_eventfd = cc.has_header('sys/eventfd.h', dependencies: epoll_dep)
@@ -613,6 +615,7 @@ inc = include_directories(
     'randr',
     'render',
     'xfixes',
+    epoll_inc,
 )
 
 build_xselinux = false


### PR DESCRIPTION
The epoll-shim dependency did not get detected on FreeBSD, because of missing prefix and dependency arguments in has_function() call in include/meson.build.
Also added the path of epoll-shim headers include directory (/usr/local/include/libepoll-shim/) to the compiler include search paths for proper detection and build.
Related to https://github.com/X11Libre/xserver/issues/511