### PR TITLE
compext: simplify ProcCompositeQueryVersion() a little bit

### DIFF
--- a/composite/compext.c
+++ b/composite/compext.c
@@ -104,16 +104,17 @@ ProcCompositeQueryVersion(ClientPtr client)
 
     CompositeClientPtr pCompositeClient = GetCompositeClient(client);
 
-    xCompositeQueryVersionReply rep = { 0 };
+    xCompositeQueryVersionReply rep = {
+        .majorVersion = SERVER_COMPOSITE_MAJOR_VERSION,
+        .minorVersion = SERVER_COMPOSITE_MINOR_VERSION
+    };
 
+    /* if client asking for a lower version, use this one */
     if (stuff->majorVersion < SERVER_COMPOSITE_MAJOR_VERSION) {
         rep.majorVersion = stuff->majorVersion;
         rep.minorVersion = stuff->minorVersion;
     }
-    else {
-        rep.majorVersion = SERVER_COMPOSITE_MAJOR_VERSION;
-        rep.minorVersion = SERVER_COMPOSITE_MINOR_VERSION;
-    }
+
     pCompositeClient->major_version = rep.majorVersion;
     pCompositeClient->minor_version = rep.minorVersion;
     if (client->swapped) {


### PR DESCRIPTION
Since we're already statically initializing the reply header anyways,
use the default case values here and overwrite them only when requested
version is lower than server's one.

That code path is so cold (at max only called once per client), we really
don't need to care whether there's any chance for saving a few cycles.
So not trying to be clever, but instead focus on readability.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
