### PR TITLE
dix: use X_SEND_REPLY_SIMPLE()

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -985,9 +985,6 @@ ProcGetGeometry(ClientPtr client)
         return rc;
 
     xGetGeometryReply rep = {
-        .type = X_Reply,
-        .length = 0,
-        .sequenceNumber = client->sequence,
         .root = pDraw->pScreen->root->drawable.id,
         .depth = pDraw->depth,
         .width = pDraw->width,
@@ -1003,7 +1000,6 @@ ProcGetGeometry(ClientPtr client)
     }
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
         swapl(&rep.root);
         swaps(&rep.x);
         swaps(&rep.y);
@@ -1011,7 +1007,7 @@ ProcGetGeometry(ClientPtr client)
         swaps(&rep.height);
         swaps(&rep.borderWidth);
     }
-    WriteToClient(client, sizeof(xGetGeometryReply), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 
@@ -1082,17 +1078,13 @@ ProcInternAtom(ClientPtr client)
         return BadAlloc;
 
     xInternAtomReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0,
         .atom = atom
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
         swapl(&rep.atom);
     }
-    WriteToClient(client, sizeof(rep), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 
@@ -1208,11 +1200,7 @@ ProcTranslateCoords(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xTranslateCoordsReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0
-    };
+    xTranslateCoordsReply rep = { 0 };
     if (!SAME_SCREENS(pWin->drawable, pDst->drawable)) {
         rep.sameScreen = xFalse;
         rep.child = None;
@@ -1261,12 +1249,11 @@ ProcTranslateCoords(ClientPtr client)
     }
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
         swapl(&rep.child);
         swaps(&rep.dstX);
         swaps(&rep.dstY);
     }
