### PR TITLE
Xext: shape: fix non-ximerama build

### DIFF
--- a/Xext/shape.c
+++ b/Xext/shape.c
@@ -316,7 +316,7 @@ ProcShapeRectangles(ClientPtr client)
     }
     return result;
 #else
-    return ShapeRectangles(client);
+    return ShapeRectangles(client, stuff);
 #endif
 }
 


### PR DESCRIPTION
In the non-XINERAMA code path, a parameter was missing.

Fixes: a57db845bbc67a7fe3f90390365420692b16b1ab