### PR TITLE
glx: fix duplicate typedef

### DIFF
--- a/glx/glxscreens.h
+++ b/glx/glxscreens.h
@@ -35,10 +35,11 @@
  * Silicon Graphics, Inc.
  */
 
+#include "include/glx_extinit.h"
+
 #include "extension_string.h"
 #include "glxvndabi.h"
 
-typedef struct __GLXconfig __GLXconfig;
 struct __GLXconfig {
     /* Management */
     __GLXconfig *next;
@@ -114,7 +115,6 @@ GLint glxConvertToXVisualType(int visualType);
 ** and DDX layers of the GLX server extension.  The methods provide an
 ** interface for context management on a screen.
 */
-typedef struct __GLXscreen __GLXscreen;
 struct __GLXscreen {
     void (*destroy) (__GLXscreen * screen);
 

--- a/include/glx_extinit.h
+++ b/include/glx_extinit.h
@@ -29,8 +29,11 @@
 /* this is separate due to sdksyms pulling in extinit.h */
 /* XXX this comment no longer makes sense i think */
 #ifdef GLXEXT
+
 typedef struct __GLXprovider __GLXprovider;
 typedef struct __GLXscreen __GLXscreen;
+typedef struct __GLXconfig __GLXconfig;
+
 struct __GLXprovider {
     __GLXscreen *(*screenProbe) (ScreenPtr pScreen);
     const char *name;


### PR DESCRIPTION
../glx/indirect_table.c
  In file included from ../glx/indirect_table.c:28:
  In file included from ../glx/glxserver.h:66:
  ../include/glx_extinit.h:33:28: warning: redefinition of typedef '__GLXscreen' is a C11 feature [-Wtypedef-redefinition]
     33 | typedef struct __GLXscreen __GLXscreen;
        |                            ^
  ../glx/glxscreens.h:113:28: note: previous definition is here
    113 | typedef struct __GLXscreen __GLXscreen;
        |                            ^