-    WriteToClient(client, sizeof(rep), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 
@@ -1386,10 +1373,7 @@ ProcQueryTextExtents(ClientPtr client)
         return BadAlloc;
 
     xQueryTextExtentsReply rep = {
-        .type = X_Reply,
         .drawDirection = info.drawDirection,
-        .sequenceNumber = client->sequence,
-        .length = 0,
         .fontAscent = info.fontAscent,
         .fontDescent = info.fontDescent,
         .overallAscent = info.overallAscent,
@@ -1400,7 +1384,6 @@ ProcQueryTextExtents(ClientPtr client)
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
         swaps(&rep.fontAscent);
         swaps(&rep.fontDescent);
         swaps(&rep.overallAscent);
@@ -1409,7 +1392,7 @@ ProcQueryTextExtents(ClientPtr client)
         swapl(&rep.overallLeft);
         swapl(&rep.overallRight);
     }
-    WriteToClient(client, sizeof(rep), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 
@@ -2616,13 +2599,9 @@ ProcAllocColor(ClientPtr client)
     }
 
     xAllocColorReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0,
         .red = stuff->red,
         .green = stuff->green,
         .blue = stuff->blue,
-        .pixel = 0
     };
 
     if ((rc = AllocColor(pmap, &rep.red, &rep.green, &rep.blue,
@@ -2630,7 +2609,6 @@ ProcAllocColor(ClientPtr client)
         return rc;
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
         swaps(&rep.red);
         swaps(&rep.green);
         swaps(&rep.blue);
@@ -2640,7 +2618,7 @@ ProcAllocColor(ClientPtr client)
 #ifdef XINERAMA
     if (noPanoramiXExtension || !pmap->pScreen->myNum)
 #endif /* XINERAMA */
-        WriteToClient(client, sizeof(rep), &rep);
+        X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 
@@ -2660,11 +2638,7 @@ ProcAllocNamedColor(ClientPtr client)
         return rc;
     }
 
-    xAllocNamedColorReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0
-    };
+    xAllocNamedColorReply rep = { 0 };
 
     if (!dixLookupBuiltinColor
             (pcmp->pScreen->myNum, (char *) &stuff[1], stuff->nbytes,
@@ -2674,7 +2648,6 @@ ProcAllocNamedColor(ClientPtr client)
     rep.screenRed = rep.exactRed;
     rep.screenGreen = rep.exactGreen;
     rep.screenBlue = rep.exactBlue;
-    rep.pixel = 0;
 
     if ((rc = AllocColor(pcmp,
                          &rep.screenRed, &rep.screenGreen,
@@ -2682,7 +2655,6 @@ ProcAllocNamedColor(ClientPtr client)
         return rc;
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
         swapl(&rep.pixel);
         swaps(&rep.exactRed);
         swaps(&rep.exactGreen);
@@ -2695,7 +2667,7 @@ ProcAllocNamedColor(ClientPtr client)
 #ifdef XINERAMA
     if (noPanoramiXExtension || !pcmp->pScreen->myNum)
 #endif /* XINERAMA */
-        WriteToClient(client, sizeof(rep), &rep);
+        X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 
@@ -2993,9 +2965,6 @@ ProcLookupColor(ClientPtr client)
                                   &exactGreen,
                                   &exactBlue)) {
             xLookupColorReply rep = {
-                .type = X_Reply,
-                .sequenceNumber = client->sequence,
-                .length = 0,
                 .exactRed = exactRed,
                 .exactGreen = exactGreen,
                 .exactBlue = exactBlue,
@@ -3007,7 +2976,6 @@ ProcLookupColor(ClientPtr client)
                                             &rep.screenGreen,
                                             &rep.screenBlue, pcmp->pVisual);
             if (client->swapped) {
-                swaps(&rep.sequenceNumber);
                 swaps(&rep.exactRed);
                 swaps(&rep.exactGreen);
                 swaps(&rep.exactBlue);
@@ -3015,7 +2983,7 @@ ProcLookupColor(ClientPtr client)
                 swaps(&rep.screenGreen);
                 swaps(&rep.screenBlue);
             }
-            WriteToClient(client, sizeof(rep), &rep);
+            X_SEND_REPLY_SIMPLE(client, rep);
             return Success;
         }
         return BadName;
@@ -3203,19 +3171,15 @@ ProcQueryBestSize(ClientPtr client)
                                &stuff->height, pScreen);
 
     xQueryBestSizeReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0,
         .width = stuff->width,
         .height = stuff->height
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
         swaps(&rep.width);
         swaps(&rep.height);
     }
-    WriteToClient(client, sizeof(rep), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 
@@ -3292,9 +3256,6 @@ ProcGetScreenSaver(ClientPtr client)
     }
 
     xGetScreenSaverReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0,
         .timeout = ScreenSaverTime / MILLI_PER_SECOND,
         .interval = ScreenSaverInterval / MILLI_PER_SECOND,
         .preferBlanking = ScreenSaverBlanking,
@@ -3302,11 +3263,10 @@ ProcGetScreenSaver(ClientPtr client)
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
         swaps(&rep.timeout);
         swaps(&rep.interval);
     }
-    WriteToClient(client, sizeof(rep), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 

--- a/dix/events.c
+++ b/dix/events.c
@@ -4982,9 +4982,6 @@ ProcGetInputFocus(ClientPtr client)
         return rc;
 
     xGetInputFocusReply rep = {
-        .type = X_Reply,
-        .length = 0,
-        .sequenceNumber = client->sequence,
         .revertTo = focus->revert
     };
 
@@ -4996,10 +4993,9 @@ ProcGetInputFocus(ClientPtr client)
         rep.focus = focus->win->drawable.id;
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
         swapl(&rep.focus);
     }
-    WriteToClient(client, sizeof(rep), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 
@@ -5052,16 +5048,10 @@ ProcGrabPointer(ClientPtr client)
         return rc;
 
     xGrabPointerReply rep = {
-        .type = X_Reply,
         .status = status,
-        .sequenceNumber = client->sequence,
-        .length = 0
     };
 
-    if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-    }
-    WriteToClient(client, sizeof(rep), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 
@@ -5298,17 +5288,10 @@ ProcGrabKeyboard(ClientPtr client)
         return result;
 
     xGrabKeyboardReply rep = {
-        .type = X_Reply,
         .status = status,
-        .sequenceNumber = client->sequence,
-        .length = 0
     };
 
-    if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-    }
-
-    WriteToClient(client, sizeof(rep), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 
@@ -5371,9 +5354,6 @@ ProcQueryPointer(ClientPtr client)
         MaybeStopHint(mouse, client);
 
     xQueryPointerReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0,
         .mask = event_get_corestate(mouse, keyboard),
         .root = (InputDevCurrentRootWindow(mouse))->drawable.id,
         .rootX = pSprite->hot.x,
@@ -5392,8 +5372,6 @@ ProcQueryPointer(ClientPtr client)
     }
     else {
         rep.sameScreen = xFalse;
-        rep.winX = 0;
-        rep.winY = 0;
     }
 
 #ifdef XINERAMA
@@ -5417,7 +5395,6 @@ ProcQueryPointer(ClientPtr client)
     }
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
         swapl(&rep.root);
         swapl(&rep.child);
         swaps(&rep.rootX);
@@ -5426,7 +5403,7 @@ ProcQueryPointer(ClientPtr client)
         swaps(&rep.winY);
         swaps(&rep.mask);
     }
