### PR TITLE
use PIXMAN_FORMAT_* defines instead of PICT_FORMAT_* ones

### DIFF
--- a/composite/compinit.c
+++ b/composite/compinit.c
@@ -262,7 +262,7 @@ compAddAlternateVisual(ScreenPtr pScreen, CompScreenPtr cs,
     visual->bitsPerRGBValue = 8;
     if (PICT_FORMAT_TYPE(alt->format) == PICT_TYPE_COLOR) {
         visual->class = PseudoColor;
-        visual->nplanes = PICT_FORMAT_BPP(alt->format);
+        visual->nplanes = PIXMAN_FORMAT_BPP(alt->format);
         visual->ColormapEntries = 1 << visual->nplanes;
     }
     else {

--- a/composite/compinit.c
+++ b/composite/compinit.c
@@ -260,7 +260,7 @@ compAddAlternateVisual(ScreenPtr pScreen, CompScreenPtr cs,
 
     /* Initialize the visual */
     visual->bitsPerRGBValue = 8;
-    if (PICT_FORMAT_TYPE(alt->format) == PICT_TYPE_COLOR) {
+    if (PIXMAN_FORMAT_TYPE(alt->format) == PICT_TYPE_COLOR) {
         visual->class = PseudoColor;
         visual->nplanes = PIXMAN_FORMAT_BPP(alt->format);
         visual->ColormapEntries = 1 << visual->nplanes;

--- a/exa/exa_glyphs.c
+++ b/exa/exa_glyphs.c
@@ -138,7 +138,7 @@ exaUnrealizeGlyphCaches(ScreenPtr pScreen, unsigned int format)
     }
 }
 
-#define NeedsComponent(f) (PICT_FORMAT_A(f) != 0 && PICT_FORMAT_RGB(f) != 0)
+#define NeedsComponent(f) (PIXMAN_FORMAT_A(f) != 0 && PICT_FORMAT_RGB(f) != 0)
 
 /* All caches for a single format share a single pixmap for glyph storage,
  * allowing mixing glyphs of different sizes without paying a penalty

--- a/exa/exa_glyphs.c
+++ b/exa/exa_glyphs.c
@@ -138,7 +138,7 @@ exaUnrealizeGlyphCaches(ScreenPtr pScreen, unsigned int format)
     }
 }
 
-#define NeedsComponent(f) (PIXMAN_FORMAT_A(f) != 0 && PICT_FORMAT_RGB(f) != 0)
+#define NeedsComponent(f) (PIXMAN_FORMAT_A(f) != 0 && PIXMAN_FORMAT_RGB(f) != 0)
 
 /* All caches for a single format share a single pixmap for glyph storage,
  * allowing mixing glyphs of different sizes without paying a penalty

--- a/exa/exa_glyphs.c
+++ b/exa/exa_glyphs.c
@@ -552,7 +552,7 @@ exaBufferGlyph(ScreenPtr pScreen,
     if (buffer->count == GLYPH_BUFFER_SIZE)
         return ExaGlyphNeedFlush;
 
-    if (PICT_FORMAT_BPP(format) == 1)
+    if (PIXMAN_FORMAT_BPP(format) == 1)
         format = PICT_a8;
 
     for (i = 0; i < EXA_NUM_GLYPH_CACHES; i++) {

--- a/exa/exa_render.c
+++ b/exa/exa_render.c
@@ -149,7 +149,7 @@ exaGetPixelFromRGBA(CARD32 *pixel,
     *pixel = 0;
 
     if (!PICT_FORMAT_COLOR(pFormat->format) &&
-        PICT_FORMAT_TYPE(pFormat->format) != PICT_TYPE_A)
+        PIXMAN_FORMAT_TYPE(pFormat->format) != PICT_TYPE_A)
         return FALSE;
 
     rbits = PICT_FORMAT_R(pFormat->format);
@@ -181,7 +181,7 @@ exaGetRGBAFromPixel(CARD32 pixel,
     int rbits, bbits, gbits;
     int rshift, bshift, gshift, ashift;
 
-    if (!PICT_FORMAT_COLOR(format) && PICT_FORMAT_TYPE(format) != PICT_TYPE_A)
+    if (!PICT_FORMAT_COLOR(format) && PIXMAN_FORMAT_TYPE(format) != PICT_TYPE_A)
         return FALSE;
 
     rbits = PICT_FORMAT_R(format);
@@ -906,7 +906,7 @@ exaComposite(CARD8 op,
                     (PICT_FORMAT_COLOR(pDst->format) &&
                      PICT_FORMAT_COLOR(pSrc->format) &&
                      pDst->format == PICT_FORMAT(PIXMAN_FORMAT_BPP(pSrc->format),
-                                                 PICT_FORMAT_TYPE(pSrc->format),
+                                                 PIXMAN_FORMAT_TYPE(pSrc->format),
                                                  0,
                                                  PICT_FORMAT_R(pSrc->format),
                                                  PICT_FORMAT_G(pSrc->format),

--- a/exa/exa_render.c
+++ b/exa/exa_render.c
@@ -143,7 +143,7 @@ exaGetPixelFromRGBA(CARD32 *pixel,
                     CARD16 green,
                     CARD16 blue, CARD16 alpha, PictFormatPtr pFormat)
 {
-    int rbits, bbits, gbits;
+    int bbits, gbits;
     int rshift, bshift, gshift, ashift;
 
     *pixel = 0;
@@ -152,7 +152,7 @@ exaGetPixelFromRGBA(CARD32 *pixel,
         PIXMAN_FORMAT_TYPE(pFormat->format) != PICT_TYPE_A)
         return FALSE;
 
-    rbits = PICT_FORMAT_R(pFormat->format);
+    int rbits = PIXMAN_FORMAT_R(pFormat->format);
     gbits = PICT_FORMAT_G(pFormat->format);
     bbits = PICT_FORMAT_B(pFormat->format);
     int abits = PIXMAN_FORMAT_A(pFormat->format);
@@ -178,13 +178,13 @@ exaGetRGBAFromPixel(CARD32 pixel,
                     CARD16 *alpha,
                     PictFormatPtr pFormat, PictFormatShort format)
 {
-    int rbits, bbits, gbits;
+    int bbits, gbits;
     int rshift, bshift, gshift, ashift;
 
     if (!PIXMAN_FORMAT_COLOR(format) && PIXMAN_FORMAT_TYPE(format) != PICT_TYPE_A)
         return FALSE;
 
-    rbits = PICT_FORMAT_R(format);
+    int rbits = PIXMAN_FORMAT_R(format);
     gbits = PICT_FORMAT_G(format);
     bbits = PICT_FORMAT_B(format);
     int abits = PIXMAN_FORMAT_A(format);
@@ -908,7 +908,7 @@ exaComposite(CARD8 op,
                      pDst->format == PICT_FORMAT(PIXMAN_FORMAT_BPP(pSrc->format),
                                                  PIXMAN_FORMAT_TYPE(pSrc->format),
                                                  0,
-                                                 PICT_FORMAT_R(pSrc->format),
+                                                 PIXMAN_FORMAT_R(pSrc->format),
                                                  PICT_FORMAT_G(pSrc->format),
                                                  PICT_FORMAT_B(pSrc->format)))))
                   || (op == PictOpOver && pSrc->format == pDst->format &&

--- a/exa/exa_render.c
+++ b/exa/exa_render.c
@@ -143,7 +143,7 @@ exaGetPixelFromRGBA(CARD32 *pixel,
                     CARD16 green,
                     CARD16 blue, CARD16 alpha, PictFormatPtr pFormat)
 {
-    int rbits, bbits, gbits, abits;
+    int rbits, bbits, gbits;
     int rshift, bshift, gshift, ashift;
 
     *pixel = 0;
@@ -155,7 +155,7 @@ exaGetPixelFromRGBA(CARD32 *pixel,
     rbits = PICT_FORMAT_R(pFormat->format);
     gbits = PICT_FORMAT_G(pFormat->format);
     bbits = PICT_FORMAT_B(pFormat->format);
-    abits = PICT_FORMAT_A(pFormat->format);
+    int abits = PIXMAN_FORMAT_A(pFormat->format);
 
     rshift = pFormat->direct.red;
     gshift = pFormat->direct.green;
@@ -178,7 +178,7 @@ exaGetRGBAFromPixel(CARD32 pixel,
                     CARD16 *alpha,
                     PictFormatPtr pFormat, PictFormatShort format)
 {
-    int rbits, bbits, gbits, abits;
+    int rbits, bbits, gbits;
     int rshift, bshift, gshift, ashift;
 
     if (!PICT_FORMAT_COLOR(format) && PICT_FORMAT_TYPE(format) != PICT_TYPE_A)
@@ -187,7 +187,7 @@ exaGetRGBAFromPixel(CARD32 pixel,
     rbits = PICT_FORMAT_R(format);
     gbits = PICT_FORMAT_G(format);
     bbits = PICT_FORMAT_B(format);
-    abits = PICT_FORMAT_A(format);
+    int abits = PIXMAN_FORMAT_A(format);
 
     if (pFormat) {
         rshift = pFormat->direct.red;
@@ -889,7 +889,7 @@ exaComposite(CARD8 op,
         pSrc->repeat = 0;
 
     if (!pMask && !pSrc->alphaMap && !pDst->alphaMap &&
-        (op == PictOpSrc || (op == PictOpOver && !PICT_FORMAT_A(pSrc->format))))
+        (op == PictOpSrc || (op == PictOpOver && !PIXMAN_FORMAT_A(pSrc->format))))
     {
         if (pSrc->pDrawable ?
             (pSrc->pDrawable->width == 1 && pSrc->pDrawable->height == 1 &&
@@ -912,7 +912,7 @@ exaComposite(CARD8 op,
                                                  PICT_FORMAT_G(pSrc->format),
                                                  PICT_FORMAT_B(pSrc->format)))))
                   || (op == PictOpOver && pSrc->format == pDst->format &&
-                      !PICT_FORMAT_A(pSrc->format)))) {
+                      !PIXMAN_FORMAT_A(pSrc->format)))) {
             if (!pSrc->repeat && xSrc >= 0 && ySrc >= 0 &&
                 (xSrc + width <= pSrc->pDrawable->width) &&
                 (ySrc + height <= pSrc->pDrawable->height)) {

--- a/exa/exa_render.c
+++ b/exa/exa_render.c
@@ -143,7 +143,6 @@ exaGetPixelFromRGBA(CARD32 *pixel,
                     CARD16 green,
                     CARD16 blue, CARD16 alpha, PictFormatPtr pFormat)
 {
-    int bbits;
     int rshift, bshift, gshift, ashift;
 
     *pixel = 0;
@@ -154,7 +153,7 @@ exaGetPixelFromRGBA(CARD32 *pixel,
 
     int rbits = PIXMAN_FORMAT_R(pFormat->format);
     int gbits = PIXMAN_FORMAT_G(pFormat->format);
-    bbits = PICT_FORMAT_B(pFormat->format);
+    int bbits = PIXMAN_FORMAT_B(pFormat->format);
     int abits = PIXMAN_FORMAT_A(pFormat->format);
 
     rshift = pFormat->direct.red;
@@ -178,7 +177,6 @@ exaGetRGBAFromPixel(CARD32 pixel,
                     CARD16 *alpha,
                     PictFormatPtr pFormat, PictFormatShort format)
 {
-    int bbits;
     int rshift, bshift, gshift, ashift;
 
     if (!PIXMAN_FORMAT_COLOR(format) && PIXMAN_FORMAT_TYPE(format) != PICT_TYPE_A)
@@ -186,7 +184,7 @@ exaGetRGBAFromPixel(CARD32 pixel,
 
     int rbits = PIXMAN_FORMAT_R(format);
     int gbits = PIXMAN_FORMAT_G(format);
-    bbits = PICT_FORMAT_B(format);
+    int bbits = PIXMAN_FORMAT_B(format);
     int abits = PIXMAN_FORMAT_A(format);
 
     if (pFormat) {
@@ -910,7 +908,7 @@ exaComposite(CARD8 op,
                                                  0,
                                                  PIXMAN_FORMAT_R(pSrc->format),
                                                  PIXMAN_FORMAT_G(pSrc->format),
-                                                 PICT_FORMAT_B(pSrc->format)))))
+                                                 PIXMAN_FORMAT_B(pSrc->format)))))
                   || (op == PictOpOver && pSrc->format == pDst->format &&
                       !PIXMAN_FORMAT_A(pSrc->format)))) {
             if (!pSrc->repeat && xSrc >= 0 && ySrc >= 0 &&

--- a/exa/exa_render.c
+++ b/exa/exa_render.c
@@ -143,7 +143,7 @@ exaGetPixelFromRGBA(CARD32 *pixel,
                     CARD16 green,
                     CARD16 blue, CARD16 alpha, PictFormatPtr pFormat)
 {
-    int bbits, gbits;
+    int bbits;
     int rshift, bshift, gshift, ashift;
 
     *pixel = 0;
@@ -153,7 +153,7 @@ exaGetPixelFromRGBA(CARD32 *pixel,
         return FALSE;
 
     int rbits = PIXMAN_FORMAT_R(pFormat->format);
-    gbits = PICT_FORMAT_G(pFormat->format);
+    int gbits = PIXMAN_FORMAT_G(pFormat->format);
     bbits = PICT_FORMAT_B(pFormat->format);
     int abits = PIXMAN_FORMAT_A(pFormat->format);
 
@@ -178,14 +178,14 @@ exaGetRGBAFromPixel(CARD32 pixel,
                     CARD16 *alpha,
                     PictFormatPtr pFormat, PictFormatShort format)
 {
-    int bbits, gbits;
+    int bbits;
     int rshift, bshift, gshift, ashift;
 
     if (!PIXMAN_FORMAT_COLOR(format) && PIXMAN_FORMAT_TYPE(format) != PICT_TYPE_A)
         return FALSE;
 
     int rbits = PIXMAN_FORMAT_R(format);
-    gbits = PICT_FORMAT_G(format);
+    int gbits = PIXMAN_FORMAT_G(format);
     bbits = PICT_FORMAT_B(format);
     int abits = PIXMAN_FORMAT_A(format);
 
@@ -909,7 +909,7 @@ exaComposite(CARD8 op,
                                                  PIXMAN_FORMAT_TYPE(pSrc->format),
                                                  0,
                                                  PIXMAN_FORMAT_R(pSrc->format),
-                                                 PICT_FORMAT_G(pSrc->format),
+                                                 PIXMAN_FORMAT_G(pSrc->format),
                                                  PICT_FORMAT_B(pSrc->format)))))
                   || (op == PictOpOver && pSrc->format == pDst->format &&
                       !PIXMAN_FORMAT_A(pSrc->format)))) {

--- a/exa/exa_render.c
+++ b/exa/exa_render.c
@@ -148,7 +148,7 @@ exaGetPixelFromRGBA(CARD32 *pixel,
 
     *pixel = 0;
 
-    if (!PICT_FORMAT_COLOR(pFormat->format) &&
+    if (!PIXMAN_FORMAT_COLOR(pFormat->format) &&
         PIXMAN_FORMAT_TYPE(pFormat->format) != PICT_TYPE_A)
         return FALSE;
 
@@ -181,7 +181,7 @@ exaGetRGBAFromPixel(CARD32 pixel,
     int rbits, bbits, gbits;
     int rshift, bshift, gshift, ashift;
 
-    if (!PICT_FORMAT_COLOR(format) && PIXMAN_FORMAT_TYPE(format) != PICT_TYPE_A)
+    if (!PIXMAN_FORMAT_COLOR(format) && PIXMAN_FORMAT_TYPE(format) != PICT_TYPE_A)
         return FALSE;
 
     rbits = PICT_FORMAT_R(format);
@@ -903,8 +903,8 @@ exaComposite(CARD8 op,
         else if (pSrc->pDrawable && !pSrc->transform &&
                  ((op == PictOpSrc &&
                    (pSrc->format == pDst->format ||
-                    (PICT_FORMAT_COLOR(pDst->format) &&
-                     PICT_FORMAT_COLOR(pSrc->format) &&
+                    (PIXMAN_FORMAT_COLOR(pDst->format) &&
+                     PIXMAN_FORMAT_COLOR(pSrc->format) &&
                      pDst->format == PICT_FORMAT(PIXMAN_FORMAT_BPP(pSrc->format),
                                                  PIXMAN_FORMAT_TYPE(pSrc->format),
                                                  0,

--- a/exa/exa_render.c
+++ b/exa/exa_render.c
@@ -905,7 +905,7 @@ exaComposite(CARD8 op,
                    (pSrc->format == pDst->format ||
                     (PICT_FORMAT_COLOR(pDst->format) &&
                      PICT_FORMAT_COLOR(pSrc->format) &&
-                     pDst->format == PICT_FORMAT(PICT_FORMAT_BPP(pSrc->format),
+                     pDst->format == PICT_FORMAT(PIXMAN_FORMAT_BPP(pSrc->format),
                                                  PICT_FORMAT_TYPE(pSrc->format),
                                                  0,
                                                  PICT_FORMAT_R(pSrc->format),

--- a/fb/fbtrap.c
+++ b/fb/fbtrap.c
@@ -126,7 +126,7 @@ fbShapes(CompositeShapesFunc composite,
             }
         }
         else {
-            switch (PICT_FORMAT_A(maskFormat->format)) {
+            switch (PIXMAN_FORMAT_A(maskFormat->format)) {
             case 1:
                 format = PIXMAN_a1;
                 break;

--- a/glamor/glamor_picture.c
+++ b/glamor/glamor_picture.c
@@ -226,7 +226,7 @@ glamor_get_tex_format_type_from_pictformat(ScreenPtr pScreen,
         return FALSE;
     }
 
-    if (!PICT_FORMAT_A(format))
+    if (!PIXMAN_FORMAT_A(format))
         swizzle[3] = GL_ONE;
 
     return TRUE;

--- a/glamor/glamor_program.c
+++ b/glamor/glamor_program.c
@@ -507,7 +507,7 @@ glamor_set_blend(CARD8 op, glamor_program_alpha alpha, PicturePtr dst)
     /* If there's no dst alpha channel, adjust the blend op so that we'll treat
      * it as always 1.
      */
-    if (PICT_FORMAT_A(dst->format) == 0 && op_info->dest_alpha) {
+    if (PIXMAN_FORMAT_A(dst->format) == 0 && op_info->dest_alpha) {
         if (src_blend == GL_DST_ALPHA)
             src_blend = GL_ONE;
         else if (src_blend == GL_ONE_MINUS_DST_ALPHA)

--- a/glamor/glamor_program.h
+++ b/glamor/glamor_program.h
@@ -132,7 +132,7 @@ typedef struct {
 
 static inline Bool
 glamor_is_component_alpha(PicturePtr mask) {
-    if (mask && mask->componentAlpha && PICT_FORMAT_RGB(mask->format))
+    if (mask && mask->componentAlpha && PIXMAN_FORMAT_RGB(mask->format))
         return TRUE;
     return FALSE;
 }

--- a/glamor/glamor_render.c
+++ b/glamor/glamor_render.c
@@ -759,21 +759,21 @@ combine_pict_format(PictFormatShort * des, const PictFormatShort src,
 
     switch (in_ca) {
     case glamor_program_alpha_normal:
-        src_type = PICT_FORMAT_TYPE(src);
+        src_type = PIXMAN_FORMAT_TYPE(src);
         mask_type = PICT_TYPE_A;
         break;
     case glamor_program_alpha_ca_first:
-        src_type = PICT_FORMAT_TYPE(src);
-        mask_type = PICT_FORMAT_TYPE(mask);
+        src_type = PIXMAN_FORMAT_TYPE(src);
+        mask_type = PIXMAN_FORMAT_TYPE(mask);
         break;
     case glamor_program_alpha_ca_second:
         src_type = PICT_TYPE_A;
-        mask_type = PICT_FORMAT_TYPE(mask);
+        mask_type = PIXMAN_FORMAT_TYPE(mask);
         break;
     case glamor_program_alpha_dual_blend:
     case glamor_program_alpha_dual_blend_gles2:
-        src_type = PICT_FORMAT_TYPE(src);
-        mask_type = PICT_FORMAT_TYPE(mask);
+        src_type = PIXMAN_FORMAT_TYPE(src);
+        mask_type = PIXMAN_FORMAT_TYPE(mask);
         break;
     default:
         return FALSE;
@@ -1552,7 +1552,7 @@ glamor_composite_clipped_region(CARD8 op,
                  || (PICT_FORMAT_COLOR(dest->format)
                      && PICT_FORMAT_COLOR(source->format)
                      && dest->format == PICT_FORMAT(PIXMAN_FORMAT_BPP(source->format),
-                                                    PICT_FORMAT_TYPE(source->format),
+                                                    PIXMAN_FORMAT_TYPE(source->format),
                                                     0,
                                                     PICT_FORMAT_R(source->format),
                                                     PICT_FORMAT_G(source->format),

--- a/glamor/glamor_render.c
+++ b/glamor/glamor_render.c
@@ -532,7 +532,7 @@ glamor_set_composite_op(ScreenPtr screen,
     /* If there's no dst alpha channel, adjust the blend op so that we'll treat
      * it as always 1.
      */
-    if (PICT_FORMAT_A(dest->format) == 0 && op_info->dest_alpha) {
+    if (PIXMAN_FORMAT_A(dest->format) == 0 && op_info->dest_alpha) {
         if (source_blend == GL_DST_ALPHA)
             source_blend = GL_ONE;
         else if (source_blend == GL_ONE_MINUS_DST_ALPHA)
@@ -640,7 +640,7 @@ glamor_set_composite_texture(glamor_screen_private *glamor_priv, int unit,
      * is RGB (no alpha), which we use for 16bpp textures.
      */
     if (glamor_pixmap_priv_is_large(pixmap_priv) ||
-        (!PICT_FORMAT_A(picture->format) &&
+        (!PIXMAN_FORMAT_A(picture->format) &&
          repeat_type == RepeatNone && picture->transform)) {
         glamor_pixmap_fbo_fix_wh_ratio(wh, pixmap, pixmap_priv);
         glUniform4fv(wh_location, 1, wh);
@@ -941,7 +941,7 @@ glamor_composite_choose_shader(CARD8 op,
             goto fail;
     }
     else {
-        if (PICT_FORMAT_A(source->format))
+        if (PIXMAN_FORMAT_A(source->format))
             key.source = SHADER_SOURCE_TEXTURE_ALPHA;
         else
             key.source = SHADER_SOURCE_TEXTURE;
@@ -959,7 +959,7 @@ glamor_composite_choose_shader(CARD8 op,
                 goto fail;
         }
         else {
-            if (PICT_FORMAT_A(mask->format))
+            if (PIXMAN_FORMAT_A(mask->format))
                 key.mask = SHADER_MASK_TEXTURE_ALPHA;
             else
                 key.mask = SHADER_MASK_TEXTURE;
@@ -1066,12 +1066,12 @@ glamor_composite_choose_shader(CARD8 op,
              * because we wire the alpha to 1.
              *
              **/
-            if (!PICT_FORMAT_A(saved_source_format)
-                && PICT_FORMAT_A(mask->format))
+            if (!PIXMAN_FORMAT_A(saved_source_format)
+                && PIXMAN_FORMAT_A(mask->format))
                 key.source = SHADER_SOURCE_TEXTURE;
 
-            if (!PICT_FORMAT_A(mask->format)
-                && PICT_FORMAT_A(saved_source_format))
+            if (!PIXMAN_FORMAT_A(mask->format)
+                && PIXMAN_FORMAT_A(saved_source_format))
                 key.mask = SHADER_MASK_TEXTURE;
         }
 
@@ -1559,7 +1559,7 @@ glamor_composite_clipped_region(CARD8 op,
                                                     PICT_FORMAT_B(source->format)))))
             || (op == PictOpOver
                 && source->format == dest->format
-                && !PICT_FORMAT_A(source->format)))
+                && !PIXMAN_FORMAT_A(source->format)))
         && x_source >= 0 && y_source >= 0
         && (x_source + width) <= source->pDrawable->width
         && (y_source + height) <= source->pDrawable->height) {

--- a/glamor/glamor_render.c
+++ b/glamor/glamor_render.c
@@ -550,7 +550,7 @@ glamor_set_composite_op(ScreenPtr screen,
             break;
         }
     } else if (mask && mask->componentAlpha
-               && PICT_FORMAT_RGB(mask->format) != 0 && op_info->source_alpha) {
+               && PIXMAN_FORMAT_RGB(mask->format) != 0 && op_info->source_alpha) {
         switch (dest_blend) {
         case GL_SRC_ALPHA:
             dest_blend = GL_SRC_COLOR;

--- a/glamor/glamor_render.c
+++ b/glamor/glamor_render.c
@@ -1555,7 +1555,7 @@ glamor_composite_clipped_region(CARD8 op,
                                                     PIXMAN_FORMAT_TYPE(source->format),
                                                     0,
                                                     PIXMAN_FORMAT_R(source->format),
-                                                    PICT_FORMAT_G(source->format),
+                                                    PIXMAN_FORMAT_G(source->format),
                                                     PICT_FORMAT_B(source->format)))))
             || (op == PictOpOver
                 && source->format == dest->format

--- a/glamor/glamor_render.c
+++ b/glamor/glamor_render.c
@@ -1554,7 +1554,7 @@ glamor_composite_clipped_region(CARD8 op,
                      && dest->format == PICT_FORMAT(PIXMAN_FORMAT_BPP(source->format),
                                                     PIXMAN_FORMAT_TYPE(source->format),
                                                     0,
-                                                    PICT_FORMAT_R(source->format),
+                                                    PIXMAN_FORMAT_R(source->format),
                                                     PICT_FORMAT_G(source->format),
                                                     PICT_FORMAT_B(source->format)))))
             || (op == PictOpOver

--- a/glamor/glamor_render.c
+++ b/glamor/glamor_render.c
@@ -1549,8 +1549,8 @@ glamor_composite_clipped_region(CARD8 op,
         && dest->pDrawable->depth == source->pDrawable->depth
         && ((op == PictOpSrc
              && (source->format == dest->format
-                 || (PICT_FORMAT_COLOR(dest->format)
-                     && PICT_FORMAT_COLOR(source->format)
+                 || (PIXMAN_FORMAT_COLOR(dest->format)
+                     && PIXMAN_FORMAT_COLOR(source->format)
                      && dest->format == PICT_FORMAT(PIXMAN_FORMAT_BPP(source->format),
                                                     PIXMAN_FORMAT_TYPE(source->format),
                                                     0,

--- a/glamor/glamor_render.c
+++ b/glamor/glamor_render.c
@@ -755,7 +755,7 @@ combine_pict_format(PictFormatShort * des, const PictFormatShort src,
 
     assert(src_bpp == PIXMAN_FORMAT_BPP(mask));
 
-    new_vis = PICT_FORMAT_VIS(src) | PICT_FORMAT_VIS(mask);
+    new_vis = PIXMAN_FORMAT_VIS(src) | PIXMAN_FORMAT_VIS(mask);
 
     switch (in_ca) {
     case glamor_program_alpha_normal:

--- a/glamor/glamor_render.c
+++ b/glamor/glamor_render.c
@@ -1556,7 +1556,7 @@ glamor_composite_clipped_region(CARD8 op,
                                                     0,
                                                     PIXMAN_FORMAT_R(source->format),
                                                     PIXMAN_FORMAT_G(source->format),
-                                                    PICT_FORMAT_B(source->format)))))
+                                                    PIXMAN_FORMAT_B(source->format)))))
             || (op == PictOpOver
                 && source->format == dest->format
                 && !PIXMAN_FORMAT_A(source->format)))

--- a/glamor/glamor_render.c
+++ b/glamor/glamor_render.c
@@ -751,9 +751,9 @@ combine_pict_format(PictFormatShort * des, const PictFormatShort src,
         *des = src;
         return TRUE;
     }
-    src_bpp = PICT_FORMAT_BPP(src);
+    src_bpp = PIXMAN_FORMAT_BPP(src);
 
-    assert(src_bpp == PICT_FORMAT_BPP(mask));
+    assert(src_bpp == PIXMAN_FORMAT_BPP(mask));
 
     new_vis = PICT_FORMAT_VIS(src) | PICT_FORMAT_VIS(mask);
 
@@ -1551,7 +1551,7 @@ glamor_composite_clipped_region(CARD8 op,
              && (source->format == dest->format
                  || (PICT_FORMAT_COLOR(dest->format)
                      && PICT_FORMAT_COLOR(source->format)
-                     && dest->format == PICT_FORMAT(PICT_FORMAT_BPP(source->format),
+                     && dest->format == PICT_FORMAT(PIXMAN_FORMAT_BPP(source->format),
                                                     PICT_FORMAT_TYPE(source->format),
                                                     0,
                                                     PICT_FORMAT_R(source->format),

--- a/glamor/glamor_transfer.c
+++ b/glamor/glamor_transfer.c
@@ -43,7 +43,7 @@ glamor_upload_boxes(DrawablePtr drawable, BoxPtr in_boxes, int in_nbox,
     glamor_pixmap_private       *priv = glamor_get_pixmap_private(pixmap);
     int                         box_index;
     const struct glamor_format *f = glamor_format_for_pixmap(pixmap);
-    int                         bytes_per_pixel = PICT_FORMAT_BPP(f->render_format) >> 3;
+    int                         bytes_per_pixel = PIXMAN_FORMAT_BPP(f->render_format) >> 3;
     char *tmp_bits = NULL;
 
     if (glamor_drawable_effective_depth(drawable) == 24 && pixmap->drawable.depth == 32)
@@ -153,7 +153,7 @@ glamor_download_boxes(DrawablePtr drawable, BoxPtr in_boxes, int in_nbox,
     glamor_pixmap_private *priv = glamor_get_pixmap_private(pixmap);
     int box_index;
     const struct glamor_format *f = glamor_format_for_pixmap(pixmap);
-    int bytes_per_pixel = PICT_FORMAT_BPP(f->render_format) >> 3;
+    int bytes_per_pixel = PIXMAN_FORMAT_BPP(f->render_format) >> 3;
 
     glamor_make_current(glamor_priv);
 

--- a/glamor/glamor_utils.h
+++ b/glamor/glamor_utils.h
@@ -620,7 +620,7 @@ glamor_get_rgba_from_pixel(CARD32 pixel,
         ashift = 0;
         rshift = abits;
         if (abits == 0)
-            rshift = PICT_FORMAT_BPP(format) - (rbits + gbits + bbits);
+            rshift = PIXMAN_FORMAT_BPP(format) - (rbits + gbits + bbits);
         gshift = rshift + rbits;
         bshift = gshift + gbits;
     }

--- a/glamor/glamor_utils.h
+++ b/glamor/glamor_utils.h
@@ -601,22 +601,22 @@ glamor_get_rgba_from_pixel(CARD32 pixel,
     bbits = PICT_FORMAT_B(format);
     int abits = PIXMAN_FORMAT_A(format);
 
-    if (PICT_FORMAT_TYPE(format) == PICT_TYPE_A) {
+    if (PIXMAN_FORMAT_TYPE(format) == PICT_TYPE_A) {
         rshift = gshift = bshift = ashift = 0;
     }
-    else if (PICT_FORMAT_TYPE(format) == PICT_TYPE_ARGB) {
+    else if (PIXMAN_FORMAT_TYPE(format) == PICT_TYPE_ARGB) {
         bshift = 0;
         gshift = bbits;
         rshift = gshift + gbits;
         ashift = rshift + rbits;
     }
-    else if (PICT_FORMAT_TYPE(format) == PICT_TYPE_ABGR) {
+    else if (PIXMAN_FORMAT_TYPE(format) == PICT_TYPE_ABGR) {
         rshift = 0;
         gshift = rbits;
         bshift = gshift + gbits;
         ashift = bshift + bbits;
     }
-    else if (PICT_FORMAT_TYPE(format) == PICT_TYPE_BGRA) {
+    else if (PIXMAN_FORMAT_TYPE(format) == PICT_TYPE_BGRA) {
         ashift = 0;
         rshift = abits;
         if (abits == 0)

--- a/glamor/glamor_utils.h
+++ b/glamor/glamor_utils.h
@@ -593,13 +593,13 @@ glamor_get_rgba_from_pixel(CARD32 pixel,
                            float *green,
                            float *blue, float *alpha, CARD32 format)
 {
-    int rbits, bbits, gbits, abits;
+    int rbits, bbits, gbits;
     int rshift, bshift, gshift, ashift;
 
     rbits = PICT_FORMAT_R(format);
     gbits = PICT_FORMAT_G(format);
     bbits = PICT_FORMAT_B(format);
-    abits = PICT_FORMAT_A(format);
+    int abits = PIXMAN_FORMAT_A(format);
 
     if (PICT_FORMAT_TYPE(format) == PICT_TYPE_A) {
         rshift = gshift = bshift = ashift = 0;

--- a/glamor/glamor_utils.h
+++ b/glamor/glamor_utils.h
@@ -593,10 +593,10 @@ glamor_get_rgba_from_pixel(CARD32 pixel,
                            float *green,
                            float *blue, float *alpha, CARD32 format)
 {
-    int rbits, bbits, gbits;
+    int bbits, gbits;
     int rshift, bshift, gshift, ashift;
 
-    rbits = PICT_FORMAT_R(format);
+    int rbits = PIXMAN_FORMAT_R(format);
     gbits = PICT_FORMAT_G(format);
     bbits = PICT_FORMAT_B(format);
     int abits = PIXMAN_FORMAT_A(format);

--- a/glamor/glamor_utils.h
+++ b/glamor/glamor_utils.h
@@ -593,12 +593,11 @@ glamor_get_rgba_from_pixel(CARD32 pixel,
                            float *green,
                            float *blue, float *alpha, CARD32 format)
 {
-    int bbits;
     int rshift, bshift, gshift, ashift;
 
     int rbits = PIXMAN_FORMAT_R(format);
     int gbits = PIXMAN_FORMAT_G(format);
-    bbits = PICT_FORMAT_B(format);
+    int bbits = PIXMAN_FORMAT_B(format);
     int abits = PIXMAN_FORMAT_A(format);
 
     if (PIXMAN_FORMAT_TYPE(format) == PICT_TYPE_A) {

--- a/glamor/glamor_utils.h
+++ b/glamor/glamor_utils.h
@@ -593,11 +593,11 @@ glamor_get_rgba_from_pixel(CARD32 pixel,
                            float *green,
                            float *blue, float *alpha, CARD32 format)
 {
-    int bbits, gbits;
+    int bbits;
     int rshift, bshift, gshift, ashift;
 
     int rbits = PIXMAN_FORMAT_R(format);
-    gbits = PICT_FORMAT_G(format);
+    int gbits = PIXMAN_FORMAT_G(format);
     bbits = PICT_FORMAT_B(format);
     int abits = PIXMAN_FORMAT_A(format);
 

--- a/render/glyph.c
+++ b/render/glyph.c
@@ -542,7 +542,7 @@ GlyphExtents(int nlist, GlyphListPtr list, GlyphPtr * glyphs, BoxPtr extents)
     }
 }
 
-#define NeedsComponent(f) (PICT_FORMAT_A(f) != 0 && PICT_FORMAT_RGB(f) != 0)
+#define NeedsComponent(f) (PIXMAN_FORMAT_A(f) != 0 && PICT_FORMAT_RGB(f) != 0)
 
 void
 CompositeGlyphs(CARD8 op,

--- a/render/glyph.c
+++ b/render/glyph.c
@@ -542,7 +542,7 @@ GlyphExtents(int nlist, GlyphListPtr list, GlyphPtr * glyphs, BoxPtr extents)
     }
 }
 
-#define NeedsComponent(f) (PIXMAN_FORMAT_A(f) != 0 && PICT_FORMAT_RGB(f) != 0)
+#define NeedsComponent(f) (PIXMAN_FORMAT_A(f) != 0 && PIXMAN_FORMAT_RGB(f) != 0)
 
 void
 CompositeGlyphs(CARD8 op,

--- a/render/mipict.c
+++ b/render/mipict.c
@@ -444,7 +444,7 @@ miIsSolidAlpha(PicturePtr pSrc)
     pScreen = pSrc->pDrawable->pScreen;
 
     /* Alpha-only */
-    if (PICT_FORMAT_TYPE(pSrc->format) != PICT_TYPE_A)
+    if (PIXMAN_FORMAT_TYPE(pSrc->format) != PICT_TYPE_A)
         return FALSE;
     /* repeat */
     if (!pSrc->repeat)

--- a/render/picture.c
+++ b/render/picture.c
@@ -299,11 +299,11 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
             pFormats[f].direct.alphaMask = Mask (PIXMAN_FORMAT_A(format));
 
             if (pFormats[f].direct.alphaMask)
-                pFormats[f].direct.alpha = (PICT_FORMAT_R(format) +
+                pFormats[f].direct.alpha = (PIXMAN_FORMAT_R(format) +
                                             PICT_FORMAT_G(format) +
                                             PICT_FORMAT_B(format));
 
-            pFormats[f].direct.redMask = Mask (PICT_FORMAT_R(format));
+            pFormats[f].direct.redMask = Mask (PIXMAN_FORMAT_R(format));
 
             pFormats[f].direct.red = (PICT_FORMAT_G(format) +
                                       PICT_FORMAT_B(format));
@@ -325,18 +325,18 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
             if (pFormats[f].direct.alphaMask)
                 pFormats[f].direct.alpha = (PICT_FORMAT_B(format) +
                                             PICT_FORMAT_G(format) +
-                                            PICT_FORMAT_R(format));
+                                            PIXMAN_FORMAT_R(format));
 
             pFormats[f].direct.blueMask = Mask (PICT_FORMAT_B(format));
 
             pFormats[f].direct.blue = (PICT_FORMAT_G(format) +
-                                       PICT_FORMAT_R(format));
+                                       PIXMAN_FORMAT_R(format));
 
             pFormats[f].direct.greenMask = Mask (PICT_FORMAT_G(format));
 
-            pFormats[f].direct.green = PICT_FORMAT_R(format);
+            pFormats[f].direct.green = PIXMAN_FORMAT_R(format);
 
-            pFormats[f].direct.redMask = Mask (PICT_FORMAT_R(format));
+            pFormats[f].direct.redMask = Mask (PIXMAN_FORMAT_R(format));
 
             pFormats[f].direct.red = 0;
             break;
@@ -355,11 +355,11 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
                 (PIXMAN_FORMAT_BPP(format) - PICT_FORMAT_B(format) -
                  PICT_FORMAT_G(format));
 
-            pFormats[f].direct.redMask = Mask (PICT_FORMAT_R(format));
+            pFormats[f].direct.redMask = Mask (PIXMAN_FORMAT_R(format));
 
             pFormats[f].direct.red =
                 (PIXMAN_FORMAT_BPP(format) - PICT_FORMAT_B(format) -
-                 PICT_FORMAT_G(format) - PICT_FORMAT_R(format));
+                 PICT_FORMAT_G(format) - PIXMAN_FORMAT_R(format));
 
             pFormats[f].direct.alphaMask = Mask (PIXMAN_FORMAT_A(format));
 

--- a/render/picture.c
+++ b/render/picture.c
@@ -379,7 +379,7 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
         case PICT_TYPE_GRAY:
             pFormats[f].type = PictTypeIndexed;
             pFormats[f].index.vid =
-                pScreen->visuals[PICT_FORMAT_VIS(format)].vid;
+                pScreen->visuals[PIXMAN_FORMAT_VIS(format)].vid;
             break;
         }
     }

--- a/render/picture.c
+++ b/render/picture.c
@@ -301,18 +301,18 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
             if (pFormats[f].direct.alphaMask)
                 pFormats[f].direct.alpha = (PIXMAN_FORMAT_R(format) +
                                             PIXMAN_FORMAT_G(format) +
-                                            PICT_FORMAT_B(format));
+                                            PIXMAN_FORMAT_B(format));
 
             pFormats[f].direct.redMask = Mask (PIXMAN_FORMAT_R(format));
 
             pFormats[f].direct.red = (PIXMAN_FORMAT_G(format) +
-                                      PICT_FORMAT_B(format));
+                                      PIXMAN_FORMAT_B(format));
 
             pFormats[f].direct.greenMask = Mask (PIXMAN_FORMAT_G(format));
 
-            pFormats[f].direct.green = PICT_FORMAT_B(format);
+            pFormats[f].direct.green = PIXMAN_FORMAT_B(format);
 
-            pFormats[f].direct.blueMask = Mask (PICT_FORMAT_B(format));
+            pFormats[f].direct.blueMask = Mask (PIXMAN_FORMAT_B(format));
 
             pFormats[f].direct.blue = 0;
             break;
@@ -323,11 +323,11 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
             pFormats[f].direct.alphaMask = Mask (PIXMAN_FORMAT_A(format));
 
             if (pFormats[f].direct.alphaMask)
-                pFormats[f].direct.alpha = (PICT_FORMAT_B(format) +
+                pFormats[f].direct.alpha = (PIXMAN_FORMAT_B(format) +
                                             PIXMAN_FORMAT_G(format) +
                                             PIXMAN_FORMAT_R(format));
 
-            pFormats[f].direct.blueMask = Mask (PICT_FORMAT_B(format));
+            pFormats[f].direct.blueMask = Mask (PIXMAN_FORMAT_B(format));
 
             pFormats[f].direct.blue = (PIXMAN_FORMAT_G(format) +
                                        PIXMAN_FORMAT_R(format));
@@ -344,21 +344,21 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
         case PICT_TYPE_BGRA:
             pFormats[f].type = PictTypeDirect;
 
-            pFormats[f].direct.blueMask = Mask (PICT_FORMAT_B(format));
+            pFormats[f].direct.blueMask = Mask (PIXMAN_FORMAT_B(format));
 
             pFormats[f].direct.blue =
-                (PIXMAN_FORMAT_BPP(format) - PICT_FORMAT_B(format));
+                (PIXMAN_FORMAT_BPP(format) - PIXMAN_FORMAT_B(format));
 
             pFormats[f].direct.greenMask = Mask (PIXMAN_FORMAT_G(format));
 
             pFormats[f].direct.green =
-                (PIXMAN_FORMAT_BPP(format) - PICT_FORMAT_B(format) -
+                (PIXMAN_FORMAT_BPP(format) - PIXMAN_FORMAT_B(format) -
                  PIXMAN_FORMAT_G(format));
 
             pFormats[f].direct.redMask = Mask (PIXMAN_FORMAT_R(format));
 
             pFormats[f].direct.red =
-                (PIXMAN_FORMAT_BPP(format) - PICT_FORMAT_B(format) -
+                (PIXMAN_FORMAT_BPP(format) - PIXMAN_FORMAT_B(format) -
                  PIXMAN_FORMAT_G(format) - PIXMAN_FORMAT_R(format));
 
             pFormats[f].direct.alphaMask = Mask (PIXMAN_FORMAT_A(format));

--- a/render/picture.c
+++ b/render/picture.c
@@ -292,7 +292,7 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
         pFormats[f].depth = formats[f].depth;
         format = formats[f].format;
         pFormats[f].format = format;
-        switch (PICT_FORMAT_TYPE(format)) {
+        switch (PIXMAN_FORMAT_TYPE(format)) {
         case PICT_TYPE_ARGB:
             pFormats[f].type = PictTypeDirect;
 

--- a/render/picture.c
+++ b/render/picture.c
@@ -347,18 +347,18 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
             pFormats[f].direct.blueMask = Mask (PICT_FORMAT_B(format));
 
             pFormats[f].direct.blue =
-                (PICT_FORMAT_BPP(format) - PICT_FORMAT_B(format));
+                (PIXMAN_FORMAT_BPP(format) - PICT_FORMAT_B(format));
 
             pFormats[f].direct.greenMask = Mask (PICT_FORMAT_G(format));
 
             pFormats[f].direct.green =
-                (PICT_FORMAT_BPP(format) - PICT_FORMAT_B(format) -
+                (PIXMAN_FORMAT_BPP(format) - PICT_FORMAT_B(format) -
                  PICT_FORMAT_G(format));
 
             pFormats[f].direct.redMask = Mask (PICT_FORMAT_R(format));
 
             pFormats[f].direct.red =
-                (PICT_FORMAT_BPP(format) - PICT_FORMAT_B(format) -
+                (PIXMAN_FORMAT_BPP(format) - PICT_FORMAT_B(format) -
                  PICT_FORMAT_G(format) - PICT_FORMAT_R(format));
 
             pFormats[f].direct.alphaMask = Mask (PIXMAN_FORMAT_A(format));

--- a/render/picture.c
+++ b/render/picture.c
@@ -296,7 +296,7 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
         case PICT_TYPE_ARGB:
             pFormats[f].type = PictTypeDirect;
 
-            pFormats[f].direct.alphaMask = Mask (PICT_FORMAT_A(format));
+            pFormats[f].direct.alphaMask = Mask (PIXMAN_FORMAT_A(format));
 
             if (pFormats[f].direct.alphaMask)
                 pFormats[f].direct.alpha = (PICT_FORMAT_R(format) +
@@ -320,7 +320,7 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
         case PICT_TYPE_ABGR:
             pFormats[f].type = PictTypeDirect;
 
-            pFormats[f].direct.alphaMask = Mask (PICT_FORMAT_A(format));
+            pFormats[f].direct.alphaMask = Mask (PIXMAN_FORMAT_A(format));
 
             if (pFormats[f].direct.alphaMask)
                 pFormats[f].direct.alpha = (PICT_FORMAT_B(format) +
@@ -361,7 +361,7 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
                 (PICT_FORMAT_BPP(format) - PICT_FORMAT_B(format) -
                  PICT_FORMAT_G(format) - PICT_FORMAT_R(format));
 
-            pFormats[f].direct.alphaMask = Mask (PICT_FORMAT_A(format));
+            pFormats[f].direct.alphaMask = Mask (PIXMAN_FORMAT_A(format));
 
             pFormats[f].direct.alpha = 0;
             break;
@@ -370,7 +370,7 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
             pFormats[f].type = PictTypeDirect;
 
             pFormats[f].direct.alpha = 0;
-            pFormats[f].direct.alphaMask = Mask (PICT_FORMAT_A(format));
+            pFormats[f].direct.alphaMask = Mask (PIXMAN_FORMAT_A(format));
 
             /* remaining fields already set to zero */
             break;
@@ -1431,7 +1431,7 @@ ReduceCompositeOp(CARD8 op, PicturePtr pSrc, PicturePtr pMask, PicturePtr pDst,
      * picture.
      */
     no_src_alpha = PICT_FORMAT_COLOR(pSrc->format) &&
-        PICT_FORMAT_A(pSrc->format) == 0 &&
+        PIXMAN_FORMAT_A(pSrc->format) == 0 &&
         (pSrc->repeatType != RepeatNone ||
          (!pSrc->transform &&
           xSrc >= 0 && ySrc >= 0 &&
@@ -1439,7 +1439,7 @@ ReduceCompositeOp(CARD8 op, PicturePtr pSrc, PicturePtr pMask, PicturePtr pDst,
           ySrc + height <= pSrc->pDrawable->height)) &&
         pSrc->alphaMap == NULL && pMask == NULL;
     no_dst_alpha = PICT_FORMAT_COLOR(pDst->format) &&
-        PICT_FORMAT_A(pDst->format) == 0 && pDst->alphaMap == NULL;
+        PIXMAN_FORMAT_A(pDst->format) == 0 && pDst->alphaMap == NULL;
 
     /* TODO, maybe: Conjoint and Disjoint op reductions? */
 

--- a/render/picture.c
+++ b/render/picture.c
@@ -1430,7 +1430,7 @@ ReduceCompositeOp(CARD8 op, PicturePtr pSrc, PicturePtr pMask, PicturePtr pDst,
      * simplest case where there is no transform on the source
      * picture.
      */
-    no_src_alpha = PICT_FORMAT_COLOR(pSrc->format) &&
+    no_src_alpha = PIXMAN_FORMAT_COLOR(pSrc->format) &&
         PIXMAN_FORMAT_A(pSrc->format) == 0 &&
         (pSrc->repeatType != RepeatNone ||
          (!pSrc->transform &&
@@ -1438,7 +1438,7 @@ ReduceCompositeOp(CARD8 op, PicturePtr pSrc, PicturePtr pMask, PicturePtr pDst,
           xSrc + width <= pSrc->pDrawable->width &&
           ySrc + height <= pSrc->pDrawable->height)) &&
         pSrc->alphaMap == NULL && pMask == NULL;
-    no_dst_alpha = PICT_FORMAT_COLOR(pDst->format) &&
+    no_dst_alpha = PIXMAN_FORMAT_COLOR(pDst->format) &&
         PIXMAN_FORMAT_A(pDst->format) == 0 && pDst->alphaMap == NULL;
 
     /* TODO, maybe: Conjoint and Disjoint op reductions? */

--- a/render/picture.c
+++ b/render/picture.c
@@ -300,15 +300,15 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
 
             if (pFormats[f].direct.alphaMask)
                 pFormats[f].direct.alpha = (PIXMAN_FORMAT_R(format) +
-                                            PICT_FORMAT_G(format) +
+                                            PIXMAN_FORMAT_G(format) +
                                             PICT_FORMAT_B(format));
 
             pFormats[f].direct.redMask = Mask (PIXMAN_FORMAT_R(format));
 
-            pFormats[f].direct.red = (PICT_FORMAT_G(format) +
+            pFormats[f].direct.red = (PIXMAN_FORMAT_G(format) +
                                       PICT_FORMAT_B(format));
 
-            pFormats[f].direct.greenMask = Mask (PICT_FORMAT_G(format));
+            pFormats[f].direct.greenMask = Mask (PIXMAN_FORMAT_G(format));
 
             pFormats[f].direct.green = PICT_FORMAT_B(format);
 
@@ -324,15 +324,15 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
 
             if (pFormats[f].direct.alphaMask)
                 pFormats[f].direct.alpha = (PICT_FORMAT_B(format) +
-                                            PICT_FORMAT_G(format) +
+                                            PIXMAN_FORMAT_G(format) +
                                             PIXMAN_FORMAT_R(format));
 
             pFormats[f].direct.blueMask = Mask (PICT_FORMAT_B(format));
 
-            pFormats[f].direct.blue = (PICT_FORMAT_G(format) +
+            pFormats[f].direct.blue = (PIXMAN_FORMAT_G(format) +
                                        PIXMAN_FORMAT_R(format));
 
-            pFormats[f].direct.greenMask = Mask (PICT_FORMAT_G(format));
+            pFormats[f].direct.greenMask = Mask (PIXMAN_FORMAT_G(format));
 
             pFormats[f].direct.green = PIXMAN_FORMAT_R(format);
 
@@ -349,17 +349,17 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
             pFormats[f].direct.blue =
                 (PIXMAN_FORMAT_BPP(format) - PICT_FORMAT_B(format));
 
-            pFormats[f].direct.greenMask = Mask (PICT_FORMAT_G(format));
+            pFormats[f].direct.greenMask = Mask (PIXMAN_FORMAT_G(format));
 
             pFormats[f].direct.green =
                 (PIXMAN_FORMAT_BPP(format) - PICT_FORMAT_B(format) -
-                 PICT_FORMAT_G(format));
+                 PIXMAN_FORMAT_G(format));
 
             pFormats[f].direct.redMask = Mask (PIXMAN_FORMAT_R(format));
 
             pFormats[f].direct.red =
                 (PIXMAN_FORMAT_BPP(format) - PICT_FORMAT_B(format) -
-                 PICT_FORMAT_G(format) - PIXMAN_FORMAT_R(format));
+                 PIXMAN_FORMAT_G(format) - PIXMAN_FORMAT_R(format));
 
             pFormats[f].direct.alphaMask = Mask (PIXMAN_FORMAT_A(format));
 

--- a/render/render.c
+++ b/render/render.c
@@ -989,7 +989,7 @@ typedef struct _GlyphNew {
     unsigned char sha1[20];
 } GlyphNewRec, *GlyphNewPtr;
 
-#define NeedsComponent(f) (PIXMAN_FORMAT_A(f) != 0 && PICT_FORMAT_RGB(f) != 0)
+#define NeedsComponent(f) (PIXMAN_FORMAT_A(f) != 0 && PIXMAN_FORMAT_RGB(f) != 0)
 
 static int
 ProcRenderAddGlyphs(ClientPtr client)

--- a/render/render.c
+++ b/render/render.c
@@ -989,7 +989,7 @@ typedef struct _GlyphNew {
     unsigned char sha1[20];
 } GlyphNewRec, *GlyphNewPtr;
 
-#define NeedsComponent(f) (PICT_FORMAT_A(f) != 0 && PICT_FORMAT_RGB(f) != 0)
+#define NeedsComponent(f) (PIXMAN_FORMAT_A(f) != 0 && PICT_FORMAT_RGB(f) != 0)
 
 static int
 ProcRenderAddGlyphs(ClientPtr client)


### PR DESCRIPTION
PICT_FORMAT_* are just aliases to PIXMAN_FORMAT_* back from when PICT_* had been moved out into pixman.