### PR TITLE
treewide: macro for computing extra units needed for reply header

### DIFF
--- a/Xext/sync.c
+++ b/Xext/sync.c
@@ -1852,8 +1852,7 @@ ProcSyncQueryAlarm(ClientPtr client)
     xSyncQueryAlarmReply rep = {
         .type = X_Reply,
         .sequenceNumber = client->sequence,
-        .length =
-          bytes_to_int32(sizeof(xSyncQueryAlarmReply) - sizeof(xGenericReply)),
+        .length = X_REPLY_HEADER_UNITS(xSyncQueryAlarmReply),
         .counter = (pTrigger->pSync) ? pTrigger->pSync->id : None,
 
 #if 0  /* XXX unclear what to do, depends on whether relative value-types

--- a/Xext/vidmode.c
+++ b/Xext/vidmode.c
@@ -256,8 +256,7 @@ ProcVidModeGetModeLine(ClientPtr client)
         .vsyncend = VidModeGetModeValue(mode, VIDMODE_V_SYNCEND),
         .vtotal = VidModeGetModeValue(mode, VIDMODE_V_TOTAL),
         .flags = VidModeGetModeValue(mode, VIDMODE_FLAGS),
-        .length = bytes_to_int32(sizeof(xXF86VidModeGetModeLineReply) -
-                                    sizeof(xGenericReply)),
+        .length = X_REPLY_HEADER_UNITS(xXF86VidModeGetModeLineReply),
         /*
          * Older servers sometimes had server privates that the VidMode
          * extension made available. So to be compatible pretend that
@@ -294,8 +293,7 @@ ProcVidModeGetModeLine(ClientPtr client)
         xXF86OldVidModeGetModeLineReply oldrep = {
             .type = rep.type,
             .sequenceNumber = rep.sequenceNumber,
-            .length = bytes_to_int32(sizeof(xXF86OldVidModeGetModeLineReply) -
-                                     sizeof(xGenericReply)),
+            .length = X_REPLY_HEADER_UNITS(xXF86OldVidModeGetModeLineReply),
             .dotclock = rep.dotclock,
             .hdisplay = rep.hdisplay,
             .hsyncstart = rep.hsyncstart,
@@ -395,8 +393,8 @@ ProcVidModeGetAllModeLines(ClientPtr client)
 
     xXF86VidModeGetAllModeLinesReply rep = {
         .type = X_Reply,
-        .length = bytes_to_int32(sizeof(xXF86VidModeGetAllModeLinesReply) -
-                                 sizeof(xGenericReply) + rpcbuf.wpos),
+        .length = X_REPLY_HEADER_UNITS(xXF86VidModeGetAllModeLinesReply)
+                + x_rpcbuf_wsize_units(&rpcbuf),
         .sequenceNumber = client->sequence,
         .modecount = modecount
     };
@@ -1009,8 +1007,7 @@ VidModeValidateModeLine(ClientPtr client, xXF86VidModeValidateModeLineReq *stuff
     xXF86VidModeValidateModeLineReply rep = {
         .type = X_Reply,
         .sequenceNumber = client->sequence,
-        .length = bytes_to_int32(sizeof(xXF86VidModeValidateModeLineReply)
-                                 - sizeof(xGenericReply)),
+        .length = X_REPLY_HEADER_UNITS(xXF86VidModeValidateModeLineReply),
         .status = status
     };
     if (client->swapped) {
@@ -1258,8 +1255,7 @@ ProcVidModeGetMonitor(ClientPtr client)
         .nvsync = nVrefresh,
         .vendorLength = x_safe_strlen(vendorStr),
         .modelLength = x_safe_strlen(modelStr),
-        .length = bytes_to_int32(sizeof(xXF86VidModeGetMonitorReply) -
-                                 sizeof(xGenericReply)) +
+        .length = X_REPLY_HEADER_UNITS(xXF86VidModeGetMonitorReply) +
                   x_rpcbuf_wsize_units(&rpcbuf)
     };
 
@@ -1387,8 +1383,7 @@ ProcVidModeGetDotClocks(ClientPtr client)
     xXF86VidModeGetDotClocksReply rep = {
         .type = X_Reply,
         .sequenceNumber = client->sequence,
-        .length = bytes_to_int32(sizeof(xXF86VidModeGetDotClocksReply)
-                                 - sizeof(xGenericReply)) + numClocks,
+        .length = X_REPLY_HEADER_UNITS(xXF86VidModeGetDotClocksReply) + numClocks,
         .clocks = numClocks,
         .maxclocks = MAXCLOCKS,
         .flags = (ClockProg ? CLKFLAG_PROGRAMABLE : 0),

--- a/Xext/xf86bigfont.c
+++ b/Xext/xf86bigfont.c
@@ -55,6 +55,7 @@
 #include <X11/fonts/fontstruct.h>
 #include <X11/fonts/libxfont2.h>
 
+#include "dix/dix_priv.h"
 #include "miext/extinit_priv.h"
 
 #include "misc.h"
@@ -529,8 +530,7 @@ ProcXF86BigfontQueryFont(ClientPtr client)
 
         xXF86BigfontQueryFontReply rep = {
             .type = X_Reply,
-            .length = bytes_to_int32(sizeof(xXF86BigfontQueryFontReply)
-                                     - sizeof(xGenericReply) + rlength),
+            .length = X_REPLY_HEADER_UNITS(xXF86BigfontQueryFontReply) + rlength,
             .sequenceNumber = client->sequence,
             .minBounds = pFont->info.ink_minbounds,
             .maxBounds = pFont->info.ink_maxbounds,

--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -980,8 +980,8 @@ doListFontsWithInfo(ClientPtr client, LFWIclosurePtr c)
             }
             reply->type = X_Reply;
             reply->length =
-                bytes_to_int32(sizeof *reply - sizeof(xGenericReply) +
-                               pFontInfo->nprops * sizeof(xFontProp) + namelen);
+                X_REPLY_HEADER_UNITS(xListFontsWithInfoReply)
+                + bytes_to_int32(pFontInfo->nprops*sizeof(xFontProp)+namelen);
             reply->sequenceNumber = client->sequence;
             reply->nameLength = namelen;
             reply->minBounds = pFontInfo->ink_minbounds;
@@ -1020,8 +1020,7 @@ doListFontsWithInfo(ClientPtr client, LFWIclosurePtr c)
     xListFontsWithInfoReply rep = {
         .type = X_Reply,
         .sequenceNumber = client->sequence,
-        .length = bytes_to_int32(sizeof(xListFontsWithInfoReply)
-                                 - sizeof(xGenericReply))
+        .length = X_REPLY_HEADER_UNITS(xListFontsWithInfoReply)
     };
     if (client->swapped) {
         SwapFont((xQueryFontReply *) &rep, FALSE);

--- a/dix/window.c
+++ b/dix/window.c
@@ -1578,8 +1578,7 @@ ProcGetWindowAttributes(ClientPtr client)
         .bitGravity = pWin->bitGravity,
         .winGravity = pWin->winGravity,
         .backingStore = pWin->backingStore,
-        .length = bytes_to_int32(sizeof(xGetWindowAttributesReply) -
-                                 sizeof(xGenericReply)),
+        .length = X_REPLY_HEADER_UNITS(xGetWindowAttributesReply),
         .sequenceNumber = client->sequence,
         .backingBitPlanes = wBackingBitPlanes(pWin),
         .backingPixel = wBackingPixel(pWin),

--- a/hw/xfree86/dri/xf86dri.c
+++ b/hw/xfree86/dri/xf86dri.c
@@ -162,9 +162,8 @@ ProcXF86DRIOpenConnection(register ClientPtr client)
     rep = (xXF86DRIOpenConnectionReply) {
         .type = X_Reply,
         .sequenceNumber = client->sequence,
-        .length = bytes_to_int32(SIZEOF(xXF86DRIOpenConnectionReply) -
-                                 SIZEOF(xGenericReply) +
-                                 pad_to_int32(busIdStringLength)),
+        .length = X_REPLY_HEADER_UNITS(xXF86DRIOpenConnectionReply)
+                + bytes_to_int32(busIdStringLength),
         .busIdStringLength = busIdStringLength,
 
         .hSAREALow = (CARD32) (hSAREA & 0xffffffff),
@@ -246,9 +245,8 @@ ProcXF86DRIGetClientDriverName(register ClientPtr client)
 
     if (clientDriverName)
         rep.clientDriverNameLength = strlen(clientDriverName);
-    rep.length = bytes_to_int32(SIZEOF(xXF86DRIGetClientDriverNameReply) -
-                                SIZEOF(xGenericReply) +
-                                pad_to_int32(rep.clientDriverNameLength));
+    rep.length = X_REPLY_HEADER_UNITS(xXF86DRIGetClientDriverNameReply)
+               + bytes_to_int32(rep.clientDriverNameLength);
 
     WriteToClient(client, sizeof(xXF86DRIGetClientDriverNameReply), &rep);
     if (rep.clientDriverNameLength)
@@ -407,8 +405,7 @@ ProcXF86DRIGetDrawableInfo(register ClientPtr client)
     rep.drawableY = Y;
     rep.drawableWidth = W;
     rep.drawableHeight = H;
-    rep.length = (SIZEOF(xXF86DRIGetDrawableInfoReply) - SIZEOF(xGenericReply));
-
+    rep.length = X_REPLY_HEADER_UNITS(xXF86DRIGetDrawableInfoReply);
     rep.backX = backX;
     rep.backY = backY;
 
@@ -498,9 +495,8 @@ ProcXF86DRIGetDeviceInfo(register ClientPtr client)
 #endif
 
     if (rep.devPrivateSize) {
-        rep.length = bytes_to_int32(SIZEOF(xXF86DRIGetDeviceInfoReply) -
-                                    SIZEOF(xGenericReply) +
-                                    pad_to_int32(rep.devPrivateSize));
+        rep.length = X_REPLY_HEADER_UNITS(xXF86DRIGetDeviceInfoReply)
+                   + bytes_to_int32(rep.devPrivateSize);
     }
 
     WriteToClient(client, sizeof(xXF86DRIGetDeviceInfoReply), &rep);

--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -709,8 +709,7 @@ ProcXkbGetControls(ClientPtr client)
         .type = X_Reply,
         .deviceID = ((DeviceIntPtr) dev)->id,
         .sequenceNumber = client->sequence,
-        .length = bytes_to_int32(sizeof(xkbGetControlsReply) -
-                                 sizeof(xGenericReply)),
+        .length = X_REPLY_HEADER_UNITS(xkbGetControlsReply),
         .mkDfltBtn = xkb->mk_dflt_btn,
         .numGroups = xkb->num_groups,
         .groupsWrap = xkb->groups_wrap,
@@ -5800,8 +5799,7 @@ ProcXkbGetKbdByName(ClientPtr client)
             reported &= ~(XkbGBN_SymbolsMask | XkbGBN_TypesMask);
         else if (reported & (XkbGBN_SymbolsMask | XkbGBN_TypesMask)) {
             mrep.deviceID = dev->id;
-            mrep.length =
-                ((SIZEOF(xkbGetMapReply) - SIZEOF(xGenericReply)) >> 2);
+            mrep.length = X_REPLY_HEADER_UNITS(xkbGetMapReply);
             mrep.minKeyCode = new->min_key_code;
             mrep.maxKeyCode = new->max_key_code;
             mrep.totalSyms = mrep.totalActs =


### PR DESCRIPTION
Add and use macro X_REPLY_HEADER_UNITS() for computing how many
extra protocol units are needed for a reply header (for .length field)

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