-    WriteToClient(client, sizeof(rep), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 

--- a/dix/extension.c
+++ b/dix/extension.c
@@ -49,6 +49,7 @@ SOFTWARE.
 #include <X11/X.h>
 #include <X11/Xproto.h>
 
+#include "dix/dix_priv.h"
 #include "dix/extension_priv.h"
 #include "dix/registry_priv.h"
 
@@ -285,12 +286,7 @@ ProcQueryExtension(ClientPtr client)
     REQUEST(xQueryExtensionReq);
     REQUEST_FIXED_SIZE(xQueryExtensionReq, stuff->nbytes);
 
-    xQueryExtensionReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0,
-        .major_opcode = 0
-    };
+    xQueryExtensionReply rep = { 0 };
 
     if (!NumExtensions || !extensions)
         rep.present = xFalse;
@@ -309,10 +305,7 @@ ProcQueryExtension(ClientPtr client)
         }
     }
 
-    if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-    }
-    WriteToClient(client, sizeof(rep), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 

--- a/dix/property.c
+++ b/dix/property.c
@@ -547,14 +547,8 @@ ProcGetProperty(ClientPtr client)
 
     rc = dixLookupProperty(&pProp, pWin, p.property, p.client, prop_mode);
     if (rc == BadMatch) {
-        xGetPropertyReply rep = {
-            .type = X_Reply,
-            .sequenceNumber = client->sequence,
-        };
-        if (client->swapped) {
-            swaps(&rep.sequenceNumber);
-        }
-        WriteToClient(client, sizeof(rep), &rep);
+        xGetPropertyReply rep = { 0 };
+        X_SEND_REPLY_SIMPLE(client, rep);
         return Success;
     }
     else if (rc != Success)
@@ -565,18 +559,15 @@ ProcGetProperty(ClientPtr client)
 
     if (((p.type != pProp->type) && (p.type != AnyPropertyType))) {
         xGetPropertyReply rep = {
-            .type = X_Reply,
-            .sequenceNumber = client->sequence,
             .bytesAfter = pProp->size,
             .format = pProp->format,
             .propertyType = pProp->type
         };
         if (client->swapped) {
-            swaps(&rep.sequenceNumber);
             swapl(&rep.propertyType);
             swapl(&rep.bytesAfter);
         }
-        WriteToClient(client, sizeof(rep), &rep);
+        X_SEND_REPLY_SIMPLE(client, rep);
         return Success;
     }
 

--- a/dix/selection.c
+++ b/dix/selection.c
@@ -261,11 +261,7 @@ ProcGetSelectionOwner(ClientPtr client)
         goto out;
     }
 
-    xGetSelectionOwnerReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0,
-    };
+    xGetSelectionOwnerReply rep = { 0 };
 
     param.status = dixLookupSelection(&pSel, param.selection, param.client, DixGetAttrAccess);
     if (param.status == Success)
@@ -276,11 +272,10 @@ ProcGetSelectionOwner(ClientPtr client)
         goto out;
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
         swapl(&rep.owner);
     }
 
-    WriteToClient(client, sizeof(rep), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 
 out:

--- a/dix/window.c
+++ b/dix/window.c
@@ -1574,12 +1574,9 @@ ProcGetWindowAttributes(ClientPtr client)
         return rc;
 
     xGetWindowAttributesReply rep = {
-        .type = X_Reply,
         .bitGravity = pWin->bitGravity,
         .winGravity = pWin->winGravity,
         .backingStore = pWin->backingStore,
-        .length = X_REPLY_HEADER_UNITS(xGetWindowAttributesReply),
-        .sequenceNumber = client->sequence,
         .backingBitPlanes = wBackingBitPlanes(pWin),
         .backingPixel = wBackingPixel(pWin),
         .saveUnder = (BOOL) pWin->saveUnder,
@@ -1597,8 +1594,6 @@ ProcGetWindowAttributes(ClientPtr client)
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swapl(&rep.visualID);
         swaps(&rep.class);
         swapl(&rep.backingBitPlanes);
@@ -1608,7 +1603,7 @@ ProcGetWindowAttributes(ClientPtr client)
         swapl(&rep.yourEventMask);
         swaps(&rep.doNotPropagateMask);
     }
-    WriteToClient(client, sizeof(rep), &rep);
+    X_SEND_REPLY_SIMPLE(client, rep);
     return Success;
 }
 


### PR DESCRIPTION
Use X_SEND_REPLY_SIMPLE() for sending out simple replies.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
