### PR TITLE
dix: let CreateGCperDepth() accept ScreenPtr instead of screen id

### DIFF
--- a/dix/gc.c
+++ b/dix/gc.c
@@ -831,13 +831,11 @@ FreeGCperDepth(ScreenPtr pScreen)
 }
 
 Bool
-CreateGCperDepth(int screenNum)
+CreateGCperDepth(ScreenPtr pScreen)
 {
-    ScreenPtr pScreen;
     DepthPtr pDepth;
     GCPtr *ppGC;
 
-    pScreen = screenInfo.screens[screenNum];
     ppGC = pScreen->GCperDepth;
     /* do depth 1 separately because it's not included in list */
     if (!(ppGC[0] = CreateScratchGC(pScreen, 1)))

--- a/dix/gc_priv.h
+++ b/dix/gc_priv.h
@@ -24,7 +24,7 @@ int FreeGC(void *pGC, XID gid);
 
 void FreeGCperDepth(ScreenPtr pScreen);
 
-Bool CreateGCperDepth(int screenNum);
+Bool CreateGCperDepth(ScreenPtr pScreen);
 
 Bool CreateDefaultStipple(int screenNum);
 

--- a/dix/main.c
+++ b/dix/main.c
@@ -216,7 +216,7 @@ dix_main(int argc, char *argv[], char *envp[])
                 FatalError("failed to create screen pixmap properties");
             if (!dixScreenRaiseCreateResources(pScreen))
                 FatalError("failed to create screen resources");
-            if (!CreateGCperDepth(i))
+            if (!CreateGCperDepth(pScreen))
                 FatalError("failed to create scratch GCs");
             if (!CreateDefaultStipple(i))
                 FatalError("failed to create default stipple");


### PR DESCRIPTION
It's only caller already has the ScreenPtr, so it doesn't make any sense passing in the screen number and let that function retrieve the pointer on its own again.