### PR TITLE
dix: ProcQueryColors(): use x_rpcbuf_t

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -2896,37 +2896,29 @@ ProcQueryColors(ClientPtr client)
                                  client, DixReadAccess);
     if (rc == Success) {
         int count;
-        xrgb *prgbs;
-
         count =
             bytes_to_int32((client->req_len << 2) - sizeof(xQueryColorsReq));
-        prgbs = calloc(count, sizeof(xrgb));
+
+        x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+        xrgb *prgbs = x_rpcbuf_reserve(&rpcbuf, count * sizeof(xrgb));
         if (!prgbs && count)
             return BadAlloc;
         if ((rc =
              QueryColors(pcmp, count, (Pixel *) &stuff[1], prgbs, client))) {
-            free(prgbs);
+            x_rpcbuf_clear(&rpcbuf);
             return rc;
         }
 
         xQueryColorsReply rep = {
-            .type = X_Reply,
-            .sequenceNumber = client->sequence,
-            .length = bytes_to_int32(count * sizeof(xrgb)),
             .nColors = count
         };
 
         if (client->swapped) {
-            swaps(&rep.sequenceNumber);
-            swapl(&rep.length);
             swaps(&rep.nColors);
             SwapShorts((short*)prgbs, count * 4); // xrgb = 4 shorts
         }
 
-        WriteToClient(client, sizeof(rep), &rep);
-        WriteToClient(client, count * sizeof(xrgb), prgbs);
-        free(prgbs);
-        return Success;
+        return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
     }
     else {
         client->errorValue = stuff->cmap;


### PR DESCRIPTION
Use x_rpcbuf_t for payload assembly and X_SEND_REPLY_WITH_RPCBUF()
for sending it all out.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
