### PR TITLE
Use smaller cursor sizes

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -2001,17 +2001,12 @@ ScreenInit(ScreenPtr pScreen, int argc, char **argv)
         PointPriv->spriteFuncs = &drmmode_sprite_funcs;
     }
 
-    /* Get the maximum cursor size. */
-    drmmode_cursor_dim_rec cursor_dim = { 0 };
-    if (!drmmode_get_largest_cursor(pScrn, &cursor_dim))
-        return FALSE;
-
     /* Need to extend HWcursor support to handle mask interleave */
     if (!ms->drmmode.sw_cursor) {
         /* XXX Is there any spec that says we should interleave the cursor bits? XXX */
         int interleave = modesetting_get_cursor_interleave(pScrn->scrnIndex);
 
-        xf86_cursors_init(pScreen, cursor_dim.width, cursor_dim.height,
+        xf86_cursors_init(pScreen, ms->cursor_image_width, ms->cursor_image_height,
                           interleave |
                           HARDWARE_CURSOR_UPDATE_UNHIDDEN |
                           HARDWARE_CURSOR_ARGB);

--- a/hw/xfree86/drivers/video/modesetting/driver.h
+++ b/hw/xfree86/drivers/video/modesetting/driver.h
@@ -131,6 +131,9 @@ typedef struct _modesettingRec {
     DamagePtr damage;
     Bool dirty_enabled;
 
+    uint32_t cursor_image_width;
+    uint32_t cursor_image_height;
+
     Bool has_queue_sequence;
     Bool tried_queue_sequence;
 

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.h
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.h
@@ -235,7 +235,8 @@ typedef struct {
 
     uint64_t next_msc;
 
-    int cursor_width, cursor_height;
+    int cursor_width;
+    int cursor_height;
 
     Bool need_modeset;
     struct xorg_list mode_list;
@@ -359,7 +360,4 @@ Bool drmmode_crtc_get_fb_id(xf86CrtcPtr crtc, uint32_t *fb_id, int *x, int *y);
 
 void drmmode_set_dpms(ScrnInfoPtr scrn, int PowerManagementMode, int flags);
 void drmmode_crtc_set_vrr(xf86CrtcPtr crtc, Bool enabled);
-
-Bool drmmode_get_largest_cursor(ScrnInfoPtr pScrn, drmmode_cursor_dim_ptr cursor_lim);
-
 #endif


### PR DESCRIPTION
Split from https://github.com/X11Libre/xserver/pull/734

Still incomplete, as on most hw this just uses the largest cursor available, and coloring the cursor buffer is really inefficient, but I have to pick somewhere to split the above pr.

Part-of: #549
Part-of: #675