### PR TITLE
os: xtrans: silence printf format warning on prmsg() call

### DIFF
--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -1340,7 +1340,7 @@ static int _XSERVTransSocketRead (
 static ssize_t _XSERVTransSocketWrite (
     XtransConnInfo ciptr, const char *buf, size_t size)
 {
-    prmsg (2,"SocketWrite(%d,%p,%ld)\n", ciptr->fd, (void *) buf, (unsigned long)size);
+    prmsg (2,"SocketWrite(%d,%p,%lu)\n", ciptr->fd, (void *) buf, (unsigned long)size);
 
 #if XTRANS_SEND_FDS
     if (ciptr->send_fds)


### PR DESCRIPTION
size_t is unsigned, but might have different sizes depending on CPU arch,
so casting it to unsigned long, so we can safely use %ld.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
