### PR TITLE
Xext: canonical naming for reply structs

### DIFF
--- a/Xext/bigreq.c
+++ b/Xext/bigreq.c
@@ -51,13 +51,13 @@ ProcBigReqDispatch(ClientPtr client)
         return BadRequest;
     client->big_requests = TRUE;
 
-    xBigReqEnableReply rep = {
+    xBigReqEnableReply reply = {
         .max_request_size = maxBigRequestSize
     };
     if (client->swapped) {
-        swapl(&rep.max_request_size);
+        swapl(&reply.max_request_size);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 

--- a/Xext/dpms.c
+++ b/Xext/dpms.c
@@ -305,7 +305,7 @@ static int
 ProcDPMSGetVersion(ClientPtr client)
 {
     /* REQUEST(xDPMSGetVersionReq); */
-    xDPMSGetVersionReply rep = {
+    xDPMSGetVersionReply reply = {
         .majorVersion = SERVER_DPMS_MAJOR_VERSION,
         .minorVersion = SERVER_DPMS_MINOR_VERSION
     };
@@ -313,10 +313,10 @@ ProcDPMSGetVersion(ClientPtr client)
     REQUEST_SIZE_MATCH(xDPMSGetVersionReq);
 
     if (client->swapped) {
-        swaps(&rep.majorVersion);
-        swaps(&rep.minorVersion);
+        swaps(&reply.majorVersion);
+        swaps(&reply.minorVersion);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -324,13 +324,13 @@ static int
 ProcDPMSCapable(ClientPtr client)
 {
     /* REQUEST(xDPMSCapableReq); */
-    xDPMSCapableReply rep = {
+    xDPMSCapableReply reply = {
         .capable = TRUE
     };
 
     REQUEST_SIZE_MATCH(xDPMSCapableReq);
 
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -338,7 +338,7 @@ static int
 ProcDPMSGetTimeouts(ClientPtr client)
 {
     /* REQUEST(xDPMSGetTimeoutsReq); */
-    xDPMSGetTimeoutsReply rep = {
+    xDPMSGetTimeoutsReply reply = {
         .standby = DPMSStandbyTime / MILLI_PER_SECOND,
         .suspend = DPMSSuspendTime / MILLI_PER_SECOND,
         .off = DPMSOffTime / MILLI_PER_SECOND
@@ -347,11 +347,11 @@ ProcDPMSGetTimeouts(ClientPtr client)
     REQUEST_SIZE_MATCH(xDPMSGetTimeoutsReq);
 
     if (client->swapped) {
-        swaps(&rep.standby);
-        swaps(&rep.suspend);
-        swaps(&rep.off);
+        swaps(&reply.standby);
+        swaps(&reply.suspend);
+        swaps(&reply.off);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -439,7 +439,7 @@ static int
 ProcDPMSInfo(ClientPtr client)
 {
     /* REQUEST(xDPMSInfoReq); */
-    xDPMSInfoReply rep = {
+    xDPMSInfoReply reply = {
         .power_level = DPMSPowerLevel,
         .state = DPMSEnabled
     };
@@ -447,9 +447,9 @@ ProcDPMSInfo(ClientPtr client)
     REQUEST_SIZE_MATCH(xDPMSInfoReq);
 
     if (client->swapped) {
-        swaps(&rep.power_level);
+        swaps(&reply.power_level);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 

--- a/Xext/geext.c
+++ b/Xext/geext.c
@@ -73,7 +73,7 @@ ProcGEQueryVersion(ClientPtr client)
     REQUEST(xGEQueryVersionReq);
     REQUEST_SIZE_MATCH(xGEQueryVersionReq);
 
-    xGEQueryVersionReply rep = {
+    xGEQueryVersionReply reply = {
         .RepType = X_GEQueryVersion,
         /* return the supported version by the server */
         .majorVersion = SERVER_GE_MAJOR_VERSION,
@@ -85,11 +85,11 @@ ProcGEQueryVersion(ClientPtr client)
     pGEClient->minor_version = stuff->minorVersion;
 
     if (client->swapped) {
-        swaps(&rep.majorVersion);
-        swaps(&rep.minorVersion);
+        swaps(&reply.majorVersion);
+        swaps(&reply.minorVersion);
     }
 
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 

--- a/Xext/panoramiX.c
+++ b/Xext/panoramiX.c
@@ -903,17 +903,17 @@ int
 ProcPanoramiXQueryVersion(ClientPtr client)
 {
     /* REQUEST(xPanoramiXQueryVersionReq); */
-    xPanoramiXQueryVersionReply rep = {
+    xPanoramiXQueryVersionReply reply = {
         .majorVersion = SERVER_PANORAMIX_MAJOR_VERSION,
         .minorVersion = SERVER_PANORAMIX_MINOR_VERSION
     };
 
     REQUEST_SIZE_MATCH(xPanoramiXQueryVersionReq);
     if (client->swapped) {
-        swaps(&rep.majorVersion);
-        swaps(&rep.minorVersion);
+        swaps(&reply.majorVersion);
+        swaps(&reply.minorVersion);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -929,15 +929,15 @@ ProcPanoramiXGetState(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xPanoramiXGetStateReply rep = {
+    xPanoramiXGetStateReply reply = {
         .state = !noPanoramiXExtension,
         .window = stuff->window
     };
 
     if (client->swapped) {
-        swapl(&rep.window);
+        swapl(&reply.window);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 
 }
@@ -954,15 +954,15 @@ ProcPanoramiXGetScreenCount(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xPanoramiXGetScreenCountReply rep = {
+    xPanoramiXGetScreenCountReply reply = {
         .ScreenCount = PanoramiXNumScreens,
         .window = stuff->window
     };
 
     if (client->swapped) {
-        swapl(&rep.window);
+        swapl(&reply.window);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -982,7 +982,7 @@ ProcPanoramiXGetScreenSize(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xPanoramiXGetScreenSizeReply rep = {
+    xPanoramiXGetScreenSizeReply reply = {
         /* screen dimensions */
         .width = screenInfo.screens[stuff->screen]->width,
         .height = screenInfo.screens[stuff->screen]->height,
@@ -991,12 +991,12 @@ ProcPanoramiXGetScreenSize(ClientPtr client)
     };
 
     if (client->swapped) {
-        swapl(&rep.width);
-        swapl(&rep.height);
-        swapl(&rep.window);
-        swapl(&rep.screen);
+        swapl(&reply.width);
+        swapl(&reply.height);
+        swapl(&reply.window);
+        swapl(&reply.screen);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -1006,7 +1006,7 @@ ProcXineramaIsActive(ClientPtr client)
     /* REQUEST(xXineramaIsActiveReq); */
     REQUEST_SIZE_MATCH(xXineramaIsActiveReq);
 
-    xXineramaIsActiveReply rep = {
+    xXineramaIsActiveReply reply = {
 #if 1
         /* The following hack fools clients into thinking that Xinerama
          * is disabled even though it is not. */
@@ -1017,9 +1017,9 @@ ProcXineramaIsActive(ClientPtr client)
     };
 
     if (client->swapped) {
-        swapl(&rep.state);
+        swapl(&reply.state);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -1028,14 +1028,14 @@ ProcXineramaQueryScreens(ClientPtr client)
 {
     /* REQUEST(xXineramaQueryScreensReq); */
     CARD32 number = (noPanoramiXExtension) ? 0 : PanoramiXNumScreens;
-    xXineramaQueryScreensReply rep = {
+    xXineramaQueryScreensReply reply = {
         .number = number
     };
 
     REQUEST_SIZE_MATCH(xXineramaQueryScreensReq);
 
     if (client->swapped) {
-        swapl(&rep.number);
+        swapl(&reply.number);
     }
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
@@ -1056,7 +1056,7 @@ ProcXineramaQueryScreens(ClientPtr client)
         }
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     return Success;
 }
 

--- a/Xext/panoramiXprocs.c
+++ b/Xext/panoramiXprocs.c
@@ -570,7 +570,7 @@ PanoramiXGetGeometry(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xGetGeometryReply rep = {
+    xGetGeometryReply reply = {
         .root = screenInfo.screens[0]->root->drawable.id,
         .depth = pDraw->depth,
         .width = pDraw->width,
@@ -580,36 +580,36 @@ PanoramiXGetGeometry(ClientPtr client)
         .borderWidth = 0
     };
 
-    if (stuff->id == rep.root) {
+    if (stuff->id == reply.root) {
         xWindowRoot *root = (xWindowRoot *)
             (ConnectionInfo + connBlockScreenStart);
 
-        rep.width = root->pixWidth;
-        rep.height = root->pixHeight;
+        reply.width = root->pixWidth;
+        reply.height = root->pixHeight;
     }
     else if (WindowDrawable(pDraw->type)) {
         WindowPtr pWin = (WindowPtr) pDraw;
 
-        rep.x = pWin->origin.x - wBorderWidth(pWin);
-        rep.y = pWin->origin.y - wBorderWidth(pWin);
+        reply.x = pWin->origin.x - wBorderWidth(pWin);
+        reply.y = pWin->origin.y - wBorderWidth(pWin);
         if ((pWin->parent == screenInfo.screens[0]->root) ||
             (pWin->parent->drawable.id ==
              screenInfo.screens[0]->screensaver.wid)) {
-            rep.x += screenInfo.screens[0]->x;
-            rep.y += screenInfo.screens[0]->y;
+            reply.x += screenInfo.screens[0]->x;
+            reply.y += screenInfo.screens[0]->y;
         }
-        rep.borderWidth = pWin->borderWidth;
+        reply.borderWidth = pWin->borderWidth;
     }
 
     if (client->swapped) {
-        swapl(&rep.root);
-        swaps(&rep.x);
-        swaps(&rep.y);
-        swaps(&rep.width);
-        swaps(&rep.height);
-        swaps(&rep.borderWidth);
+        swapl(&reply.root);
+        swaps(&reply.x);
+        swaps(&reply.y);
+        swaps(&reply.width);
+        swaps(&reply.height);
+        swaps(&reply.borderWidth);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -676,7 +676,7 @@ PanoramiXTranslateCoords(ClientPtr client)
         dstY += screenInfo.screens[0]->y;
     }
 
-    xTranslateCoordsReply rep = {
+    xTranslateCoordsReply reply = {
         .sameScreen = xTrue,
         .dstX = dstX,
         .dstY = dstY,
@@ -684,11 +684,11 @@ PanoramiXTranslateCoords(ClientPtr client)
     };
 
     if (client->swapped) {
-        swapl(&rep.child);
-        swaps(&rep.dstX);
-        swaps(&rep.dstY);
+        swapl(&reply.child);
+        swaps(&reply.dstX);
+        swaps(&reply.dstY);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -2119,17 +2119,17 @@ PanoramiXGetImage(ClientPtr client)
         }
     }
 
-    xGetImageReply rep = {
+    xGetImageReply reply = {
         .visual = wVisual(((WindowPtr) pDraw)),
         .depth = pDraw->depth,
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.visual);
+        swaps(&reply.sequenceNumber);
+        swapl(&reply.visual);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     return Success;
 }
 

--- a/Xext/saver.c
+++ b/Xext/saver.c
@@ -588,7 +588,7 @@ ScreenSaverHandle(ScreenPtr pScreen, int xstate, Bool force)
 static int
 ProcScreenSaverQueryVersion(ClientPtr client)
 {
-    xScreenSaverQueryVersionReply rep = {
+    xScreenSaverQueryVersionReply reply = {
         .majorVersion = SERVER_SAVER_MAJOR_VERSION,
         .minorVersion = SERVER_SAVER_MINOR_VERSION
     };
@@ -596,10 +596,10 @@ ProcScreenSaverQueryVersion(ClientPtr client)
     REQUEST_SIZE_MATCH(xScreenSaverQueryVersionReq);
 
     if (client->swapped) {
-        swaps(&rep.majorVersion);
-        swaps(&rep.minorVersion);
+        swaps(&reply.majorVersion);
+        swaps(&reply.minorVersion);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -628,39 +628,39 @@ ProcScreenSaverQueryInfo(ClientPtr client)
     UpdateCurrentTime();
     lastInput = GetTimeInMillis() - LastEventTime(XIAllDevices).milliseconds;
 
-    xScreenSaverQueryInfoReply rep = {
+    xScreenSaverQueryInfoReply reply = {
         .window = pSaver->wid
     };
     if (screenIsSaved != SCREEN_SAVER_OFF) {
-        rep.state = ScreenSaverOn;
+        reply.state = ScreenSaverOn;
         if (ScreenSaverTime)
-            rep.tilOrSince = lastInput - ScreenSaverTime;
+            reply.tilOrSince = lastInput - ScreenSaverTime;
     }
     else {
         if (ScreenSaverTime) {
-            rep.state = ScreenSaverOff;
+            reply.state = ScreenSaverOff;
             if (ScreenSaverTime >= lastInput)
-                rep.tilOrSince = ScreenSaverTime - lastInput;
+                reply.tilOrSince = ScreenSaverTime - lastInput;
         }
         else {
-            rep.state = ScreenSaverDisabled;
+            reply.state = ScreenSaverDisabled;
         }
     }
-    rep.idle = lastInput;
-    rep.eventMask = getEventMask(pDraw->pScreen, client);
+    reply.idle = lastInput;
+    reply.eventMask = getEventMask(pDraw->pScreen, client);
     if (pPriv && pPriv->attr)
-        rep.kind = ScreenSaverExternal;
+        reply.kind = ScreenSaverExternal;
     else if (ScreenSaverBlanking != DontPreferBlanking)
-        rep.kind = ScreenSaverBlanked;
+        reply.kind = ScreenSaverBlanked;
     else
-        rep.kind = ScreenSaverInternal;
+        reply.kind = ScreenSaverInternal;
     if (client->swapped) {
-        swapl(&rep.window);
-        swapl(&rep.tilOrSince);
-        swapl(&rep.idle);
-        swapl(&rep.eventMask);
+        swapl(&reply.window);
+        swapl(&reply.tilOrSince);
+        swapl(&reply.idle);
+        swapl(&reply.eventMask);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 

--- a/Xext/security.c
+++ b/Xext/security.c
@@ -348,7 +348,7 @@ static int
 ProcSecurityQueryVersion(ClientPtr client)
 {
     /* REQUEST(xSecurityQueryVersionReq); */
-    xSecurityQueryVersionReply rep = {
+    xSecurityQueryVersionReply reply = {
         .majorVersion = SERVER_SECURITY_MAJOR_VERSION,
         .minorVersion = SERVER_SECURITY_MINOR_VERSION
     };
@@ -356,10 +356,10 @@ ProcSecurityQueryVersion(ClientPtr client)
     REQUEST_SIZE_MATCH(xSecurityQueryVersionReq);
 
     if (client->swapped) {
-        swaps(&rep.majorVersion);
-        swaps(&rep.minorVersion);
+        swaps(&reply.majorVersion);
+        swaps(&reply.minorVersion);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }                               /* ProcSecurityQueryVersion */
 
@@ -403,7 +403,7 @@ ProcSecurityGenerateAuthorization(ClientPtr client)
     Bool removeAuth = FALSE;    /* if bailout, call RemoveAuthorization? */
     int err;                    /* error to return from this function */
     XID authId;                 /* authorization ID assigned by os layer */
-    xSecurityGenerateAuthorizationReply rep;    /* reply struct */
+    xSecurityGenerateAuthorizationReply reply;    /* reply struct */
     unsigned int trustLevel;    /* trust level of new auth */
     XID group;                  /* group of new auth */
     CARD32 timeout;             /* timeout of new auth */
@@ -533,7 +533,7 @@ ProcSecurityGenerateAuthorization(ClientPtr client)
 
     /* tell client the auth id and data */
 
-    rep = (xSecurityGenerateAuthorizationReply) {
+    reply = (xSecurityGenerateAuthorizationReply) {
         .type = X_Reply,
         .sequenceNumber = client->sequence,
         .length = bytes_to_int32(authdata_len),
@@ -542,13 +542,13 @@ ProcSecurityGenerateAuthorization(ClientPtr client)
     };
 
     if (client->swapped) {
-        swapl(&rep.length);
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.authId);
-        swaps(&rep.dataLength);
+        swapl(&reply.length);
+        swaps(&reply.sequenceNumber);
+        swapl(&reply.authId);
+        swaps(&reply.dataLength);
     }
 
-    WriteToClient(client, SIZEOF(xSecurityGenerateAuthorizationReply), &rep);
+    WriteToClient(client, SIZEOF(xSecurityGenerateAuthorizationReply), &reply);
     WriteToClient(client, authdata_len, pAuthdata);
 
     SecurityAudit

--- a/Xext/shape.c
+++ b/Xext/shape.c
@@ -208,16 +208,16 @@ ProcShapeQueryVersion(ClientPtr client)
 {
     REQUEST_SIZE_MATCH(xShapeQueryVersionReq);
 
-    xShapeQueryVersionReply rep = {
+    xShapeQueryVersionReply reply = {
         .majorVersion = SERVER_SHAPE_MAJOR_VERSION,
         .minorVersion = SERVER_SHAPE_MINOR_VERSION
     };
 
     if (client->swapped) {
-        swaps(&rep.majorVersion);
-        swaps(&rep.minorVersion);
+        swaps(&reply.majorVersion);
+        swaps(&reply.minorVersion);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -649,7 +649,7 @@ ProcShapeQueryExtents(ClientPtr client)
         shapeBox.y2 = pWin->drawable.height;
     }
 
-    xShapeQueryExtentsReply rep = {
+    xShapeQueryExtentsReply reply = {
         .boundingShaped = (wBoundingShape(pWin) != 0),
         .clipShaped = (wClipShape(pWin) != 0),
         .xBoundingShape = boundBox.x1,
@@ -663,16 +663,16 @@ ProcShapeQueryExtents(ClientPtr client)
     };
 
     if (client->swapped) {
-        swaps(&rep.xBoundingShape);
-        swaps(&rep.yBoundingShape);
-        swaps(&rep.widthBoundingShape);
-        swaps(&rep.heightBoundingShape);
-        swaps(&rep.xClipShape);
-        swaps(&rep.yClipShape);
-        swaps(&rep.widthClipShape);
-        swaps(&rep.heightClipShape);
+        swaps(&reply.xBoundingShape);
+        swaps(&reply.yBoundingShape);
+        swaps(&reply.widthBoundingShape);
+        swaps(&reply.heightBoundingShape);
+        swaps(&reply.xClipShape);
+        swaps(&reply.yClipShape);
+        swaps(&reply.widthClipShape);
+        swaps(&reply.heightClipShape);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -915,11 +915,11 @@ ProcShapeInputSelected(ClientPtr client)
         }
     }
 
-    xShapeInputSelectedReply rep = {
+    xShapeInputSelectedReply reply = {
         .enabled = enabled,
     };
 
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -994,16 +994,16 @@ ProcShapeGetRectangles(ClientPtr client)
     if (rpcbuf.error) /* buffer already cleared */
         return BadAlloc;
 
-    xShapeGetRectanglesReply rep = {
+    xShapeGetRectanglesReply reply = {
         .ordering = YXBanded,
         .nrects = nrects
     };
 
     if (client->swapped) {
-        swapl(&rep.nrects);
+        swapl(&reply.nrects);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     return Success;
 }
 

--- a/Xext/shm.c
+++ b/Xext/shm.c
@@ -254,7 +254,7 @@ ShmRegisterFbFuncs(ScreenPtr pScreen)
 static int
 ProcShmQueryVersion(ClientPtr client)
 {
-    xShmQueryVersionReply rep = {
+    xShmQueryVersionReply reply = {
         .sharedPixmaps = sharedPixmaps,
         .majorVersion = SERVER_SHM_MAJOR_VERSION,
         .minorVersion = SERVER_SHM_MINOR_VERSION,
@@ -266,12 +266,12 @@ ProcShmQueryVersion(ClientPtr client)
     REQUEST_SIZE_MATCH(xShmQueryVersionReq);
 
     if (client->swapped) {
-        swaps(&rep.majorVersion);
-        swaps(&rep.minorVersion);
-        swaps(&rep.uid);
-        swaps(&rep.gid);
+        swaps(&reply.majorVersion);
+        swaps(&reply.minorVersion);
+        swaps(&reply.uid);
+        swaps(&reply.gid);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -1259,7 +1259,7 @@ ProcShmCreateSegment(ClientPtr client)
 
     int fd;
     ShmDescPtr shmdesc;
-    xShmCreateSegmentReply rep = {
+    xShmCreateSegmentReply reply = {
         .nfd = 1,
     };
 
@@ -1317,7 +1317,7 @@ ProcShmCreateSegment(ClientPtr client)
         close(fd);
         return BadAlloc;
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 #endif /* SHM_FD_PASSING */

--- a/Xext/sync.c
+++ b/Xext/sync.c
@@ -1262,14 +1262,14 @@ FreeAlarmClient(void *value, XID id)
 static int
 ProcSyncInitialize(ClientPtr client)
 {
-    xSyncInitializeReply rep = {
+    xSyncInitializeReply reply = {
         .majorVersion = SERVER_SYNC_MAJOR_VERSION,
         .minorVersion = SERVER_SYNC_MINOR_VERSION,
     };
 
     REQUEST_SIZE_MATCH(xSyncInitializeReq);
 
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -1307,15 +1307,15 @@ ProcSyncListSystemCounters(ClientPtr client)
     if (rpcbuf.error)
         return BadAlloc;
 
-    xSyncListSystemCountersReply rep = {
+    xSyncListSystemCountersReply reply = {
         .nCounters = nCounters
     };
 
     if (client->swapped) {
-        swapl(&rep.nCounters);
+        swapl(&reply.nCounters);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     return Success;
 }
 
@@ -1376,15 +1376,15 @@ ProcSyncGetPriority(ClientPtr client)
             return rc;
     }
 
-    xSyncGetPriorityReply rep = {
+    xSyncGetPriorityReply reply = {
         .priority = priorityclient->priority
     };
 
     if (client->swapped) {
-        swapl(&rep.priority);
+        swapl(&reply.priority);
     }
 
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -1656,16 +1656,16 @@ ProcSyncQueryCounter(ClientPtr client)
                                                   &pCounter->value);
     }
 
-    xSyncQueryCounterReply rep = {
+    xSyncQueryCounterReply reply = {
         .value_hi = pCounter->value >> 32,
         .value_lo = pCounter->value
     };
 
     if (client->swapped) {
-        swapl(&rep.value_hi);
-        swapl(&rep.value_lo);
+        swapl(&reply.value_hi);
+        swapl(&reply.value_lo);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -1813,7 +1813,7 @@ ProcSyncQueryAlarm(ClientPtr client)
 
     pTrigger = &pAlarm->trigger;
 
-    xSyncQueryAlarmReply rep = {
+    xSyncQueryAlarmReply reply = {
         .counter = (pTrigger->pSync) ? pTrigger->pSync->id : None,
 
 #if 0  /* XXX unclear what to do, depends on whether relative value-types
@@ -1837,15 +1837,15 @@ ProcSyncQueryAlarm(ClientPtr client)
     };
 
     if (client->swapped) {
-        swapl(&rep.counter);
-        swapl(&rep.wait_value_hi);
-        swapl(&rep.wait_value_lo);
-        swapl(&rep.test_type);
-        swapl(&rep.delta_hi);
-        swapl(&rep.delta_lo);
+        swapl(&reply.counter);
+        swapl(&reply.wait_value_hi);
+        swapl(&reply.wait_value_lo);
+        swapl(&reply.test_type);
+        swapl(&reply.delta_hi);
+        swapl(&reply.delta_lo);
     }
 
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -1987,11 +1987,11 @@ ProcSyncQueryFence(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xSyncQueryFenceReply rep = {
+    xSyncQueryFenceReply reply = {
         .triggered = pFence->funcs.CheckTriggered(pFence)
     };
 
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 

--- a/Xext/vidmode.c
+++ b/Xext/vidmode.c
@@ -199,16 +199,16 @@ ProcVidModeQueryVersion(ClientPtr client)
     DEBUG_P("XF86VidModeQueryVersion");
     REQUEST_SIZE_MATCH(xXF86VidModeQueryVersionReq);
 
-    xXF86VidModeQueryVersionReply rep = {
+    xXF86VidModeQueryVersionReply reply = {
         .majorVersion = SERVER_XF86VIDMODE_MAJOR_VERSION,
         .minorVersion = SERVER_XF86VIDMODE_MINOR_VERSION
     };
 
     if (client->swapped) {
-        swaps(&rep.majorVersion);
-        swaps(&rep.minorVersion);
+        swaps(&reply.majorVersion);
+        swaps(&reply.minorVersion);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -237,7 +237,7 @@ ProcVidModeGetModeLine(ClientPtr client)
     if (!pVidMode->GetCurrentModeline(pScreen, &mode, &dotClock))
         return BadValue;
 
-    xXF86VidModeGetModeLineReply rep = {
+    xXF86VidModeGetModeLineReply reply = {
         .dotclock = dotClock,
         .hdisplay = VidModeGetModeValue(mode, VIDMODE_H_DISPLAY),
         .hsyncstart = VidModeGetModeValue(mode, VIDMODE_H_SYNCSTART),
@@ -258,45 +258,45 @@ ProcVidModeGetModeLine(ClientPtr client)
     };
 
     DebugF("GetModeLine - scrn: %d clock: %ld\n",
-           stuff->screen, (unsigned long) rep.dotclock);
+           stuff->screen, (unsigned long) reply.dotclock);
     DebugF("GetModeLine - hdsp: %d hbeg: %d hend: %d httl: %d\n",
-           rep.hdisplay, rep.hsyncstart, rep.hsyncend, rep.htotal);
+           reply.hdisplay, reply.hsyncstart, reply.hsyncend, reply.htotal);
     DebugF("              vdsp: %d vbeg: %d vend: %d vttl: %d flags: %ld\n",
-           rep.vdisplay, rep.vsyncstart, rep.vsyncend,
-           rep.vtotal, (unsigned long) rep.flags);
+           reply.vdisplay, reply.vsyncstart, reply.vsyncend,
+           reply.vtotal, (unsigned long) reply.flags);
 
     if (client->swapped) {
-        swapl(&rep.dotclock);
-        swaps(&rep.hdisplay);
-        swaps(&rep.hsyncstart);
-        swaps(&rep.hsyncend);
-        swaps(&rep.htotal);
-        swaps(&rep.hskew);
-        swaps(&rep.vdisplay);
-        swaps(&rep.vsyncstart);
-        swaps(&rep.vsyncend);
-        swaps(&rep.vtotal);
-        swapl(&rep.flags);
-        swapl(&rep.privsize);
+        swapl(&reply.dotclock);
+        swaps(&reply.hdisplay);
+        swaps(&reply.hsyncstart);
+        swaps(&reply.hsyncend);
+        swaps(&reply.htotal);
+        swaps(&reply.hskew);
+        swaps(&reply.vdisplay);
+        swaps(&reply.vsyncstart);
+        swaps(&reply.vsyncend);
+        swaps(&reply.vtotal);
+        swapl(&reply.flags);
+        swapl(&reply.privsize);
     }
     if (ver < 2) {
         xXF86OldVidModeGetModeLineReply oldrep = {
-            .dotclock = rep.dotclock,
-            .hdisplay = rep.hdisplay,
-            .hsyncstart = rep.hsyncstart,
-            .hsyncend = rep.hsyncend,
-            .htotal = rep.htotal,
-            .vdisplay = rep.vdisplay,
-            .vsyncstart = rep.vsyncstart,
-            .vsyncend = rep.vsyncend,
-            .vtotal = rep.vtotal,
-            .flags = rep.flags,
-            .privsize = rep.privsize
+            .dotclock = reply.dotclock,
+            .hdisplay = reply.hdisplay,
+            .hsyncstart = reply.hsyncstart,
+            .hsyncend = reply.hsyncend,
+            .htotal = reply.htotal,
+            .vdisplay = reply.vdisplay,
+            .vsyncstart = reply.vsyncstart,
+            .vsyncend = reply.vsyncend,
+            .vtotal = reply.vtotal,
+            .flags = reply.flags,
+            .privsize = reply.privsize
         };
         X_SEND_REPLY_SIMPLE(client, oldrep);
     }
     else {
-        X_SEND_REPLY_SIMPLE(client, rep);
+        X_SEND_REPLY_SIMPLE(client, reply);
     }
     return Success;
 }
@@ -378,15 +378,15 @@ ProcVidModeGetAllModeLines(ClientPtr client)
     if (rpcbuf.error)
         return BadAlloc;
 
-    xXF86VidModeGetAllModeLinesReply rep = {
+    xXF86VidModeGetAllModeLinesReply reply = {
         .modecount = modecount
     };
 
     if (client->swapped) {
-        swapl(&rep.modecount);
+        swapl(&reply.modecount);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     return Success;
 }
 
@@ -984,13 +984,13 @@ VidModeValidateModeLine(ClientPtr client, xXF86VidModeValidateModeLineReq *stuff
  status_reply:
     free(modetmp);
 
-    xXF86VidModeValidateModeLineReply rep = {
+    xXF86VidModeValidateModeLineReply reply = {
         .status = status
     };
     if (client->swapped) {
-        swapl(&rep.status);
+        swapl(&reply.status);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     DebugF("ValidateModeLine - Succeeded (status = %d)\n", status);
 
     return Success;
@@ -1223,14 +1223,14 @@ ProcVidModeGetMonitor(ClientPtr client)
     if (rpcbuf.error)
         return BadAlloc;
 
-    xXF86VidModeGetMonitorReply rep = {
+    xXF86VidModeGetMonitorReply reply = {
         .nhsync = nHsync,
         .nvsync = nVrefresh,
         .vendorLength = x_safe_strlen(vendorStr),
         .modelLength = x_safe_strlen(modelStr),
     };
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     return Success;
 }
 
@@ -1256,16 +1256,16 @@ ProcVidModeGetViewPort(ClientPtr client)
 
     pVidMode->GetViewPort(pScreen, &x, &y);
 
-    xXF86VidModeGetViewPortReply rep = {
+    xXF86VidModeGetViewPortReply reply = {
         .x = x,
         .y = y
     };
 
     if (client->swapped) {
-        swapl(&rep.x);
-        swapl(&rep.y);
+        swapl(&reply.x);
+        swapl(&reply.y);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -1341,19 +1341,19 @@ ProcVidModeGetDotClocks(ClientPtr client)
     if (rpcbuf.error)
         return BadAlloc;
 
-    xXF86VidModeGetDotClocksReply rep = {
+    xXF86VidModeGetDotClocksReply reply = {
         .clocks = numClocks,
         .maxclocks = MAXCLOCKS,
         .flags = (ClockProg ? CLKFLAG_PROGRAMABLE : 0),
     };
 
     if (client->swapped) {
-        swapl(&rep.clocks);
-        swapl(&rep.maxclocks);
-        swapl(&rep.flags);
+        swapl(&reply.clocks);
+        swapl(&reply.maxclocks);
+        swapl(&reply.flags);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     return Success;
 }
 
@@ -1411,17 +1411,17 @@ ProcVidModeGetGamma(ClientPtr client)
     if (!pVidMode->GetGamma(pScreen, &red, &green, &blue))
         return BadValue;
 
-    xXF86VidModeGetGammaReply rep = {
+    xXF86VidModeGetGammaReply reply = {
         .red = (CARD32) (red * 10000.),
         .green = (CARD32) (green * 10000.),
         .blue = (CARD32) (blue * 10000.)
     };
     if (client->swapped) {
-        swapl(&rep.red);
-        swapl(&rep.green);
-        swapl(&rep.blue);
+        swapl(&reply.red);
+        swapl(&reply.green);
+        swapl(&reply.blue);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -1502,14 +1502,14 @@ ProcVidModeGetGammaRamp(ClientPtr client)
             SwapShorts((short *) rpcbuf.buffer, rpcbuf.wpos / sizeof(CARD16));
     }
 
-    xXF86VidModeGetGammaRampReply rep = {
+    xXF86VidModeGetGammaRampReply reply = {
         .size = stuff->size
     };
     if (client->swapped) {
-        swaps(&rep.size);
+        swaps(&reply.size);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     return Success;
 }
 
@@ -1532,13 +1532,13 @@ ProcVidModeGetGammaRampSize(ClientPtr client)
     if (pVidMode == NULL)
         return BadImplementation;
 
-    xXF86VidModeGetGammaRampSizeReply rep = {
+    xXF86VidModeGetGammaRampSizeReply reply = {
         .size = pVidMode->GetGammaRampSize(pScreen)
     };
     if (client->swapped) {
-        swaps(&rep.size);
+        swaps(&reply.size);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -1551,16 +1551,16 @@ ProcVidModeGetPermissions(ClientPtr client)
     if (stuff->screen >= screenInfo.numScreens)
         return BadValue;
 
-    xXF86VidModeGetPermissionsReply rep =  {
+    xXF86VidModeGetPermissionsReply reply =  {
         .permissions = (XF86VM_READ_PERMISSION |
                         ((VidModeAllowNonLocal || client->local) ?
                             XF86VM_WRITE_PERMISSION : 0)),
     };
 
     if (client->swapped) {
-        swapl(&rep.permissions);
+        swapl(&reply.permissions);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 

--- a/Xext/xcmisc.c
+++ b/Xext/xcmisc.c
@@ -55,16 +55,16 @@ ProcXCMiscGetVersion(ClientPtr client)
         swaps(&stuff->minorVersion);
     }
 
-    xXCMiscGetVersionReply rep = {
+    xXCMiscGetVersionReply reply = {
         .majorVersion = XCMiscMajorVersion,
         .minorVersion = XCMiscMinorVersion
     };
 
     if (client->swapped) {
-        swaps(&rep.majorVersion);
-        swaps(&rep.minorVersion);
+        swaps(&reply.majorVersion);
+        swaps(&reply.minorVersion);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -76,15 +76,15 @@ ProcXCMiscGetXIDRange(ClientPtr client)
     XID min_id, max_id;
     GetXIDRange(client->index, FALSE, &min_id, &max_id);
 
-    xXCMiscGetXIDRangeReply rep = {
+    xXCMiscGetXIDRangeReply reply = {
         .start_id = min_id,
         .count = max_id - min_id + 1
     };
     if (client->swapped) {
-        swapl(&rep.start_id);
-        swapl(&rep.count);
+        swapl(&reply.start_id);
+        swapl(&reply.count);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -115,14 +115,14 @@ ProcXCMiscGetXIDList(ClientPtr client)
     if (rpcbuf.error)
         return BadAlloc;
 
-    xXCMiscGetXIDListReply rep = {
+    xXCMiscGetXIDListReply reply = {
         .count = count
     };
     if (client->swapped) {
-        swapl(&rep.count);
+        swapl(&reply.count);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     return Success;
 }
 

--- a/Xext/xf86bigfont.c
+++ b/Xext/xf86bigfont.c
@@ -527,7 +527,7 @@ ProcXF86BigfontQueryFont(ClientPtr client)
 
     {
         int nfontprops = pFont->info.nprops;
-        xXF86BigfontQueryFontReply rep = {
+        xXF86BigfontQueryFontReply reply = {
             .minBounds = pFont->info.ink_minbounds,
             .maxBounds = pFont->info.ink_maxbounds,
             .minCharOrByte2 = pFont->info.firstCol,
@@ -546,18 +546,18 @@ ProcXF86BigfontQueryFont(ClientPtr client)
         };
 
         if (client->swapped) {
-            swapCharInfo(&rep.minBounds);
-            swapCharInfo(&rep.maxBounds);
-            swaps(&rep.minCharOrByte2);
-            swaps(&rep.maxCharOrByte2);
-            swaps(&rep.defaultChar);
-            swaps(&rep.nFontProps);
-            swaps(&rep.fontAscent);
-            swaps(&rep.fontDescent);
-            swapl(&rep.nCharInfos);
-            swapl(&rep.nUniqCharInfos);
-            swapl(&rep.shmid);
-            swapl(&rep.shmsegoffset);
+            swapCharInfo(&reply.minBounds);
+            swapCharInfo(&reply.maxBounds);
+            swaps(&reply.minCharOrByte2);
+            swaps(&reply.maxCharOrByte2);
+            swaps(&reply.defaultChar);
+            swaps(&reply.nFontProps);
+            swaps(&reply.fontAscent);
+            swaps(&reply.fontDescent);
+            swapl(&reply.nCharInfos);
+            swapl(&reply.nUniqCharInfos);
+            swapl(&reply.shmid);
+            swapl(&reply.shmsegoffset);
         }
 
         int rc = Success;
@@ -580,7 +580,7 @@ ProcXF86BigfontQueryFont(ClientPtr client)
             goto out;
         }
 
-        X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+        X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 out:
         if (nCharInfos > 0) {
             if (shmid == -1)

--- a/Xext/xselinux_ext.c
+++ b/Xext/xselinux_ext.c
@@ -67,15 +67,15 @@ SELinuxCopyContext(char *ptr, unsigned len)
 static int
 ProcSELinuxQueryVersion(ClientPtr client)
 {
-    SELinuxQueryVersionReply rep = {
+    SELinuxQueryVersionReply reply = {
         .server_major = SELINUX_MAJOR_VERSION,
         .server_minor = SELINUX_MINOR_VERSION
     };
     if (client->swapped) {
-        swaps(&rep.server_major);
-        swaps(&rep.server_minor);
+        swaps(&reply.server_major);
+        swaps(&reply.server_minor);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -91,7 +91,7 @@ SELinuxSendContextReply(ClientPtr client, security_id_t sid)
         len = strlen(ctx) + 1;
     }
 
-    SELinuxGetContextReply rep = {
+    SELinuxGetContextReply reply = {
         .type = X_Reply,
         .sequenceNumber = client->sequence,
         .length = bytes_to_int32(len),
@@ -99,12 +99,12 @@ SELinuxSendContextReply(ClientPtr client, security_id_t sid)
     };
 
     if (client->swapped) {
-        swapl(&rep.length);
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.context_len);
+        swapl(&reply.length);
+        swaps(&reply.sequenceNumber);
+        swapl(&reply.context_len);
     }
 
-    WriteToClient(client, sizeof(SELinuxGetContextReply), &rep);
+    WriteToClient(client, sizeof(SELinuxGetContextReply), &reply);
     WriteToClient(client, len, ctx);
     freecon(ctx);
     return Success;
@@ -377,7 +377,7 @@ SELinuxSendItemsToClient(ClientPtr client, SELinuxListItemRec * items,
 
 sendreply: ;
     /* Send reply to client */
-    SELinuxListItemsReply rep = {
+    SELinuxListItemsReply reply = {
         .type = X_Reply,
         .sequenceNumber = client->sequence,
         .length = size,
@@ -385,12 +385,12 @@ sendreply: ;
     };
 
     if (client->swapped) {
-        swapl(&rep.length);
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.count);
+        swapl(&reply.length);
+        swaps(&reply.sequenceNumber);
+        swapl(&reply.count);
     }
 
-    WriteToClient(client, sizeof(SELinuxListItemsReply), &rep);
+    WriteToClient(client, sizeof(SELinuxListItemsReply), &reply);
     WriteToClient(client, size * 4, buf);
 
     /* Free stuff and return */

--- a/Xext/xtest.c
+++ b/Xext/xtest.c
@@ -89,7 +89,7 @@ static int XTestSwapFakeInput(ClientPtr /* client */ ,
 static int
 ProcXTestGetVersion(ClientPtr client)
 {
-    xXTestGetVersionReply rep = {
+    xXTestGetVersionReply reply = {
         .majorVersion = XTestMajorVersion,
         .minorVersion = XTestMinorVersion
     };
@@ -97,9 +97,9 @@ ProcXTestGetVersion(ClientPtr client)
     REQUEST_SIZE_MATCH(xXTestGetVersionReq);
 
     if (client->swapped) {
-        swaps(&rep.minorVersion);
+        swaps(&reply.minorVersion);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -133,11 +133,11 @@ ProcXTestCompareCursor(ClientPtr client)
         }
     }
 
-    xXTestCompareCursorReply rep = {
+    xXTestCompareCursorReply reply = {
         .same = (wCursor(pWin) == pCursor)
     };
 
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 

--- a/Xext/xvdisp.c
+++ b/Xext/xvdisp.c
@@ -61,17 +61,17 @@ ProcXvQueryExtension(ClientPtr client)
     /* REQUEST(xvQueryExtensionReq); */
     REQUEST_SIZE_MATCH(xvQueryExtensionReq);
 
-    xvQueryExtensionReply rep = {
+    xvQueryExtensionReply reply = {
         .version = XvVersion,
         .revision = XvRevision
     };
 
     if (client->swapped) {
-        swaps(&rep.version);
-        swaps(&rep.revision);
+        swaps(&reply.version);
+        swaps(&reply.revision);
     }
 
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -127,15 +127,15 @@ ProcXvQueryAdaptors(ClientPtr client)
         }
     }
 
-    xvQueryAdaptorsReply rep = {
+    xvQueryAdaptorsReply reply = {
         .num_adaptors = numAdaptors,
     };
 
     if (client->swapped) {
-        swaps(&rep.num_adaptors);
+        swaps(&reply.num_adaptors);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     return Success;
 }
 
@@ -169,15 +169,15 @@ ProcXvQueryEncodings(ClientPtr client)
     if (rpcbuf.error)
         return BadAlloc;
 
-    xvQueryEncodingsReply rep = {
+    xvQueryEncodingsReply reply = {
         .num_encodings = pPort->pAdaptor->nEncodings,
     };
 
     if (client->swapped) {
-        swaps(&rep.num_encodings);
+        swaps(&reply.num_encodings);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     return Success;
 }
 
@@ -371,11 +371,11 @@ ProcXvGrabPort(ClientPtr client)
     if (status != Success) {
         return status;
     }
-    xvGrabPortReply rep = {
+    xvGrabPortReply reply = {
         .result = result
     };
 
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -485,15 +485,15 @@ ProcXvGetPortAttribute(ClientPtr client)
         return status;
     }
 
-    xvGetPortAttributeReply rep = {
+    xvGetPortAttributeReply reply = {
         .value = value
     };
 
     if (client->swapped) {
-        swapl(&rep.value);
+        swapl(&reply.value);
     }
 
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -513,17 +513,17 @@ ProcXvQueryBestSize(ClientPtr client)
                                          stuff->drw_w, stuff->drw_h,
                                          &actual_width, &actual_height);
 
-    xvQueryBestSizeReply rep = {
+    xvQueryBestSizeReply reply = {
         .actual_width = actual_width,
         .actual_height = actual_height
     };
 
     if (client->swapped) {
-        swaps(&rep.actual_width);
-        swaps(&rep.actual_height);
+        swaps(&reply.actual_width);
+        swaps(&reply.actual_height);
     }
 
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -555,17 +555,17 @@ ProcXvQueryPortAttributes(ClientPtr client)
     if (rpcbuf.error)
         return BadAlloc;
 
-    xvQueryPortAttributesReply rep = {
+    xvQueryPortAttributesReply reply = {
         .num_attributes = pPort->pAdaptor->nAttributes,
         .text_size = textSize,
     };
 
     if (client->swapped) {
-        swapl(&rep.num_attributes);
-        swapl(&rep.text_size);
+        swapl(&reply.num_attributes);
+        swapl(&reply.text_size);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     return Success;
 }
 
@@ -785,7 +785,7 @@ ProcXvQueryImageAttributes(ClientPtr client)
                                                        &width, &height, offsets,
                                                        pitches);
 
-    xvQueryImageAttributesReply rep = {
+    xvQueryImageAttributesReply reply = {
         .num_planes = num_planes,
         .width = width,
         .height = height,
@@ -793,16 +793,16 @@ ProcXvQueryImageAttributes(ClientPtr client)
     };
 
     if (client->swapped) {
-        swapl(&rep.num_planes);
-        swapl(&rep.data_size);
-        swaps(&rep.width);
-        swaps(&rep.height);
+        swapl(&reply.num_planes);
+        swapl(&reply.data_size);
+        swaps(&reply.width);
+        swaps(&reply.height);
         /* needed here, because ddQueryImageAttributes() directly wrote into
            our rpcbuf area */
         SwapLongs((CARD32 *) offsets, x_rpcbuf_wsize_units(&rpcbuf));
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     return Success;
 }
 
@@ -866,15 +866,15 @@ ProcXvListImageFormats(ClientPtr client)
         LogMessage(X_WARNING, "ProcXvListImageFormats() payload_len mismatch: %ld but shoud be %d\n",
                    rpcbuf.wpos, (pPort->pAdaptor->nImages*sz_xvImageFormatInfo));
 
-    xvListImageFormatsReply rep = {
+    xvListImageFormatsReply reply = {
         .num_formats = pPort->pAdaptor->nImages,
     };
 
     if (client->swapped) {
-        swapl(&rep.num_formats);
+        swapl(&reply.num_formats);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     return Success;
 }
 

--- a/Xext/xvmc.c
+++ b/Xext/xvmc.c
@@ -110,7 +110,7 @@ XvMCDestroySubpictureRes(void *data, XID id)
 static int
 ProcXvMCQueryVersion(ClientPtr client)
 {
-    xvmcQueryVersionReply rep = {
+    xvmcQueryVersionReply reply = {
         .major = SERVER_XVMC_MAJOR_VERSION,
         .minor = SERVER_XVMC_MINOR_VERSION
     };
@@ -118,7 +118,7 @@ ProcXvMCQueryVersion(ClientPtr client)
     /* REQUEST(xvmcQueryVersionReq); */
     REQUEST_SIZE_MATCH(xvmcQueryVersionReq);
 
-    X_SEND_REPLY_SIMPLE(client, rep);
+    X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
 
@@ -167,14 +167,14 @@ ProcXvMCListSurfaceTypes(ClientPtr client)
         }
     }
 
-    xvmcListSurfaceTypesReply rep = {
+    xvmcListSurfaceTypesReply reply = {
         .type = X_Reply,
         .sequenceNumber = client->sequence,
         .num = num_surfaces,
         .length = bytes_to_int32(sizeof(xvmcSurfaceInfo) * num_surfaces),
     };
 
-    WriteToClient(client, sizeof(xvmcListSurfaceTypesReply), &rep);
+    WriteToClient(client, sizeof(xvmcListSurfaceTypesReply), &reply);
     WriteToClient(client, sizeof(xvmcSurfaceInfo) * num_surfaces, info);
     free(info);
 
@@ -257,7 +257,7 @@ ProcXvMCCreateContext(ClientPtr client)
         return BadAlloc;
     }
 
-    xvmcCreateContextReply rep = {
+    xvmcCreateContextReply reply = {
         .type = X_Reply,
         .sequenceNumber = client->sequence,
         .length = dwords,
@@ -266,7 +266,7 @@ ProcXvMCCreateContext(ClientPtr client)
         .flags_return = pContext->flags
     };
 
-    WriteToClient(client, sizeof(xvmcCreateContextReply), &rep);
+    WriteToClient(client, sizeof(xvmcCreateContextReply), &reply);
     if (dwords)
         WriteToClient(client, dwords << 2, data);
 
@@ -335,13 +335,13 @@ ProcXvMCCreateSurface(ClientPtr client)
         return BadAlloc;
     }
 
-    xvmcCreateSurfaceReply rep = {
+    xvmcCreateSurfaceReply reply = {
         .type = X_Reply,
         .sequenceNumber = client->sequence,
         .length = dwords
     };
 
-    WriteToClient(client, sizeof(xvmcCreateSurfaceReply), &rep);
+    WriteToClient(client, sizeof(xvmcCreateSurfaceReply), &reply);
     if (dwords)
         WriteToClient(client, dwords << 2, data);
 
@@ -454,7 +454,7 @@ ProcXvMCCreateSubpicture(ClientPtr client)
         return BadAlloc;
     }
 
-    xvmcCreateSubpictureReply rep = {
+    xvmcCreateSubpictureReply reply = {
         .type = X_Reply,
         .sequenceNumber = client->sequence,
         .length = dwords,
@@ -468,7 +468,7 @@ ProcXvMCCreateSubpicture(ClientPtr client)
         .component_order[3] = pSubpicture->component_order[3]
     };
 
-    WriteToClient(client, sizeof(xvmcCreateSubpictureReply), &rep);
+    WriteToClient(client, sizeof(xvmcCreateSubpictureReply), &reply);
     if (dwords)
         WriteToClient(client, dwords << 2, data);
 
@@ -589,14 +589,14 @@ ProcXvMCListSubpictureTypes(ClientPtr client)
         }
     }
 
-    xvmcListSubpictureTypesReply rep = {
+    xvmcListSubpictureTypesReply reply = {
         .type = X_Reply,
         .sequenceNumber = client->sequence,
         .num = num,
         .length = bytes_to_int32(num * sizeof(xvImageFormatInfo)),
     };
 
-    WriteToClient(client, sizeof(xvmcListSubpictureTypesReply), &rep);
+    WriteToClient(client, sizeof(xvmcListSubpictureTypesReply), &reply);
     WriteToClient(client, sizeof(xvImageFormatInfo) * num, info);
     free(info);
     return Success;
@@ -633,7 +633,7 @@ ProcXvMCGetDRInfo(ClientPtr client)
     memcpy(buf, pScreenPriv->clientDriverName, nameLen);
     memcpy(buf+nameLen, pScreenPriv->busID, busIDLen);
 
-    xvmcGetDRInfoReply rep = {
+    xvmcGetDRInfoReply reply = {
         .type = X_Reply,
         .sequenceNumber = client->sequence,
         .major = pScreenPriv->major,
@@ -657,12 +657,12 @@ ProcXvMCGetDRInfo(ClientPtr client)
         int i;
         CARD32 magic = stuff->magic;
 
-        rep.isLocal = 1;
+        reply.isLocal = 1;
         i = 1024 / sizeof(CARD32);
 
         while (i--) {
             if (*patternC++ != magic) {
-                rep.isLocal = 0;
+                reply.isLocal = 0;
                 break;
             }
             magic = ~magic;
@@ -671,7 +671,7 @@ ProcXvMCGetDRInfo(ClientPtr client)
     }
 #endif                          /* HAS_XVMCSHM */
 
-    WriteToClient(client, sizeof(xvmcGetDRInfoReply), &rep);
+    WriteToClient(client, sizeof(xvmcGetDRInfoReply), &reply);
     WriteToClient(client, buflen, buf);
     free(buf);
     return Success;


### PR DESCRIPTION
Let all reply structs be called `reply`.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
