### PR TITLE
RFC: os: WaitForSomething(): also try to flush out older buffer content

### DIFF
--- a/os/WaitFor.c
+++ b/os/WaitFor.c
@@ -196,8 +196,15 @@ WaitForSomething(Bool are_ready)
             timeout = 0;
 
         BlockHandler(&timeout);
-        if (NewOutputPending)
-            FlushAllOutput();
+
+        /* Always try to flush out anything we have, even for clients that had
+           been stuck for a short while because we've tried to send out too
+           much at once. If we'd only do it when someting *new* is in the queue,
+           then those clients might get stuck for long time, until something else
+           triggers the flush by mere accident.
+        */
+        FlushAllOutput();
+
         /* keep this check close to select() call to minimize race */
         if (dispatchException)
             i = -1;


### PR DESCRIPTION
Always try to flush out anything we have, even for clients that had been stuck for a short while because we've tried to send out too much at once. If we'd only do it when someting *new* is in the queue, then those clients might get stuck for long time, until something else triggers the flush by mere accident.
