### PR TITLE
config: fix inttype mismatches on device major/minor numbers

### DIFF
--- a/config/hotplug_priv.h
+++ b/config/hotplug_priv.h
@@ -53,10 +53,10 @@ struct OdevAttributes {
     int         fd;
 
     /* Major number of the device node pointed to by ODEV_ATTRIB_PATH */
-    int         major;
+    unsigned int major;
 
     /* Minor number of the device node pointed to by ODEV_ATTRIB_PATH */
-    int         minor;
+    unsigned int minor;
 
     /* kernel driver name */
     char        *driver;
@@ -80,7 +80,7 @@ void DeleteGPUDeviceRequest(struct OdevAttributes *attribs);
 #define ServerIsNotSeat0() (SeatId && strcmp(SeatId, "seat0"))
 
 struct xf86_platform_device *
-xf86_find_platform_device_by_devnum(int major, int minor);
+xf86_find_platform_device_by_devnum(unsigned int major, unsigned int minor);
 
 void config_pre_init(void);
 

--- a/config/udev.c
+++ b/config/udev.c
@@ -62,17 +62,9 @@ static struct udev_monitor *udev_monitor;
 #ifdef CONFIG_UDEV_KMS
 static void
 config_udev_odev_setup_attribs(struct udev_device *udev_device, const char *path, const char *syspath,
-                               int major, int minor,
+                               unsigned int major, unsigned int minor,
                                config_odev_probe_proc_ptr probe_callback);
 #endif
-
-static char itoa_buf[16];
-
-static const char *itoa(int i)
-{
-    snprintf(itoa_buf, sizeof(itoa_buf), "%d", i);
-    return itoa_buf;
-}
 
 static Bool
 check_seat(struct udev_device *udev_device)
@@ -197,11 +189,15 @@ device_added(struct udev_device *udev_device)
         name = "(unnamed)";
     else
         attrs.product = strdup(name);
+
+    char buf[128];
     input_options = input_option_new(input_options, "name", name);
     input_options = input_option_new(input_options, "path", path);
     input_options = input_option_new(input_options, "device", path);
-    input_options = input_option_new(input_options, "major", itoa(major(devnum)));
-    input_options = input_option_new(input_options, "minor", itoa(minor(devnum)));
+    sprintf(buf, "%u", major(devnum));
+    input_options = input_option_new(input_options, "major", buf);
+    sprintf(buf, "%u", minor(devnum));
+    input_options = input_option_new(input_options, "minor", buf);
     if (path)
         attrs.device = strdup(path);
 
@@ -533,7 +529,7 @@ config_udev_get_fallback_bus_id(struct udev_device *udev_device)
 
 static void
 config_udev_odev_setup_attribs(struct udev_device *udev_device, const char *path, const char *syspath,
-                               int major, int minor,
+                               unsigned int major, unsigned int minor,
                                config_odev_probe_proc_ptr probe_callback)
 {
     struct OdevAttributes *attribs = config_odev_allocate_attributes();

--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -1003,7 +1003,7 @@ DeleteGPUDeviceRequest(struct OdevAttributes *attribs)
 
 #if defined(CONFIG_UDEV) || defined(CONFIG_HAL)
 struct xf86_platform_device *
-xf86_find_platform_device_by_devnum(int major, int minor)
+xf86_find_platform_device_by_devnum(unsigned int major, unsigned int minor)
 {
     return NULL;
 }

--- a/hw/xfree86/common/xf86platformBus.c
+++ b/hw/xfree86/common/xf86platformBus.c
@@ -101,13 +101,11 @@ xf86_get_platform_device_unowned(int index)
 }
 
 struct xf86_platform_device *
-xf86_find_platform_device_by_devnum(int major, int minor)
+xf86_find_platform_device_by_devnum(unsigned int major, unsigned int minor)
 {
-    int i, attr_major, attr_minor;
-
-    for (i = 0; i < xf86_num_platform_devices; i++) {
-        attr_major = xf86_platform_odev_attributes(i)->major;
-        attr_minor = xf86_platform_odev_attributes(i)->minor;
+    for (unsigned int i = 0; i < xf86_num_platform_devices; i++) {
+        unsigned int attr_major = xf86_platform_odev_attributes(i)->major;
+        unsigned int attr_minor = xf86_platform_odev_attributes(i)->minor;
         if (attr_major == major && attr_minor == minor)
             return &xf86_platform_devices[i];
     }


### PR DESCRIPTION
System headers define them as unsigned.