### PR TITLE
xfixes: use X_SEND_REPLY_SIMPLE() for simple replies

### DIFF
--- a/xfixes/disconnect.c
+++ b/xfixes/disconnect.c
@@ -91,19 +91,15 @@ ProcXFixesGetClientDisconnectMode(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xXFixesGetClientDisconnectModeReq);
 
-    xXFixesGetClientDisconnectModeReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0,
+    xXFixesGetClientDisconnectModeReply reply = {
         .disconnect_mode = pDisconnect->disconnect_mode,
     };
-    if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.disconnect_mode);
-    }
-    WriteToClient(client, sizeof(rep), &rep);
 
-    return Success;
+    if (client->swapped) {
+        swapl(&reply.disconnect_mode);
+    }
+
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 Bool

--- a/xfixes/xfixes.c
+++ b/xfixes/xfixes.c
@@ -44,6 +44,7 @@
 
 #include <dix-config.h>
 
+#include "dix/dix_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/fmt.h"
 
@@ -65,11 +66,6 @@ ProcXFixesQueryVersion(ClientPtr client)
 {
     int major, minor;
     XFixesClientPtr pXFixesClient = GetXFixesClient(client);
-    xXFixesQueryVersionReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0
-    };
 
     REQUEST(xXFixesQueryVersionReq);
 
@@ -87,16 +83,18 @@ ProcXFixesQueryVersion(ClientPtr client)
     }
 
     pXFixesClient->major_version = major;
-    rep.majorVersion = min(stuff->majorVersion, major);
-    rep.minorVersion = minor;
+
+    xXFixesQueryVersionReply reply = {
+        .majorVersion = min(stuff->majorVersion, major),
+        .minorVersion = minor
+    };
+
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
-        swapl(&rep.majorVersion);
-        swapl(&rep.minorVersion);
+        swapl(&reply.majorVersion);
+        swapl(&reply.minorVersion);
     }
-    WriteToClient(client, sizeof(xXFixesQueryVersionReply), &rep);
-    return Success;
+
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 /* Major version controls available requests */


### PR DESCRIPTION
Use the X_SEND_REPLY_SIMPLE() macro for sending out simple replies.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
