### PR TITLE
Xi: inline SProcXGetDeviceControl()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -465,7 +465,7 @@ SProcIDispatch(ClientPtr client)
         case X_SetDeviceValuators:
             return ProcXSetDeviceValuators(client);
         case X_GetDeviceControl:
-            return SProcXGetDeviceControl(client);
+            return ProcXGetDeviceControl(client);
         case X_ChangeDeviceControl:
             return SProcXChangeDeviceControl(client);
         /* XI 1.5 */

--- a/Xi/getdctl.c
+++ b/Xi/getdctl.c
@@ -44,12 +44,6 @@ SOFTWARE.
 
 ********************************************************/
 
-/********************************************************************
- *
- *  Get Device control attributes for an extension device.
- *
- */
-
 #include <dix-config.h>
 
 #include <X11/extensions/XI.h>
@@ -61,28 +55,6 @@ SOFTWARE.
 #include "inputstr.h"           /* DeviceIntPtr      */
 #include "exglobals.h"
 #include "getdctl.h"
-
-/***********************************************************************
- *
- * This procedure gets the control attributes for an extension device,
- * for clients on machines with a different byte ordering than the server.
- *
- */
-
-int _X_COLD
-SProcXGetDeviceControl(ClientPtr client)
-{
-    REQUEST(xGetDeviceControlReq);
-    REQUEST_SIZE_MATCH(xGetDeviceControlReq);
-    swaps(&stuff->control);
-    return (ProcXGetDeviceControl(client));
-}
-
-/***********************************************************************
- *
- * This procedure copies DeviceResolution data, swapping if necessary.
- *
- */
 
 static void
 _writeDeviceResolution(ClientPtr client, ValuatorClassPtr v, x_rpcbuf_t *rpcbuf)
@@ -145,6 +117,9 @@ ProcXGetDeviceControl(ClientPtr client)
         return rc;
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+
+    if (rpcbuf.swapped)
+        swaps(&stuff->control);
 
     switch (stuff->control) {
     case DEVICE_RESOLUTION:

--- a/Xi/getdctl.h
+++ b/Xi/getdctl.h
@@ -25,9 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef GETDCTL_H
 #define GETDCTL_H 1
 
-int SProcXGetDeviceControl(ClientPtr    /* client */
-    );
-
 int ProcXGetDeviceControl(ClientPtr     /* client */
     );
 


### PR DESCRIPTION
move the only one relevant line into ProcXGetDeviceControl()

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
