### PR TITLE
dix: unexport internal QueryFont() function

### DIFF
--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -272,6 +272,9 @@ int CorePointerProc(DeviceIntPtr dev, int what);
 
 int CoreKeyboardProc(DeviceIntPtr dev, int what);
 
+typedef struct _xQueryFontReply *xQueryFontReplyPtr;
+void QueryFont(FontPtr pFont, xQueryFontReplyPtr pReply, int nProtoCCIStructs);
+
 extern Bool whiteRoot;
 
 extern volatile char isItTimeToYield;

--- a/include/dixfont.h
+++ b/include/dixfont.h
@@ -43,12 +43,6 @@ extern _X_EXPORT int OpenFont(ClientPtr /*client */ ,
 extern _X_EXPORT int CloseFont(void *pfont,
                                XID fid);
 
-typedef struct _xQueryFontReply *xQueryFontReplyPtr;
-
-extern _X_EXPORT void QueryFont(FontPtr /*pFont */ ,
-                                xQueryFontReplyPtr /*pReply */ ,
-                                int /*nProtoCCIStructs */ );
-
 extern _X_EXPORT int ListFonts(ClientPtr /*client */ ,
                                unsigned char * /*pattern */ ,
                                unsigned int /*length */ ,


### PR DESCRIPTION
This function is internal to DIX (used for assembling XQueryFont replies
and not used by any drivers (not even proprietary NVidia), and really
shouldn't ever called by them at all. It's been one the many victims of a
really unthoughtful mass export back 17 years ago.

That'S a necessary step for refactoring the RPC reply mechanics.

Since it's never used by any driver at all, we can easily to this change
within the current ABI level.

Fixes: d6cbd4511e35a89a0353f11834c6fdb8d4d2189f
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
