### PR TITLE
dbe: locally scope variables and declare when needed

### DIFF
--- a/dbe/dbe.c
+++ b/dbe/dbe.c
@@ -152,21 +152,11 @@ static int
 ProcDbeAllocateBackBufferName(ClientPtr client)
 {
     REQUEST(xDbeAllocateBackBufferNameReq);
-    WindowPtr pWin;
-    DbeScreenPrivPtr pDbeScreenPriv;
-    DbeWindowPrivPtr pDbeWindowPriv;
-    XdbeScreenVisualInfo scrVisInfo;
-    register int i;
-    Bool visualMatched = FALSE;
-    xDbeSwapAction swapAction;
-    VisualID visual;
-    int status;
-    int add_index;
-
     REQUEST_SIZE_MATCH(xDbeAllocateBackBufferNameReq);
 
     /* The window must be valid. */
-    status = dixLookupWindow(&pWin, stuff->window, client, DixManageAccess);
+    WindowPtr pWin;
+    int status = dixLookupWindow(&pWin, stuff->window, client, DixManageAccess);
     if (status != Success)
         return status;
 
@@ -176,7 +166,7 @@ ProcDbeAllocateBackBufferName(ClientPtr client)
     }
 
     /* The swap action must be valid. */
-    swapAction = stuff->swapAction;     /* use local var for performance. */
+    xDbeSwapAction swapAction = stuff->swapAction; /* use local var for performance. */
     if ((swapAction != XdbeUndefined) &&
         (swapAction != XdbeBackground) &&
         (swapAction != XdbeUntouched) && (swapAction != XdbeCopied)) {
@@ -189,18 +179,20 @@ ProcDbeAllocateBackBufferName(ClientPtr client)
     /* The visual of the window must be in the list returned by
      * GetVisualInfo.
      */
-    pDbeScreenPriv = DBE_SCREEN_PRIV_FROM_WINDOW(pWin);
+    DbeScreenPrivPtr pDbeScreenPriv = DBE_SCREEN_PRIV_FROM_WINDOW(pWin);
     if (!pDbeScreenPriv->GetVisualInfo)
         return BadMatch;        /* screen doesn't support double buffering */
 
+    XdbeScreenVisualInfo scrVisInfo;
     if (!(*pDbeScreenPriv->GetVisualInfo) (pWin->drawable.pScreen, &scrVisInfo)) {
         /* GetVisualInfo() failed to allocate visual info data. */
         return BadAlloc;
     }
 
     /* See if the window's visual is on the list. */
-    visual = wVisual(pWin);
-    for (i = 0; (i < scrVisInfo.count) && !visualMatched; i++) {
+    VisualID visual = wVisual(pWin);
+    Bool visualMatched = FALSE;
+    for (int i = 0; (i < scrVisInfo.count) && !visualMatched; i++) {
         if (scrVisInfo.visinfo[i].visual == visual) {
             visualMatched = TRUE;
         }
@@ -213,7 +205,10 @@ ProcDbeAllocateBackBufferName(ClientPtr client)
         return BadMatch;
     }
 
-    if ((pDbeWindowPriv = DBE_WINDOW_PRIV(pWin)) == NULL) {
+    int add_index = 0;
+
+    DbeWindowPrivPtr pDbeWindowPriv = DBE_WINDOW_PRIV(pWin);
+    if (!pDbeWindowPriv) {
         /* There is no buffer associated with the window.
          * Allocate a window priv.
          */
@@ -237,10 +232,8 @@ ProcDbeAllocateBackBufferName(ClientPtr client)
         pDbeWindowPriv->maxAvailableIDs = DBE_INIT_MAX_IDS;
         pDbeWindowPriv->IDs[0] = stuff->buffer;
 
-        add_index = 0;
-        for (i = 0; i < DBE_INIT_MAX_IDS; i++) {
+        for (int i = 0; i < DBE_INIT_MAX_IDS; i++)
             pDbeWindowPriv->IDs[i] = DBE_FREE_ID_ELEMENT;
-        }
 
         /* Actually connect the window priv to the window. */
         dixSetPrivate(&pWin->devPrivates, dbeWindowPrivKey, pDbeWindowPriv);
@@ -248,6 +241,7 @@ ProcDbeAllocateBackBufferName(ClientPtr client)
     }                           /* if -- There is no buffer associated with the window. */
 
     else {
+        int i=0;
         /* A buffer is already associated with the window.
          * Add the new buffer ID to the array, reallocating the array memory
          * if necessary.
@@ -365,18 +359,17 @@ ProcDbeDeallocateBackBufferName(ClientPtr client)
 {
     REQUEST(xDbeDeallocateBackBufferNameReq);
     DbeWindowPrivPtr pDbeWindowPriv;
-    int rc, i;
-    void *val;
 
     REQUEST_SIZE_MATCH(xDbeDeallocateBackBufferNameReq);
 
     /* Buffer name must be valid */
-    rc = dixLookupResourceByType((void **) &pDbeWindowPriv, stuff->buffer,
+    int rc = dixLookupResourceByType((void **) &pDbeWindowPriv, stuff->buffer,
                                  dbeWindowPrivResType, client,
                                  DixDestroyAccess);
     if (rc != Success)
         return rc;
 
+    void *val;
     rc = dixLookupResourceByType(&val, stuff->buffer, dbeDrawableResType,
                                  client, DixDestroyAccess);
     if (rc != Success)
@@ -387,6 +380,7 @@ ProcDbeDeallocateBackBufferName(ClientPtr client)
      * above.
      */
 
+    int i = 0;
     for (i = 0; i < pDbeWindowPriv->nBufferIDs; i++) {
         /* Loop through the ID list to find the ID. */
         if (pDbeWindowPriv->IDs[i] == stuff->buffer) {
@@ -433,17 +427,10 @@ static int
 ProcDbeSwapBuffers(ClientPtr client)
 {
     REQUEST(xDbeSwapBuffersReq);
-    WindowPtr pWin;
-    DbeScreenPrivPtr pDbeScreenPriv;
-    DbeSwapInfoPtr swapInfo;
-    xDbeSwapInfo *dbeSwapInfo;
-    int error;
-    unsigned int i, j;
-    unsigned int nStuff;
-    int nStuff_i;       /* DDX API requires int for nStuff */
+    int error = Success;
 
     REQUEST_AT_LEAST_SIZE(xDbeSwapBuffersReq);
-    nStuff = stuff->n;          /* use local variable for performance. */
+    unsigned int nStuff = stuff->n; /* use local variable for performance. */
 
     if (nStuff == 0) {
         REQUEST_SIZE_MATCH(xDbeSwapBuffersReq);
@@ -455,15 +442,16 @@ ProcDbeSwapBuffers(ClientPtr client)
     REQUEST_FIXED_SIZE(xDbeSwapBuffersReq, nStuff * sizeof(xDbeSwapInfo));
 
     /* Get to the swap info appended to the end of the request. */
-    dbeSwapInfo = (xDbeSwapInfo *) &stuff[1];
+    xDbeSwapInfo* dbeSwapInfo = (xDbeSwapInfo *) &stuff[1];
 
     /* Allocate array to record swap information. */
-    swapInfo = calloc(nStuff, sizeof(DbeSwapInfoRec));
+    DbeSwapInfoPtr swapInfo = calloc(nStuff, sizeof(DbeSwapInfoRec));
     if (swapInfo == NULL) {
         return BadAlloc;
     }
 
-    for (i = 0; i < nStuff; i++) {
+    for (int i = 0; i < nStuff; i++) {
+        WindowPtr pWin;
         /* Check all windows to swap. */
 
         /* Each window must be a valid window - BadWindow. */
@@ -481,7 +469,7 @@ ProcDbeSwapBuffers(ClientPtr client)
         }
 
         /* Each window must only be specified once - BadMatch. */
-        for (j = i + 1; j < nStuff; j++) {
+        for (int j = i + 1; j < nStuff; j++) {
             if (dbeSwapInfo[i].window == dbeSwapInfo[j].window) {
                 free(swapInfo);
                 return BadMatch;
@@ -516,9 +504,9 @@ ProcDbeSwapBuffers(ClientPtr client)
      * could deal with cross-screen synchronization.
      */
 
-    nStuff_i = nStuff;
+    int nStuff_i = nStuff;
     while (nStuff_i > 0) {
-        pDbeScreenPriv = DBE_SCREEN_PRIV_FROM_WINDOW(swapInfo[0].pWindow);
+        DbeScreenPrivPtr pDbeScreenPriv = DBE_SCREEN_PRIV_FROM_WINDOW(swapInfo[0].pWindow);
         error = (*pDbeScreenPriv->SwapBuffers) (client, &nStuff_i, swapInfo);
         if (error != Success) {
             free(swapInfo);
@@ -555,7 +543,7 @@ ProcDbeGetVisualInfo(ClientPtr client)
     DbeScreenPrivPtr pDbeScreenPriv;
     Drawable *drawables;
     DrawablePtr *pDrawables = NULL;
-    register int i, rc;
+    register int rc;
     register int count;         /* number of visual infos in reply */
 
     REQUEST_AT_LEAST_SIZE(xDbeGetVisualInfoReq);
@@ -573,7 +561,7 @@ ProcDbeGetVisualInfo(ClientPtr client)
 
         drawables = (Drawable *) &stuff[1];
 
-        for (i = 0; i < stuff->n; i++) {
+        for (int i = 0; i < stuff->n; i++) {
             rc = dixLookupDrawable(pDrawables + i, drawables[i], client, 0,
                                    DixGetAttrAccess);
             if (rc != Success) {
@@ -587,7 +575,7 @@ ProcDbeGetVisualInfo(ClientPtr client)
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
-    for (i = 0; i < count; i++) {
+    for (int i = 0; i < count; i++) {
         ScreenPtr pScreen = (stuff->n == 0) ? screenInfo.screens[i] :
             pDrawables[i]->pScreen;
         pDbeScreenPriv = DBE_SCREEN_PRIV(pScreen);
@@ -833,7 +821,6 @@ static int _X_COLD
 SProcDbeSwapBuffers(ClientPtr client)
 {
     REQUEST(xDbeSwapBuffersReq);
-    unsigned int i;
     xDbeSwapInfo *pSwapInfo;
 
     REQUEST_AT_LEAST_SIZE(xDbeSwapBuffersReq);
@@ -850,7 +837,7 @@ SProcDbeSwapBuffers(ClientPtr client)
          * followed by a 1 byte swap action and then 3 pad bytes.  We only need
          * to swap the window information.
          */
-        for (i = 0; i < stuff->n; i++, pSwapInfo++) {
+        for (int i = 0; i < stuff->n; i++, pSwapInfo++) {
             swapl(&pSwapInfo->window);
         }
     }
@@ -1161,10 +1148,9 @@ static void miDbeWindowDestroy(CallbackListPtr *pcbl, ScreenPtr pScreen, WindowP
 static void
 DbeResetProc(ExtensionEntry * extEntry)
 {
-    int i;
     DbeScreenPrivPtr pDbeScreenPriv;
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
+    for (int i = 0; i < screenInfo.numScreens; i++) {
         ScreenPtr walkScreen = screenInfo.screens[i];
         pDbeScreenPriv = DBE_SCREEN_PRIV(walkScreen);
 
@@ -1216,7 +1202,6 @@ void
 DbeExtensionInit(void)
 {
     ExtensionEntry *extEntry;
-    register int i, j;
     DbeScreenPrivPtr pDbeScreenPriv;
     int nStubbedScreens = 0;
     Bool ddxInitSuccess;
@@ -1244,7 +1229,7 @@ DbeExtensionInit(void)
     if (!dixRegisterPrivateKey(&dbeWindowPrivKeyRec, PRIVATE_WINDOW, 0))
         return;
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
+    for (int i = 0; i < screenInfo.numScreens; i++) {
         /* For each screen, set up DBE screen privates and init DIX and DDX
          * interface.
          */
@@ -1256,7 +1241,7 @@ DbeExtensionInit(void)
              * then free any privates that we already alloc'ed and return
              */
 
-            for (j = 0; j < i; j++) {
+            for (int j = 0; j < i; j++) {
                 walkScreen = screenInfo.screens[j];
                 free(dixLookupPrivate(&walkScreen->devPrivates,
                                       dbeScreenPrivKey));
@@ -1304,7 +1289,7 @@ DbeExtensionInit(void)
     if (nStubbedScreens == screenInfo.numScreens) {
         /* All screens stubbed.  Clean up and return. */
 
-        for (i = 0; i < screenInfo.numScreens; i++) {
+        for (int i = 0; i < screenInfo.numScreens; i++) {
             ScreenPtr walkScreen = screenInfo.screens[i];
             free(dixLookupPrivate(&walkScreen->devPrivates, dbeScreenPrivKey));
             dixSetPrivate(&walkScreen->devPrivates, dbeScreenPrivKey, NULL);


### PR DESCRIPTION
Use locally scoped variables where possible, and declare variables
where they're needed - instead of all on the top of functions.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
