### PR TITLE
dix: Xext: replace bytes_to_int32(pad_to_int32(x)) with bytes_to_int32(x)

### DIFF
--- a/Xext/vidmode.c
+++ b/Xext/vidmode.c
@@ -1265,8 +1265,8 @@ ProcVidModeGetMonitor(ClientPtr client)
     const int vendorLength = (vendorStr ? strlen(vendorStr) : 0);
     const int modelLength = (modelStr ? strlen(modelStr) : 0);
 
-    const int nVendorItems = bytes_to_int32(pad_to_int32(vendorLength));
-    const int nModelItems = bytes_to_int32(pad_to_int32(modelLength));
+    const int nVendorItems = bytes_to_int32(vendorLength);
+    const int nModelItems = bytes_to_int32(modelLength);
 
     xXF86VidModeGetMonitorReply rep = {
         .type = X_Reply,


### PR DESCRIPTION
bytes_to_int32 already adds padding, no need to compute that too.

@metux @callmetango Thoughts?