### PR TITLE
Xext: replace WriteRpcbufToClient() by X_SEND_REPLY_WITH_RPCBUF() macro

### DIFF
--- a/Xext/panoramiX.c
+++ b/Xext/panoramiX.c
@@ -1046,17 +1046,12 @@ ProcXineramaQueryScreens(ClientPtr client)
     /* REQUEST(xXineramaQueryScreensReq); */
     CARD32 number = (noPanoramiXExtension) ? 0 : PanoramiXNumScreens;
     xXineramaQueryScreensReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = bytes_to_int32(number * sz_XineramaScreenInfo),
         .number = number
     };
 
     REQUEST_SIZE_MATCH(xXineramaQueryScreensReq);
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swapl(&rep.number);
     }
 
@@ -1078,8 +1073,7 @@ ProcXineramaQueryScreens(ClientPtr client)
         }
     }
 
-    WriteToClient(client, sizeof(xXineramaQueryScreensReply), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 

--- a/Xext/panoramiXprocs.c
+++ b/Xext/panoramiXprocs.c
@@ -2128,21 +2128,16 @@ PanoramiXGetImage(ClientPtr client)
     }
 
     xGetImageReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
         .visual = wVisual(((WindowPtr) pDraw)),
         .depth = pDraw->depth,
-        .length = bytes_to_int32(length),
     };
 
     if (client->swapped) {
         swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swapl(&rep.visual);
     }
 
-    WriteToClient(client, sizeof(rep), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 

--- a/Xext/vidmode.c
+++ b/Xext/vidmode.c
@@ -392,21 +392,14 @@ ProcVidModeGetAllModeLines(ClientPtr client)
         return BadAlloc;
 
     xXF86VidModeGetAllModeLinesReply rep = {
-        .type = X_Reply,
-        .length = X_REPLY_HEADER_UNITS(xXF86VidModeGetAllModeLinesReply)
-                + x_rpcbuf_wsize_units(&rpcbuf),
-        .sequenceNumber = client->sequence,
         .modecount = modecount
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swapl(&rep.modecount);
     }
 
-    WriteToClient(client, sizeof(xXF86VidModeGetAllModeLinesReply), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 
@@ -1249,23 +1242,13 @@ ProcVidModeGetMonitor(ClientPtr client)
         return BadAlloc;
 
     xXF86VidModeGetMonitorReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
         .nhsync = nHsync,
         .nvsync = nVrefresh,
         .vendorLength = x_safe_strlen(vendorStr),
         .modelLength = x_safe_strlen(modelStr),
-        .length = X_REPLY_HEADER_UNITS(xXF86VidModeGetMonitorReply) +
-                  x_rpcbuf_wsize_units(&rpcbuf)
     };
 
-    if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
-    }
-
-    WriteToClient(client, sizeof(xXF86VidModeGetMonitorReply), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 
@@ -1381,24 +1364,18 @@ ProcVidModeGetDotClocks(ClientPtr client)
         return BadAlloc;
 
     xXF86VidModeGetDotClocksReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = X_REPLY_HEADER_UNITS(xXF86VidModeGetDotClocksReply) + numClocks,
         .clocks = numClocks,
         .maxclocks = MAXCLOCKS,
         .flags = (ClockProg ? CLKFLAG_PROGRAMABLE : 0),
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swapl(&rep.clocks);
         swapl(&rep.maxclocks);
         swapl(&rep.flags);
     }
 
-    WriteToClient(client, sizeof(xXF86VidModeGetDotClocksReply), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 

--- a/Xext/xcmisc.c
+++ b/Xext/xcmisc.c
@@ -116,19 +116,13 @@ ProcXCMiscGetXIDList(ClientPtr client)
         return BadAlloc;
 
     xXCMiscGetXIDListReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = count,
         .count = count
     };
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swapl(&rep.count);
     }
 
