### PR TITLE
render: canonical `walkScreenIdx` variable on screen list iterations

### DIFF
--- a/render/animcur.c
+++ b/render/animcur.c
@@ -305,8 +305,8 @@ AnimCursorCreate(CursorPtr *cursors, CARD32 *deltas, int ncursor,
     int rc = BadAlloc, i;
     AnimCurPtr ac;
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         if (!GetAnimCurScreen(walkScreen))
             return BadImplementation;
     }

--- a/render/filter.c
+++ b/render/filter.c
@@ -337,13 +337,11 @@ SetPictureFilter(PicturePtr pPicture, char *name, int len, xFixed * params,
         return BadName;
 
     if (pPicture->pDrawable == NULL) {
-        int s;
-
         /* For source pictures, the picture isn't tied to a screen.  So, ensure
          * that all screens can handle a filter we set for the picture.
          */
-        for (s = 1; s < screenInfo.numScreens; s++) {
-            ScreenPtr walkScreen = screenInfo.screens[s];
+        for (unsigned int walkScreenIdx = 1; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
             PictFilterPtr pScreenFilter;
 
             pScreenFilter = PictureFindFilter(walkScreen, name, len);

--- a/render/glyph.c
+++ b/render/glyph.c
@@ -232,10 +232,8 @@ CheckDuplicates(GlyphHashPtr hash, char *where)
 static void
 FreeGlyphPicture(GlyphPtr glyph)
 {
-    int i;
-
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
 
         if (GetGlyphPicture(glyph, walkScreen))
             FreePicture((void *) GetGlyphPicture(glyph, walkScreen), 0);
@@ -344,7 +342,6 @@ GlyphPtr
 AllocateGlyph(xGlyphInfo * gi, int fdepth)
 {
     int size;
-    int i;
     int head_size;
 
     head_size = sizeof(GlyphRec) + screenInfo.numScreens * sizeof(PicturePtr);
@@ -357,14 +354,17 @@ AllocateGlyph(xGlyphInfo * gi, int fdepth)
     glyph->info = *gi;
     dixInitPrivates(glyph, (char *) glyph + head_size, PRIVATE_GLYPH);
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    unsigned int i;
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         SetGlyphPicture(glyph, walkScreen, NULL);
         PictureScreenPtr ps = GetPictureScreenIfSet(walkScreen);
 
         if (ps) {
-            if (!(ps->RealizeGlyph(walkScreen, glyph)))
+            if (!(ps->RealizeGlyph(walkScreen, glyph))) {
+                i = walkScreenIdx;
                 goto bail;
+            }
         }
     }
 

--- a/render/picture.c
+++ b/render/picture.c
@@ -450,10 +450,8 @@ PictureInitIndexedFormats(ScreenPtr pScreen)
 Bool
 PictureFinishInit(void)
 {
-    int s;
-
-    for (s = 0; s < screenInfo.numScreens; s++) {
-        ScreenPtr walkScreen = screenInfo.screens[s];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         if (!PictureInitIndexedFormats(walkScreen))
             return FALSE;
         (void) AnimCurInit(walkScreen);


### PR DESCRIPTION
When iterating screen lists, consistently use the same variable name
`walkScreenIdx` for holding current screen index everywhere.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
