### PR TITLE
dix: rpcbuf: add x_rpcbuf_write_CARD64() and x_rpcbuf_write_CARD64s()

### DIFF
--- a/dix/rpcbuf.c
+++ b/dix/rpcbuf.c
@@ -145,6 +145,20 @@ Bool x_rpcbuf_write_CARD32(x_rpcbuf_t *rpcbuf, CARD32 value)
     return TRUE;
 }
 
+Bool x_rpcbuf_write_CARD64(x_rpcbuf_t *rpcbuf, CARD64 value)
+{
+    CARD64 *reserved = x_rpcbuf_reserve(rpcbuf, sizeof(value));
+    if (!reserved)
+        return FALSE;
+
+    *reserved = value;
+
+    if (rpcbuf->swapped)
+        swapll(reserved);
+
+    return TRUE;
+}
+
 Bool x_rpcbuf_write_CARD8s(x_rpcbuf_t *rpcbuf, const CARD8 *values,
                            size_t count)
 {
@@ -192,6 +206,25 @@ Bool x_rpcbuf_write_CARD32s(x_rpcbuf_t *rpcbuf, const CARD32 *values,
 
     if (rpcbuf->swapped)
         SwapLongs(reserved, count);
+
+    return TRUE;
+}
+
+Bool x_rpcbuf_write_CARD64s(x_rpcbuf_t *rpcbuf, const CARD64 *values,
+                            size_t count)
+{
+    if ((!values) || (!count))
+        return TRUE;
+
+    CARD64 *reserved = x_rpcbuf_reserve(rpcbuf, sizeof(CARD64) * count);
+    if (!reserved)
+        return FALSE;
+
+    memcpy(reserved, values, sizeof(CARD64) * count);
+
+    if (rpcbuf->swapped)
+        for (size_t x=0; x<count; x++)
+            swapll(&reserved[x]);
 
     return TRUE;
 }

--- a/dix/rpcbuf_priv.h
+++ b/dix/rpcbuf_priv.h
@@ -217,6 +217,21 @@ static inline Bool x_rpcbuf_write_INT32(x_rpcbuf_t *rpcbuf, INT32 value) {
 }
 
 /*
+ * write a CARD64 and do byte-swapping (when needed).
+ *
+ * allocate a region for CARD64, write it into the buffer and do byte-swap
+ * if buffer is configured to do so (`swapped` field is TRUE).
+ *
+ * doesn't do any padding.
+ *
+ * @param rpcbuf    pointer to x_rpcbuf_t to operate on
+ * @param value     the CARD64 value to write
+ * @return          TRUE on success, FALSE on allocation failure
+ */
+Bool x_rpcbuf_write_CARD64(x_rpcbuf_t *rpcbuf, CARD64 value)
+    _X_ATTRIBUTE_NONNULL_ARG(1);
+
+/*
  * write array of CARD8s and do byte-swapping (when needed).
  *
  * allocate a region for CARD8, write them into the buffer.
@@ -285,6 +300,23 @@ static inline Bool x_rpcbuf_write_INT32s(x_rpcbuf_t *rpcbuf,
 {
     return x_rpcbuf_write_CARD32s(rpcbuf, (CARD32*)values, count);
 }
+
+/*
+ * write array of CARD64s and do byte-swapping (when needed).
+ *
+ * allocate a region for CARD64s, write them into the buffer and do byte-swap
+ * if buffer is configured to do so (`swapped` field is TRUE).
+ * when `values` or `count` are zero, does nothing.
+ *
+ * doesn't do any padding.
+ *
+ * @param rpcbuf    pointer to x_rpcbuf_t to operate on
+ * @param values    pointer to CARD64 array to write
+ * @param count     number of elements in the array
+ * @return          TRUE on success, FALSE on allocation failure
+ */
+Bool x_rpcbuf_write_CARD64s(x_rpcbuf_t *rpcbuf, const CARD64 *values,
+    size_t count) _X_ATTRIBUTE_NONNULL_ARG(1);
 
 /*
  * retrieve number of 4-byte-units (padded) of data written in the buffer


### PR DESCRIPTION
Add functions for writing (and byte-swapping) CARD64 values.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
