### PR TITLE
os: ospoll: add missing include of <assert.h>

### DIFF
--- a/os/ospoll.c
+++ b/os/ospoll.c
@@ -22,6 +22,7 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
We're using assert() here, so need to include <assert.h>