### PR TITLE
xserver: {config,dix,include}: make the padding for nvidia settable in config

### DIFF
--- a/dix/pixmap.c
+++ b/dix/pixmap.c
@@ -87,6 +87,12 @@ PixmapScreenInit(ScreenPtr pScreen)
     pScreen->totalPixmapSize =
         BitmapBytePad(pixmap_size * 8);
 
+#ifdef LEGACY_NVIDIA_PADDING
+    /* This field is used by the 470 proprietary nvidia DDX driver, and should always be NULL */
+    /* NULL this out as it is no longer used */
+    pScreen->reserved_for_legacy_nvidia = NULL;
+#endif /* LEGACY_NVIDIA_PADDING */
+
     return TRUE;
 }
 

--- a/hw/xfree86/common/xf86Module.h
+++ b/hw/xfree86/common/xf86Module.h
@@ -78,6 +78,11 @@
 #define ABI_XINPUT_VERSION	SET_ABI_VERSION(26, 0)
 #define ABI_EXTENSION_VERSION	SET_ABI_VERSION(11, 0)
 
+#ifdef LEGACY_NVIDIA_PADDING
+/* hack to get both modern and ancient nvidia DDX drivers to work at the same time */
+#define ABI_NVIDIA_VERSION      SET_ABI_VERSION(25, 2)
+#endif /* LEGACY_NVIDIA_PADDING */
+
 #define MODINFOSTRING1	0xef23fdc5
 #define MODINFOSTRING2	0x10dc023a
 

