### PR TITLE
dix: inpututils: don't use `%hhx` printf pattern

### DIFF
--- a/dix/inpututils.c
+++ b/dix/inpututils.c
@@ -705,7 +705,7 @@ verify_internal_event(const InternalEvent *ev)
         ErrorF("dix: invalid event type %d\n", ev->any.header);
 
         for (i = 0; i < sizeof(xEvent); i++, data++) {
-            ErrorF("%02hhx ", *data);
+            ErrorF("%02hx ", *data);
 
             if ((i % 8) == 7)
                 ErrorF("\n");


### PR DESCRIPTION
mingw's printf() doesn't understand it yet, and it's not really important here, so just use `%hx` instead.