### PR TITLE
treewide: explicitly cast %p printf parameters to void*

### DIFF
--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -1993,7 +1993,7 @@ _init_fs_handlers(FontPathElementPtr fpe, FontBlockHandlerProcPtr block_handler)
     }
     if (fs_handlers_installed == 0) {
         if (!RegisterBlockAndWakeupHandlers(fs_block_handler,
-                                            FontWakeup, (void *) block_handler))
+                                            FontWakeup, block_handler))
             return AllocError;
         xorg_list_init(&fs_fd_list);
         fs_handlers_installed++;

--- a/hw/xfree86/dri/dri.c
+++ b/hw/xfree86/dri/dri.c
@@ -471,7 +471,7 @@ DRIScreenInit(ScreenPtr pScreen, DRIInfoPtr pDRIInfo, int *pDRMFD)
             return FALSE;
         }
         DRIDrvMsg(pScreen->myNum, X_INFO, "[drm] mapped SAREA %p to %p\n",
-                  (void *) (uintptr_t) pDRIPriv->hSAREA, pDRIPriv->pSAREA);
+                  (void *) (uintptr_t) pDRIPriv->hSAREA, (void*)pDRIPriv->pSAREA);
         memset(pDRIPriv->pSAREA, 0, pDRIPriv->pDriverInfo->SAREASize);
     }
     else {
@@ -772,13 +772,16 @@ DRICloseScreen(ScreenPtr pScreen)
         if (closeMaster || pDRIPriv->hSAREA != pDRIEntPriv->hLSAREA) {
             DRIDrvMsg(pScreen->myNum, X_INFO,
                       "[drm] unmapping %d bytes of SAREA %p at %p\n",
-                      (int) pDRIInfo->SAREASize, (void *) (uintptr_t) pDRIPriv->hSAREA, pDRIPriv->pSAREA);
+                      (int) pDRIInfo->SAREASize,
+                      (void*) (uintptr_t) pDRIPriv->hSAREA,
+                      (void*) pDRIPriv->pSAREA);
             if (drmUnmap(pDRIPriv->pSAREA, pDRIInfo->SAREASize)) {
                 DRIDrvMsg(pScreen->myNum, X_ERROR,
                           "[drm] unable to unmap %d bytes"
                           " of SAREA %p at %p\n",
                           (int) pDRIInfo->SAREASize,
-                          (void *) (uintptr_t) pDRIPriv->hSAREA, pDRIPriv->pSAREA);
+                          (void*) (uintptr_t) pDRIPriv->hSAREA,
+                          (void*) pDRIPriv->pSAREA);
             }
         }
         else {
@@ -2240,7 +2243,8 @@ DRILock(ScreenPtr pScreen, int flags)
                   "[DRI] Locking deadlock.\n"
                   "\tAlready locked with context %p,\n"
                   "\ttrying to lock with context %p.\n",
-                  pDRIPriv->pLockingContext, (void *) (uintptr_t) pDRIPriv->myContext);
+                  (void*) pDRIPriv->pLockingContext,
+                  (void*) (uintptr_t) pDRIPriv->myContext);
     }
     (*pDRIPriv->pLockRefCount)++;
 }
@@ -2258,7 +2262,8 @@ DRIUnlock(ScreenPtr pScreen)
             DRIDrvMsg(pScreen->myNum, X_ERROR,
                       "[DRI] Unlocking inconsistency:\n"
                       "\tContext %p trying to unlock lock held by context %p\n",
-                      pDRIPriv->pLockingContext, (void *) (uintptr_t) pDRIPriv->myContext);
+                      (void*) pDRIPriv->pLockingContext,
+                      (void*) (uintptr_t) pDRIPriv->myContext);
         }
         (*pDRIPriv->pLockRefCount)--;
     }
@@ -2347,7 +2352,8 @@ DRIAdjustFrame(ScrnInfoPtr pScrn, int x, int y)
 
     if (!pDRIPriv || !pDRIPriv->pSAREA) {
         DRIDrvMsg(pScrn->scrnIndex, X_ERROR, "[DRI] No SAREA (%p %p)\n",
-                  pDRIPriv, pDRIPriv ? pDRIPriv->pSAREA : NULL);
+                  (void*)pDRIPriv,
+                  pDRIPriv ? (void*)pDRIPriv->pSAREA : NULL);
         return;
     }
 

--- a/mi/mieq.c
+++ b/mi/mieq.c
@@ -300,7 +300,10 @@ mieqSetHandler(int event, mieqHandler handler)
 {
     if (handler && miEventQueue.handlers[event] != handler)
         ErrorF("[mi] mieq: warning: overriding existing handler %p with %p for "
-               "event %d\n", miEventQueue.handlers[event], handler, event);
+               "event %d\n",
+               (void*) miEventQueue.handlers[event],
+               (void*) handler,
+               event);
 
     miEventQueue.handlers[event] = handler;
 }


### PR DESCRIPTION
Do it the ISO C way, so -pendantic is shouting a little bit less.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
