### PR TITLE
dix: doListFontsWithInfo(): inline SwapFonts() call

### DIFF
--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -984,7 +984,44 @@ doListFontsWithInfo(ClientPtr client, LFWIclosurePtr c)
                 pFP++;
             }
             if (client->swapped) {
-                SwapFont((xQueryFontReply *) reply, FALSE);
+                swaps(&reply->sequenceNumber);
+                swapl(&reply->length);
+                unsigned nprops = reply->nFontProps;
+
+                /* from SwapInfo() */
+                swaps(&reply->minCharOrByte2);
+                swaps(&reply->maxCharOrByte2);
+                swaps(&reply->defaultChar);
+                swaps(&reply->nFontProps);
+                swaps(&reply->fontAscent);
+                swaps(&reply->fontDescent);
+                swapl(&reply->nReplies);
+
+                /* from SwapCharInfo */
+                swaps(&reply->minBounds.leftSideBearing);
+                swaps(&reply->minBounds.rightSideBearing);
+                swaps(&reply->minBounds.characterWidth);
+                swaps(&reply->minBounds.ascent);
+                swaps(&reply->minBounds.descent);
+                swaps(&reply->minBounds.attributes);
+
+                /* from SwapCharInfo */
+                swaps(&reply->maxBounds.leftSideBearing);
+                swaps(&reply->maxBounds.rightSideBearing);
+                swaps(&reply->maxBounds.characterWidth);
+                swaps(&reply->maxBounds.ascent);
+                swaps(&reply->maxBounds.descent);
+                swaps(&reply->maxBounds.attributes);
+
+                char *pby = (char *) &reply[1];
+                /* Font properties are an atom and either an int32 or a CARD32, so
+                 * they are always 2 4 byte values */
+                for (unsigned i = 0; i < nprops; i++) {
+                    swapl((int *) pby);
+                    pby += 4;
+                    swapl((int *) pby);
+                    pby += 4;
+                }
             }
             WriteToClient(client, length, reply);
             WriteToClient(client, namelen, name);


### PR DESCRIPTION
As preparation for moving doListFontsWithInfo() (and it's callers) to
x_rpcbuf_t, inline the SwapFonts() call into the caller function.

SwapFonts() has several problems, eg. directly operating on a buffer that's
holding xQueryFontReply struct (which isn't the correct one, just happens to
match) as well as the whole payload.

We first need to get them out of the way, before we can split off the reply
into the (statically declared) header struct and the (x_rpcbuf_t-filled)
payload.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
