### PR TITLE
dix: let CreateDefaultStipple() accept ScreenPtr instead of screen id

### DIFF
--- a/dix/gc.c
+++ b/dix/gc.c
@@ -858,15 +858,12 @@ CreateGCperDepth(int screenNum)
 }
 
 Bool
-CreateDefaultStipple(int screenNum)
+CreateDefaultStipple(ScreenPtr pScreen)
 {
-    ScreenPtr pScreen;
     ChangeGCVal tmpval[3];
     xRectangle rect;
     CARD16 w, h;
     GCPtr pgcScratch;
-
-    pScreen = screenInfo.screens[screenNum];
 
     w = 16;
     h = 16;

--- a/dix/gc_priv.h
+++ b/dix/gc_priv.h
@@ -26,7 +26,7 @@ void FreeGCperDepth(ScreenPtr pScreen);
 
 Bool CreateGCperDepth(int screenNum);
 
-Bool CreateDefaultStipple(int screenNum);
+Bool CreateDefaultStipple(ScreenPtr pScreen);
 
 int SetDashes(GCPtr pGC, unsigned offset, unsigned ndash, unsigned char *pdash);
 

--- a/dix/main.c
+++ b/dix/main.c
@@ -218,7 +218,7 @@ dix_main(int argc, char *argv[], char *envp[])
                 FatalError("failed to create screen resources");
             if (!CreateGCperDepth(i))
                 FatalError("failed to create scratch GCs");
-            if (!CreateDefaultStipple(i))
+            if (!CreateDefaultStipple(pScreen))
                 FatalError("failed to create default stipple");
             if (!CreateRootWindow(pScreen))
                 FatalError("failed to create root window");


### PR DESCRIPTION
It's only caller already has the ScreenPtr, so it doesn't make any sense passing in the screen number and let that function retrieve the pointer on its own again.