### PR TITLE
treewide return code of X_SEND_REPLY_WITH_RPCBUF()

### DIFF
--- a/Xext/panoramiX.c
+++ b/Xext/panoramiX.c
@@ -1051,13 +1051,11 @@ ProcXineramaQueryScreens(ClientPtr client)
                 .height = walkScreen->height,
             };
             /* scratch consists of 4x CARD16 */
-            if (!x_rpcbuf_write_CARD16s(&rpcbuf, (CARD16*)&scratch, 4))
-                return BadAlloc;
+            x_rpcbuf_write_CARD16s(&rpcbuf, (CARD16*)&scratch, 4);
         }
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static int

--- a/Xext/panoramiXprocs.c
+++ b/Xext/panoramiXprocs.c
@@ -2129,8 +2129,7 @@ PanoramiXGetImage(ClientPtr client)
         swapl(&reply.visual);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 /* The text stuff should be rewritten so that duplication happens

--- a/Xext/shape.c
+++ b/Xext/shape.c
@@ -991,9 +991,6 @@ ProcShapeGetRectangles(ClientPtr client)
         };
     }
 
-    if (rpcbuf.error) /* buffer already cleared */
-        return BadAlloc;
-
     xShapeGetRectanglesReply reply = {
         .ordering = YXBanded,
         .nrects = nrects
@@ -1003,8 +1000,7 @@ ProcShapeGetRectangles(ClientPtr client)
         swapl(&reply.nrects);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static int

--- a/Xext/vidmode.c
+++ b/Xext/vidmode.c
@@ -375,9 +375,6 @@ ProcVidModeGetAllModeLines(ClientPtr client)
             fillModeInfoV2(&rpcbuf, dotClock, mode);
     } while (pVidMode->GetNextModeline(pScreen, &mode, &dotClock));
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     xXF86VidModeGetAllModeLinesReply reply = {
         .modecount = modecount
     };
@@ -386,8 +383,7 @@ ProcVidModeGetAllModeLines(ClientPtr client)
         swapl(&reply.modecount);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 #define MODEMATCH(mode,stuff)	  \
@@ -1220,9 +1216,6 @@ ProcVidModeGetMonitor(ClientPtr client)
     x_rpcbuf_write_string_pad(&rpcbuf, vendorStr);
     x_rpcbuf_write_string_pad(&rpcbuf, modelStr);
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     xXF86VidModeGetMonitorReply reply = {
         .nhsync = nHsync,
         .nvsync = nVrefresh,
@@ -1230,8 +1223,7 @@ ProcVidModeGetMonitor(ClientPtr client)
         .modelLength = x_safe_strlen(modelStr),
     };
 
-    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static int
@@ -1338,9 +1330,6 @@ ProcVidModeGetDotClocks(ClientPtr client)
         free(Clocks);
     }
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     xXF86VidModeGetDotClocksReply reply = {
         .clocks = numClocks,
         .maxclocks = MAXCLOCKS,
@@ -1353,8 +1342,7 @@ ProcVidModeGetDotClocks(ClientPtr client)
         swapl(&reply.flags);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static int
@@ -1509,10 +1497,8 @@ ProcVidModeGetGammaRamp(ClientPtr client)
         swaps(&reply.size);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
-
 
 static int
 ProcVidModeGetGammaRampSize(ClientPtr client)

--- a/Xext/xcmisc.c
+++ b/Xext/xcmisc.c
@@ -112,9 +112,6 @@ ProcXCMiscGetXIDList(ClientPtr client)
     x_rpcbuf_write_CARD32s(&rpcbuf, pids, count);
     free(pids);
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     xXCMiscGetXIDListReply reply = {
         .count = count
     };
@@ -122,8 +119,7 @@ ProcXCMiscGetXIDList(ClientPtr client)
         swapl(&reply.count);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static int

--- a/Xext/xf86bigfont.c
+++ b/Xext/xf86bigfont.c
@@ -575,13 +575,8 @@ ProcXF86BigfontQueryFont(ClientPtr client)
             x_rpcbuf_write_CARD16s(&rpcbuf, pIndex2UniqIndex, nCharInfos);
         }
 
