### PR TITLE
render: ProcRenderQueryPictFormats(): use x_rpcbuf_t

### DIFF
--- a/render/render.c
+++ b/render/render.c
@@ -308,7 +308,6 @@ ProcRenderQueryPictFormats(ClientPtr client)
     VisualPtr pVisual;
     DepthPtr pDepth;
     int v, d;
-    PictFormatPtr pFormat;
     int nformat;
     int ndepth;
     int nvisual;
@@ -377,6 +376,7 @@ ProcRenderQueryPictFormats(ClientPtr client)
         PictureScreenPtr ps = GetPictureScreenIfSet(walkScreen);
         if (ps) {
             size_t idx;
+            PictFormatPtr pFormat;
             for (idx = 0, pFormat = ps->formats;
                  idx < ps->nformats; idx++, pFormat++) {
                 pictForm->id = pFormat->id;
@@ -422,6 +422,8 @@ ProcRenderQueryPictFormats(ClientPtr client)
             pDepth = walkScreen->allowedDepths + d;
             pictDepth->nPictVisuals = 0; /* counting in here */
             for (v = 0; v < pDepth->numVids; v++) {
+                PictFormatPtr pFormat;
+
                 pVisual = findVisual(walkScreen, pDepth->vids[v]);
                 if (pVisual && (pFormat = PictureMatchVisual(walkScreen,
                                                              pDepth->depth,

--- a/render/render.c
+++ b/render/render.c
@@ -303,7 +303,6 @@ ProcRenderQueryPictFormats(ClientPtr client)
     xPictScreen *pictScreen;
     xPictDepth *pictDepth;
     xPictVisual *pictVisual;
-    xPictFormInfo *pictForm;
     CARD32 *pictSubpixel;
     VisualPtr pVisual;
     DepthPtr pDepth;
@@ -351,25 +350,16 @@ ProcRenderQueryPictFormats(ClientPtr client)
     else
         numSubpixel = numScreens;
 
-    rlength = (sizeof(xRenderQueryPictFormatsReply) +
-               nformat * sizeof(xPictFormInfo) +
+    rlength = (nformat * sizeof(xPictFormInfo) +
                numScreens * sizeof(xPictScreen) +
                ndepth * sizeof(xPictDepth) +
                nvisual * sizeof(xPictVisual) + numSubpixel * sizeof(CARD32));
 
-    xRenderQueryPictFormatsReply *reply = calloc(1, rlength);
-    if (!reply)
-        return BadAlloc;
-    reply->type = X_Reply;
-    reply->sequenceNumber = client->sequence;
-    reply->length = bytes_to_int32(rlength - sizeof(xGenericReply));
-    reply->numFormats = nformat;
-    reply->numScreens = numScreens;
-    reply->numDepths = ndepth;
-    reply->numVisuals = nvisual;
-    reply->numSubpixel = numSubpixel;
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
-    pictForm = (xPictFormInfo *) (reply + 1);
+    xPictFormInfo *pictForm = x_rpcbuf_reserve(&rpcbuf, rlength);
+    if (!pictForm)
+        return BadAlloc;
 
     for (s = 0; s < numScreens; s++) {
         ScreenPtr walkScreen = screenInfo.screens[s];
@@ -471,18 +461,23 @@ ProcRenderQueryPictFormats(ClientPtr client)
         ++pictSubpixel;
     }
 
+    xRenderQueryPictFormatsReply reply = {
+        .numFormats = nformat,
+        .numScreens = numScreens,
+        .numDepths = ndepth,
+        .numVisuals = nvisual,
+        .numSubpixel = numSubpixel,
+    };
+
     if (client->swapped) {
-        swaps(&reply->sequenceNumber);
-        swapl(&reply->length);
-        swapl(&reply->numFormats);
-        swapl(&reply->numScreens);
-        swapl(&reply->numDepths);
-        swapl(&reply->numVisuals);
-        swapl(&reply->numSubpixel);
+        swapl(&reply.numFormats);
+        swapl(&reply.numScreens);
+        swapl(&reply.numDepths);
+        swapl(&reply.numVisuals);
+        swapl(&reply.numSubpixel);
     }
-    WriteToClient(client, rlength, reply);
-    free(reply);
-    return Success;
+
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static int

--- a/render/render.c
+++ b/render/render.c
@@ -376,8 +376,9 @@ ProcRenderQueryPictFormats(ClientPtr client)
         ScreenPtr walkScreen = screenInfo.screens[s];
         PictureScreenPtr ps = GetPictureScreenIfSet(walkScreen);
         if (ps) {
-            for (nformat = 0, pFormat = ps->formats;
-                 nformat < ps->nformats; nformat++, pFormat++) {
+            size_t idx;
+            for (idx = 0, pFormat = ps->formats;
+                 idx < ps->nformats; idx++, pFormat++) {
                 pictForm->id = pFormat->id;
                 pictForm->type = pFormat->type;
                 pictForm->depth = pFormat->depth;
@@ -415,12 +416,11 @@ ProcRenderQueryPictFormats(ClientPtr client)
     for (s = 0; s < numScreens; s++) {
         ScreenPtr walkScreen = screenInfo.screens[s];
         pictDepth = (xPictDepth *) (pictScreen + 1);
-        ndepth = 0;
+        pictScreen->nDepth = 0; /* counting in here */
         for (d = 0; d < walkScreen->numDepths; d++) {
             pictVisual = (xPictVisual *) (pictDepth + 1);
             pDepth = walkScreen->allowedDepths + d;
-
-            nvisual = 0;
+            pictDepth->nPictVisuals = 0; /* counting in here */
             for (v = 0; v < pDepth->numVids; v++) {
                 pVisual = findVisual(walkScreen, pDepth->vids[v]);
                 if (pVisual && (pFormat = PictureMatchVisual(walkScreen,
@@ -433,18 +433,16 @@ ProcRenderQueryPictFormats(ClientPtr client)
                         swapl(&pictVisual->format);
                     }
                     pictVisual++;
-                    nvisual++;
+                    pictDepth->nPictVisuals++;
                 }
             }
             pictDepth->depth = pDepth->depth;
-            pictDepth->nPictVisuals = nvisual;
             if (client->swapped) {
                 swaps(&pictDepth->nPictVisuals);
             }
-            ndepth++;
+            pictScreen->nDepth++;
             pictDepth = (xPictDepth *) pictVisual;
         }
-        pictScreen->nDepth = ndepth;
         PictureScreenPtr ps = GetPictureScreenIfSet(walkScreen);
         if (ps)
             pictScreen->fallback = ps->fallback->id;


### PR DESCRIPTION
Use x_rpcbuf_t for reply payload assembly and X_SEND_REPLY_WITH_RPCBUF()
for sending it all out.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
