### PR TITLE
xfree86: fbdevhw: fix fbdevHWProbe() parameter

### DIFF
--- a/hw/xfree86/fbdevhw/fbdevhw.c
+++ b/hw/xfree86/fbdevhw/fbdevhw.c
@@ -384,7 +384,7 @@ fbdev_open(int scrnIndex, const char *dev, char **namep)
 /* -------------------------------------------------------------------- */
 
 Bool
-fbdevHWProbe(struct pci_device *pPci, char *device, char **namep)
+fbdevHWProbe(struct pci_device *pPci, const char *device, char **namep)
 {
     int fd;
 

--- a/hw/xfree86/fbdevhw/fbdevhw.h
+++ b/hw/xfree86/fbdevhw/fbdevhw.h
@@ -9,7 +9,7 @@
 #define FBDEVHW_TEXT			3       /* Text/attributes      */
 #define FBDEVHW_VGA_PLANES		4       /* EGA/VGA planes       */
 
-extern _X_EXPORT Bool fbdevHWProbe(struct pci_device *pPci, char *device,
+extern _X_EXPORT Bool fbdevHWProbe(struct pci_device *pPci, const char *device,
                                    char **namep);
 extern _X_EXPORT Bool fbdevHWInit(ScrnInfoPtr pScrn, struct pci_device *pPci,
                                   char *device);


### PR DESCRIPTION
the device name parameter should be const char *.