### PR TITLE
sync: ProcSyncListSystemCounters(): use x_rpcbuf_t

### DIFF
--- a/Xext/sync.c
+++ b/Xext/sync.c
@@ -1284,66 +1284,43 @@ ProcSyncInitialize(ClientPtr client)
 static int
 ProcSyncListSystemCounters(ClientPtr client)
 {
-    xSyncListSystemCountersReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-    };
     SysCounterInfo *psci;
-    int len = 0;
-    xSyncSystemCounter *list = NULL, *walklist = NULL;
 
     REQUEST_SIZE_MATCH(xSyncListSystemCountersReq);
 
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+
+    CARD32 nCounters = 0;
     xorg_list_for_each_entry(psci, &SysCounterList, entry) {
-        /* pad to 4 byte boundary */
-        len += pad_to_int32(sz_xSyncSystemCounter + strlen(psci->name));
-        ++rep.nCounters;
+        CARD16 namelen = strlen(psci->name);
+
+        /* write xSyncSystemCounter:
+           the name chars (`namelen` amount of bytes) are directly written
+           after the header fields, then the whole thing is padded to
+           full protocol units.
+        */
+        x_rpcbuf_write_CARD32(&rpcbuf, psci->pCounter->sync.id);
+        x_rpcbuf_write_INT32(&rpcbuf, psci->resolution >> 32);
+        x_rpcbuf_write_INT32(&rpcbuf, psci->resolution);
+        x_rpcbuf_write_CARD16(&rpcbuf, namelen);
+        x_rpcbuf_write_CARD8s(&rpcbuf, (CARD8*)psci->name, namelen);
+        x_rpcbuf_pad(&rpcbuf);
+
+        nCounters++;
     }
 
-    if (len) {
-        walklist = list = calloc(1, len);
-        if (!list)
-            return BadAlloc;
-    }
+    if (rpcbuf.error)
+        return BadAlloc;
 
-    rep.length = bytes_to_int32(len);
+    xSyncListSystemCountersReply rep = {
+        .nCounters = nCounters
+    };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swapl(&rep.nCounters);
     }
 
-    xorg_list_for_each_entry(psci, &SysCounterList, entry) {
-        int namelen;
-        char *pname_in_reply;
-
-        walklist->counter = psci->pCounter->sync.id;
-        walklist->resolution_hi = psci->resolution >> 32;
-        walklist->resolution_lo = psci->resolution;
-        namelen = strlen(psci->name);
-        walklist->name_length = namelen;
-
-        if (client->swapped) {
-            swapl(&walklist->counter);
-            swapl(&walklist->resolution_hi);
-            swapl(&walklist->resolution_lo);
-            swaps(&walklist->name_length);
-        }
-
-        pname_in_reply = ((char *) walklist) + sz_xSyncSystemCounter;
-        strncpy(pname_in_reply, psci->name, namelen);
-        walklist = (xSyncSystemCounter *) (((char *) walklist) +
-                                           pad_to_int32(sz_xSyncSystemCounter +
-                                                        namelen));
-    }
-
-    WriteToClient(client, sizeof(rep), &rep);
-    if (len) {
-        WriteToClient(client, len, list);
-        free(list);
-    }
-
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 


### PR DESCRIPTION
Use x_rpcbuf_t for reply payload assembly, and sending out the whole
thing via X_SEND_REPLY_WITH_RPCBUF().

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
