### PR TITLE
Add overflow check to calloc in doListFontsAndAliases

### DIFF
--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -73,6 +73,7 @@ Equipment Corporation.
 #include "closestr.h"
 #include "dixfont.h"
 #include "xace.h"
+#include <limits.h>  // for SIZE_MAX
 
 #ifdef XF86BIGFONT
 #include "xf86bigfontsrv.h"
@@ -745,7 +746,12 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
         .sequenceNumber = client->sequence
     };
 
-    char *bufferStart = calloc(1, rep.length << 2);
+    size_t bufsize = (size_t)rep.length << 2;
+    if (rep.length > (SIZE_MAX >> 2)) {
+	SendErrorToClient(client, X_ListFonts, 0, 0, BadAlloc);
+	goto bail;
+    }
+    char *bufferStart = calloc(1, bufsize);
     char *bufptr = bufferStart;
 
     if (!bufptr && rep.length) {


### PR DESCRIPTION
Fixes the following compiler warning:

../dix/dixfonts.c: In function ‘doListFontsAndAliases’:
../dix/dixfonts.c:748:25: warning: argument 2 range [2147483648, 4294967295] exceeds maximum object size 2147483647 [-Walloc-size-larger-than=]
  748 |     char *bufferStart = calloc(1, rep.length << 2);

This could lead to undefined behavior or crash due to integer overflow in the `calloc` size calculation.

      
_This is my first PR — happy to make changes if needed!_