### PR TITLE
xfree86: fbdevhw: fix bdevHWInit() parameter

### DIFF
--- a/hw/xfree86/fbdevhw/fbdevhw.c
+++ b/hw/xfree86/fbdevhw/fbdevhw.c
@@ -400,7 +400,7 @@ fbdevHWProbe(struct pci_device *pPci, const char *device, char **namep)
 }
 
 Bool
-fbdevHWInit(ScrnInfoPtr pScrn, struct pci_device *pPci, char *device)
+fbdevHWInit(ScrnInfoPtr pScrn, struct pci_device *pPci, const char *device)
 {
     fbdevHWPtr fPtr;
 

--- a/hw/xfree86/fbdevhw/fbdevhw.h
+++ b/hw/xfree86/fbdevhw/fbdevhw.h
@@ -12,7 +12,7 @@
 extern _X_EXPORT Bool fbdevHWProbe(struct pci_device *pPci, const char *device,
                                    char **namep);
 extern _X_EXPORT Bool fbdevHWInit(ScrnInfoPtr pScrn, struct pci_device *pPci,
-                                  char *device);
+                                  const char *device);
 
 extern _X_EXPORT char *fbdevHWGetName(ScrnInfoPtr pScrn);
 extern _X_EXPORT int fbdevHWGetDepth(ScrnInfoPtr pScrn, int *fbbpp);


### PR DESCRIPTION
device name should be const char *.