### PR TITLE
[25.0] Xext: xres: fix XResQueryClientResources request

### DIFF
--- a/Xext/xres.c
+++ b/Xext/xres.c
@@ -304,11 +304,27 @@ ProcXResQueryClientResources(ClientPtr client)
 
     FindAllClientResources(resClient, ResFindAllRes, counts);
 
-    int num_types = 0;
-    for (int i = 0; i <= lastResourceType; i++) {
-        if (counts[i])
-            num_types++;
+    xXResType *scratch = calloc(sizeof(xXResType), lastResourceType + 1);
+    if (!scratch) {
+        free(counts);
+        return BadAlloc;
     }
+
+    int num_types = 0;
+    for (int i = 0; i < num_types; i++) {
+        if (!(counts[i]))
+            continue;
+
+        scratch[num_types].resource_type = resourceTypeAtom(i + 1);
+        scratch[num_types].count = counts[i];
+        if (client->swapped) {
+            swapl(&scratch[num_types].resource_type);
+            swapl(&scratch[num_types].count);
+        }
+        num_types++;
+    }
+
+    free(counts);
 
     xXResQueryClientResourcesReply rep = {
         .type = X_Reply,
@@ -321,24 +337,6 @@ ProcXResQueryClientResources(ClientPtr client)
         swapl(&rep.length);
         swapl(&rep.num_types);
     }
-
-    xXResType *scratch = calloc(sizeof(xXResType), num_types);
-    if (!scratch) {
-        free(counts);
-        return BadAlloc;
-    }
-
-    for (int i = 0; i < num_types; i++) {
-        scratch[i].resource_type = resourceTypeAtom(i + 1);
-        scratch[i].count = counts[i];
-
-        if (client->swapped) {
-            swapl(&scratch[i].resource_type);
-            swapl(&scratch[i].count);
-        }
-    }
-
-    free(counts);
 
     WriteToClient(client, sizeof(xXResQueryClientResourcesReply), &rep);
     WriteToClient(client, num_types * sizeof(xXResType), scratch);


### PR DESCRIPTION
been using the wrong index for retrieving the resource type atom.