### PR TITLE
xserver: {include, os}: reexport TimerForce()

### DIFF
--- a/os/osdep.h
+++ b/os/osdep.h
@@ -118,7 +118,11 @@ extern Bool ComputeLocalClient(ClientPtr client);
 
 /* OsTimer functions */
 void TimerInit(void);
-Bool TimerForce(OsTimerPtr timer);
+
+/* must be exported for backwards compatibility with legacy nvidia390,
+ * not for use in maintained drivers
+ */
+_X_EXPORT Bool TimerForce(OsTimerPtr);
 
 #ifdef WIN32
 #include <X11/Xwinsock.h>


### PR DESCRIPTION
This function is called by nvidia390 legacy proprietary driver. With it the driver mostly works, cf https://github.com/ONykyf/nvidia390-slackbuild , provided https://github.com/X11Libre/xserver/pull/525 is also applied.