### PR TITLE
glx: replace __GLX_SWAP_SHORT() by swaps()

### DIFF
--- a/glx/glxcmds.c
+++ b/glx/glxcmds.c
@@ -914,7 +914,7 @@ __glXDisp_GetVisualConfigs(__GLXclientState * cl, GLbyte * pc)
     };
 
     if (client->swapped) {
-        __GLX_SWAP_SHORT(&reply.sequenceNumber);
+        swaps(&reply.sequenceNumber);
         __GLX_SWAP_INT(&reply.length);
         __GLX_SWAP_INT(&reply.numVisuals);
         __GLX_SWAP_INT(&reply.numProps);
@@ -1027,7 +1027,7 @@ DoGetFBConfigs(__GLXclientState * cl, unsigned screen)
     };
 
     if (client->swapped) {
-        __GLX_SWAP_SHORT(&reply.sequenceNumber);
+        swaps(&reply.sequenceNumber);
         __GLX_SWAP_INT(&reply.length);
         __GLX_SWAP_INT(&reply.numFBConfigs);
         __GLX_SWAP_INT(&reply.numAttribs);
@@ -1916,7 +1916,7 @@ DoGetDrawableAttributes(__GLXclientState * cl, XID drawId)
 
         __GLX_DECLARE_SWAP_VARIABLES;
         __GLX_DECLARE_SWAP_ARRAY_VARIABLES;
-        __GLX_SWAP_SHORT(&reply.sequenceNumber);
+        swaps(&reply.sequenceNumber);
         __GLX_SWAP_INT(&reply.length);
         __GLX_SWAP_INT(&reply.numAttribs);
         WriteToClient(client, sizeof(xGLXGetDrawableAttributesReply), &reply);
@@ -1994,7 +1994,7 @@ __glXDisp_Render(__GLXclientState * cl, GLbyte * pc)
 
     req = (xGLXRenderReq *) pc;
     if (client->swapped) {
-        __GLX_SWAP_SHORT(&req->length);
+        swaps(&req->length);
         __GLX_SWAP_INT(&req->contextTag);
     }
 
@@ -2021,8 +2021,8 @@ __glXDisp_Render(__GLXclientState * cl, GLbyte * pc)
          */
         hdr = (__GLXrenderHeader *) pc;
         if (client->swapped) {
-            __GLX_SWAP_SHORT(&hdr->length);
-            __GLX_SWAP_SHORT(&hdr->opcode);
+            swaps(&hdr->length);
+            swaps(&hdr->opcode);
         }
         cmdlen = hdr->length;
         opcode = hdr->opcode;
@@ -2096,11 +2096,11 @@ __glXDisp_RenderLarge(__GLXclientState * cl, GLbyte * pc)
 
     req = (xGLXRenderLargeReq *) pc;
     if (client->swapped) {
-        __GLX_SWAP_SHORT(&req->length);
+        swaps(&req->length);
         __GLX_SWAP_INT(&req->contextTag);
         __GLX_SWAP_INT(&req->dataBytes);
-        __GLX_SWAP_SHORT(&req->requestNumber);
-        __GLX_SWAP_SHORT(&req->requestTotal);
+        swaps(&req->requestNumber);
+        swaps(&req->requestTotal);
     }
 
     glxc = __glXForceCurrent(cl, req->contextTag, &error);
@@ -2377,7 +2377,7 @@ __glXDisp_QueryExtensionsString(__GLXclientState * cl, GLbyte * pc)
     if (client->swapped) {
         __GLX_DECLARE_SWAP_VARIABLES;
         __GLX_DECLARE_SWAP_ARRAY_VARIABLES;
-        __GLX_SWAP_SHORT(&reply.sequenceNumber);
+        swaps(&reply.sequenceNumber);
         __GLX_SWAP_INT(&reply.length);
         __GLX_SWAP_INT(&reply.n);
         WriteToClient(client, sizeof(xGLXQueryExtensionsStringReply), &reply);
@@ -2449,7 +2449,7 @@ __glXDisp_QueryServerString(__GLXclientState * cl, GLbyte * pc)
 
     if (client->swapped) {
         __GLX_DECLARE_SWAP_VARIABLES;
-        __GLX_SWAP_SHORT(&reply.sequenceNumber);
+        swaps(&reply.sequenceNumber);
         __GLX_SWAP_INT(&reply.length);
         __GLX_SWAP_INT(&reply.n);
         WriteToClient(client, sizeof(xGLXQueryServerStringReply), &reply);

--- a/glx/glxcmdsswap.c
+++ b/glx/glxcmdsswap.c
@@ -58,7 +58,7 @@ __glXDispSwap_CreateContext(__GLXclientState * cl, GLbyte * pc)
 
     __GLX_DECLARE_SWAP_VARIABLES;
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->context);
     __GLX_SWAP_INT(&req->visual);
     __GLX_SWAP_INT(&req->screen);
@@ -74,7 +74,7 @@ __glXDispSwap_CreateNewContext(__GLXclientState * cl, GLbyte * pc)
 
     __GLX_DECLARE_SWAP_VARIABLES;
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->context);
     __GLX_SWAP_INT(&req->fbconfig);
     __GLX_SWAP_INT(&req->screen);
@@ -94,7 +94,7 @@ __glXDispSwap_CreateContextWithConfigSGIX(__GLXclientState * cl, GLbyte * pc)
 
     REQUEST_SIZE_MATCH(xGLXCreateContextWithConfigSGIXReq);
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->context);
     __GLX_SWAP_INT(&req->fbconfig);
     __GLX_SWAP_INT(&req->screen);
