### PR TITLE
xfree86: enable semantic versioning

### DIFF
--- a/hw/xfree86/loader/loadmod.c
+++ b/hw/xfree86/loader/loadmod.c
@@ -180,6 +180,12 @@ static const char *stdSubdirs[] = {
     XORG_MODULE_ABI_TAG "/input/",
     XORG_MODULE_ABI_TAG "/drivers/",
     XORG_MODULE_ABI_TAG "/extensions/",
+    // next try loading from legacy xlibre-25.0 ABI subdir
+    // TODO remove this in version 26
+    "xlibre-25.0/",
+    "xlibre-25.0/input/",
+    "xlibre-25.0/drivers/",
+    "xlibre-25.0/extensions/",
     // now try loading from legacy / unversioned directories
     "",
     "input/",

--- a/hw/xfree86/meson.build
+++ b/hw/xfree86/meson.build
@@ -1,4 +1,4 @@
-module_abi_tag = 'xlibre-25.0'
+module_abi_tag = 'xlibre-25'
 module_abi_dir = join_paths(module_dir, module_abi_tag)
 
 xorg_inc = include_directories(


### PR DESCRIPTION
* switch major version from 25.0 to 25
* make loader respect legacy 25.0 module dirs (to be removed in version
  26)

Fixes: #646
Signed-off-by: callmetango <callmetango@users.noreply.github.com>
