### PR TITLE
Xext: add missing implicit padding to vidmode fillModeInfoV2

### DIFF
--- a/Xext/vidmode.c
+++ b/Xext/vidmode.c
@@ -333,6 +333,7 @@ static void fillModeInfoV2(x_rpcbuf_t *rpcbuf, int dotClock,
     x_rpcbuf_write_CARD16(rpcbuf, VidModeGetModeValue(mode, VIDMODE_V_SYNCEND));
     x_rpcbuf_write_CARD16(rpcbuf, VidModeGetModeValue(mode, VIDMODE_V_TOTAL));
     x_rpcbuf_reserve0(rpcbuf, sizeof(CARD16)); /* pad1 */
+    x_rpcbuf_reserve0(rpcbuf, sizeof(CARD16)); /* XXX extra padding not explicitly defined in struct XXX */
     x_rpcbuf_write_CARD32(rpcbuf, VidModeGetModeValue(mode, VIDMODE_FLAGS));
     x_rpcbuf_reserve0(rpcbuf, sizeof(CARD32) * 4); /* reserved[1,2,3], privsize */
 }


### PR DESCRIPTION
Fixes a bug I touched on about at https://github.com/X11Libre/xserver/pull/804#issuecomment-3224071823

struct xXF86VidModeModeInfo is defined as such, with comments added by me:
```
typedef struct {
    CARD32      dotclock;
    CARD16      hdisplay;
    CARD16      hsyncstart;
    CARD16      hsyncend;
    CARD16      htotal;
    CARD32      hskew;
    CARD16      vdisplay; /* 1 */
    CARD16      vsyncstart; /* 2 */
    CARD16      vsyncend; /* 3 */
    CARD16      vtotal; /* 4 */
    CARD16      pad1; /* 5 */
/*  CARD16      implicit, but in memory; */ /* 6 */
    CARD32      flags;
    CARD32      reserved1;
    CARD32      reserved2;
    CARD32      reserved3;
    CARD32      privsize;
} xXF86VidModeModeInfo;
```

No idea why this extra padding was added, which breaks alignment, but it is there, and we have to take it into account.

@metux These kinds of things really shouldn't happen, but it looks like they do. We have to look out for them.