### PR TITLE
xkb: xkbDflts.h: drop not needed include of <dix-config.h>

### DIFF
--- a/xkb/xkbDflts.h
+++ b/xkb/xkbDflts.h
@@ -1,7 +1,3 @@
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #include "dix/dix_priv.h"
 
 #ifndef DEFAULT_H


### PR DESCRIPTION
All source files need to include it anyways, so no need to include it here, and neither having an extra check for HAVE_DIX_CONFIG_H