### PR TITLE
dix: ProcGetFontPath(): use x_rpcbuf_t

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -3419,31 +3419,24 @@ ProcSetFontPath(ClientPtr client)
 int
 ProcGetFontPath(ClientPtr client)
 {
-    int rc, stringLens, numpaths;
-    unsigned char *bufferStart;
-
     /* REQUEST (xReq); */
-
     REQUEST_SIZE_MATCH(xReq);
-    rc = GetFontPath(client, &numpaths, &stringLens, &bufferStart);
+
+    int rc = XaceHookServerAccess(client, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+
     xGetFontPathReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = bytes_to_int32(stringLens + numpaths),
-        .nPaths = numpaths
+        .nPaths = FillFontPath(&rpcbuf)
     };
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
         swaps(&rep.nPaths);
     }
-    WriteToClient(client, sizeof(rep), &rep);
-    WriteToClient(client, stringLens + numpaths, bufferStart);
-    return Success;
+
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
 int

--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -94,6 +94,8 @@ void CloseDownClient(ClientPtr client);
 ClientPtr GetCurrentClient(void);
 void InitClient(ClientPtr client, int i, void *ospriv);
 
+int FillFontPath(x_rpcbuf_t *rpcbuf);
+
 /* lookup builtin color by name */
 Bool dixLookupBuiltinColor(int screen,
                            char *name,

--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -59,6 +59,7 @@ Equipment Corporation.
 
 #include "dix/dix_priv.h"
 #include "dix/gc_priv.h"
+#include "dix/rpcbuf_priv.h"
 #include "include/swaprep.h"
 #include "os/auth.h"
 #include "os/log_priv.h"
@@ -1777,6 +1778,17 @@ DeleteClientFontStuff(ClientPtr client)
         if (fpe_functions[fpe->type]->client_died)
             (*fpe_functions[fpe->type]->client_died) ((void *) client, fpe);
     }
+}
+
+int FillFontPath(x_rpcbuf_t *rpcbuf)
+{
+    for (int i = 0; i < num_fpes; i++) {
+        FontPathElementPtr fpe = font_path_elements[i];
+        /* write a pascal-string */
+        x_rpcbuf_write_CARD8(rpcbuf, fpe->name_length);
+        x_rpcbuf_write_CARD8s(rpcbuf, (CARD8*)fpe->name, fpe->name_length);
+    }
+    return num_fpes;
 }
 
 static int

--- a/include/dixfont.h
+++ b/include/dixfont.h
@@ -80,9 +80,10 @@ extern _X_EXPORT int SetFontPath(ClientPtr /*client */ ,
 
 extern _X_EXPORT int SetDefaultFontPath(const char * /*path */ );
 
+/* not used by any known external driver, so can be removed soon */
 extern _X_EXPORT int GetFontPath(ClientPtr client,
                                  int *count,
-                                 int *length, unsigned char **result);
+                                 int *length, unsigned char **result) _X_DEPRECATED;
 
 extern _X_EXPORT void DeleteClientFontStuff(ClientPtr /*client */ );
 


### PR DESCRIPTION
Use x_rpcbuf_t for payload assembly and X_SEND_REPLY_WITH_RPCBUF()
for sending it all out.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
