### PR TITLE
modesetting: Initialize the cursor image with the smallest size supported by all CRTCs.

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -1953,14 +1953,9 @@ ScreenInit(ScreenPtr pScreen, int argc, char **argv)
         PointPriv->spriteFuncs = &drmmode_sprite_funcs;
     }
 
-    /* Get the maximum cursor size. */
-    drmmode_cursor_dim_rec cursor_dim = { 0 };
-    if (!drmmode_get_largest_cursor(pScrn, &cursor_dim))
-        return FALSE;
-
     /* Need to extend HWcursor support to handle mask interleave */
     if (!ms->drmmode.sw_cursor)
-        xf86_cursors_init(pScreen, cursor_dim.width, cursor_dim.height,
+        xf86_cursors_init(pScreen, ms->cursor_image_width, ms->cursor_image_height,
                           HARDWARE_CURSOR_SOURCE_MASK_INTERLEAVE_64 |
                           HARDWARE_CURSOR_UPDATE_UNHIDDEN |
                           HARDWARE_CURSOR_ARGB);

--- a/hw/xfree86/drivers/video/modesetting/driver.h
+++ b/hw/xfree86/drivers/video/modesetting/driver.h
@@ -131,6 +131,9 @@ typedef struct _modesettingRec {
     DamagePtr damage;
     Bool dirty_enabled;
 
+    uint32_t cursor_image_width;
+    uint32_t cursor_image_height;
+
     Bool has_queue_sequence;
     Bool tried_queue_sequence;
 

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -1835,18 +1835,6 @@ drmmode_set_cursor(xf86CrtcPtr crtc, int width, int height)
 
 static void drmmode_hide_cursor(xf86CrtcPtr crtc);
 
-static inline int
-get_maximum_cursor_width(drmmode_cursor_rec cursor)
-{
-    return cursor.dimensions[cursor.num_dimensions - 1].width;
-}
-
-static inline int
-get_maximum_cursor_height(drmmode_cursor_rec cursor)
-{
-    return cursor.dimensions[cursor.num_dimensions - 1].height;
-}
-
 /*
  * The load_cursor_argb_check driver hook.
  *
@@ -1858,27 +1846,39 @@ static Bool
 drmmode_load_cursor_argb_check(xf86CrtcPtr crtc, CARD32 *image)
 {
     drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
+    modesettingPtr ms = modesettingPTR(crtc->scrn);
     CursorPtr cursor = xf86CurrentCursor(crtc->scrn->pScreen);
     drmmode_cursor_rec drmmode_cursor = drmmode_crtc->cursor;
-    int width, height, x, y, i;
+    int width, height, i;
     int max_width, max_height;
     uint32_t *ptr;
 
     /* cursor should be mapped already */
     ptr = (uint32_t *) (drmmode_cursor.bo->ptr);
 
-    /* We need to know what our limit is for HW cursors. */
-    max_width  = get_maximum_cursor_width(drmmode_cursor);
-    max_height = get_maximum_cursor_height(drmmode_cursor);
+    /* We need to know what our limit is for HW cursors.*/
+    max_width  = ms->cursor_image_width;
+    max_height = ms->cursor_image_height;
 
     /* Find the most compatiable size. */
     for (i = 0; i < drmmode_cursor.num_dimensions; i++)
     {
         drmmode_cursor_dim_rec dimensions = drmmode_cursor.dimensions[i];
 
-        if (dimensions.width > cursor->bits->width &&
-            dimensions.height > cursor->bits->height)
+        if (dimensions.width >= cursor->bits->width &&
+            dimensions.height >= cursor->bits->height) {
+                break;
+        }
+
+        if (dimensions.width > max_width ||
+            dimensions.height > max_height) {
+
+            /* If this ever happens, i should not be 0, but check for good measure */
+            if (i > 0) {
+                i--;
+            }
             break;
+        }
     }
 
     /* Get the resolution of the cursor. */
@@ -4572,6 +4572,9 @@ drmmode_uevent_fini(ScrnInfoPtr scrn, drmmode_ptr drmmode)
 #endif
 }
 
+static void
+drmmode_get_smallest_supported_cursor(ScrnInfoPtr pScrn, uint32_t *owidth, uint32_t *oheight);
+
 /* create front and cursor BOs */
 Bool
 drmmode_create_initial_bos(ScrnInfoPtr pScrn, drmmode_ptr drmmode)
@@ -4593,20 +4596,12 @@ drmmode_create_initial_bos(ScrnInfoPtr pScrn, drmmode_ptr drmmode)
 
     bpp = 32;
 
+    drmmode_get_smallest_supported_cursor(pScrn, &ms->cursor_image_width, &ms->cursor_image_height);
+
     for (i = 0; i < xf86_config->num_crtc; i++) {
         xf86CrtcPtr crtc = xf86_config->crtc[i];
         drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
-        drmmode_cursor_rec cursor = drmmode_crtc->cursor;
-        
-        /* If we don't have any dimensions then 
-         * something has gone terribly wrong. */
-        assert(cursor.num_dimensions);
-
-        /* Use the maximum available size. */
-        width  = get_maximum_cursor_width(cursor);
-        height = get_maximum_cursor_height(cursor);
-
-        drmmode_crtc->cursor.bo = dumb_bo_create(drmmode->fd, width, height, bpp);
+        drmmode_crtc->cursor.bo = dumb_bo_create(drmmode->fd, ms->cursor_image_width, ms->cursor_image_height, bpp);
     }
 
     return TRUE;
@@ -4743,37 +4738,30 @@ drmmode_crtc_set_vrr(xf86CrtcPtr crtc, Bool enabled)
         drmmode_crtc->vrr_enabled = enabled;
 }
 