-        if (rpcbuf.error) {
-            rc = BadAlloc;
-            goto out;
-        }
+        rc = X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 
-        X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-out:
         if (nCharInfos > 0) {
             if (shmid == -1)
                 free(pIndex2UniqIndex);

--- a/Xext/xres.c
+++ b/Xext/xres.c
@@ -222,8 +222,7 @@ ProcXResQueryClients(ClientPtr client)
         swapl(&reply.num_clients);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static void

--- a/Xext/xvdisp.c
+++ b/Xext/xvdisp.c
@@ -135,8 +135,7 @@ ProcXvQueryAdaptors(ClientPtr client)
         swaps(&reply.num_adaptors);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static int
@@ -166,9 +165,6 @@ ProcXvQueryEncodings(ClientPtr client)
         pe++;
     }
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     xvQueryEncodingsReply reply = {
         .num_encodings = pPort->pAdaptor->nEncodings,
     };
@@ -177,8 +173,7 @@ ProcXvQueryEncodings(ClientPtr client)
         swaps(&reply.num_encodings);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static int
@@ -552,9 +547,6 @@ ProcXvQueryPortAttributes(ClientPtr client)
         x_rpcbuf_write_string_0t_pad(&rpcbuf, pAtt->name);
     }
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     xvQueryPortAttributesReply reply = {
         .num_attributes = pPort->pAdaptor->nAttributes,
         .text_size = textSize,
@@ -565,8 +557,7 @@ ProcXvQueryPortAttributes(ClientPtr client)
         swapl(&reply.text_size);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static int
@@ -802,8 +793,7 @@ ProcXvQueryImageAttributes(ClientPtr client)
         SwapLongs((CARD32 *) offsets, x_rpcbuf_wsize_units(&rpcbuf));
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static int
@@ -854,9 +844,6 @@ ProcXvListImageFormats(ClientPtr client)
         x_rpcbuf_reserve(&rpcbuf, sizeof(CARD8)+sizeof(CARD16)+(sizeof(CARD32)*2)); /* pad7, pad8, pad9, pad10 */
     }
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     /* use rpc.wpos here, in order to get how much we've really written */
     if (rpcbuf.wpos != (pPort->pAdaptor->nImages*sz_xvImageFormatInfo))
         LogMessage(X_WARNING, "ProcXvListImageFormats() payload_len mismatch: %ld but shoud be %d\n",
@@ -870,8 +857,7 @@ ProcXvListImageFormats(ClientPtr client)
         swapl(&reply.num_formats);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int

--- a/Xi/getkmap.c
+++ b/Xi/getkmap.c
@@ -117,14 +117,10 @@ ProcXGetDeviceKeyMapping(ClientPtr client)
     free(syms->map);
     free(syms);
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     xGetDeviceKeyMappingReply rep = {
         .RepType = X_GetDeviceKeyMapping,
         .keySymsPerKeyCode = mapWidth,
     };
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }

--- a/Xi/getprop.c
+++ b/Xi/getprop.c
@@ -129,14 +129,11 @@ ProcXGetDeviceDontPropagateList(ClientPtr client)
         }
     }
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     if (client->swapped) {
         swaps(&rep.count);
     }
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 /***********************************************************************

--- a/Xi/getselev.c
+++ b/Xi/getselev.c
@@ -148,13 +148,10 @@ ProcXGetSelectedExtensionEvents(ClientPtr client)
         free(buf);
     }
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     if (client->swapped) {
         swaps(&rep.this_client_count);
         swaps(&rep.all_clients_count);
     }
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }

--- a/Xi/xiproperty.c
+++ b/Xi/xiproperty.c
@@ -858,8 +858,8 @@ ProcXListDeviceProperties(ClientPtr client)
     if (client->swapped) {
         swaps(&rep.nAtoms);
     }
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 int
@@ -976,9 +976,6 @@ ProcXGetDeviceProperty(ClientPtr client)
         }
     }
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     /* delete the Property */
     if (stuff->delete && (rep.bytesAfter == 0)) {
         XIPropertyPtr prop, *prev;
@@ -993,8 +990,7 @@ ProcXGetDeviceProperty(ClientPtr client)
         }
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 int _X_COLD
@@ -1055,8 +1051,7 @@ ProcXIListProperties(ClientPtr client)
         swaps(&rep.num_properties);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 int
