### PR TITLE
kdrive: replace dix-config.h with kdrive-config.h

### DIFF
--- a/hw/kdrive/ephyr/ephyr.c
+++ b/hw/kdrive/ephyr/ephyr.c
@@ -23,7 +23,7 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <dix-config.h>
+#include <kdrive-config.h>
 
 #include <xcb/xcb_keysyms.h>
 #include <X11/keysym.h>

--- a/hw/kdrive/ephyr/ephyr_draw.c
+++ b/hw/kdrive/ephyr/ephyr_draw.c
@@ -25,7 +25,7 @@
  *
  */
 
-#include <dix-config.h>
+#include <kdrive-config.h>
 
 #include "ephyr.h"
 #include "exa_priv.h"

--- a/hw/kdrive/ephyr/ephyr_glamor.h
+++ b/hw/kdrive/ephyr/ephyr_glamor.h
@@ -25,7 +25,7 @@
 #define XSERVER_KDRIVE_EPHYR_GLAMOR_H
 
 #include <xcb/xcb.h>
-#include "dix-config.h"
+#include "kdrive-config.h"
 
 struct ephyr_glamor;
 struct pixman_region16;

--- a/hw/kdrive/ephyr/ephyr_glamor_xv.c
+++ b/hw/kdrive/ephyr/ephyr_glamor_xv.c
@@ -21,7 +21,7 @@
  * IN THE SOFTWARE.
  */
 
-#include <dix-config.h>
+#include <kdrive-config.h>
 
 #include "kdrive.h"
 #include "kxv.h"

--- a/hw/kdrive/ephyr/ephyrcursor.c
+++ b/hw/kdrive/ephyr/ephyrcursor.c
@@ -24,7 +24,7 @@
  *      Adam Jackson <ajax@redhat.com>
  */
 
-#include <dix-config.h>
+#include <kdrive-config.h>
 
 #include <xcb/render.h>
 #include <xcb/xcb_renderutil.h>

--- a/hw/kdrive/ephyr/ephyrinit.c
+++ b/hw/kdrive/ephyr/ephyrinit.c
@@ -23,7 +23,7 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <dix-config.h>
+#include <kdrive-config.h>
 
 #include "dix/dix_priv.h"
 #include "os/cmdline.h"

--- a/hw/kdrive/ephyr/ephyrvideo.c
+++ b/hw/kdrive/ephyr/ephyrvideo.c
@@ -26,7 +26,7 @@
  *    Dodji Seketeli <dodji@openedhand.com>
  */
 
-#include <dix-config.h>
+#include <kdrive-config.h>
 #include <string.h>
 #include <X11/extensions/Xv.h>
 #include <xcb/xcb.h>

--- a/hw/kdrive/ephyr/hostx.c
+++ b/hw/kdrive/ephyr/hostx.c
@@ -23,7 +23,7 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <dix-config.h>
+#include <kdrive-config.h>
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/hw/kdrive/meson.build
+++ b/hw/kdrive/meson.build
@@ -1,6 +1,11 @@
 build_xephyr = get_option('xephyr')
 build_kdrive = build_xephyr
 
+build_kdrive_kbd = false
+build_kdrive_mouse = false
+build_kdrive_evdev = false
+build_kdrive_tslib = false
+
 if build_kdrive
     subdir('src')
 endif

--- a/hw/kdrive/src/kcmap.c
+++ b/hw/kdrive/src/kcmap.c
@@ -20,7 +20,7 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <dix-config.h>
+#include <kdrive-config.h>
 #include "kdrive.h"
 
 #include "dix/colormap_priv.h"

--- a/hw/kdrive/src/kdrive-config.h.meson.in
+++ b/hw/kdrive/src/kdrive-config.h.meson.in
@@ -1,0 +1,22 @@
+/* kdrive-config.h.in: not at all generated.                      -*- c -*-
+ *
+ */
+
+#ifndef _KDRIVE_CONFIG_H_
+#define _KDRIVE_CONFIG_H_
+
+#include <dix-config.h>
+
+/* Build the kdrive keyboard input driver */
+#mesondefine KDRIVE_KBD
+
+/* Build the kdrive mouse input driver */
+#mesondefine KDRIVE_MOUSE
+
+/* Build the kdrive evdev input driver */
+#mesondefine KDRIVE_EVDEV
+
+/* Build the kdrive tslib input driver */
+#mesondefine KDRIVE_TSLIB
+
+#endif /* _KDRIVE_CONFIG_H_ */

