### PR TITLE
xkb: XkbWriteGeomKeyAliases(): use x_rpcbuf_t

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -4394,17 +4394,11 @@ XkbSizeGeomKeyAliases(XkbGeometryPtr geom)
     return geom->num_key_aliases * (2 * XkbKeyNameLength);
 }
 
-static char *
-XkbWriteGeomKeyAliases(char *wire, XkbGeometryPtr geom, Bool swap)
+static inline void XkbWriteGeomKeyAliases(x_rpcbuf_t *rpcbuf, XkbGeometryPtr geom)
 {
-    register int sz;
-
-    sz = geom->num_key_aliases * (XkbKeyNameLength * 2);
-    if (sz > 0) {
-        memcpy(wire, (char *) geom->key_aliases, sz);
-        wire += sz;
-    }
-    return wire;
+    x_rpcbuf_write_CARD8s(rpcbuf,
+                          (CARD8*) geom->key_aliases,
+                          geom->num_key_aliases * sizeof(XkbKeyAliasRec));
 }
 
 static int
@@ -4795,8 +4789,13 @@ XkbAssembleGeometry(ClientPtr client,
         desc += rpcbuf.wpos;
         x_rpcbuf_clear(&rpcbuf);
     }
-    if (rep.nKeyAliases > 0)
-        desc = XkbWriteGeomKeyAliases(desc, geom, client->swapped);
+    if (rep.nKeyAliases > 0) {
+        x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+        XkbWriteGeomKeyAliases(&rpcbuf, geom);
+        memcpy(desc, rpcbuf.buffer, rpcbuf.wpos);
+        desc += rpcbuf.wpos;
+        x_rpcbuf_clear(&rpcbuf);
+    }
 }
 
 int


### PR DESCRIPTION
Use x_rpcbuf_t for assembling the reply payload chunk.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
