### PR TITLE
randr: ProcRRQueryProviderProperty(): use x_rpcbuf_t

### DIFF
--- a/randr/rrproviderproperty.c
+++ b/randr/rrproviderproperty.c
@@ -400,26 +400,16 @@ ProcRRQueryProviderProperty(ClientPtr client)
     if (!prop)
         return BadName;
 
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    x_rpcbuf_write_INT32s(&rpcbuf, prop->valid_values, prop->num_valid);
+
     xRRQueryProviderPropertyReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = prop->num_valid,
         .pending = prop->is_pending,
         .range = prop->range,
         .immutable = prop->immutable
     };
-    if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
-    }
-    WriteToClient(client, sizeof(xRRQueryProviderPropertyReply), (char *) &rep);
-    if (prop->num_valid) {
-        if (client->swapped)
-            CopySwap32Write(client, prop->num_valid * sizeof(INT32), (CARD32*)prop->valid_values);
-        else
-            WriteToClient(client, prop->num_valid * sizeof(INT32), prop->valid_values);
-    }
-    return Success;
+
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 int


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
