### PR TITLE
kdrive: xephyr: link pthread on mingw for nanosleep()

### DIFF
--- a/hw/kdrive/ephyr/meson.build
+++ b/hw/kdrive/ephyr/meson.build
@@ -37,6 +37,11 @@ if build_xv
     xephyr_dep += dependency('xcb-xv')
 endif
 
+# mingw needs this for nanosleep()
+if host_machine.system() == 'windows'
+    xephyr_dep += cc.find_library('pthread', required : true, static: true)
+endif
+
 xephyr_server = executable(
     'Xephyr',
     srcs,


### PR DESCRIPTION
For strange reaons, nanosleep() is in libpthread on mingw platform, so we have to link it here.