### PR TITLE
Backport from Xorg

### DIFF
--- a/hw/xfree86/loader/loadmod.c
+++ b/hw/xfree86/loader/loadmod.c
@@ -83,7 +83,7 @@ const ModuleVersions LoaderVersionInfo = {
     ABI_EXTENSION_VERSION,
 };
 
-static int ModuleDuplicated[] = { };
+static int ModuleDuplicated[] = { 0 };
 
 static void
 FreeStringList(char **paths)


### PR DESCRIPTION
All other recent commits were already made in Xlibre.
Only this remains, which I'm not sure about: https://gitlab.freedesktop.org/xorg/xserver/-/commit/4ca8b9a47459d0e0827556da48cc5f1bfe873952

Do we build xf86bigfont in CI?