@@ -111,7 +111,7 @@ __glXDispSwap_DestroyContext(__GLXclientState * cl, GLbyte * pc)
 
     __GLX_DECLARE_SWAP_VARIABLES;
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->context);
 
     return __glXDisp_DestroyContext(cl, pc);
@@ -142,7 +142,7 @@ __glXDispSwap_IsDirect(__GLXclientState * cl, GLbyte * pc)
 
     __GLX_DECLARE_SWAP_VARIABLES;
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->context);
 
     return __glXDisp_IsDirect(cl, pc);
@@ -155,7 +155,7 @@ __glXDispSwap_QueryVersion(__GLXclientState * cl, GLbyte * pc)
 
     __GLX_DECLARE_SWAP_VARIABLES;
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->majorVersion);
     __GLX_SWAP_INT(&req->minorVersion);
 
@@ -169,7 +169,7 @@ __glXDispSwap_WaitGL(__GLXclientState * cl, GLbyte * pc)
 
     __GLX_DECLARE_SWAP_VARIABLES;
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->contextTag);
 
     return __glXDisp_WaitGL(cl, pc);
@@ -182,7 +182,7 @@ __glXDispSwap_WaitX(__GLXclientState * cl, GLbyte * pc)
 
     __GLX_DECLARE_SWAP_VARIABLES;
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->contextTag);
 
     return __glXDisp_WaitX(cl, pc);
@@ -195,7 +195,7 @@ __glXDispSwap_CopyContext(__GLXclientState * cl, GLbyte * pc)
 
     __GLX_DECLARE_SWAP_VARIABLES;
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->source);
     __GLX_SWAP_INT(&req->dest);
     __GLX_SWAP_INT(&req->mask);
@@ -246,7 +246,7 @@ __glXDispSwap_CreateGLXPixmap(__GLXclientState * cl, GLbyte * pc)
 
     __GLX_DECLARE_SWAP_VARIABLES;
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->screen);
     __GLX_SWAP_INT(&req->visual);
     __GLX_SWAP_INT(&req->pixmap);
@@ -267,7 +267,7 @@ __glXDispSwap_CreatePixmap(__GLXclientState * cl, GLbyte * pc)
 
     REQUEST_AT_LEAST_SIZE(xGLXCreatePixmapReq);
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->screen);
     __GLX_SWAP_INT(&req->fbconfig);
     __GLX_SWAP_INT(&req->pixmap);
@@ -295,7 +295,7 @@ __glXDispSwap_CreateGLXPixmapWithConfigSGIX(__GLXclientState * cl, GLbyte * pc)
 
     REQUEST_SIZE_MATCH(xGLXCreateGLXPixmapWithConfigSGIXReq);
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->screen);
     __GLX_SWAP_INT(&req->fbconfig);
     __GLX_SWAP_INT(&req->pixmap);
