### PR TITLE
treewide: drop unnecessary pixmap field initialization

### DIFF
--- a/fb/fbpixmap.c
+++ b/fb/fbpixmap.c
@@ -57,14 +57,10 @@ fbCreatePixmap(ScreenPtr pScreen, int width, int height, int depth,
     if (!pPixmap)
         return NullPixmap;
     pPixmap->drawable.type = DRAWABLE_PIXMAP;
-    pPixmap->drawable.class = 0;
     pPixmap->drawable.pScreen = pScreen;
     pPixmap->drawable.depth = depth;
     pPixmap->drawable.bitsPerPixel = bpp;
-    pPixmap->drawable.id = 0;
     pPixmap->drawable.serialNumber = NEXT_SERIAL_NUMBER;
-    pPixmap->drawable.x = 0;
-    pPixmap->drawable.y = 0;
     pPixmap->drawable.width = width;
     pPixmap->drawable.height = height;
     pPixmap->devKind = paddedWidth;
@@ -77,9 +73,6 @@ fbCreatePixmap(ScreenPtr pScreen, int width, int height, int depth,
         (void *) ((char *) pPixmap->devPrivate.ptr + paddedWidth);
     fbInitializeDrawable(&pPixmap->drawable);
 #endif
-
-    pPixmap->screen_x = 0;
-    pPixmap->screen_y = 0;
 
     pPixmap->usage_hint = usage_hint;
 

--- a/hw/xnest/Pixmap.c
+++ b/hw/xnest/Pixmap.c
@@ -43,12 +43,8 @@ xnestCreatePixmap(ScreenPtr pScreen, int width, int height, int depth,
     if (!pPixmap)
         return NullPixmap;
     pPixmap->drawable.type = DRAWABLE_PIXMAP;
-    pPixmap->drawable.class = 0;
     pPixmap->drawable.depth = depth;
     pPixmap->drawable.bitsPerPixel = depth;
-    pPixmap->drawable.id = 0;
-    pPixmap->drawable.x = 0;
-    pPixmap->drawable.y = 0;
     pPixmap->drawable.width = width;
     pPixmap->drawable.height = height;
     pPixmap->drawable.pScreen = pScreen;

--- a/hw/xwin/winmultiwindowwindow.c
+++ b/hw/xwin/winmultiwindowwindow.c
@@ -962,22 +962,16 @@ winCreatePixmapMultiwindow(ScreenPtr pScreen, int width, int height, int depth,
 
     /* setup Pixmap header */
     pPixmap->drawable.type = DRAWABLE_PIXMAP;
-    pPixmap->drawable.class = 0;
     pPixmap->drawable.pScreen = pScreen;
     pPixmap->drawable.depth = depth;
     pPixmap->drawable.bitsPerPixel = bpp;
-    pPixmap->drawable.id = 0;
     pPixmap->drawable.serialNumber = NEXT_SERIAL_NUMBER;
-    pPixmap->drawable.x = 0;
-    pPixmap->drawable.y = 0;
     pPixmap->drawable.width = width;
     pPixmap->drawable.height = height;
     pPixmap->devKind = paddedwidth;
     pPixmap->refcnt = 1;
     pPixmap->devPrivate.ptr = NULL; // later set to pbBits
     pPixmap->primary_pixmap = NULL;
-    pPixmap->screen_x = 0;
-    pPixmap->screen_y = 0;
     pPixmap->usage_hint = usage_hint;
 
     /* Check for zero width or height pixmaps */


### PR DESCRIPTION
The PixmapRec is already calloc()'ed, so no need for additional zero-writes
into individual fields. This also removes some unncessary #ifdefs.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
