### PR TITLE
composite: canonical `walkScreenIdx` variable on screen list iterations

### DIFF
--- a/composite/compext.c
+++ b/composite/compext.c
@@ -500,13 +500,12 @@ void
 CompositeExtensionInit(void)
 {
     ExtensionEntry *extEntry;
-    int s;
 
     /* Assume initialization is going to fail */
     noCompositeExtension = TRUE;
 
-    for (s = 0; s < screenInfo.numScreens; s++) {
-        ScreenPtr walkScreen = screenInfo.screens[s];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         VisualPtr vis;
 
         /* Composite on 8bpp pseudocolor root windows appears to fail, so
@@ -545,8 +544,8 @@ CompositeExtensionInit(void)
                                sizeof(CompositeClientRec)))
         return;
 
-    for (s = 0; s < screenInfo.numScreens; s++) {
-        ScreenPtr walkScreen = screenInfo.screens[s];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         if (!compScreenInit(walkScreen))
             return;
     }
@@ -573,7 +572,7 @@ ProcCompositeRedirectWindow(ClientPtr client)
         return SingleCompositeRedirectWindow(client, stuff);
 
     PanoramiXRes *win;
-    int rc = 0, j;
+    int rc = 0;
 
     if ((rc = dixLookupResourceByType((void **) &win, stuff->window, XRT_WINDOW,
                                       client, DixUnknownAccess))) {
@@ -581,8 +580,9 @@ ProcCompositeRedirectWindow(ClientPtr client)
         return rc;
     }
 
-    FOR_NSCREENS_FORWARD(j) {
-        stuff->window = win->info[j].id;
+    int walkScreenIdx;
+    FOR_NSCREENS_FORWARD(walkScreenIdx) {
+        stuff->window = win->info[walkScreenIdx].id;
         rc = SingleCompositeRedirectWindow(client, stuff);
         if (rc != Success)
             break;
@@ -605,7 +605,7 @@ ProcCompositeRedirectSubwindows(ClientPtr client)
         return SingleRedirectSubwindows(client, stuff);
 
     PanoramiXRes *win;
-    int rc = 0, j;
+    int rc = 0;
 
     if ((rc = dixLookupResourceByType((void **) &win, stuff->window, XRT_WINDOW,
                                       client, DixUnknownAccess))) {
@@ -613,8 +613,9 @@ ProcCompositeRedirectSubwindows(ClientPtr client)
         return rc;
     }
 
-    FOR_NSCREENS_FORWARD(j) {
-        stuff->window = win->info[j].id;
+    unsigned int walkScreenIdx;
+    FOR_NSCREENS_FORWARD(walkScreenIdx) {
+        stuff->window = win->info[walkScreenIdx].id;
         rc = SingleRedirectSubwindows(client, stuff);
         if (rc != Success)
             break;
@@ -637,7 +638,7 @@ ProcCompositeUnredirectWindow(ClientPtr client)
         return SingleCompositeUnredirectWindow(client, stuff);
 
     PanoramiXRes *win;
-    int rc = 0, j;
+    int rc = 0;
 
     if ((rc = dixLookupResourceByType((void **) &win, stuff->window, XRT_WINDOW,
                                       client, DixUnknownAccess))) {
@@ -645,8 +646,9 @@ ProcCompositeUnredirectWindow(ClientPtr client)
         return rc;
     }
 
-    FOR_NSCREENS_FORWARD(j) {
-        stuff->window = win->info[j].id;
+    unsigned int walkScreenIdx;
+    FOR_NSCREENS_FORWARD(walkScreenIdx) {
+        stuff->window = win->info[walkScreenIdx].id;
         rc = SingleCompositeUnredirectWindow(client, stuff);
         if (rc != Success)
             break;
@@ -669,7 +671,7 @@ ProcCompositeUnredirectSubwindows(ClientPtr client)
         return SingleCompositeUnredirectSubwindows(client, stuff);
 
     PanoramiXRes *win;
-    int rc = 0, j;
+    int rc = 0;
 
     if ((rc = dixLookupResourceByType((void **) &win, stuff->window, XRT_WINDOW,
                                       client, DixUnknownAccess))) {
@@ -677,8 +679,9 @@ ProcCompositeUnredirectSubwindows(ClientPtr client)
         return rc;
     }
 
-    FOR_NSCREENS_FORWARD(j) {
-        stuff->window = win->info[j].id;
+    unsigned int walkScreenIdx;
+    FOR_NSCREENS_FORWARD(walkScreenIdx) {
+        stuff->window = win->info[walkScreenIdx].id;
         rc = SingleCompositeUnredirectSubwindows(client, stuff);
         if (rc != Success)
             break;
@@ -705,7 +708,6 @@ ProcCompositeNameWindowPixmap(ClientPtr client)
     PixmapPtr pPixmap;
     int rc;
     PanoramiXRes *win, *newPix;
-    int i;
 
     if ((rc = dixLookupResourceByType((void **) &win, stuff->window, XRT_WINDOW,
                                       client, DixUnknownAccess))) {
@@ -722,8 +724,9 @@ ProcCompositeNameWindowPixmap(ClientPtr client)
     newPix->u.pix.shared = FALSE;
     panoramix_setup_ids(newPix, client, stuff->pixmap);
 
-    FOR_NSCREENS_BACKWARD(i) {
-        rc = dixLookupResourceByType((void **) &pWin, win->info[i].id,
+    int walkScreenIdx;
+    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+        rc = dixLookupResourceByType((void **) &pWin, win->info[walkScreenIdx].id,
                                      X11_RESTYPE_WINDOW, client,
                                      DixGetAttrAccess);
         if (rc != Success) {
@@ -749,7 +752,7 @@ ProcCompositeNameWindowPixmap(ClientPtr client)
             return BadMatch;
         }
 
-        if (!AddResource(newPix->info[i].id, X11_RESTYPE_PIXMAP, (void *) pPixmap))
+        if (!AddResource(newPix->info[walkScreenIdx].id, X11_RESTYPE_PIXMAP, (void *) pPixmap))
             return BadAlloc;
 
         ++pPixmap->refcnt;
@@ -781,7 +784,6 @@ ProcCompositeGetOverlayWindow(ClientPtr client)
     CompOverlayClientPtr pOc;
     int rc;
     PanoramiXRes *win, *overlayWin = NULL;
-    int i;
 
     if ((rc = dixLookupResourceByType((void **) &win, stuff->window, XRT_WINDOW,
                                       client, DixUnknownAccess))) {
@@ -798,8 +800,9 @@ ProcCompositeGetOverlayWindow(ClientPtr client)
         overlayWin->u.win.root = FALSE;
     }
 
-    FOR_NSCREENS_BACKWARD(i) {
-        rc = dixLookupResourceByType((void **) &pWin, win->info[i].id,
+    int walkScreenIdx;
+    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+        rc = dixLookupResourceByType((void **) &pWin, win->info[walkScreenIdx].id,
                                      X11_RESTYPE_WINDOW, client,
                                      DixGetAttrAccess);
         if (rc != Success) {
@@ -842,10 +845,10 @@ ProcCompositeGetOverlayWindow(ClientPtr client)
     }
 
     if (overlayWin) {
-        FOR_NSCREENS_BACKWARD(i) {
-            ScreenPtr walkScreen = screenInfo.screens[i];
+        FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
             cs = GetCompScreen(walkScreen);
-            overlayWin->info[i].id = cs->pOverlayWin->drawable.id;
+            overlayWin->info[walkScreenIdx].id = cs->pOverlayWin->drawable.id;
         }
 
         AddResource(overlayWin->info[0].id, XRT_WINDOW, overlayWin);
@@ -880,7 +883,7 @@ ProcCompositeReleaseOverlayWindow(ClientPtr client)
     WindowPtr pWin;
     CompOverlayClientPtr pOc;
     PanoramiXRes *win;
-    int i, rc;
+    int rc;
 
     if ((rc = dixLookupResourceByType((void **) &win, stuff->window, XRT_WINDOW,
                                       client, DixUnknownAccess))) {
@@ -888,8 +891,9 @@ ProcCompositeReleaseOverlayWindow(ClientPtr client)
         return rc;
     }
 
-    FOR_NSCREENS_BACKWARD(i) {
-        if ((rc = dixLookupResourceByType((void **) &pWin, win->info[i].id,
+    int walkScreenIdx;
+    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+        if ((rc = dixLookupResourceByType((void **) &pWin, win->info[walkScreenIdx].id,
                                           XRT_WINDOW, client,
                                           DixUnknownAccess))) {
             client->errorValue = stuff->window;


### PR DESCRIPTION
When iterating screen lists, consistently use the same variable name
`walkScreenIdx` for holding current screen index everywhere.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
