### PR TITLE
dix: replace WriteRpcbufToClient() by X_SEND_REPLY_WITH_RPCBUF() macro

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -1939,11 +1939,7 @@ ProcGetKeyboardMapping(ClientPtr client)
     const int count = syms->mapWidth * stuff->count;
 
     xGetKeyboardMappingReply rep = {
-        .type = X_Reply,
         .keySymsPerKeyCode = syms->mapWidth,
-        .sequenceNumber = client->sequence,
-        /* length is a count of 4 byte quantities and KeySyms are 4 bytes */
-        .length = count
     };
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
@@ -1958,13 +1954,7 @@ ProcGetKeyboardMapping(ClientPtr client)
     if (rpcbuf.error)
         return BadAlloc;
 
-    if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
-    }
-
-    WriteToClient(client, sizeof(rep), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -1042,24 +1042,18 @@ ProcQueryTree(ClientPtr client)
         return BadAlloc;
 
     xQueryTreeReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
         .root = pWin->drawable.pScreen->root->drawable.id,
         .parent = (pWin->parent) ? pWin->parent->drawable.id : (Window) None,
         .nChildren = numChildren,
-        .length = x_rpcbuf_wsize_units(&rpcbuf)
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swapl(&rep.root);
         swapl(&rep.parent);
         swaps(&rep.nChildren);
     }
 
-    WriteToClient(client, sizeof(rep), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 

--- a/dix/property.c
+++ b/dix/property.c
@@ -597,11 +597,8 @@ ProcGetProperty(ClientPtr client)
     len = min(n - ind, 4 * p.longLength);
 
     xGetPropertyReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
         .bytesAfter = n - (ind + len),
         .format = pProp->format,
-        .length = bytes_to_int32(len),
         .nItems = len / (pProp->format / 8),
         .propertyType = pProp->type
     };
@@ -649,15 +646,12 @@ ProcGetProperty(ClientPtr client)
     }
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swapl(&rep.propertyType);
         swapl(&rep.bytesAfter);
         swapl(&rep.nItems);
     }
 
-    WriteToClient(client, sizeof(rep), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 
@@ -689,20 +683,14 @@ ProcListProperties(ClientPtr client)
         return BadAlloc;
 
     xListPropertiesReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = x_rpcbuf_wsize_units(&rpcbuf),
         .nProperties = numProps
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swaps(&rep.nProperties);
     }
 
-    WriteToClient(client, sizeof(rep), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 


### PR DESCRIPTION
Use the new X_SEND_REPLY_WITH_RPCBUF() macro for final reply write out.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
