### PR TITLE
Xext: saver: drop duplicate ScreenPtr retrival in SendScreenSaverNoti…

### DIFF
--- a/Xext/saver.c
+++ b/Xext/saver.c
@@ -381,7 +381,6 @@ SendScreenSaverNotify(ScreenPtr pScreen, int state, Bool forced)
     mask = ScreenSaverNotifyMask;
     if (state == ScreenSaverCycle)
         mask = ScreenSaverCycleMask;
-    pScreen = screenInfo.screens[pScreen->myNum];
     pPriv = GetScreenPrivate(pScreen);
     if (!pPriv)
         return;


### PR DESCRIPTION
…fy()

If we've already got the ScreenPtr, there's no need to retrieve it again via the screen number, which we're getting via the ScreenPtr that we've already got.