### PR TITLE
[25.0] os: ospoll: include winsock2.h on WIN32 instead of misc.h

### DIFF
--- a/include/fd_notify.h
+++ b/include/fd_notify.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ *
+ * @brief: defines needed for SetNotifyFd() as well as ospoll
+ */
+#ifndef _XSERVER_INCLUDE_FDNOTIFY_H
+#define _XSERVER_INCLUDE_FDNOTIFY_H
+
+#define X_NOTIFY_NONE   0x0
+#define X_NOTIFY_READ   0x1
+#define X_NOTIFY_WRITE  0x2
+#define X_NOTIFY_ERROR  0x4     /* don't need to select for, always reported */
+
+#endif /* _XSERVER_INCLUDE_FDNOTIFY_H */

--- a/include/meson.build
+++ b/include/meson.build
@@ -446,6 +446,7 @@ if build_xorg
             'extension.h',
             'extinit.h',
             'extnsionst.h',
+            'fd_notify.h',
             'fourcc.h',
             'gc.h',
             'gcstruct.h',

--- a/include/os.h
+++ b/include/os.h
@@ -98,10 +98,7 @@ extern _X_EXPORT int WriteToClient(ClientPtr /*who */ , int /*count */ ,
 
 typedef void (*NotifyFdProcPtr)(int fd, int ready, void *data);
 
-#define X_NOTIFY_NONE   0x0
-#define X_NOTIFY_READ   0x1
-#define X_NOTIFY_WRITE  0x2
-#define X_NOTIFY_ERROR  0x4     /* don't need to select for, always reported */
+#include "fd_notify.h"
 
 extern _X_EXPORT Bool SetNotifyFd(int fd, NotifyFdProcPtr notify_fd, int mask, void *data);
 

--- a/os/ospoll.c
+++ b/os/ospoll.c
@@ -31,6 +31,7 @@
 #include <winsock2.h>
 #endif
 
+#include "include/fd_notify.h"
 #include "os/xserver_poll.h"
 
 #include "ospoll.h"

--- a/os/ospoll.c
+++ b/os/ospoll.c
@@ -27,9 +27,12 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#ifdef WIN32
+#include <winsock2.h>
+#endif
+
 #include "os/xserver_poll.h"
 
-#include "misc.h"               /* for typedef of pointer */
 #include "ospoll.h"
 #include "list.h"
 


### PR DESCRIPTION
On WIN32 we need to include winsock2.h, but we can't include misc.h here becaues it pulling in X11 headers that are conflicting with win32 headers.