### PR TITLE
Xi: make ListDeviceClasses() static

### DIFF
--- a/Xi/xiquerydevice.c
+++ b/Xi/xiquerydevice.c
@@ -523,6 +523,9 @@ GetDeviceUse(DeviceIntPtr dev, uint16_t * attachment)
     return use;
 }
 
+static int ListDeviceClasses(ClientPtr client, DeviceIntPtr dev, char *any,
+                             uint16_t * nclasses);
+
 /**
  * Write the info for device dev into the buffer pointed to by info.
  *
@@ -556,7 +559,7 @@ ListDeviceInfo(ClientPtr client, DeviceIntPtr dev, xXIDeviceInfo * info)
  * nclasses to the number of classes in total and return the number of bytes
  * written.
  */
-int
+static int
 ListDeviceClasses(ClientPtr client, DeviceIntPtr dev,
                   char *any, uint16_t * nclasses)
 {

--- a/Xi/xiquerydevice.h
+++ b/Xi/xiquerydevice.h
@@ -31,8 +31,6 @@
 int SProcXIQueryDevice(ClientPtr client);
 int ProcXIQueryDevice(ClientPtr client);
 int SizeDeviceClasses(DeviceIntPtr dev);
-int ListDeviceClasses(ClientPtr client, DeviceIntPtr dev,
-                      char *any, uint16_t * nclasses);
 int GetDeviceUse(DeviceIntPtr dev, uint16_t * attachment);
 int ListButtonInfo(DeviceIntPtr dev, xXIButtonInfo * info, Bool reportState);
 int ListKeyInfo(DeviceIntPtr dev, xXIKeyInfo * info);


### PR DESCRIPTION
Only used within the same source file, so can be made static.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
