### PR TITLE
Xi: replace WriteRpcbufToClient() by X_SEND_REPLY_WITH_RPCBUF() macro

### DIFF
--- a/Xi/getkmap.c
+++ b/Xi/getkmap.c
@@ -121,20 +121,10 @@ ProcXGetDeviceKeyMapping(ClientPtr client)
         return BadAlloc;
 
     xGetDeviceKeyMappingReply rep = {
-        .repType = X_Reply,
         .RepType = X_GetDeviceKeyMapping,
-        .sequenceNumber = client->sequence,
         .keySymsPerKeyCode = mapWidth,
-        .length = numKeySyms /* KeySyms are 4 bytes */
     };
 
-    if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
-    }
-
-    WriteToClient(client, sizeof(xGetDeviceKeyMappingReply), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
-
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }

--- a/Xi/getprop.c
+++ b/Xi/getprop.c
@@ -101,9 +101,7 @@ ProcXGetDeviceDontPropagateList(ClientPtr client)
     REQUEST_SIZE_MATCH(xGetDeviceDontPropagateListReq);
 
     xGetDeviceDontPropagateListReply rep = {
-        .repType = X_Reply,
         .RepType = X_GetDeviceDontPropagateList,
-        .sequenceNumber = client->sequence,
     };
 
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
@@ -120,7 +118,6 @@ ProcXGetDeviceDontPropagateList(ClientPtr client)
             buf = calloc(rep.count, sizeof(XEventClass));
             if (!buf)
                 return BadAlloc;
-            rep.length = bytes_to_int32(rep.count * sizeof(XEventClass));
 
             tbuf = buf;
             for (i = 0; i < EMASKSIZE; i++)
@@ -136,12 +133,9 @@ ProcXGetDeviceDontPropagateList(ClientPtr client)
         return BadAlloc;
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swaps(&rep.count);
     }
-    WriteToClient(client, sizeof(xGetDeviceDontPropagateListReply), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 

--- a/Xi/getselev.c
+++ b/Xi/getselev.c
@@ -103,9 +103,7 @@ ProcXGetSelectedExtensionEvents(ClientPtr client)
     REQUEST_SIZE_MATCH(xGetSelectedExtensionEventsReq);
 
     xGetSelectedExtensionEventsReply rep = {
-        .repType = X_Reply,
         .RepType = X_GetSelectedExtensionEvents,
-        .sequenceNumber = client->sequence,
     };
 
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
@@ -130,7 +128,6 @@ ProcXGetSelectedExtensionEvents(ClientPtr client)
 
         size_t total_count = rep.all_clients_count + rep.this_client_count;
         size_t total_length = total_count * sizeof(XEventClass);
-        rep.length = bytes_to_int32(total_length);
         buf = calloc(1, total_length);
         if (!buf) /* rpcbuf still empty */
             return BadAlloc;
@@ -155,12 +152,9 @@ ProcXGetSelectedExtensionEvents(ClientPtr client)
         return BadAlloc;
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swaps(&rep.this_client_count);
         swaps(&rep.all_clients_count);
     }
-    WriteToClient(client, sizeof(xGetSelectedExtensionEventsReply), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }

--- a/Xi/xiproperty.c
+++ b/Xi/xiproperty.c
@@ -851,20 +851,14 @@ ProcXListDeviceProperties(ClientPtr client)
         return rc;
 
     xListDevicePropertiesReply rep = {
-        .repType = X_Reply,
         .RepType = X_ListDeviceProperties,
-        .sequenceNumber = client->sequence,
-        .length = natoms,
         .nAtoms = natoms
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swaps(&rep.nAtoms);
     }
-    WriteToClient(client, sizeof(xListDevicePropertiesReply), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 
@@ -949,10 +943,7 @@ ProcXGetDeviceProperty(ClientPtr client)
         return rc;
 
     xGetDevicePropertyReply rep = {
-        .repType = X_Reply,
         .RepType = X_GetDeviceProperty,
-        .sequenceNumber = client->sequence,
-        .length = bytes_to_int32(length),
         .propertyType = type,
         .bytesAfter = bytes_after,
         .nItems = nitems,
@@ -964,8 +955,6 @@ ProcXGetDeviceProperty(ClientPtr client)
         send_property_event(dev, stuff->property, XIPropertyDeleted);
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swapl(&rep.propertyType);
         swapl(&rep.bytesAfter);
         swapl(&rep.nItems);
@@ -1004,8 +993,7 @@ ProcXGetDeviceProperty(ClientPtr client)
         }
     }
 
-    WriteToClient(client, sizeof(rep), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 
@@ -1059,21 +1047,15 @@ ProcXIListProperties(ClientPtr client)
         return rc;
 
     xXIListPropertiesReply rep = {
-        .repType = X_Reply,
         .RepType = X_XIListProperties,
-        .sequenceNumber = client->sequence,
-        .length = natoms,
         .num_properties = natoms
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swaps(&rep.num_properties);
     }
 
-    WriteToClient(client, sizeof(xXIListPropertiesReply), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 
@@ -1159,10 +1141,7 @@ ProcXIGetProperty(ClientPtr client)
         return rc;
 
     xXIGetPropertyReply rep = {
-        .repType = X_Reply,
         .RepType = X_XIGetProperty,
-        .sequenceNumber = client->sequence,
-        .length = bytes_to_int32(length),
         .type = type,
         .bytes_after = bytes_after,
         .num_items = nitems,
@@ -1173,8 +1152,6 @@ ProcXIGetProperty(ClientPtr client)
         send_property_event(dev, stuff->property, XIPropertyDeleted);
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swapl(&rep.type);
         swapl(&rep.bytes_after);
         swapl(&rep.num_items);
@@ -1199,8 +1176,7 @@ ProcXIGetProperty(ClientPtr client)
     if (rpcbuf.error)
         return BadAlloc;
 
-    WriteToClient(client, sizeof(xXIGetPropertyReply), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 
     /* delete the Property */
     if (stuff->delete && (rep.bytes_after == 0)) {


### PR DESCRIPTION
Use the new X_SEND_REPLY_WITH_RPCBUF() macro for final reply write out.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
