### PR TITLE
os: ospoll: add missing include of <string.h>

### DIFF
--- a/os/ospoll.c
+++ b/os/ospoll.c
@@ -22,6 +22,7 @@
 
 #include <dix-config.h>
 
+#include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Needed for memmove()