### PR TITLE
dix : ensure that event fix-up is not performed on core events

### DIFF
--- a/Xi/exevents.c
+++ b/Xi/exevents.c
@@ -1097,7 +1097,7 @@ DeliverOneTouchEvent(ClientPtr client, DeviceIntPtr dev, TouchPointInfoPtr ti,
         FatalError("[Xi] %s: XI2 conversion failed in %s"
                    " (%d)\n", dev->name, __func__, err);
 
-    FixUpEventFromWindow(&ti->sprite, xi2, win, child, FALSE);
+    FixUpEventFromWindow(&ti->sprite, xi2, win, child, FALSE, XI2);
     filter = GetEventFilter(dev, xi2);
     if (XaceHookReceiveAccess(client, win, xi2, 1) != Success)
         return FALSE;
@@ -2236,7 +2236,7 @@ DeliverOneGestureEvent(ClientPtr client, DeviceIntPtr dev, GestureInfoPtr gi,
         FatalError("[Xi] %s: XI2 conversion failed in %s"
                    " (%d)\n", dev->name, __func__, err);
 
-    FixUpEventFromWindow(&gi->sprite, xi2, win, child, FALSE);
+    FixUpEventFromWindow(&gi->sprite, xi2, win, child, FALSE, XI2);
     filter = GetEventFilter(dev, xi2);
     if (XaceHookReceiveAccess(client, win, xi2, 1) != Success)
         return FALSE;

--- a/dix/enterleave.c
+++ b/dix/enterleave.c
@@ -805,7 +805,7 @@ DeviceFocusEvent(DeviceIntPtr dev, int type, int mode, int detail,
     }
 
     FixUpEventFromWindow(dev->spriteInfo->sprite, (xEvent *) xi2event, pWin,
-                         None, FALSE);
+                         None, FALSE, XI2);
 
     DeliverEventsToWindow(dev, pWin, (xEvent *) xi2event, 1,
                           GetEventFilter(dev, (xEvent *) xi2event), NullGrab);

--- a/dix/events.c
+++ b/dix/events.c
@@ -2683,7 +2683,7 @@ FixUpXI2SwipeEventFromWindow(SpritePtr pSprite, xXIGestureSwipeEvent *event,
  */
 void
 FixUpEventFromWindow(SpritePtr pSprite,
-                     xEvent *xE, WindowPtr pWin, Window child, Bool calcChild)
+                     xEvent *xE, WindowPtr pWin, Window child, Bool calcChild, enum InputLevel XILevel)
 {
     int evtype;
 
@@ -2691,38 +2691,40 @@ FixUpEventFromWindow(SpritePtr pSprite,
         child = FindChildForEvent(pSprite, pWin);
 
     if ((evtype = xi2_get_type(xE))) {
-        switch (evtype) {
-        case XI_RawKeyPress:
-        case XI_RawKeyRelease:
-        case XI_RawButtonPress:
-        case XI_RawButtonRelease:
-        case XI_RawMotion:
-        case XI_RawTouchBegin:
-        case XI_RawTouchUpdate:
-        case XI_RawTouchEnd:
-        case XI_DeviceChanged:
-        case XI_HierarchyChanged:
-        case XI_PropertyEvent:
-        case XI_BarrierHit:
-        case XI_BarrierLeave:
-            return;
-        case XI_GesturePinchBegin:
-        case XI_GesturePinchUpdate:
-        case XI_GesturePinchEnd:
-            FixUpXI2PinchEventFromWindow(pSprite,
-                                         (xXIGesturePinchEvent*) xE, pWin, child);
-            break;
-        case XI_GestureSwipeBegin:
-        case XI_GestureSwipeUpdate:
-        case XI_GestureSwipeEnd:
-            FixUpXI2SwipeEventFromWindow(pSprite,
-                                         (xXIGestureSwipeEvent*) xE, pWin, child);
-            break;
-        default:
-            FixUpXI2DeviceEventFromWindow(pSprite, evtype,
-                                          (xXIDeviceEvent*) xE, pWin, child);
-            break;
-        }
+       if(XILevel >= XI) {
+          switch (evtype) {
+             case XI_RawKeyPress:
+             case XI_RawKeyRelease:
+             case XI_RawButtonPress:
+             case XI_RawButtonRelease:
+             case XI_RawMotion:
+             case XI_RawTouchBegin:
+             case XI_RawTouchUpdate:
+             case XI_RawTouchEnd:
+             case XI_DeviceChanged:
+             case XI_HierarchyChanged:
+             case XI_PropertyEvent:
+             case XI_BarrierHit:
+             case XI_BarrierLeave:
+                return;
+             case XI_GesturePinchBegin:
+             case XI_GesturePinchUpdate:
+             case XI_GesturePinchEnd:
+                FixUpXI2PinchEventFromWindow(pSprite,
+                      (xXIGesturePinchEvent*) xE, pWin, child);
+                break;
+             case XI_GestureSwipeBegin:
+             case XI_GestureSwipeUpdate:
+             case XI_GestureSwipeEnd:
+                FixUpXI2SwipeEventFromWindow(pSprite,
+                      (xXIGestureSwipeEvent*) xE, pWin, child);
+                break;
+             default:
+                FixUpXI2DeviceEventFromWindow(pSprite, evtype,
+                      (xXIDeviceEvent*) xE, pWin, child);
+                break;
+          }
+       }
     }
     else {
         XE_KBPTR.root = RootWindow(pSprite)->drawable.id;
@@ -2801,7 +2803,7 @@ EventIsDeliverable(DeviceIntPtr dev, int evtype, WindowPtr win)
 
 static int
 DeliverEvent(DeviceIntPtr dev, xEvent *xE, int count,
-             WindowPtr win, Window child, GrabPtr grab)
+             WindowPtr win, Window child, GrabPtr grab, enum InputLevel XILevel)
 {
     SpritePtr pSprite = dev->spriteInfo->sprite;
     Mask filter;
@@ -2809,7 +2811,7 @@ DeliverEvent(DeviceIntPtr dev, xEvent *xE, int count,
 
     if (XaceHookSendAccess(NULL, dev, win, xE, count) == Success) {
         filter = GetEventFilter(dev, xE);
-        FixUpEventFromWindow(pSprite, xE, win, child, FALSE);
+        FixUpEventFromWindow(pSprite, xE, win, child, FALSE, XILevel);
         deliveries = DeliverEventsToWindow(dev, win, xE, count, filter, grab);
     }
 
@@ -2842,7 +2844,7 @@ DeliverOneEvent(InternalEvent *event, DeviceIntPtr dev, enum InputLevel level,
     }
 
     if (rc == Success) {
-        deliveries = DeliverEvent(dev, xE, count, win, child, grab);
+        deliveries = DeliverEvent(dev, xE, count, win, child, grab, level);
         free(xE);
     }
     else
@@ -3823,7 +3825,7 @@ ActivatePassiveGrab(DeviceIntPtr device, GrabPtr grab, InternalEvent *event,
     ActivateGrabNoDelivery(device, grab, event, real_event);
 
     if (xE) {
-        FixUpEventFromWindow(pSprite, xE, grab->window, None, TRUE);
+        FixUpEventFromWindow(pSprite, xE, grab->window, None, TRUE, grab->grabtype);
 
         /* XXX: XACE? */
         TryClientEvents(dixClientForGrab(grab), device, xE, count,
@@ -4221,7 +4223,7 @@ DeliverFocusedEvent(DeviceIntPtr keybd, InternalEvent *event, WindowPtr window)
         /* XXX: XACE */
         int filter = GetEventFilter(keybd, xi2);
 
-        FixUpEventFromWindow(ptr->spriteInfo->sprite, xi2, focus, None, FALSE);
+        FixUpEventFromWindow(ptr->spriteInfo->sprite, xi2, focus, None, FALSE, XI2);
         deliveries = DeliverEventsToWindow(keybd, focus, xi2, 1,
                                            filter, NullGrab);
         if (deliveries > 0)
@@ -4235,7 +4237,7 @@ DeliverFocusedEvent(DeviceIntPtr keybd, InternalEvent *event, WindowPtr window)
     rc = EventToXI(event, &xE, &count);
     if (rc == Success &&
         XaceHookSendAccess(NULL, keybd, focus, xE, count) == Success) {
-        FixUpEventFromWindow(ptr->spriteInfo->sprite, xE, focus, None, FALSE);
+        FixUpEventFromWindow(ptr->spriteInfo->sprite, xE, focus, None, FALSE, XI);
         deliveries = DeliverEventsToWindow(keybd, focus, xE, count,
                                            GetEventFilter(keybd, xE), NullGrab);
 
@@ -4252,8 +4254,7 @@ DeliverFocusedEvent(DeviceIntPtr keybd, InternalEvent *event, WindowPtr window)
         if (rc == Success) {
             if (XaceHookSendAccess(NULL, keybd, focus, core, count) ==
                 Success) {
-                FixUpEventFromWindow(keybd->spriteInfo->sprite, core, focus,
-                                     None, FALSE);
+                FixUpEventFromWindow(keybd->spriteInfo->sprite, core, focus, None, FALSE, CORE);
                 deliveries =
                     DeliverEventsToWindow(keybd, focus, core, count,
                                           GetEventFilter(keybd, core),
@@ -4296,7 +4297,6 @@ DeliverOneGrabbedEvent(InternalEvent *event, DeviceIntPtr dev,
         count = 1;
         if (rc == Success) {
             int evtype = xi2_get_type(xE);
-
             mask = GetXI2MaskByte(grab->xi2mask, dev, evtype);
             filter = GetEventFilter(dev, xE);
         }
@@ -4322,7 +4322,7 @@ DeliverOneGrabbedEvent(InternalEvent *event, DeviceIntPtr dev,
     }
 
     if (rc == Success) {
-        FixUpEventFromWindow(pSprite, xE, grab->window, None, TRUE);
+        FixUpEventFromWindow(pSprite, xE, grab->window, None, TRUE, level);
         if (XaceHookSendAccess(NULL, dev, grab->window, xE, count) ||
             XaceHookReceiveAccess(dixClientForGrab(grab), grab->window, xE, count))
             deliveries = 1;     /* don't send, but pretend we did */
@@ -4661,7 +4661,7 @@ CoreEnterLeaveEvent(DeviceIntPtr mouse,
 {
     xEvent event = {
         .u.u.type = type,
-        .u.u.detail = detail
+        .u.u.detail = detail,
     };
     WindowPtr focus;
     DeviceIntPtr keybd;
@@ -4686,7 +4686,7 @@ CoreEnterLeaveEvent(DeviceIntPtr mouse,
     event.u.enterLeave.rootX = mouse->spriteInfo->sprite->hot.x;
     event.u.enterLeave.rootY = mouse->spriteInfo->sprite->hot.y;
     /* Counts on the same initial structure of crossing & button events! */
-    FixUpEventFromWindow(mouse->spriteInfo->sprite, &event, pWin, None, FALSE);
+    FixUpEventFromWindow(mouse->spriteInfo->sprite, &event, pWin, None, FALSE, CORE);
     /* Enter/Leave events always set child */
     event.u.enterLeave.child = child;
     event.u.enterLeave.flags = event.u.keyButtonPointer.sameScreen ?
@@ -4788,8 +4788,7 @@ DeviceEnterLeaveEvent(DeviceIntPtr mouse,
         ((pWin == focus) || (focus == PointerRootWin) || WindowIsParent(focus, pWin)))
         event->focus = TRUE;
 
-    FixUpEventFromWindow(mouse->spriteInfo->sprite, (xEvent *) event, pWin,
-                         None, FALSE);
+    FixUpEventFromWindow(mouse->spriteInfo->sprite, (xEvent *) event, pWin, None, FALSE, XI);
 
     filter = GetEventFilter(mouse, (xEvent *) event);
 

--- a/dix/input_priv.h
+++ b/dix/input_priv.h
@@ -289,7 +289,8 @@ void FixUpEventFromWindow(SpritePtr pSprite,
                           xEvent *xE,
                           WindowPtr pWin,
                           Window child,
-                          Bool calcChild);
+                          Bool calcChild,
+                          enum InputLevel XILevel);
 Bool PointInBorderSize(WindowPtr pWin, int x, int y);
 WindowPtr XYToWindow(SpritePtr pSprite, int x, int y);
 int EventIsDeliverable(DeviceIntPtr dev, int evtype, WindowPtr win);


### PR DESCRIPTION
`CoreEnterLeaveEvent` calls `FixUpEventFromWindow` with a pointer to a stack-allocated `xEvent` structure, which may get later casted into an `xXIDeviceEvent*,` with writes done by `FixUpXI2DeviceEventFromWindow` at an offset larger than `sizeof(xEvent).` This code-path is protected by `xi2_get_type()` but the following warning is generated by building with -O3 and LTO:

```
In function 'FixUpXI2DeviceEventFromWindow',
    inlined from 'FixUpEventFromWindow' at ../dix/events.c:2716:13,
    inlined from 'CoreEnterLeaveEvent' at ../dix/events.c:4679:5:
../dix/events.c:2628:48: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 2628 |         ((xXIEnterEvent *) event)->same_screen =
      |                                                ^
../dix/events.c: In function 'CoreEnterLeaveEvent':
../dix/events.c:4652:12: note: at offset 48 into destination object 'event' of size 32
 4652 |     xEvent event = {
      |            ^

```
This PR suppresses this warning, by tracking the level of the event (ie., core event, XI or XI2) and ensuring that fix-up is performed only on XI2 events.