### PR TITLE
xres: ProcXResQueryClients(): use X_SEND_REPLY_WITH_RPCBUF() macro

### DIFF
--- a/Xext/xres.c
+++ b/Xext/xres.c
@@ -219,20 +219,14 @@ ProcXResQueryClients(ClientPtr client)
     }
 
     xXResQueryClientsReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = x_rpcbuf_wsize_units(&rpcbuf),
         .num_clients = num_clients
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swapl(&rep.num_clients);
     }
 
-    WriteToClient(client, sizeof(xXResQueryClientsReply), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 


### PR DESCRIPTION
Use the new X_SEND_REPLY_WITH_RPCBUF() macro for final reply write out.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
