### PR TITLE
Run-time configurable IgnoreABI + module search paths - the first commit to resolve build issue immediately

### DIFF
--- a/hw/xfree86/loader/loader.c
+++ b/hw/xfree86/loader/loader.c
@@ -203,10 +203,13 @@ LoaderGetABIVersion(const char *abiclass)
          * complexity to the codebase, we will no longer be able to
          * support both abi's at once.
          *
-         * We will probably have to add a compile-time flag that switches
+         * Therefore we have added a compile-time flag that switches
          * between abi's.
          */
-        {ABI_CLASS_VIDEODRV, is_nvidia_proprietary ? ABI_NVIDIA_VERSION :
+        {ABI_CLASS_VIDEODRV,
+#ifdef CONFIG_LEGACY_NVIDIA_PADDING
+                             is_nvidia_proprietary ? ABI_NVIDIA_VERSION :
+#endif
                              LoaderVersionInfo.videodrvVersion},
         {ABI_CLASS_XINPUT, LoaderVersionInfo.xinputVersion},
         {ABI_CLASS_EXTENSION, LoaderVersionInfo.extensionVersion},

--- a/include/xorg-server.h.meson.in
+++ b/include/xorg-server.h.meson.in
@@ -38,6 +38,9 @@
 /* Support XDM-AUTH*-1 */
 #mesondefine HASXDMAUTH
 
+/* Add a padding for legacy nvidia drivers that support old ABI */
+#mesondefine CONFIG_LEGACY_NVIDIA_PADDING
+
 /* Define to 1 if you have the `reallocarray' function. */
 #mesondefine HAVE_REALLOCARRAY
 


### PR DESCRIPTION
As @stefan11111 asked in https://github.com/X11Libre/xserver/pull/658#discussion_r2296163239, a PR that contains the first commit of  https://github.com/X11Libre/xserver/pull/658 only, is submitted separately to fix a build issue right now.