### PR TITLE
hw/xfree86/modes: Update Default Mode Selection in xf86Crtc to use highest refresh rate

### DIFF
--- a/hw/xfree86/modes/xf86Crtc.c
+++ b/hw/xfree86/modes/xf86Crtc.c
@@ -1450,12 +1450,25 @@ preferredMode(ScrnInfoPtr pScrn, xf86OutputPtr output)
 {
     const char *preferred_mode = NULL;
 
-    /* Check for a configured preference for a particular mode */
-    preferred_mode = xf86GetOptValString(output->options,
-                                         OPTION_PREFERRED_MODE);
+    /* First: user-configured preferred mode */
+    preferred_mode = xf86GetOptValString(output->options, OPTION_PREFERRED_MODE);
     if (preferred_mode)
         return preferred_mode;
+  
+    /* Try to find a high refresh rate mode greater than or equal to ~75hz  */
+    DisplayModePtr mode = output->probed_modes;
+    while (mode) {
+        /* Some drivers don’t populate VRefresh—manually calculate it */
+        float refresh = 0.0f;
+        if (mode->HTotal > 0 && mode->VTotal > 0)
+            refresh = ((float)mode->Clock * 1000.0f) /
+                      ((float)mode->HTotal * (float)mode->VTotal);
+        if ((int)(refresh + 0.5f) >= 75)
+            return mode->name;
+        mode = mode->next;
+    }
 
+    /* Fallback: use first mode in display list */
     if (pScrn->display->modes && *pScrn->display->modes)
         preferred_mode = *pScrn->display->modes;
 


### PR DESCRIPTION
…sue #122

This change makes the Default Mode Selection set itself to Highest Refresh Rate at and after 75hz or fallback to the default setting in xorg.conf as requested by issue #122

Feel free to simplify or edit the function for further compatibility.

Reposted from #409 into one single commit