### PR TITLE
Xnamespace: fix printf patterns

### DIFF
--- a/Xext/namespace/hook-init-rootwindow.c
+++ b/Xext/namespace/hook-init-rootwindow.c
@@ -2,6 +2,7 @@
 
 #include <dix-config.h>
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <X11/Xatom.h>
 #include <X11/Xmd.h>
@@ -34,7 +35,7 @@ void hookInitRootWindow(CallbackListPtr *pcbl, void *data, void *screen)
     xorg_list_for_each_entry(walk, &ns_list, entry) {
         if (strcmp(walk->name, NS_NAME_ROOT)==0) {
             walk->rootWindow = realRoot;
-            XNS_LOG("<%s> actual root 0x%0x\n", walk->name, walk->rootWindow->drawable.id);
+            XNS_LOG("<%s> actual root 0x%0" PRIx32 "\n", walk->name, walk->rootWindow->drawable.id);
             continue;
         }
 
@@ -66,6 +67,6 @@ void hookInitRootWindow(CallbackListPtr *pcbl, void *data, void *screen)
         snprintf(buf, sizeof(buf)-1, "XNS-ROOT:%s", walk->name);
         setWinStrProp(pWin, XA_WM_NAME, buf);
 
-        XNS_LOG("<%s> virtual root 0x%0x\n", walk->name, walk->rootWindow->drawable.id);
+        XNS_LOG("<%s> virtual root 0x%0" PRIx32 "\n", walk->name, walk->rootWindow->drawable.id);
     }
 }

--- a/Xext/namespace/hook-resource.c
+++ b/Xext/namespace/hook-resource.c
@@ -2,6 +2,7 @@
 
 #include <dix-config.h>
 
+#include <inttypes.h>
 #include <X11/extensions/XI2proto.h>
 
 #include "dix/dix_priv.h"
@@ -55,7 +56,7 @@ void hookResourceAccess(CallbackListPtr *pcbl, void *unused, void *calldata)
                 case X_QueryTree:
                     goto pass;
             }
-            XNS_HOOK_LOG("unhandled access to NS' virtual root window 0x%0x\n", pWindow->drawable.id);
+            XNS_HOOK_LOG("unhandled access to NS' virtual root window 0x%0" PRIx32 "\n", pWindow->drawable.id);
         }
 
         /* white-listed operations on actual root window */
@@ -113,7 +114,7 @@ void hookResourceAccess(CallbackListPtr *pcbl, void *unused, void *calldata)
 
         if (param->rtype == X11_RESTYPE_WINDOW) {
             /* allowed ones should already been catched above */
-            XNS_HOOK_LOG("REJECT server owned window 0x%0x!\n", ((WindowPtr)param->res)->drawable.id);
+            XNS_HOOK_LOG("REJECT server owned window 0x%0" PRIx32 "!\n", ((WindowPtr)param->res)->drawable.id);
             goto reject;
         }
 

--- a/Xext/namespace/hook-windowproperty.c
+++ b/Xext/namespace/hook-windowproperty.c
@@ -2,6 +2,7 @@
 
 #include <dix-config.h>
 
+#include <inttypes.h>
 #include <X11/Xmd.h>
 
 #include "dix/dix_priv.h"
@@ -23,7 +24,7 @@ void hookWindowProperty(CallbackListPtr *pcbl, void *unused, void *calldata)
     if (!owner) {
         param->status = BadWindow;
         param->skip = TRUE;
-        XNS_HOOK_LOG("owner of window 0x%0x doesn't exist\n", param->window);
+        XNS_HOOK_LOG("owner of window 0x%0" PRIx32 "doesn't exist\n", param->window);
         return;
     }
 


### PR DESCRIPTION
For printing 32bit integers, we need to use PR*32 macros.