### PR TITLE
.github: drop xtrans dependency

### DIFF
--- a/.github/scripts/macos/install-pkg.sh
+++ b/.github/scripts/macos/install-pkg.sh
@@ -32,7 +32,6 @@ brew install \
 	xdpyinfo \
 	xkbcomp \
 	xkeyboard-config \
-	xtrans
 
 pip3 install --break-system-packages \
 	mako


### PR DESCRIPTION
We don't need external xtrans anymore - we've now have our own (heavily modified) copy.

This btw is one of the repos that often makes transient build errors.
