### PR TITLE
os: xdmcp: make dependency conditional

### DIFF
--- a/os/xdmcp.h
+++ b/os/xdmcp.h
@@ -1,6 +1,7 @@
 #ifndef _XSERVER_OS_XDMCP_H
 #define _XSERVER_OS_XDMCP_H
 
+#ifdef XDMCP
 #include <X11/Xdmcp.h>
 
 #include "osdep.h"
@@ -30,5 +31,6 @@ void XdmcpRegisterAuthentication(const char *name,
 
 struct sockaddr_in;
 void XdmcpRegisterBroadcastAddress(const struct sockaddr_in *addr);
+#endif
 
 #endif /* _XSERVER_OS_XDMCP_H */


### PR DESCRIPTION
Only depend on xdmcp when building w/o -Dxdmcp=false

Fixes: #239
Signed-off-by: callmetango <callmetango@users.noreply.github.com>
