### PR TITLE
xkb: fix swapping bug in ProcXkbGetKbdByName()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -6026,6 +6026,8 @@ ProcXkbGetKbdByName(ClientPtr client)
             return BadAlloc;
         }
 
+        const size_t mrep_length = mrep.length; /* save before swapping */
+
         if (client->swapped) {
             swaps(&mrep.sequenceNumber);
             swapl(&mrep.length);
@@ -6036,7 +6038,7 @@ ProcXkbGetKbdByName(ClientPtr client)
 
         // struct is 8 bytes (2 units) longer than generic reply, so need to
         // compute the payload length carefully
-        const size_t payloadBytes = (mrep.length * 4) - (sizeof(mrep) - sizeof(xGenericReply));
+        const size_t payloadBytes = (mrep_length * 4) - (sizeof(mrep) - sizeof(xGenericReply));
         memcpy(payload_walk, &mrep, sizeof(mrep));
         payload_walk += sizeof(mrep);
         memcpy(payload_walk, rpcbuf.buffer, payloadBytes);
@@ -6048,6 +6050,8 @@ ProcXkbGetKbdByName(ClientPtr client)
         char *buf = payload_walk + sizeof(crep);
         XkbAssembleCompatMap(client, new->compat, crep, buf);
 
+        const size_t crep_length = crep.length; /* save before swapping */
+
         if (client->swapped) {
             swaps(&crep.sequenceNumber);
             swapl(&crep.length);
@@ -6057,12 +6061,14 @@ ProcXkbGetKbdByName(ClientPtr client)
         }
 
         memcpy(payload_walk, &crep, sizeof(crep));
-        payload_walk = buf + (crep.length * 4) - (sizeof(crep) - sizeof(xGenericReply));
+        payload_walk = buf + (crep_length * 4) - (sizeof(crep) - sizeof(xGenericReply));
     }
 
     if (reported & XkbGBN_IndicatorMapMask) {
         char *buf = payload_walk + sizeof(irep);
         XkbAssembleIndicatorMap(client, new->indicators, irep, buf);
+
+        const size_t irep_length = irep.length;
 
         if (client->swapped) {
             swaps(&irep.sequenceNumber);
@@ -6072,12 +6078,14 @@ ProcXkbGetKbdByName(ClientPtr client)
         }
 
         memcpy(payload_walk, &irep, sizeof(irep));
-        payload_walk = buf + (irep.length * 4) - (sizeof(irep) - sizeof(xGenericReply));
+        payload_walk = buf + (irep_length * 4) - (sizeof(irep) - sizeof(xGenericReply));
     }
 
     if (reported & (XkbGBN_KeyNamesMask | XkbGBN_OtherNamesMask)) {
         char *buf = payload_walk + sizeof(nrep);
         XkbAssembleNames(client, new, nrep, buf);
+
+        const size_t nrep_length = nrep.length; /* save before swapping */
 
         if (client->swapped) {
             swaps(&nrep.sequenceNumber);
@@ -6088,12 +6096,14 @@ ProcXkbGetKbdByName(ClientPtr client)
         }
 
         memcpy(payload_walk, &nrep, sizeof(nrep));
-        payload_walk = buf + (nrep.length * 4) - (sizeof(nrep) - sizeof(xGenericReply));
+        payload_walk = buf + (nrep_length * 4) - (sizeof(nrep) - sizeof(xGenericReply));
     }
 
     if (reported & XkbGBN_GeometryMask) {
         char *buf = payload_walk + sizeof(grep);
         XkbAssembleGeometry(client, new->geom, grep, buf);
+
+        const size_t grep_length = grep.length; /* save before swapping */
 
         if (client->swapped) {
             swaps(&grep.sequenceNumber);
@@ -6110,7 +6120,7 @@ ProcXkbGetKbdByName(ClientPtr client)
         }
 
         memcpy(payload_walk, &grep, sizeof(grep));
-        payload_walk = buf + (grep.length * 4) - (sizeof(grep) - sizeof(xGenericReply));
+        payload_walk = buf + (grep_length * 4) - (sizeof(grep) - sizeof(xGenericReply));
     }
 
     WriteToClient(client, sizeof(xkbGetKbdByNameReply), &rep);


### PR DESCRIPTION
We've been adding the individual sub-packet's payload bytes *after* the swapping, which is leading to totally wrong sizes.