@@ -1173,10 +1168,9 @@ ProcXIGetProperty(ClientPtr client)
         }
     }
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    rc = X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    if (rc != Success)
+        return rc;
 
     /* delete the Property */
     if (stuff->delete && (rep.bytes_after == 0)) {
@@ -1192,7 +1186,7 @@ ProcXIGetProperty(ClientPtr client)
         }
     }
 
-    return Success;
+    return rc;
 }
 
 int _X_COLD

--- a/dbe/dbe.c
+++ b/dbe/dbe.c
@@ -627,11 +627,6 @@ ProcDbeGetVisualInfo(ClientPtr client)
         free(visualInfo.visinfo);
     }
 
-    if (rpcbuf.error) {
-        rc = BadAlloc;
-        goto clearRpcBuf;
-    }
-
     xDbeGetVisualInfoReply rep = {
         .m = count
     };
@@ -640,8 +635,7 @@ ProcDbeGetVisualInfo(ClientPtr client)
         swapl(&rep.m);
     }
 
-    rc = Success;
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    rc = X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 
 clearRpcBuf:
     x_rpcbuf_clear(&rpcbuf);

--- a/dix/devices.c
+++ b/dix/devices.c
@@ -1930,11 +1930,7 @@ ProcGetKeyboardMapping(ClientPtr client)
     free(syms->map);
     free(syms);
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 int

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -1034,9 +1034,6 @@ ProcQueryTree(ClientPtr client)
         numChildren++;
     }
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     xQueryTreeReply rep = {
         .root = pWin->drawable.pScreen->root->drawable.id,
         .parent = (pWin->parent) ? pWin->parent->drawable.id : (Window) None,
@@ -1049,8 +1046,7 @@ ProcQueryTree(ClientPtr client)
         swaps(&rep.nChildren);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 int

--- a/dix/property.c
+++ b/dix/property.c
@@ -614,6 +614,7 @@ ProcGetProperty(ClientPtr client)
         break;
     }
 
+    /* don't delete if there's an error */
     if (rpcbuf.error)
         return BadAlloc;
 
@@ -642,8 +643,7 @@ ProcGetProperty(ClientPtr client)
         swapl(&rep.nItems);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 int
@@ -670,9 +670,6 @@ ProcListProperties(ClientPtr client)
         }
     }
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     xListPropertiesReply rep = {
         .nProperties = numProps
     };
@@ -681,8 +678,7 @@ ProcListProperties(ClientPtr client)
         swaps(&rep.nProperties);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 int

--- a/randr/rrcrtc.c
+++ b/randr/rrcrtc.c
@@ -1217,9 +1217,6 @@ ProcRRGetCrtcInfo(ClientPtr client)
         }
     }
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     if (pScrPriv->rrCrtcGet)
         pScrPriv->rrCrtcGet(pScreen, crtc, &rep);
 
@@ -1236,8 +1233,7 @@ ProcRRGetCrtcInfo(ClientPtr client)
         swaps(&rep.nPossibleOutput);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 int
