### PR TITLE
dix: devices: use X_SEND_REPLY_SIMPLE()

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -1742,16 +1742,10 @@ ProcSetModifierMapping(ClientPtr client)
         return rc;
 
     xSetModifierMappingReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0,
         .success = rc,
     };
 
-    if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-    }
-    WriteToClient(client, sizeof(rep), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 
@@ -1892,16 +1886,10 @@ ProcSetPointerMapping(ClientPtr client)
         return ret;
 
     xSetPointerMappingReply rep = {
-        .type = X_Reply,
         .success = (ret == MappingBusy) ? MappingBusy : MappingSuccess,
-        .sequenceNumber = client->sequence,
     };
 
-    if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-    }
-
-    WriteToClient(client, sizeof(rep), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 
@@ -2235,10 +2223,7 @@ ProcGetKeyboardControl(ClientPtr client)
         return rc;
 
     xGetKeyboardControlReply rep = {
-        .type = X_Reply,
         .globalAutoRepeat = ctrl->autoRepeat,
-        .sequenceNumber = client->sequence,
-        .length = 5,
         .ledMask = ctrl->leds,
         .keyClickPercent = ctrl->click,
         .bellPercent = ctrl->bell,
@@ -2249,13 +2234,11 @@ ProcGetKeyboardControl(ClientPtr client)
         rep.map[i] = ctrl->autoRepeats[i];
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swapl(&rep.ledMask);
         swaps(&rep.bellPitch);
         swaps(&rep.bellDuration);
     }
-    WriteToClient(client, sizeof(rep), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 
@@ -2395,21 +2378,17 @@ ProcGetPointerControl(ClientPtr client)
         return rc;
 
     xGetPointerControlReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0,
         .accelNumerator = ctrl->num,
         .accelDenominator = ctrl->den,
         .threshold = ctrl->threshold
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
         swaps(&rep.accelNumerator);
         swaps(&rep.accelDenominator);
         swaps(&rep.threshold);
     }
-    WriteToClient(client, sizeof(rep), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 
@@ -2513,11 +2492,7 @@ ProcQueryKeymap(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xReq);
 
-    xQueryKeymapReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 2
-    };
+    xQueryKeymapReply rep = { 0 };
 
     rc = XaceHookDeviceAccess(client, keybd, DixReadAccess);
     /* If rc is Success, we're allowed to copy out the keymap.
@@ -2534,8 +2509,7 @@ ProcQueryKeymap(ClientPtr client)
         swaps(&rep.sequenceNumber);
         swapl(&rep.length);
     }
-    WriteToClient(client, sizeof(rep), &rep);
-
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 


### PR DESCRIPTION
Use X_SEND_REPLY_SIMPLE() for sending out simple replies.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