@@ -311,7 +311,7 @@ __glXDispSwap_DestroyGLXPixmap(__GLXclientState * cl, GLbyte * pc)
 
     __GLX_DECLARE_SWAP_VARIABLES;
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->glxpixmap);
 
     return __glXDisp_DestroyGLXPixmap(cl, pc);
@@ -327,7 +327,7 @@ __glXDispSwap_DestroyPixmap(__GLXclientState * cl, GLbyte * pc)
 
     REQUEST_AT_LEAST_SIZE(xGLXDestroyGLXPixmapReq);
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->glxpixmap);
 
     return __glXDisp_DestroyGLXPixmap(cl, pc);
@@ -526,7 +526,7 @@ __glXDispSwap_SwapBuffers(__GLXclientState * cl, GLbyte * pc)
 
     __GLX_DECLARE_SWAP_VARIABLES;
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->contextTag);
     __GLX_SWAP_INT(&req->drawable);
 
@@ -540,7 +540,7 @@ __glXDispSwap_UseXFont(__GLXclientState * cl, GLbyte * pc)
 
     __GLX_DECLARE_SWAP_VARIABLES;
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->contextTag);
     __GLX_SWAP_INT(&req->font);
     __GLX_SWAP_INT(&req->first);
@@ -557,7 +557,7 @@ __glXDispSwap_QueryExtensionsString(__GLXclientState * cl, GLbyte * pc)
 
     __GLX_DECLARE_SWAP_VARIABLES;
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->screen);
 
     return __glXDisp_QueryExtensionsString(cl, pc);
@@ -570,7 +570,7 @@ __glXDispSwap_QueryServerString(__GLXclientState * cl, GLbyte * pc)
 
     __GLX_DECLARE_SWAP_VARIABLES;
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->screen);
     __GLX_SWAP_INT(&req->name);
 
@@ -587,7 +587,7 @@ __glXDispSwap_ClientInfo(__GLXclientState * cl, GLbyte * pc)
 
     REQUEST_AT_LEAST_SIZE(xGLXClientInfoReq);
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->major);
     __GLX_SWAP_INT(&req->minor);
     __GLX_SWAP_INT(&req->numbytes);
@@ -605,7 +605,7 @@ __glXDispSwap_QueryContextInfoEXT(__GLXclientState * cl, GLbyte * pc)
 
     REQUEST_SIZE_MATCH(xGLXQueryContextInfoEXTReq);
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->context);
 
     return __glXDisp_QueryContextInfoEXT(cl, pc);
@@ -631,7 +631,7 @@ __glXDispSwap_BindTexImageEXT(__GLXclientState * cl, GLbyte * pc)
     buffer = ((int *) (pc + 4));
     num_attribs = ((CARD32 *) (pc + 8));
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->contextTag);
     __GLX_SWAP_INT(drawId);
     __GLX_SWAP_INT(buffer);
@@ -657,7 +657,7 @@ __glXDispSwap_ReleaseTexImageEXT(__GLXclientState * cl, GLbyte * pc)
     drawId = ((GLXDrawable *) (pc));
     buffer = ((int *) (pc + 4));
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->contextTag);
     __GLX_SWAP_INT(drawId);
     __GLX_SWAP_INT(buffer);
@@ -682,7 +682,7 @@ __glXDispSwap_CopySubBufferMESA(__GLXclientState * cl, GLbyte * pc)
 
     pc += __GLX_VENDPRIV_HDR_SIZE;
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->contextTag);
     __GLX_SWAP_INT(pc);
     __GLX_SWAP_INT(pc + 4);
@@ -706,7 +706,7 @@ __glXDispSwap_GetDrawableAttributesSGIX(__GLXclientState * cl, GLbyte * pc)
     REQUEST_SIZE_MATCH(xGLXGetDrawableAttributesSGIXReq);
 
     data = (CARD32 *) (req + 1);
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->contextTag);
     __GLX_SWAP_INT(data);
 
