### PR TITLE
xserver: miext/sync/meson.build: compile misyncshm.c if xshmfence found

### DIFF
--- a/miext/sync/meson.build
+++ b/miext/sync/meson.build
@@ -10,7 +10,7 @@ hdrs_miext_sync = [
     'misyncstr.h',
 ]
 
-if build_dri3
+if xshmfence_dep.found()
     srcs_miext_sync += 'misyncshm.c'
 endif
 


### PR DESCRIPTION
It is a patch that fixes xserver build if libdrm is too old.

Now misyncshm.c compilation depends on dri3, which is incorrect. If libdrm is not recent enough, then dri3 is not built, the file misyncshm.c is not compiled, and the function miSyncShmScreenInit() is unavailable. It is called in glamor_sync.c if xshmfence is present, which causes a compilation error. This patch makes misyncshm.c compile if xshmfence is found.