### PR TITLE
meson: move MAXCLIENTS and LIMITCLIENTS into dix-config.h

### DIFF
--- a/hw/xfree86/common/xf86Config.c
+++ b/hw/xfree86/common/xf86Config.c
@@ -957,7 +957,7 @@ configServerFlags(XF86ConfFlagsPtr flagsconf, XF86OptionPtr layoutopts)
 #endif
 
     from = X_DEFAULT;
-    if (LimitClients != LIMITCLIENTS)
+    if (LimitClients != DIX_LIMITCLIENTS)
 	from = X_CMDLINE;
     i = -1;
     if (xf86GetOptValInteger(FlagOptions, FLAG_MAX_CLIENTS, &i)) {

--- a/include/meson.build
+++ b/include/meson.build
@@ -204,6 +204,12 @@ conf_data.set('TCPCONN', '1')
 conf_data.set('UNIXCONN', host_machine.system() != 'windows' ? '1' : false)
 conf_data.set('IPv6', build_ipv6 ? '1' : false)
 
+# potentially tunable - needed also in places that cannot include misc.h
+conf_data.set('MAXCLIENTS', 2048)
+
+# Must be a power of 2 and <= MAXCLIENTS */
+conf_data.set('DIX_LIMITCLIENTS', 256)
+
 # some drivers (eg. xf86-video-intel) still relying on this symbol being set
 conf_data.set('COMPOSITE', '1')
 

--- a/include/misc.h
+++ b/include/misc.h
@@ -87,7 +87,6 @@ OF THIS SOFTWARE.
 #ifndef MAXGPUSCREENS
 #define MAXGPUSCREENS	16
 #endif
-#define MAXCLIENTS	2048
 #define MAXFORMATS	8
 #ifndef MAXDEVICES
 #define MAXDEVICES	256      /* input devices */

--- a/include/xorg-server.h.meson.in
+++ b/include/xorg-server.h.meson.in
@@ -205,6 +205,9 @@
 /* byte order */
 #mesondefine X_BYTE_ORDER
 
+/* maximum number of clients */
+#mesondefine MAXCLIENTS
+
 /* announce server API features */
 #define XORG_API_DIX_SCREEN_HOOK_WINDOW_DESTROY 1
 #define XORG_API_DIX_SCREEN_HOOK_WINDOW_POSITION 1

--- a/os/osinit.c
+++ b/os/osinit.c
@@ -75,7 +75,7 @@ SOFTWARE.
 #endif
 
 /* The actual user defined max number of clients */
-int LimitClients = LIMITCLIENTS;
+int LimitClients = DIX_LIMITCLIENTS;
 
 static OsSigWrapperPtr OsSigWrapper = NULL;
 


### PR DESCRIPTION
Both are potentially tunable variables, and MAXCLIENTS is (still) used by intel-driver, but also by os specific parts that must not include misc.h