@@ -1626,8 +1622,7 @@ ProcRRGetCrtcGamma(ClientPtr client)
         swaps(&reply.size);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -1732,9 +1727,6 @@ ProcRRGetCrtcTransform(ClientPtr client)
         x_rpcbuf_write_CARD32s(&rpcbuf, (CARD32*)current->params, current->nparams);
     }
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     if (client->swapped) {
         SwapLongs((CARD32 *) &rep.pendingTransform, bytes_to_int32(sizeof(xRenderTransform)));
         SwapLongs((CARD32 *) &rep.currentTransform, bytes_to_int32(sizeof(xRenderTransform)));
@@ -1744,8 +1736,7 @@ ProcRRGetCrtcTransform(ClientPtr client)
         swaps(&rep.currentNparamsFilter);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 static Bool

--- a/randr/rrmonitor.c
+++ b/randr/rrmonitor.c
@@ -647,8 +647,7 @@ ProcRRGetMonitors(ClientPtr client)
         swapl(&rep.noutputs);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 int

--- a/randr/rroutput.c
+++ b/randr/rroutput.c
@@ -509,8 +509,7 @@ ProcRRGetOutputInfo(ClientPtr client)
         swaps(&rep.nameLength);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 static void

--- a/randr/rrproperty.c
+++ b/randr/rrproperty.c
@@ -430,9 +430,6 @@ ProcRRListOutputProperties(ClientPtr client)
         x_rpcbuf_write_CARD32(&rpcbuf, prop->propertyName);
     }
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     xRRListOutputPropertiesReply rep = {
         .nAtoms = numProps
     };
@@ -441,8 +438,7 @@ ProcRRListOutputProperties(ClientPtr client)
         swaps(&rep.nAtoms);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 int
@@ -462,17 +458,13 @@ ProcRRQueryOutputProperty(ClientPtr client)
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
     x_rpcbuf_write_CARD32s(&rpcbuf, (CARD32*)prop->valid_values, prop->num_valid);
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     xRRQueryOutputPropertyReply rep = {
         .pending = prop->is_pending,
         .range = prop->range,
         .immutable = prop->immutable
     };
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 int

--- a/randr/rrproviderproperty.c
+++ b/randr/rrproviderproperty.c
@@ -610,15 +610,11 @@ ProcRRGetProviderProperty(ClientPtr client)
         }
     }
 
-    if (rpcbuf.error)
-        return BadAlloc;
-
     if (stuff->delete && (reply.bytesAfter == 0)) {     /* delete the Property */
         *prev = prop->next;
         RRDestroyProviderProperty(prop);
     }
 
 sendout:
-    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }

--- a/xfixes/cursor.c
+++ b/xfixes/cursor.c
@@ -400,8 +400,7 @@ ProcXFixesGetCursorImage(ClientPtr client)
         swapl(&rep.cursorSerial);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 int
@@ -460,8 +459,8 @@ ProcXFixesGetCursorName(ClientPtr client)
         swapl(&rep.atom);
         swaps(&rep.nbytes);
     }
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 int _X_COLD
@@ -536,8 +535,7 @@ ProcXFixesGetCursorImageAndName(ClientPtr client)
         swaps(&rep.nbytes);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 /*

--- a/xfixes/region.c
+++ b/xfixes/region.c
@@ -550,8 +550,7 @@ ProcXFixesFetchRegion(ClientPtr client)
         swaps(&rep.height);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 int _X_COLD

--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -1492,8 +1492,7 @@ ProcXkbGetMap(ClientPtr client)
         swaps(&rep.totalActs);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 /***====================================================================***/
@@ -2808,8 +2807,7 @@ ProcXkbGetCompatMap(ClientPtr client)
         swaps(&rep.nTotalSI);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 /**
@@ -3141,8 +3139,7 @@ ProcXkbGetIndicatorMap(ClientPtr client)
         swapl(&rep.realIndicators);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 /**
@@ -3778,8 +3775,7 @@ ProcXkbGetNames(ClientPtr client)
         swapl(&rep.indicators);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 /***====================================================================***/


### PR DESCRIPTION
The macro will automatically return BadAlloc if the buffer is broken,
otherwise Success. Thus, we don't need extra prior rpcbuf check.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
