### PR TITLE
os: xserver_poll: skip defining symbols already defined by mingw

### DIFF
--- a/os/xserver_poll.h
+++ b/os/xserver_poll.h
@@ -32,6 +32,8 @@
 #define xserver_poll(fds, nfds, timeout) poll(fds, nfds, timeout)
 #else
 
+#ifndef WIN32
+
 #define POLLIN		0x01
 #define POLLPRI		0x02
 #define POLLOUT		0x04
@@ -45,6 +47,8 @@ struct pollfd
     short   events;
     short   revents;
 };
+
+#endif /* WIN32 */
 
 typedef unsigned long nfds_t;
 


### PR DESCRIPTION
mingw already has struct pollfd and POLL* defines.