### PR TITLE
.github: notify on merge conflicts in PRs

### DIFF
--- a/.github/workflows/conflict-notify.yml
+++ b/.github/workflows/conflict-notify.yml
@@ -1,0 +1,22 @@
+name: check PRs for merge conflicts
+
+on:
+    push:
+        branches:
+          - master
+          - 'maint-*'
+          - 'rfc/new-abi*'
+
+permissions:
+    pull-requests: write
+
+jobs:
+    notify:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: nokamoto/merge-conflict-action@v0.0.4
+              with:
+                owner: X11Libre
+                repo: xserver
+                token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a pipeline that's checking for and notifying on merge conflicts within open pull requests. It's triggered whenever one of the baseline branches (eg. master, maint-*, etc) are pushed.

Unfortunately, we don't have any way for rate limiting within a single PR yet, so on a day with lots of merges, it could become a bit spammy.

Should also go into maint-25.0
