### PR TITLE
Xext: panoramix: drop dead code path on GLXPROXY symbol

### DIFF
--- a/Xext/panoramiX.c
+++ b/Xext/panoramiX.c
@@ -59,11 +59,6 @@ Equipment Corporation.
 #include "compint.h"
 #include "protocol-versions.h"
 
-#ifdef GLXPROXY
-extern VisualPtr glxMatchVisual(ScreenPtr pScreen,
-                                VisualPtr pVisual, ScreenPtr pMatchScreen);
-#endif
-
 /* Xinerama is disabled by default unless enabled via +xinerama */
 Bool noPanoramiXExtension = TRUE;
 
@@ -761,11 +756,7 @@ PanoramiXMaybeAddVisual(VisualPtr pVisual)
         for (k = 0; k < walkScreen->numVisuals; k++) {
             VisualPtr candidate = &walkScreen->visuals[k];
 
-            if ((*XineramaVisualsEqualPtr) (pVisual, walkScreen, candidate)
-#ifdef GLXPROXY
-                && glxMatchVisual(screenInfo.screens[0], pVisual, pScreen)
-#endif
-                ) {
+            if ((*XineramaVisualsEqualPtr) (pVisual, walkScreen, candidate)) {
                 found = TRUE;
                 break;
             }


### PR DESCRIPTION
This symbol doesn't seem to be defined ever (neither in Xorg tree, nor
any headers) - it's a relic from DMX, which had been removed aeons ago.
So let's drop that dead code path.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
