### PR TITLE
include: dix.h: add missing definition of MAXCLIENTS

### DIFF
--- a/include/dix.h
+++ b/include/dix.h
@@ -55,6 +55,12 @@ SOFTWARE.
 #include "events.h"
 #include <X11/extensions/XI.h>
 
+#ifdef HAVE_DIX_CONFIG_H
+#include <dix-config.h>
+#else
+#include <xorg/xorg-server.h>
+#endif
+
 #define EARLIER -1
 #define SAMETIME 0
 #define LATER 1


### PR DESCRIPTION
MAXCLIENTS was moved from misc.h to xorg-server.h so we need to
include xorg-server.h in dix.h where MAXCLIENTS is used.

Fixes: #820
Signed-off-by: callmetango <callmetango@users.noreply.github.com>
