### PR TITLE
xext: xtest: use X_SEND_REPLY_SIMPLE()

### DIFF
--- a/Xext/xtest.c
+++ b/Xext/xtest.c
@@ -90,9 +90,6 @@ static int
 ProcXTestGetVersion(ClientPtr client)
 {
     xXTestGetVersionReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0,
         .majorVersion = XTestMajorVersion,
         .minorVersion = XTestMinorVersion
     };
@@ -100,10 +97,9 @@ ProcXTestGetVersion(ClientPtr client)
     REQUEST_SIZE_MATCH(xXTestGetVersionReq);
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
         swaps(&rep.minorVersion);
     }
-    WriteToClient(client, sizeof(xXTestGetVersionReply), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 
@@ -111,7 +107,6 @@ static int
 ProcXTestCompareCursor(ClientPtr client)
 {
     REQUEST(xXTestCompareCursorReq);
-    xXTestCompareCursorReply rep;
     WindowPtr pWin;
     CursorPtr pCursor;
     int rc;
@@ -137,16 +132,12 @@ ProcXTestCompareCursor(ClientPtr client)
             return rc;
         }
     }
-    rep = (xXTestCompareCursorReply) {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0,
+
+    xXTestCompareCursorReply rep = {
         .same = (wCursor(pWin) == pCursor)
     };
-    if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-    }
-    WriteToClient(client, sizeof(xXTestCompareCursorReply), &rep);
+
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 


### PR DESCRIPTION
Use X_SEND_REPLY_SIMPLE() for sending out simple replies.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
