### PR TITLE
xext: selinux: use X_SEND_REPLY_SIMPLE()

### DIFF
--- a/Xext/xselinux_ext.c
+++ b/Xext/xselinux_ext.c
@@ -68,18 +68,14 @@ static int
 ProcSELinuxQueryVersion(ClientPtr client)
 {
     SELinuxQueryVersionReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
         .server_major = SELINUX_MAJOR_VERSION,
         .server_minor = SELINUX_MINOR_VERSION
     };
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swaps(&rep.server_major);
         swaps(&rep.server_minor);
     }
-    WriteToClient(client, sizeof(rep), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 


### PR DESCRIPTION
Use X_SEND_REPLY_SIMPLE() for sending out simple replies.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