--- a/hw/xfree86/loader/loader.c
+++ b/hw/xfree86/loader/loader.c
@@ -172,7 +172,12 @@ LoaderGetABIVersion(const char *abiclass)
         int version;
     } classes[] = {
         {ABI_CLASS_ANSIC, LoaderVersionInfo.ansicVersion},
+#ifdef LEGACY_NVIDIA_PADDING
+        {ABI_CLASS_VIDEODRV, is_nvidia_proprietary ?
+                             ABI_NVIDIA_VERSION : LoaderVersionInfo.videodrvVersion},
+#else
         {ABI_CLASS_VIDEODRV, LoaderVersionInfo.videodrvVersion},
+#endif /* LEGACY_NVIDIA_PADDING */
         {ABI_CLASS_XINPUT, LoaderVersionInfo.xinputVersion},
         {ABI_CLASS_EXTENSION, LoaderVersionInfo.extensionVersion},
         {NULL, 0}

--- a/hw/xfree86/loader/loader.c
+++ b/hw/xfree86/loader/loader.c
@@ -172,6 +172,40 @@ LoaderGetABIVersion(const char *abiclass)
         int version;
     } classes[] = {
         {ABI_CLASS_ANSIC, LoaderVersionInfo.ansicVersion},
+        /*
+         * XXX This is a hack. XXX
+         *
+         * The 470 nvidia driver only knows about an older abi
+         * where struct _Screen has an extra field.
+         *
+         * The modern nvidia drivers (e.g. 570) know about both
+         * abi's, and have different code paths for supporting
+         * both abi's.
+         *
+         * The modern nvidia drivers use this function to determine
+         * what video abi the X server uses, so it knows whether or
+         * not to use the newer abi, or the older abi, where
+         * struct _Screen has an extra field.
+         *
+         * The X server implements the older abi for struct _Screen,
+         * that the 470 driver knows, and we lie to the nvidia drivers
+         * that we use that older abi for the entire X server, so that
+         * modern nvidia drivers know to use the code path for supporting
+         * this older abi.
+         *
+         * We lie to the nvidia driver and claim to have an older abi
+         * so that both modern and old nvidia drivers work.
+         *
+         * In the future, nvidia might remove the code path for supporting
+         * the old abi from it's DDX driver.
+         *
+         * When that happens, unless we want to add major hacks and
+         * complexity to the codebase, we will no longer be able to
+         * support both abi's at once.
+         *
+         * Therefore a configure option that switches between abi's
+         * is added.
+         */
 #ifdef LEGACY_NVIDIA_PADDING
         {ABI_CLASS_VIDEODRV, is_nvidia_proprietary ?
                              ABI_NVIDIA_VERSION : LoaderVersionInfo.videodrvVersion},

--- a/include/extinit.h
+++ b/include/extinit.h
@@ -56,6 +56,11 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 /* required by: libglx */
 extern _X_EXPORT Bool noCompositeExtension;
 
+/* required by: the 470 nvidia DDX driver */
+#ifdef DAMAGE
+extern _X_EXPORT Bool noDamageExtension;
+#endif
+
 /* required by: several video drivers (eg. vmware and sis) */
 #ifdef XINERAMA
 extern _X_EXPORT Bool noPanoramiXExtension;

--- a/include/meson.build
+++ b/include/meson.build
@@ -210,6 +210,9 @@ conf_data.set('MAXCLIENTS', 2048)
 # Must be a power of 2 and <= MAXCLIENTS */
 conf_data.set('DIX_LIMITCLIENTS', 256)
 
+# Legacy NVidia drivers (390, 470) use an older ABI and expect an additional field in ScreenRec */
+conf_data.set('LEGACY_NVIDIA_PADDING', legacy_nvidia_padding ? '1' : false)
+
 # some drivers (eg. xf86-video-intel) still relying on this symbol being set
 conf_data.set('COMPOSITE', '1')
 

--- a/include/scrnintstr.h
+++ b/include/scrnintstr.h
@@ -620,6 +620,11 @@ typedef struct _Screen {
     SetScreenPixmapProcPtr SetScreenPixmap;
     NameWindowPixmapProcPtr NameWindowPixmap;
 
+#ifdef LEGACY_NVIDIA_PADDING
+    /* This field is a padding that corrects fields position for legacy proprietary nvidia drivers */
+    void* reserved_for_legacy_nvidia;   /* should always be NULL */
+#endif /* LEGACY_NVIDIA_PADDING */
+
     unsigned int totalPixmapSize;
 
     MarkWindowProcPtr MarkWindow;

--- a/include/xorg-server.h.meson.in
+++ b/include/xorg-server.h.meson.in
@@ -38,6 +38,9 @@
 /* Support XDM-AUTH*-1 */
 #mesondefine HASXDMAUTH
 
+/* Add a padding for legacy nvidia drivers that support old ABI */
+#mesondefine LEGACY_NVIDIA_PADDING
+
 /* Define to 1 if you have the `reallocarray' function. */
 #mesondefine HAVE_REALLOCARRAY
 

--- a/meson.build
+++ b/meson.build
@@ -553,6 +553,8 @@ elif get_option('mitshm') == 'true'
     build_mitshm = true
 endif
 
+legacy_nvidia_padding = get_option('legacy_nvidia_padding')
+
 m_dep = cc.find_library('m', required : false)
 dl_dep = cc.find_library('dl', required : false)
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -145,3 +145,6 @@ option('devel-docs', type: 'combo', choices: ['true', 'false', 'auto'], value: '
         description: 'Build development documentation')
 option('docs-pdf', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
         description: 'Whether to build PDF version of documentation. Setting is ignored if documentation is not built.')
+
+option('legacy_nvidia_padding', type: 'boolean', value: false,
+        description: 'EXPERT ONLY: Add a padding to ScreenRec to match an older ABI for legacy NVidia drivers')

--- a/miext/extinit_priv.h
+++ b/miext/extinit_priv.h
@@ -8,7 +8,6 @@
 
 #include "extinit.h"
 
-extern Bool noDamageExtension;
 extern Bool noDbeExtension;
 extern Bool noDPMSExtension;
 extern Bool noGlxExtension;


### PR DESCRIPTION
Legacy NVidia drivers need an older ABI with a field in `ScreenRec`, which is now dropped. It is convenient to make adding this field back a configuration option, which allows flexibility in the future depending on new NVidia releases.
Now the default value for this option is set to true, as the nvidia drivers recognize the older ABI. This can be easily changed in the future if NVidia drops the older ABI, then a maintainer will choose which ABI to support.

Compiled and tested xserver and drivers both with `-D legacy_nvidia_padding=true` and `-D legacy_nvidia_padding=false`, no issues observed.

This is intended to address https://github.com/X11Libre/xserver/pull/558