### PR TITLE
xext: bigreq: use X_SEND_REPLY_SIMPLE()

### DIFF
--- a/Xext/bigreq.c
+++ b/Xext/bigreq.c
@@ -52,16 +52,12 @@ ProcBigReqDispatch(ClientPtr client)
     client->big_requests = TRUE;
 
     xBigReqEnableReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0,
         .max_request_size = maxBigRequestSize
     };
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
         swapl(&rep.max_request_size);
     }
-    WriteToClient(client, sizeof(xBigReqEnableReply), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 


### PR DESCRIPTION
Use X_SEND_REPLY_SIMPLE() for sending out simple replies.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
