### PR TITLE
Change presentproto requirement from 1.4 to 1.3

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -83,7 +83,7 @@ fixesproto_dep = dependency('fixesproto', version: '>= 6.0', fallback: ['xorgpro
 damageproto_dep = dependency('damageproto', version: '>= 1.1', fallback: ['xorgproto', 'ext_xorgproto'])
 xcmiscproto_dep = dependency('xcmiscproto', version: '>= 1.2.0', fallback: ['xorgproto', 'ext_xorgproto'])
 bigreqsproto_dep = dependency('bigreqsproto', version: '>= 1.1.0', fallback: ['xorgproto', 'ext_xorgproto'])
-presentproto_dep = dependency('presentproto', version: '>= 1.4', fallback: ['xorgproto', 'ext_xorgproto'])
+presentproto_dep = dependency('presentproto', version: '>= 1.3', fallback: ['xorgproto', 'ext_xorgproto'])
 
 videoproto_dep = dependency('videoproto', fallback: ['xorgproto', 'ext_xorgproto'])
 compositeproto_dep = dependency('compositeproto', version: '>= 0.4', fallback: ['xorgproto', 'ext_xorgproto'])


### PR DESCRIPTION
Currently Xlibre will not compile on Ubuntu 24.04 LTS because the version of presentproto it has is 1.3 but the meson.build file requires version 1.4 or higher. Manually editing meson.build allows for Xlibre to compile and run, indicating that there shouldn't be any concern from allowing distros that have 1.3 to run it - all currently working distros should be unaffected as they offer presentproto 1.4. The only patch notes I can locate for 1.4 do not indicate any concerns with using 1.3 https://www.suse.com/support/update/announcement/2024/suse-su-20242776-1/