### PR TITLE
xkb: ProcXkbGetKbdByName(): extra payload size sanity check

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -5899,6 +5899,10 @@ ProcXkbGetKbdByName(ClientPtr client)
             return BadAlloc;
         }
 
+        if (rpcbuf.wpos != (mrep.length * 4))
+            LogMessage(X_WARNING, "ProcXkbGetKbdByName() childbuf size (%ld) mismatch mrep size (%ld // %d units)\n",
+                       (unsigned long)rpcbuf.wpos, (unsigned long)mrep.length * 4, mrep.length);
+
         if (client->swapped) {
             swaps(&mrep.sequenceNumber);
             swapl(&mrep.length);
@@ -5918,6 +5922,10 @@ ProcXkbGetKbdByName(ClientPtr client)
         x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
         XkbAssembleCompatMap(client, new->compat, crep, &rpcbuf);
+
+        if (rpcbuf.wpos != (crep.length * 4))
+            LogMessage(X_WARNING, "ProcXkbGetKbdByName() childbuf size (%ld) mismatch crep size (%ld // %d units)\n",
+                       (unsigned long)rpcbuf.wpos, (unsigned long)crep.length * 4, crep.length);
 
         if (client->swapped) {
             swaps(&crep.sequenceNumber);
@@ -5944,6 +5952,10 @@ ProcXkbGetKbdByName(ClientPtr client)
             return BadAlloc;
         }
 
+        if (rpcbuf.wpos != (irep.length * 4))
+            LogMessage(X_WARNING, "ProcXkbGetKbdByName() childbuf size (%ld) mismatch irep size (%ld // %d units)\n",
+                       (unsigned long)rpcbuf.wpos, (unsigned long)irep.length * 4, irep.length);
+
         if (client->swapped) {
             swaps(&irep.sequenceNumber);
             swapl(&irep.length);
@@ -5962,6 +5974,10 @@ ProcXkbGetKbdByName(ClientPtr client)
         x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
         XkbAssembleNames(client, new, nrep, &rpcbuf);
+
+        if (rpcbuf.wpos != (nrep.length * 4))
+            LogMessage(X_WARNING, "ProcXkbGetKbdByName() childbuf size (%ld) mismatch nrep size (%ld // %d units)\n",
+                       (unsigned long)rpcbuf.wpos, (unsigned long)nrep.length * 4, nrep.length);
 
         if (client->swapped) {
             swaps(&nrep.sequenceNumber);


### PR DESCRIPTION
Add extra check for comparing the actually written sub-payload sizes
with their previously computed ones. This is meant for troubeshooting
while still stabelizing the previous, not entirely trivial commits.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
