### PR TITLE
treewide: fix serverGeneration int type mismatch

### DIFF
--- a/Xext/panoramiX.c
+++ b/Xext/panoramiX.c
@@ -95,7 +95,7 @@ static XineramaVisualsEqualProcPtr XineramaVisualsEqualPtr = &VisualsEqual;
  *	Function prototypes
  */
 
-static int panoramiXGeneration;
+static x_server_generation_t panoramiXGeneration;
 static int ProcPanoramiXDispatch(ClientPtr client);
 
 static void PanoramiXResetProc(ExtensionEntry *);

--- a/Xext/sleepuntil.c
+++ b/Xext/sleepuntil.c
@@ -53,7 +53,7 @@ typedef struct _Sertafied {
 static SertafiedPtr pPending;
 static RESTYPE SertafiedResType;
 static Bool BlockHandlerRegistered;
-static int SertafiedGeneration;
+static x_server_generation_t SertafiedGeneration;
 
 static void ClientAwaken(ClientPtr /* client */ ,
                          void *    /* closure */

--- a/Xext/xvmain.c
+++ b/Xext/xvmain.c
@@ -119,9 +119,9 @@ static DevPrivateKeyRec XvScreenKeyRec;
 Bool noXvExtension = FALSE;
 
 #define XvScreenKey (&XvScreenKeyRec)
-static unsigned long XvExtensionGeneration = 0;
-static unsigned long XvScreenGeneration = 0;
-static unsigned long XvResourceGeneration = 0;
+static x_server_generation_t XvExtensionGeneration = 0;
+static x_server_generation_t XvScreenGeneration = 0;
+static x_server_generation_t XvResourceGeneration = 0;
 
 int XvReqCode;
 static int XvEventBase;

--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -1919,7 +1919,7 @@ _client_auth_generation(ClientPtr client)
 }
 
 static int fs_handlers_installed = 0;
-static unsigned int last_server_gen;
+static x_server_generation_t last_server_gen;
 
 static void fs_block_handler(void *blockData, void *timeout)
 {

--- a/dix/globals.c
+++ b/dix/globals.c
@@ -86,7 +86,7 @@ int currentMaxClients;          /* current size of clients array */
 long maxBigRequestSize = MAX_BIG_REQUEST_SIZE;
 
 unsigned long globalSerialNumber = 0;
-unsigned long serverGeneration = 0;
+x_server_generation_t serverGeneration = 0;
 
 /* these next four are initialized in main.c */
 CARD32 ScreenSaverTime;

--- a/dri3/dri3.c
+++ b/dri3/dri3.c
@@ -30,7 +30,7 @@
 static int dri3_request;
 DevPrivateKeyRec dri3_screen_private_key;
 
-static int dri3_screen_generation;
+static x_server_generation_t dri3_screen_generation;
 
 static void dri3_screen_close(CallbackListPtr *pcbl, ScreenPtr screen, void *unused)
 {

--- a/glamor/glamor_font.c
+++ b/glamor/glamor_font.c
@@ -30,7 +30,7 @@
 #include "glamor_font.h"
 #include <dixfontstr.h>
 
-static int glamor_font_generation;
+static x_server_generation_t glamor_font_generation;
 static int glamor_font_private_index;
 static int glamor_font_screen_count;
 

--- a/glx/glxext.c
+++ b/glx/glxext.c
@@ -51,7 +51,7 @@
 /*
 ** X resources.
 */
-static int glxGeneration;
+static x_server_generation_t glxGeneration;
 RESTYPE __glXContextRes;
 RESTYPE __glXDrawableRes;
 

--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -77,7 +77,7 @@ KdDepths kdDepths[] = {
 #define KD_DEFAULT_BUTTONS 5
 
 DevPrivateKeyRec kdScreenPrivateKeyRec;
-unsigned long kdGeneration;
+x_server_generation_t kdGeneration;
 
 Bool kdEmulateMiddleButton;
 Bool kdRawPointerCoordinates;

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -296,7 +296,7 @@ extern DevPrivateKeyRec kdScreenPrivateKeyRec;
 
 #define kdScreenPrivateKey (&kdScreenPrivateKeyRec)
 
-extern unsigned long kdGeneration;
+extern x_server_generation_t kdGeneration;
 extern Bool kdEnabled;
 extern Bool kdEmulateMiddleButton;
 extern Bool kdDisableZaphod;

--- a/hw/kdrive/src/kxv.c
+++ b/hw/kdrive/src/kxv.c
@@ -99,7 +99,7 @@ static DevPrivateKeyRec KdXVWindowKeyRec;
 #define KdXVWindowKey (&KdXVWindowKeyRec)
 static DevPrivateKey KdXvScreenKey;
 static DevPrivateKeyRec KdXVScreenPrivateKey;
-static unsigned long KdXVGeneration = 0;
+static x_server_generation_t KdXVGeneration = 0;
 static unsigned long PortResource = 0;
 
 #define GET_XV_SCREEN(pScreen) ((XvScreenPtr) \

--- a/hw/xfree86/dri/dri.c
+++ b/hw/xfree86/dri/dri.c
@@ -82,7 +82,7 @@ static DevPrivateKeyRec DRIScreenPrivKeyRec;
 static DevPrivateKeyRec DRIWindowPrivKeyRec;
 
 #define DRIWindowPrivKey (&DRIWindowPrivKeyRec)
-static unsigned long DRIGeneration = 0;
+static x_server_generation_t DRIGeneration = 0;
 static unsigned int DRIDrawableValidationStamp = 0;
 
 static RESTYPE DRIDrawablePrivResType;

--- a/hw/xfree86/drivers/video/modesetting/dri2.c
+++ b/hw/xfree86/drivers/video/modesetting/dri2.c
@@ -77,7 +77,7 @@ typedef struct {
 
 static DevPrivateKeyRec ms_dri2_client_key;
 static RESTYPE frame_event_client_type, frame_event_drawable_type;
-static int ms_dri2_server_generation;
+static x_server_generation_t ms_dri2_server_generation;
 
 struct ms_dri2_resource {
     XID id;

--- a/hw/xfree86/drivers/video/modesetting/driver.h
+++ b/hw/xfree86/drivers/video/modesetting/driver.h
@@ -71,7 +71,7 @@ typedef struct
 {
     int fd;
     int fd_ref;
-    unsigned long fd_wakeup_registered; /* server generation for which fd has been registered for wakeup handling */
+    x_server_generation_t fd_wakeup_registered; /* server generation for which fd has been registered for wakeup handling */
     int fd_wakeup_ref;
     unsigned int assigned_crtcs;
 } modesettingEntRec, *modesettingEntPtr;
@@ -109,7 +109,7 @@ typedef struct _modesettingRec {
     Bool noAccel;
     CloseScreenProcPtr CloseScreen;
     CreateWindowProcPtr CreateWindow;
-    unsigned int SaveGeneration;
+    x_server_generation_t SaveGeneration;
 
     ScreenBlockHandlerProcPtr BlockHandler;
     miPointerSpriteFuncPtr SpriteFuncs;

--- a/hw/xfree86/modes/xf86RandR12.c
+++ b/hw/xfree86/modes/xf86RandR12.c
@@ -80,7 +80,7 @@ static Bool xf86RandR12Init12(ScreenPtr pScreen);
 static Bool xf86RandR12CreateScreenResources12(ScreenPtr pScreen);
 #endif
 
-static int xf86RandR12Generation;
+static x_server_generation_t xf86RandR12Generation;
 
 static DevPrivateKeyRec xf86RandR12KeyRec;
 

--- a/hw/xfree86/os-support/linux/int10/linux.c
+++ b/hw/xfree86/os-support/linux/int10/linux.c
@@ -29,7 +29,7 @@
 #include <string.h>
 
 static int counter = 0;
-static unsigned long int10Generation = 0;
+static x_server_generation_t int10Generation = 0;
 
 static CARD8 read_b(xf86Int10InfoPtr pInt, int addr);
 static CARD16 read_w(xf86Int10InfoPtr pInt, int addr);

--- a/hw/xquartz/applewm.c
+++ b/hw/xquartz/applewm.c
@@ -59,7 +59,7 @@
 
 #define DEFINE_ATOM_HELPER(func, atom_name)                      \
     static Atom func(void) {                                       \
-        static int generation;                                      \
+        static x_server_generation_t generation;                    \
         static Atom atom;                                           \
         if (generation != serverGeneration) {                       \
             generation = serverGeneration;                          \

--- a/hw/xquartz/xpr/xprFrame.c
+++ b/hw/xquartz/xpr/xprFrame.c
@@ -47,7 +47,7 @@
 
 #define DEFINE_ATOM_HELPER(func, atom_name)                      \
     static Atom func(void) {                                       \
-        static int generation;                                      \
+        static x_server_generation_t generation;                    \
         static Atom atom;                                           \
         if (generation != serverGeneration) {                       \
             generation = serverGeneration;                          \

--- a/hw/xwin/win.h
+++ b/hw/xwin/win.h
@@ -239,7 +239,7 @@ ErrorF (#point ": PROFILEPOINT hit %u times\n", PROFPT##point);\
 
 #define DEFINE_ATOM_HELPER(func,atom_name)			\
 static Atom func (void) {					\
-    static int generation;					\
+    static x_server_generation_t generation;			\
     static Atom atom;						\
     if (generation != serverGeneration) {			\
 	generation = serverGeneration;				\
@@ -539,7 +539,7 @@ extern DevPrivateKeyRec g_iWindowPrivateKeyRec;
 
 #define g_iWindowPrivateKey 	(&g_iWindowPrivateKeyRec)
 
-extern unsigned long g_ulServerGeneration;
+extern x_server_generation_t g_ulServerGeneration;
 extern DWORD g_dwEnginesSupported;
 extern HINSTANCE g_hInstance;
 extern int g_copyROP[];

--- a/hw/xwin/winallpriv.c
+++ b/hw/xwin/winallpriv.c
@@ -127,7 +127,7 @@ Bool
 winAllocateCmapPrivates(ColormapPtr pCmap)
 {
     winPrivCmapPtr pCmapPriv;
-    static unsigned long s_ulPrivateGeneration = 0;
+    static x_server_generation_t s_ulPrivateGeneration = 0;
 
 #if ENABLE_DEBUG
     winDebug("winAllocateCmapPrivates\n");

--- a/hw/xwin/winclipboardwrappers.c
+++ b/hw/xwin/winclipboardwrappers.c
@@ -54,7 +54,7 @@ winProcEstablishConnection(ClientPtr client)
 {
     int iReturn;
     static int s_iCallCount = 0;
-    static unsigned long s_ulServerGeneration = 0;
+    static x_server_generation_t s_ulServerGeneration = 0;
 
     if (s_iCallCount == 0)
         winDebug("winProcEstablishConnection - Hello\n");

--- a/hw/xwin/winglobals.c
+++ b/hw/xwin/winglobals.c
@@ -47,7 +47,7 @@ DevPrivateKeyRec g_iCmapPrivateKeyRec;
 DevPrivateKeyRec g_iGCPrivateKeyRec;
 DevPrivateKeyRec g_iPixmapPrivateKeyRec;
 DevPrivateKeyRec g_iWindowPrivateKeyRec;
-unsigned long g_ulServerGeneration = 0;
+x_server_generation_t g_ulServerGeneration = 0;
 DWORD g_dwEnginesSupported = 0;
 HINSTANCE g_hInstance = 0;
 HWND g_hDlgDepthChange = NULL;

--- a/hw/xwin/winmultiwindowwm.c
+++ b/hw/xwin/winmultiwindowwm.c
@@ -1715,7 +1715,7 @@ winApplyHints(WMInfoPtr pWMInfo, xcb_window_t iWindow, HWND hWnd, HWND * zstyle)
     static xcb_atom_t hiddenState, fullscreenState, belowState, aboveState,
         skiptaskbarState;
     static xcb_atom_t splashType;
-    static int generation;
+    static x_server_generation_t generation;
 
     unsigned long hint = 0, maxmin = 0;
     unsigned long style, exStyle;

--- a/hw/xwin/winwndproc.c
+++ b/hw/xwin/winwndproc.c
@@ -67,7 +67,7 @@ winWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
     static ScreenPtr s_pScreen = NULL;
     static HWND s_hwndLastPrivates = NULL;
     static Bool s_fTracking = FALSE;
-    static unsigned long s_ulServerGeneration = 0;
+    static x_server_generation_t s_ulServerGeneration = 0;
     static UINT s_uTaskbarRestart = 0;
     int iScanCode;
     int i;

--- a/include/misc.h
+++ b/include/misc.h
@@ -337,7 +337,9 @@ typedef struct _CharInfo *CharInfoPtr;  /* also in fonts/include/font.h */
 #define _XTYPEDEF_CHARINFOPTR
 #endif
 
+typedef unsigned long x_server_generation_t;
+
 extern _X_EXPORT unsigned long globalSerialNumber;
-extern _X_EXPORT unsigned long serverGeneration;
+extern _X_EXPORT x_server_generation_t serverGeneration;
 
 #endif                          /* MISC_H */

--- a/miext/rootless/rootlessWindow.c
+++ b/miext/rootless/rootlessWindow.c
@@ -59,11 +59,11 @@ extern Bool no_configure_window;
     (pScreen->y + rootlessGlobalOffsetY)
 
 #define DEFINE_ATOM_HELPER(func,atom_name)                      \
-  static Atom func (void) {                                       \
-    static unsigned int generation = 0;                             \
+  static Atom func (void) {                                     \
+    static x_server_generation_t generation = 0;                \
     static Atom atom;                                           \
     if (generation != serverGeneration) {                       \
-      generation = serverGeneration;                          \
+      generation = serverGeneration;                            \
       atom = dixAddAtom(atom_name);                             \
     }                                                           \
     return atom;                                                \

--- a/os/xdmcp.c
+++ b/os/xdmcp.c
@@ -444,7 +444,7 @@ XdmcpSetAuthentication(const ARRAY8Ptr name)
 
 static ARRAY16 ConnectionTypes;
 static ARRAYofARRAY8 ConnectionAddresses;
-static long xdmcpGeneration;
+static x_server_generation_t xdmcpGeneration;
 
 void
 XdmcpRegisterConnection(int type, const char *address, int addrlen)

--- a/pseudoramiX/pseudoramiX.c
+++ b/pseudoramiX/pseudoramiX.c
@@ -99,7 +99,7 @@ typedef struct {
 static PseudoramiXScreenRec *pseudoramiXScreens = NULL;
 static int pseudoramiXScreensAllocated = 0;
 static int pseudoramiXNumScreens = 0;
-static unsigned long pseudoramiXGeneration = 0;
+static x_server_generation_t pseudoramiXGeneration = 0;
 
 // Add a PseudoramiX screen.
 // The rest of the X server will know nothing about this screen.

--- a/randr/randr.c
+++ b/randr/randr.c
@@ -274,7 +274,7 @@ SRRNotifyEvent(xEvent *from, xEvent *to)
     }
 }
 
-static int RRGeneration;
+static x_server_generation_t RRGeneration;
 
 Bool
 RRInit(void)

--- a/render/picture.c
+++ b/render/picture.c
@@ -49,7 +49,7 @@
 
 DevPrivateKeyRec PictureScreenPrivateKeyRec;
 DevPrivateKeyRec PictureWindowPrivateKeyRec;
-static int PictureGeneration;
+static x_server_generation_t PictureGeneration;
 RESTYPE PictureType;
 RESTYPE PictFormatType;
 RESTYPE GlyphSetType;

--- a/xkb/ddxBeep.c
+++ b/xkb/ddxBeep.c
@@ -57,7 +57,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #define	HIGH_PITCH	2000
 #define CLICK_PITCH	1500
 
-static unsigned long atomGeneration = 0;
+static x_server_generation_t atomGeneration = 0;
 static Atom featureOn;
 static Atom featureOff;
 static Atom featureChange;


### PR DESCRIPTION
The global (exported) serverGeneration field is `unsigned long`, while many other places copy it and compare it two other integer types, eg. plain `int` (which is signed). Even if it's unlikely ever reaching such high number of generations that it will ever make trouble, it's still a good idea to clean this up and use the same type everywhere.

For clearity, introducing a typedef `x_server_generation_t` which is used everywhere, instead of raw `unsigned long`.