### PR TITLE
Xext: disable Xv and XvMC extension by default

### DIFF
--- a/Xext/xv/xvmain.c
+++ b/Xext/xv/xvmain.c
@@ -116,7 +116,7 @@ typedef struct _XvVideoNotifyRec {
 
 static DevPrivateKeyRec XvScreenKeyRec;
 
-Bool noXvExtension = FALSE;
+Bool noXvExtension = TRUE;
 
 static x_server_generation_t XvExtensionGeneration = 0;
 static x_server_generation_t XvScreenGeneration = 0;


### PR DESCRIPTION
Disable the Xv and XvMC extensions by default, but they still can be
enabled explicitly.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>

See discussion:
https://github.com/orgs/X11Libre/discussions/336