### PR TITLE
treewide: write xXineramaScreenInfo via x_rpcbuf_write_rect()

### DIFF
--- a/Xext/panoramiX.c
+++ b/Xext/panoramiX.c
@@ -1044,14 +1044,12 @@ ProcXineramaQueryScreens(ClientPtr client)
         int i;
         FOR_NSCREENS_BACKWARD(i) {
             ScreenPtr walkScreen = screenInfo.screens[i];
-            xXineramaScreenInfo scratch = {
-                .x_org = walkScreen->x,
-                .y_org = walkScreen->y,
-                .width = walkScreen->width,
-                .height = walkScreen->height,
-            };
-            /* scratch consists of 4x CARD16 */
-            x_rpcbuf_write_CARD16s(&rpcbuf, (CARD16*)&scratch, 4);
+            /* xXineramaScreenInfo is the same as xRectangle */
+            x_rpcbuf_write_rect(&rpcbuf,
+                                walkScreen->x,
+                                walkScreen->y,
+                                walkScreen->width,
+                                walkScreen->height);
         }
     }
 

--- a/randr/rrxinerama.c
+++ b/randr/rrxinerama.c
@@ -246,11 +246,13 @@ ProcRRXineramaQueryScreens(ClientPtr client)
     }
 
     for (m = 0; m < nmonitors; m++) {
+        BoxRec box = monitors[m].geometry.box;
         /* write xXineramaScreenInfo */
-        x_rpcbuf_write_INT16(&rpcbuf, monitors[m].geometry.box.x1);
-        x_rpcbuf_write_INT16(&rpcbuf, monitors[m].geometry.box.y1);
-        x_rpcbuf_write_CARD16(&rpcbuf, monitors[m].geometry.box.x2 - monitors[m].geometry.box.x1);
-        x_rpcbuf_write_CARD16(&rpcbuf, monitors[m].geometry.box.y2 - monitors[m].geometry.box.y1);
+        x_rpcbuf_write_rect(&rpcbuf,
+                            box.x1,
+                            box.y1,
+                            box.x2 - box.x1,
+                            box.y2 - box.y1);
     }
 
     if (monitors)


### PR DESCRIPTION
The xXineramaScreenInfo payload type has the same definition as xRectangle,
so we can just use x_rpcbuf_write_rect() for those.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