-    WriteToClient(client, sizeof(xXCMiscGetXIDListReply), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 

--- a/Xext/xf86bigfont.c
+++ b/Xext/xf86bigfont.c
@@ -527,16 +527,7 @@ ProcXF86BigfontQueryFont(ClientPtr client)
 
     {
         int nfontprops = pFont->info.nprops;
-        int rlength = nfontprops * sizeof(xFontProp)
-            + (nCharInfos > 0 && shmid == -1
-               ? nUniqCharInfos * sizeof(xCharInfo)
-               + (nCharInfos + 1) / 2 * 2 * sizeof(CARD16)
-               : 0);
-
         xXF86BigfontQueryFontReply rep = {
-            .type = X_Reply,
-            .length = X_REPLY_HEADER_UNITS(xXF86BigfontQueryFontReply) + rlength,
-            .sequenceNumber = client->sequence,
             .minBounds = pFont->info.ink_minbounds,
             .maxBounds = pFont->info.ink_maxbounds,
             .minCharOrByte2 = pFont->info.firstCol,
@@ -555,8 +546,6 @@ ProcXF86BigfontQueryFont(ClientPtr client)
         };
 
         if (client->swapped) {
-            swaps(&rep.sequenceNumber);
-            swapl(&rep.length);
             swapCharInfo(&rep.minBounds);
             swapCharInfo(&rep.maxBounds);
             swaps(&rep.minCharOrByte2);
@@ -591,8 +580,7 @@ ProcXF86BigfontQueryFont(ClientPtr client)
             goto out;
         }
 
-        WriteToClient(client, sizeof(xXF86BigfontQueryFontReply), &rep);
-        WriteRpcbufToClient(client, &rpcbuf);
+        X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 out:
         if (nCharInfos > 0) {
             if (shmid == -1)

--- a/Xext/xvdisp.c
+++ b/Xext/xvdisp.c
@@ -128,20 +128,14 @@ ProcXvQueryAdaptors(ClientPtr client)
     }
 
     xvQueryAdaptorsReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
         .num_adaptors = numAdaptors,
-        .length = x_rpcbuf_wsize_units(&rpcbuf)
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swaps(&rep.num_adaptors);
     }
 
-    WriteToClient(client, sizeof(rep), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 
@@ -176,20 +170,14 @@ ProcXvQueryEncodings(ClientPtr client)
         return BadAlloc;
 
     xvQueryEncodingsReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
         .num_encodings = pPort->pAdaptor->nEncodings,
-        .length = x_rpcbuf_wsize_units(&rpcbuf),
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swaps(&rep.num_encodings);
     }
 
-    WriteToClient(client, sizeof(rep), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 
@@ -568,22 +556,16 @@ ProcXvQueryPortAttributes(ClientPtr client)
         return BadAlloc;
 
     xvQueryPortAttributesReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
         .num_attributes = pPort->pAdaptor->nAttributes,
-        .length = x_rpcbuf_wsize_units(&rpcbuf),
         .text_size = textSize,
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swapl(&rep.num_attributes);
         swapl(&rep.text_size);
     }
 
-    WriteToClient(client, sizeof(rep), &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 
@@ -804,9 +786,6 @@ ProcXvQueryImageAttributes(ClientPtr client)
                                                        pitches);
 
     xvQueryImageAttributesReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = x_rpcbuf_wsize_units(&rpcbuf),
         .num_planes = num_planes,
         .width = width,
         .height = height,
@@ -814,8 +793,6 @@ ProcXvQueryImageAttributes(ClientPtr client)
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swapl(&rep.num_planes);
         swapl(&rep.data_size);
         swaps(&rep.width);
@@ -825,8 +802,7 @@ ProcXvQueryImageAttributes(ClientPtr client)
         SwapLongs((CARD32 *) offsets, x_rpcbuf_wsize_units(&rpcbuf));
     }
 
-    WriteToClient(client, sz_xvQueryImageAttributesReply, &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 
@@ -891,20 +867,14 @@ ProcXvListImageFormats(ClientPtr client)
                    rpcbuf.wpos, (pPort->pAdaptor->nImages*sz_xvImageFormatInfo));
 
     xvListImageFormatsReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
         .num_formats = pPort->pAdaptor->nImages,
-        .length = x_rpcbuf_wsize_units(&rpcbuf)
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swapl(&rep.num_formats);
     }
 
-    WriteToClient(client, sz_xvListImageFormatsReply, &rep);
-    WriteRpcbufToClient(client, &rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     return Success;
 }
 


### PR DESCRIPTION
Use the new X_SEND_REPLY_WITH_RPCBUF() macro for final reply write out.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
