### PR TITLE
glx: xtest: use X_SEND_REPLY_SIMPLE()

### DIFF
--- a/glx/glxcmds.c
+++ b/glx/glxcmds.c
@@ -713,19 +713,10 @@ __glXDisp_IsDirect(__GLXclientState * cl, GLbyte * pc)
         return err;
 
     xGLXIsDirectReply reply = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0,
         .isDirect = glxc->isDirect
     };
 
-    if (client->swapped) {
-        __GLX_DECLARE_SWAP_VARIABLES;
-        __GLX_SWAP_SHORT(&reply.sequenceNumber);
-        __GLX_SWAP_INT(&reply.length);
-    }
-    WriteToClient(client, sizeof(xGLXIsDirectReply), &reply);
-
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -748,22 +739,17 @@ __glXDisp_QueryVersion(__GLXclientState * cl, GLbyte * pc)
      ** implementation the server just returns its version number.
      */
     xGLXQueryVersionReply reply = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0,
         .majorVersion = SERVER_GLX_MAJOR_VERSION,
         .minorVersion = SERVER_GLX_MINOR_VERSION
     };
 
     if (client->swapped) {
         __GLX_DECLARE_SWAP_VARIABLES;
-        __GLX_SWAP_SHORT(&reply.sequenceNumber);
-        __GLX_SWAP_INT(&reply.length);
         __GLX_SWAP_INT(&reply.majorVersion);
         __GLX_SWAP_INT(&reply.minorVersion);
     }
 
-    WriteToClient(client, sizeof(xGLXQueryVersionReply), &reply);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 

--- a/glx/vndcmds.c
+++ b/glx/vndcmds.c
@@ -87,17 +87,6 @@ static GlxServerDispatchProc GetVendorDispatchFunc(CARD8 opcode, CARD32 vendorCo
     return DispatchBadRequest;
 }
 
-static void SetReplyHeader(ClientPtr client, void *replyPtr)
-{
-    xGenericReply *rep = (xGenericReply *) replyPtr;
-    rep->type = X_Reply;
-    rep->sequenceNumber = client->sequence;
-    if (client->swapped) {
-	swaps(&rep->sequenceNumber);
-    }
-    rep->length = 0;
-}
-
 /* Include the trivial dispatch handlers */
 #include "vnd_dispatch_stubs.c"
 
@@ -106,11 +95,10 @@ static int dispatch_GLXQueryVersion(ClientPtr client)
     xGLXQueryVersionReply reply;
     REQUEST_SIZE_MATCH(xGLXQueryVersionReq);
 
-    SetReplyHeader(client, &reply);
     reply.majorVersion = GlxCheckSwap(client, 1);
     reply.minorVersion = GlxCheckSwap(client, 4);
 
-    WriteToClient(client, sizeof(xGLXQueryVersionReply), &reply);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -213,8 +201,6 @@ static int CommonMakeCurrent(ClientPtr client,
     readdrawable = GlxCheckSwap(client, readdrawable);
     context = GlxCheckSwap(client, context);
 
-    SetReplyHeader(client, &reply);
-
     if (oldContextTag != 0) {
         oldTag = GlxLookupContextTag(client, oldContextTag);
         if (oldTag == NULL) {
@@ -271,7 +257,7 @@ static int CommonMakeCurrent(ClientPtr client,
     }
 
     reply.contextTag = GlxCheckSwap(client, reply.contextTag);
-    WriteToClient(client, sizeof(xGLXMakeCurrentReply), &reply);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 


### PR DESCRIPTION
Use X_SEND_REPLY_SIMPLE() for sending out simple replies.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