@@ -723,7 +723,7 @@ __glXDispSwap_GetDrawableAttributes(__GLXclientState * cl, GLbyte * pc)
 
     REQUEST_AT_LEAST_SIZE(xGLXGetDrawableAttributesReq);
 
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->drawable);
 
     return __glXDisp_GetDrawableAttributes(cl, pc);
@@ -770,7 +770,7 @@ __glXDispSwap_VendorPrivate(__GLXclientState * cl, GLbyte * pc)
     REQUEST_AT_LEAST_SIZE(xGLXVendorPrivateReq);
 
     req = (xGLXVendorPrivateReq *) pc;
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->vendorCode);
 
     vendorcode = req->vendorCode;
@@ -798,7 +798,7 @@ __glXDispSwap_VendorPrivateWithReply(__GLXclientState * cl, GLbyte * pc)
     REQUEST_AT_LEAST_SIZE(xGLXVendorPrivateWithReplyReq);
 
     req = (xGLXVendorPrivateWithReplyReq *) pc;
-    __GLX_SWAP_SHORT(&req->length);
+    swaps(&req->length);
     __GLX_SWAP_INT(&req->vendorCode);
 
     vendorcode = req->vendorCode;

--- a/glx/render2swap.c
+++ b/glx/render2swap.c
@@ -237,7 +237,7 @@ swapArray(GLint numVals, GLenum datatype,
             GLshort *pVal = (GLshort *) pc;
 
             for (j = 0; j < numVals; j++) {
-                __GLX_SWAP_SHORT(&pVal[j]);
+                swaps(&pVal[j]);
             }
             pc += stride;
         }

--- a/glx/single2swap.c
+++ b/glx/single2swap.c
@@ -210,7 +210,7 @@ __glXDispSwap_RenderMode(__GLXclientState * cl, GLbyte * pc)
         .size = nitems,
         .newMode = newMode
     };
-    __GLX_SWAP_SHORT(&reply.sequenceNumber);
+    swaps(&reply.sequenceNumber);
     __GLX_SWAP_INT(&reply.length);
     __GLX_SWAP_INT(&reply.retval);
     __GLX_SWAP_INT(&reply.size);

--- a/glx/unpack.h
+++ b/glx/unpack.h
@@ -130,11 +130,6 @@
   	((GLbyte *)(pc))[1] = ((GLbyte *)(pc))[2]; 	\
   	((GLbyte *)(pc))[2] = sw;
 
-#define __GLX_SWAP_SHORT(pc) \
-  	sw = ((GLbyte *)(pc))[0]; 		\
-  	((GLbyte *)(pc))[0] = ((GLbyte *)(pc))[1]; 	\
-  	((GLbyte *)(pc))[1] = sw;
-
 #define __GLX_SWAP_DOUBLE(pc) \
   	sw = ((GLbyte *)(pc))[0]; 		\
   	((GLbyte *)(pc))[0] = ((GLbyte *)(pc))[7]; 	\
@@ -165,14 +160,6 @@
 	    swapPC += __GLX_SIZE_INT32;		\
 	}
 
-#define __GLX_SWAP_SHORT_ARRAY(pc, count) \
-  	swapPC = ((GLbyte *)(pc));		\
-  	swapEnd = ((GLbyte *)(pc)) + (count)*__GLX_SIZE_INT16;\
-  	while (swapPC < swapEnd) {		\
-	    __GLX_SWAP_SHORT(swapPC);		\
-	    swapPC += __GLX_SIZE_INT16;		\
-	}
-
 #define __GLX_SWAP_DOUBLE_ARRAY(pc, count) \
   	swapPC = ((GLbyte *)(pc));		\
   	swapEnd = ((GLbyte *)(pc)) + (count)*__GLX_SIZE_FLOAT64;\
@@ -190,7 +177,7 @@
 	}
 
 #define __GLX_SWAP_REPLY_HEADER() \
-	__GLX_SWAP_SHORT(&reply.sequenceNumber); \
+	swaps(&reply.sequenceNumber); \
 	__GLX_SWAP_INT(&reply.length);
 
 #define __GLX_SWAP_REPLY_RETVAL() \


### PR DESCRIPTION
We have an optimized function for this, so use it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
