### PR TITLE
panoramiX: don't use FOR_NSCREENS_FORWARD_SKIP() anymore

### DIFF
--- a/Xext/panoramiX.c
+++ b/Xext/panoramiX.c
@@ -407,7 +407,9 @@ XineramaInitData(void)
     PanoramiXPixHeight =
         screenInfo.screens[0]->y + screenInfo.screens[0]->height;
 
-    FOR_NSCREENS_FORWARD_SKIP(i) {
+    FOR_NSCREENS_FORWARD(i) {
+        if (!i)
+            continue; /* skip screen #0 */
         ScreenPtr pScreen = screenInfo.screens[i];
 
         w = pScreen->x + pScreen->width;
@@ -722,7 +724,9 @@ PanoramiXMaybeAddDepth(DepthPtr pDepth)
     int j, k;
     Bool found = FALSE;
 
-    FOR_NSCREENS_FORWARD_SKIP(j) {
+    FOR_NSCREENS_FORWARD(j) {
+        if (!j)
+            continue; /* skip screen #0 */
         pScreen = screenInfo.screens[j];
         for (k = 0; k < pScreen->numDepths; k++) {
             if (pScreen->allowedDepths[k].depth == pDepth->depth) {
@@ -751,7 +755,9 @@ PanoramiXMaybeAddVisual(VisualPtr pVisual)
     int j, k;
     Bool found = FALSE;
 
-    FOR_NSCREENS_FORWARD_SKIP(j) {
+    FOR_NSCREENS_FORWARD(j) {
+        if (!j)
+            continue; /* skip screen #0 */
         pScreen = screenInfo.screens[j];
         found = FALSE;
 

--- a/Xext/panoramiXprocs.c
+++ b/Xext/panoramiXprocs.c
@@ -2032,7 +2032,9 @@ PanoramiXGetImage(ClientPtr client)
     }
 
     drawables[0] = pDraw;
-    FOR_NSCREENS_FORWARD_SKIP(i) {
+    FOR_NSCREENS_FORWARD(i) {
+        if (!i)
+            continue; /* skip screen #0 */
         rc = dixLookupDrawable(drawables + i, draw->info[i].id, client, 0,
                                DixGetAttrAccess);
         if (rc != Success)

--- a/Xext/panoramiXsrv.h
+++ b/Xext/panoramiXsrv.h
@@ -53,8 +53,9 @@ panoramix_setup_ids(PanoramiXRes * resource, ClientPtr client, XID base_id)
     int j;
 
     resource->info[0].id = base_id;
-    FOR_NSCREENS_FORWARD_SKIP(j) {
-        resource->info[j].id = FakeClientID(client->index);
+    FOR_NSCREENS_FORWARD(j) {
+        if (j) /* skip screen #0 */
+            resource->info[j].id = FakeClientID(client->index);
     }
 }
 

--- a/Xext/shm.c
+++ b/Xext/shm.c
@@ -851,7 +851,9 @@ ProcShmGetImage(ClientPtr client)
         return BadAlloc;
 
     drawables[0] = pDraw;
-    FOR_NSCREENS_FORWARD_SKIP(i) {
+    FOR_NSCREENS_FORWARD(i) {
+        if (!i)
+            continue; /* skip screen #0 */
         rc = dixLookupDrawable(drawables + i, draw->info[i].id, client, 0,
                                DixReadAccess);
         if (rc != Success) {

--- a/Xext/xvdisp.c
+++ b/Xext/xvdisp.c
@@ -1624,9 +1624,12 @@ XineramifyXv(void)
 
         MatchingAdaptors[0] = refAdapt;
         isOverlay = hasOverlay(refAdapt);
-        FOR_NSCREENS_FORWARD_SKIP(j)
+        FOR_NSCREENS_FORWARD(j) {
+            if (!j)
+                continue; /* skip screen #0 */
             MatchingAdaptors[j] =
             matchAdaptor(screenInfo.screens[j], refAdapt, isOverlay);
+        }
 
         /* now create a resource for each port */
         for (j = 0; j < refAdapt->nPorts; j++) {

--- a/dix/events.c
+++ b/dix/events.c
@@ -3012,7 +3012,9 @@ PointInBorderSize(WindowPtr pWin, int x, int y)
         SpritePtr pSprite = inputInfo.pointer->spriteInfo->sprite;
         int i;
 
-        FOR_NSCREENS_FORWARD_SKIP(i) {
+        FOR_NSCREENS_FORWARD(i) {
+            if (!i)
+                continue; /* skip screen #0 */
             if (RegionContainsPoint(&pSprite->windows[i]->borderSize,
                                     x + screenInfo.screens[0]->x -
                                     screenInfo.screens[i]->x,
@@ -3529,7 +3531,9 @@ XineramaPointInWindowIsVisible(WindowPtr pWin, int x, int y)
     xoff = x + screenInfo.screens[0]->x;
     yoff = y + screenInfo.screens[0]->y;
 
-    FOR_NSCREENS_FORWARD_SKIP(i) {
+    FOR_NSCREENS_FORWARD(i) {
+        if (!i)
+            continue; /* skip screen #0 */
         pWin = inputInfo.pointer->spriteInfo->sprite->windows[i];
 
         x = xoff - screenInfo.screens[i]->x;
@@ -3734,7 +3738,9 @@ BorderSizeNotEmpty(DeviceIntPtr pDev, WindowPtr pWin)
     if (!noPanoramiXExtension && XineramaSetWindowPntrs(pDev, pWin)) {
         int i;
 
-        FOR_NSCREENS_FORWARD_SKIP(i) {
+        FOR_NSCREENS_FORWARD(i) {
+            if (!i)
+                continue; /* skip screen #0 */
             if (RegionNotEmpty
                 (&pDev->spriteInfo->sprite->windows[i]->borderSize))
                 return TRUE;


### PR DESCRIPTION
in preparation of upcoming new iterator macros, phase out FOR_NSCREENS_FORWARD_SKIP, so we don't need an additional macro for just the case where first screen is skipped.