### PR TITLE
treewide: clean up static zero initialization

### DIFF
--- a/config/udev.c
+++ b/config/udev.c
@@ -104,7 +104,7 @@ device_added(struct udev_device *udev_device)
     const char *subsys = NULL;
 #endif
     InputOption *input_options;
-    InputAttributes attrs = { };
+    InputAttributes attrs = { 0 };
     DeviceIntPtr dev = NULL;
     struct udev_list_entry *set, *entry;
     struct udev_device *parent;

--- a/glx/vndcmds.c
+++ b/glx/vndcmds.c
@@ -47,7 +47,7 @@ typedef struct GlxVendorPrivDispatchRec {
     HashTable hh;
 } GlxVendorPrivDispatch;
 
-static GlxServerDispatchProc dispatchFuncs[OPCODE_ARRAY_LEN] = {};
+static GlxServerDispatchProc dispatchFuncs[OPCODE_ARRAY_LEN] = { 0 };
 static HashTable vendorPrivHash = NULL;
 static HtGenericHashSetupRec vendorPrivSetup = {
     .keySize = sizeof(CARD32)
@@ -192,7 +192,7 @@ static int CommonMakeCurrent(ClientPtr client,
         GLXDrawable readdrawable,
         GLXContextID context)
 {
-    xGLXMakeCurrentReply reply = {};
+    xGLXMakeCurrentReply reply = { 0 };
     GlxContextTagInfo *oldTag = NULL;
     GlxServerVendor *newVendor = NULL;
 

--- a/test/input.c
+++ b/test/input.c
@@ -239,7 +239,7 @@ dix_check_grab_values(void)
 static void
 dix_event_to_core(int type)
 {
-    DeviceEvent ev = {};
+    DeviceEvent ev = { 0 };
     xEvent *core;
     int time;
     int x, y;


### PR DESCRIPTION
Do it the ISO C way.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
