### PR TITLE
dix: drop obsolete Swap32Write()

### DIFF
--- a/dix/swaprep.c
+++ b/dix/swaprep.c
@@ -60,24 +60,6 @@ static void SwapFontInfo(xQueryFontReply * pr);
 static void SwapCharInfo(xCharInfo * pInfo);
 
 /**
- * Thanks to Jack Palevich for testing and subsequently rewriting all this
- *
- *  \param size size in bytes
- */
-void _X_COLD
-Swap32Write(ClientPtr pClient, int size, CARD32 *pbuf)
-{
-    size >>= 2;
-    for (int i = 0; i < size; i++)
-        /* brackets are mandatory here, because "swapl" macro expands
-           to several statements */
-    {
-        swapl(&pbuf[i]);
-    }
-    WriteToClient(pClient, size << 2, pbuf);
-}
-
-/**
  *
  * \param size size in bytes
  */

--- a/include/swaprep.h
+++ b/include/swaprep.h
@@ -28,10 +28,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 void SwapFont(xQueryFontReply * pr, Bool hasGlyphs);
 
-extern void Swap32Write(ClientPtr /* pClient */ ,
-                        int /* size */ ,
-                        CARD32 * /* pbuf */ );
-
 extern void CopySwap32Write(ClientPtr /* pClient */ ,
                             int /* size */ ,
                             CARD32 * /* pbuf */ );


### PR DESCRIPTION
Not used anywhere, neither exported.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