--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -20,7 +20,7 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <dix-config.h>
+#include <kdrive-config.h>
 
 #include "config/hotplug_priv.h"
 #include "dix/screenint_priv.h"

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -343,6 +343,8 @@ extern Bool kdEnabled;
 extern Bool kdSwitchPending;
 extern Bool kdEmulateMiddleButton;
 extern Bool kdDisableZaphod;
+extern Bool kdAllowZap;
+extern int kdVirtualTerminal;
 extern char *kdSwitchCmd;
 
 /*
@@ -351,9 +353,6 @@ extern char *kdSwitchCmd;
  * Initialized via KdOSInit()
  */
 extern const KdOsFuncs *kdOsFuncs;
-
-extern Bool kdAllowZap;
-extern int kdVirtualTerminal;
 
 #define KdGetScreenPriv(pScreen) ((KdPrivScreenPtr) \
     dixLookupPrivate(&(pScreen)->devPrivates, kdScreenPrivateKey))
@@ -538,7 +537,6 @@ const KdMonitorTiming *KdFindMode(KdScreenInfo * screen,
                                                      const KdMonitorTiming *));
 
 Bool
-
 KdTuneMode(KdScreenInfo * screen,
            Bool (*usable) (KdScreenInfo *),
            Bool (*supported) (KdScreenInfo *, const KdMonitorTiming *));

--- a/hw/kdrive/src/kinfo.c
+++ b/hw/kdrive/src/kinfo.c
@@ -20,7 +20,7 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <dix-config.h>
+#include <kdrive-config.h>
 #include "kdrive.h"
 
 KdCardInfo *kdCardInfo;

--- a/hw/kdrive/src/kinput.c
+++ b/hw/kdrive/src/kinput.c
@@ -21,7 +21,7 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <dix-config.h>
+#include <kdrive-config.h>
 #include <xkb-config.h>
 #include "kdrive.h"
 #include "inputstr.h"
@@ -153,8 +153,6 @@ void KdAssertSigioBlocked(char *where)
 #define KdAssertSigioBlocked(s)
 
 #endif
-
-static int kdnFds;
 #endif
 
 #ifdef FNONBLOCK

--- a/hw/kdrive/src/kmode.c
+++ b/hw/kdrive/src/kmode.c
@@ -21,7 +21,7 @@
  * Author:  Keith Packard, SuSE, Inc.
  */
 
-#include <dix-config.h>
+#include <kdrive-config.h>
 #include "kdrive.h"
 
 const KdMonitorTiming kdMonitorTimings[] = {

--- a/hw/kdrive/src/kshadow.c
+++ b/hw/kdrive/src/kshadow.c
@@ -20,7 +20,7 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <dix-config.h>
+#include <kdrive-config.h>
 #include "kdrive.h"
 
 Bool

--- a/hw/kdrive/src/kxv.c
+++ b/hw/kdrive/src/kxv.c
@@ -35,7 +35,7 @@ of the copyright holder.
 
 */
 
-#include <dix-config.h>
+#include <kdrive-config.h>
 
 #include <X11/extensions/Xv.h>
 #include <X11/extensions/Xvproto.h>

--- a/hw/kdrive/src/meson.build
+++ b/hw/kdrive/src/meson.build
@@ -13,6 +13,17 @@ if build_xv
     srcs_kdrive += 'kxv.c'
 endif
 
+kdrive_data = configuration_data()
+
+kdrive_data.set('KDRIVE_KBD', build_kdrive_kbd ? '1' : false)
+kdrive_data.set('KDRIVE_MOUSE', build_kdrive_mouse ? '1' : false)
+kdrive_data.set('KDRIVE_EVDEV', build_kdrive_evdev ? '1' : false)
+kdrive_data.set('KDRIVE_TSLIB', build_kdrive_tslib ? '1' : false)
+
+configure_file(input : 'kdrive-config.h.meson.in',
+               output : 'kdrive-config.h',
+               configuration : kdrive_data)
+
 kdrive = static_library('kdrive',
     srcs_kdrive,
     include_directories: inc,

--- a/meson.build
+++ b/meson.build
@@ -248,6 +248,7 @@ summary({
         'Xvfb': build_xvfb,
         'Xwin': build_xwin,
         'Xquartz': build_xquartz,
+        'Xephyr': get_option('xephyr'),
     },
     section: 'DDX',
     bool_yn: true,


### PR DESCRIPTION
We want to set kdrive-specific build options in a config file for Xfbdev input drivers.

This pr creates a new config file, kdrive-config.h, which includes dix-config.h and adds extra config options.