### PR TITLE
present: canonical `walkScreenIdx` variable on screen list iterations

### DIFF
--- a/present/present_scmd.c
+++ b/present/present_scmd.c
@@ -387,7 +387,6 @@ void
 present_event_notify(uint64_t event_id, uint64_t ust, uint64_t msc)
 {
     present_vblank_ptr  vblank;
-    int                 s;
 
     if (!event_id)
         return;
@@ -409,8 +408,8 @@ present_event_notify(uint64_t event_id, uint64_t ust, uint64_t msc)
         }
     }
 
-    for (s = 0; s < screenInfo.numScreens; s++) {
-        ScreenPtr walkScreen = screenInfo.screens[s];
+    for (unsigned walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         present_screen_priv_ptr screen_priv = present_screen_priv(walkScreen);
 
         if (event_id == screen_priv->unflip_event_id) {

--- a/present/present_screen.c
+++ b/present/present_screen.c
@@ -240,7 +240,6 @@ void
 present_extension_init(void)
 {
     ExtensionEntry *extension;
-    int i;
 
 #ifdef XINERAMA
     if (!noPanoramiXExtension)
@@ -261,8 +260,8 @@ present_extension_init(void)
     if (!present_event_init())
         goto bail;
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         if (!present_screen_init(walkScreen, NULL))
             goto bail;
     }


### PR DESCRIPTION
When iterating screen lists, consistently use the same variable name
`walkScreenIdx` for holding current screen index everywhere.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
