### PR TITLE
xkb: XkbWriteGeomSections(): use x_rpcbuf_t

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -4631,94 +4631,64 @@ XkbSizeGeomSections(XkbGeometryPtr geom)
     return size;
 }
 
-static char *
-XkbWriteGeomSections(char *wire, XkbGeometryPtr geom, Bool swap)
+static void XkbWriteGeomSections(x_rpcbuf_t *rpcbuf, XkbGeometryPtr geom)
 {
     register int i;
     XkbSectionPtr section;
-    xkbSectionWireDesc *sectionWire;
 
     for (i = 0, section = geom->sections; i < geom->num_sections;
          i++, section++) {
-        sectionWire = (xkbSectionWireDesc *) wire;
-        sectionWire->name = section->name;
-        sectionWire->top = section->top;
-        sectionWire->left = section->left;
-        sectionWire->width = section->width;
-        sectionWire->height = section->height;
-        sectionWire->angle = section->angle;
-        sectionWire->priority = section->priority;
-        sectionWire->nRows = section->num_rows;
-        sectionWire->nDoodads = section->num_doodads;
-        sectionWire->nOverlays = section->num_overlays;
-        sectionWire->pad = 0;
-        if (swap) {
-            swapl(&sectionWire->name);
-            swaps(&sectionWire->top);
-            swaps(&sectionWire->left);
-            swaps(&sectionWire->width);
-            swaps(&sectionWire->height);
-            swaps(&sectionWire->angle);
-        }
-        wire = (char *) &sectionWire[1];
+
+        /* write xkbSectionWireDesc */
+        x_rpcbuf_write_CARD32(rpcbuf, section->name);
+        x_rpcbuf_write_INT16(rpcbuf, section->top);
+        x_rpcbuf_write_INT16(rpcbuf, section->left);
+        x_rpcbuf_write_CARD16(rpcbuf, section->width);
+        x_rpcbuf_write_CARD16(rpcbuf, section->height);
+        x_rpcbuf_write_INT16(rpcbuf, section->angle);
+        x_rpcbuf_write_CARD8(rpcbuf, section->priority);
+        x_rpcbuf_write_CARD8(rpcbuf, section->num_rows);
+        x_rpcbuf_write_CARD8(rpcbuf, section->num_doodads);
+        x_rpcbuf_write_CARD8(rpcbuf, section->num_overlays);
+        x_rpcbuf_write_CARD16(rpcbuf, 0); /* pad1 */
+
         if (section->rows) {
             int r;
             XkbRowPtr row;
-            xkbRowWireDesc *rowWire;
 
             for (r = 0, row = section->rows; r < section->num_rows; r++, row++) {
-                rowWire = (xkbRowWireDesc *) wire;
-                rowWire->top = row->top;
-                rowWire->left = row->left;
-                rowWire->nKeys = row->num_keys;
-                rowWire->vertical = row->vertical;
-                rowWire->pad = 0;
-                if (swap) {
-                    swaps(&rowWire->top);
-                    swaps(&rowWire->left);
-                }
-                wire = (char *) &rowWire[1];
+                /* write xkbRowWireDesc */
+                x_rpcbuf_write_INT16(rpcbuf, row->top);
+                x_rpcbuf_write_INT16(rpcbuf, row->left),
+                x_rpcbuf_write_CARD8(rpcbuf, row->num_keys);
+                x_rpcbuf_write_CARD8(rpcbuf, row->vertical);
+                x_rpcbuf_write_CARD16(rpcbuf, 0); /* pad1 */
+
                 if (row->keys) {
                     int k;
                     XkbKeyPtr key;
-                    xkbKeyWireDesc *keyWire;
 
-                    keyWire = (xkbKeyWireDesc *) wire;
                     for (k = 0, key = row->keys; k < row->num_keys; k++, key++) {
-                        memcpy(keyWire[k].name, key->name.name,
-                               XkbKeyNameLength);
-                        keyWire[k].gap = key->gap;
-                        keyWire[k].shapeNdx = key->shape_ndx;
-                        keyWire[k].colorNdx = key->color_ndx;
-                        if (swap) {
-                            swaps(&keyWire[k].gap);
-                        }
+                        /* xkbKeyWireDesc */
+                        x_rpcbuf_write_CARD8s(rpcbuf, (CARD8*)key->name.name, XkbKeyNameLength);
+                        x_rpcbuf_write_INT16(rpcbuf, key->gap);
+                        x_rpcbuf_write_CARD8(rpcbuf, key->shape_ndx);
+                        x_rpcbuf_write_CARD8(rpcbuf, key->color_ndx);
                     }
-                    wire = (char *) &keyWire[row->num_keys];
                 }
             }
         }
 
         if (section->doodads) {
-            x_rpcbuf_t rpcbuf = { .swapped = swap, .err_clear = TRUE };
-            XkbWriteGeomDoodads(&rpcbuf, section->num_doodads, section->doodads);
-            memcpy(wire, rpcbuf.buffer, rpcbuf.wpos);
-            wire += rpcbuf.wpos;
-            x_rpcbuf_clear(&rpcbuf);
+            XkbWriteGeomDoodads(rpcbuf, section->num_doodads, section->doodads);
         }
         if (section->overlays) {
-            x_rpcbuf_t rpcbuf = { .swapped = swap, .err_clear = TRUE };
-
             register int o;
             for (o = 0; o < section->num_overlays; o++) {
-                XkbWriteGeomOverlay(&rpcbuf, &section->overlays[o]);
+                XkbWriteGeomOverlay(rpcbuf, &section->overlays[o]);
             }
-            memcpy(wire, rpcbuf.buffer, rpcbuf.wpos);
-            wire += rpcbuf.wpos;
-            x_rpcbuf_clear(&rpcbuf);
         }
     }
-    return wire;
 }
 
 static Status
@@ -4784,8 +4754,13 @@ XkbAssembleGeometry(ClientPtr client,
         desc += rpcbuf.wpos;
         x_rpcbuf_clear(&rpcbuf);
     }
-    if (rep.nSections > 0)
-        desc = XkbWriteGeomSections(desc, geom, client->swapped);
+    if (rep.nSections > 0) {
+        x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+        XkbWriteGeomSections(&rpcbuf, geom);
+        memcpy(desc, rpcbuf.buffer, rpcbuf.wpos);
+        desc += rpcbuf.wpos;
+        x_rpcbuf_clear(&rpcbuf);
+    }
     if (rep.nDoodads > 0) {
         x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
         XkbWriteGeomDoodads(&rpcbuf, geom->num_doodads, geom->doodads);


### PR DESCRIPTION
Use x_rpcbuf_t for payload chunk assembly / byte-swapping.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
