### PR TITLE
xwin: fix unused variables in winSetShapeMultiWindow()

### DIFF
--- a/hw/xwin/winmultiwindowshape.c
+++ b/hw/xwin/winmultiwindowshape.c
@@ -44,10 +44,6 @@
 void
 winSetShapeMultiWindow(WindowPtr pWin, int kind)
 {
-    ScreenPtr pScreen = pWin->drawable.pScreen;
-
-    winScreenPriv(pScreen);
-
 #if ENABLE_DEBUG
     ErrorF("winSetShapeMultiWindow - pWin: %p kind: %i\n", pWin, kind);
 #endif


### PR DESCRIPTION
Fix warnings on unused variables.