### PR TITLE
dix: drop obsolete WriteSwappedDataToClient() macro

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -2283,8 +2283,7 @@ DoGetImage(ClientPtr client, int format, Drawable drawable,
                                 pDraw, x, y + linesDone, width,
                                 nlines, format, pBuf);
 
-            /* Note that this is NOT a call to WriteSwappedDataToClient,
-               as we do NOT byte swap */
+            /* Note that we DO NOT byte swap here */
             ReformatImage(pBuf, (int) (nlines * widthBytesLine),
                           BitsPerPixel(pDraw->depth), ClientOrder(client));
 
@@ -2311,8 +2310,7 @@ DoGetImage(ClientPtr client, int format, Drawable drawable,
                                         pDraw, x, y + linesDone, width,
                                         nlines, format, pBuf);
 
-                    /* Note: NOT a call to WriteSwappedDataToClient,
-                       as we do NOT byte swap */
+                    /* Note that we DO NOT byte swap here */
                     ReformatImage(pBuf, (int) (nlines * widthBytesLine),
                                   1, ClientOrder(client));
 

--- a/doc/Xserver-spec.xml
+++ b/doc/Xserver-spec.xml
@@ -599,7 +599,6 @@ are useful to the extension writer.  Ones of particular interest
 are: REQUEST, REQUEST_SIZE_MATCH, REQUEST_AT_LEAST_SIZE,
 REQUEST_FIXED_SIZE, LEGAL_NEW_RESOURCE, and
 VALIDATE_DRAWABLE_AND_GC. Useful byte swapping macros can be found
-in Xserver/include/dix.h: WriteSwappedDataToClient; and
 in Xserver/include/misc.h: bswap_64, bswap_32, bswap_16, LengthRestS,
 LengthRestL, SwapRestS, SwapRestL, swapl, swaps, cpswapl, and cpswaps.</para>
 </section>

--- a/include/dix.h
+++ b/include/dix.h
@@ -90,14 +90,6 @@ SOFTWARE.
             return(BadLength);                                          \
     } while (0)
 
-#define WriteSwappedDataToClient(pClient, size, pbuf)                   \
-    do {                                                                \
-        if ((pClient)->swapped)                                         \
-            (*(pClient)->pSwapReplyFunc)(pClient, (int)(size), pbuf);   \
-        else                                                            \
-            WriteToClient(pClient, (int)(size), (pbuf));                \
-    } while (0)
-
 typedef struct _TimeStamp *TimeStampPtr;
 
 #ifndef _XTYPEDEF_CLIENTPTR


### PR DESCRIPTION
This macro isn't and shouldn't be used anymore, so get rid of it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