-Bool drmmode_get_largest_cursor(ScrnInfoPtr pScrn, drmmode_cursor_dim_ptr cursor_lim)
+static void
+drmmode_get_smallest_supported_cursor(ScrnInfoPtr pScrn, uint32_t *owidth, uint32_t *oheight)
 {
     xf86CrtcConfigPtr xf86_config = XF86_CRTC_CONFIG_PTR(pScrn);
-    int max_width = 0, max_height = 0, i;
 
-    if (!cursor_lim)
-        return FALSE;
+    drmmode_cursor_dim_rec max_size = {.width = 0, .height = 0};
 
-    for (i = 0; i < xf86_config->num_crtc; i++) {
+    for (int i = 0; i < xf86_config->num_crtc; i++) {
         xf86CrtcPtr crtc = xf86_config->crtc[i];
         drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
         drmmode_cursor_rec cursor = drmmode_crtc->cursor;
 
-        /* Get the largest cursor available. */
-        drmmode_cursor_dim_rec largest = cursor.dimensions[cursor.num_dimensions - 1];
-
-        int width  = largest.width;
-        int height = largest.height;
+        /* Get the smallest cursor available. */
+        int width  = cursor.dimensions[0].width;
+        int height = cursor.dimensions[0].height;
 
         /* Future work:
          * - We should only let sizes that all CRTCs support. */
-        if (width > max_width && height > max_height)
-        {
-            max_width  = width;
-            max_height = height;
-        }
+        max_size.width = (width > max_size.width) ? width : max_size.width;
+        max_size.height = (height > max_size.height) ? height : max_size.height;
     }
 
-    cursor_lim->width  = max_width;
-    cursor_lim->height = max_height;
-    return TRUE;
+    *owidth = max_size.width;
+    *oheight = max_size.height;
 }
 
 /*

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.h
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.h
@@ -355,7 +355,4 @@ Bool drmmode_crtc_get_fb_id(xf86CrtcPtr crtc, uint32_t *fb_id, int *x, int *y);
 
 void drmmode_set_dpms(ScrnInfoPtr scrn, int PowerManagementMode, int flags);
 void drmmode_crtc_set_vrr(xf86CrtcPtr crtc, Bool enabled);
-
-Bool drmmode_get_largest_cursor(ScrnInfoPtr pScrn, drmmode_cursor_dim_ptr cursor_lim);
-
 #endif


### PR DESCRIPTION
Part of https://github.com/X11Libre/xserver/pull/734