### PR TITLE
dix: fix int-type mismatches related to dixClientIdForXID()

### DIFF
--- a/Xi/exevents.c
+++ b/Xi/exevents.c
@@ -1747,7 +1747,7 @@ ProcessBarrierEvent(InternalEvent *e, DeviceIntPtr dev)
        Otherwise, deliver normally to the client.
      */
     if (grab &&
-        dixClientIdForXID(be->barrierid) == dixClientIdForXID(grab->resource) &&
+        dixClientIdForXID((XID)(be->barrierid)) == dixClientIdForXID(grab->resource) &&
         grab->window->drawable.id == be->window) {
         DeliverGrabbedEvent(e, dev, FALSE);
     } else {

--- a/dix/resource_priv.h
+++ b/dix/resource_priv.h
@@ -20,7 +20,7 @@
 #define SERVER_BIT           (Mask)0x40000000        /* use illegal bit */
 
 /* client field */
-#define RESOURCE_CLIENT_MASK   (((1 << ResourceClientBits()) - 1) << CLIENTOFFSET)
+#define RESOURCE_CLIENT_MASK   ((((1u << ResourceClientBits())) - 1) << CLIENTOFFSET)
 
 /* bits and fields within a resource id */
 #define RESOURCE_AND_CLIENT_COUNT   29  /* 29 bits for XIDs */
@@ -30,7 +30,7 @@
 #define CLIENT_BITS(id) ((id) & RESOURCE_CLIENT_MASK)
 
 /* resource field */
-#define RESOURCE_ID_MASK        ((1 << CLIENTOFFSET) - 1)
+#define RESOURCE_ID_MASK        ((1u << CLIENTOFFSET) - 1)
 
 /*
  * @brief retrieve client that owns given window
@@ -87,8 +87,8 @@ ClientPtr dixClientForOtherClients(OtherClientsPtr pOtherClients);
  * @param XID the ID of the resource whose client is retrieved
  * @return index of the client (within client or resource table)
  */
-static inline int dixClientIdForXID(XID xid) {
-    return ((int)(CLIENT_BITS(xid) >> CLIENTOFFSET));
+static inline unsigned short dixClientIdForXID(XID xid) {
+    return (unsigned short)((CLIENT_BITS(xid) >> CLIENTOFFSET));
 }
 
 /*

--- a/include/dixstruct.h
+++ b/include/dixstruct.h
@@ -81,7 +81,7 @@ typedef struct _Client {
     struct xorg_list ready;      /* List of clients ready to run */
     struct xorg_list output_pending; /* List of clients with output queued */
     Mask clientAsMask;
-    short index;
+    unsigned short index;
     unsigned char majorOp, minorOp;
     unsigned int swapped:1;
     unsigned int local:1;


### PR DESCRIPTION
The client index (in the client table) can never be negative, thus make it an unsigned short.