### PR TITLE
include: os.h: fix extra ;

### DIFF
--- a/include/os.h
+++ b/include/os.h
@@ -141,7 +141,7 @@ extern _X_EXPORT void GiveUp(int /*sig */ );
  * enough memory.
  */
 extern _X_EXPORT void *
-XNFalloc(unsigned long /*amount */ ) __attribute__((returns_nonnull));;
+XNFalloc(unsigned long /*amount */ ) __attribute__((returns_nonnull));
 
 /*
  * This function calloc(3)s buffer, terminating the server if there is not
@@ -155,7 +155,7 @@ XNFcalloc(unsigned long /*amount */ ) _X_DEPRECATED;
  * enough memory or the arguments overflow when multiplied
  */
 extern _X_EXPORT void *
-XNFcallocarray(size_t nmemb, size_t size) __attribute__((returns_nonnull));;
+XNFcallocarray(size_t nmemb, size_t size) __attribute__((returns_nonnull));
 
 /*
  * This function realloc(3)s passed buffer, terminating the server if there is


### PR DESCRIPTION
Fix pedantic warnings:

> ../include/os.h:144:71: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
>   144 | XNFalloc(unsigned long /*amount */ ) __attribute__((returns_nonnull));;

> ../include/os.h:158:76: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
>   158 | XNFcallocarray(size_t nmemb, size_t size) __attribute__((returns_nonnull));;

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
