### PR TITLE
glamor: don't redefine ALIGN macro if it exists

### DIFF
--- a/glamor/glamor_utils.h
+++ b/glamor/glamor_utils.h
@@ -564,7 +564,9 @@
         (c)[1] = (float)y;				\
     } while(0)
 
+#ifndef ALIGN /* FreeBSD already has it */
 #define ALIGN(i,m)	(((i) + (m) - 1) & ~((m) - 1))
+#endif
 #define MIN(a,b)	((a) < (b) ? (a) : (b))
 #define MAX(a,b)	((a) > (b) ? (a) : (b))
 


### PR DESCRIPTION
On FreeBSD the ALIGN macro already exists in the standard headers, so we sholdn't redefine it here.