### PR TITLE
glx: replace __GLX_SWAP_INT_ARRAY() by SwapLongs()

### DIFF
--- a/glx/glxcmds.c
+++ b/glx/glxcmds.c
@@ -899,7 +899,6 @@ __glXDisp_GetVisualConfigs(__GLXclientState * cl, GLbyte * pc)
     int p, i, err;
 
     __GLX_DECLARE_SWAP_VARIABLES;
-    __GLX_DECLARE_SWAP_ARRAY_VARIABLES;
 
     if (!validGlxScreen(cl->client, req->screen, &pGlxScreen, &err))
         return err;
@@ -984,7 +983,7 @@ __glXDisp_GetVisualConfigs(__GLXclientState * cl, GLbyte * pc)
 
         assert(p == GLX_VIS_CONFIG_TOTAL);
         if (client->swapped) {
-            __GLX_SWAP_INT_ARRAY(buf, p);
+            SwapLongs(buf, p);
         }
         WriteToClient(client, __GLX_SIZE_CARD32 * p, buf);
     }
@@ -1013,7 +1012,6 @@ DoGetFBConfigs(__GLXclientState * cl, unsigned screen)
     __GLXconfig *modes;
 
     __GLX_DECLARE_SWAP_VARIABLES;
-    __GLX_DECLARE_SWAP_ARRAY_VARIABLES;
 
     if (!validGlxScreen(cl->client, screen, &pGlxScreen, &err))
         return err;
@@ -1107,7 +1105,7 @@ DoGetFBConfigs(__GLXclientState * cl, unsigned screen)
         assert(p == __GLX_FBCONFIG_ATTRIBS_LENGTH);
 
         if (client->swapped) {
-            __GLX_SWAP_INT_ARRAY(buf, __GLX_FBCONFIG_ATTRIBS_LENGTH);
+            SwapLongs((CARD32*)buf, __GLX_FBCONFIG_ATTRIBS_LENGTH);
         }
         WriteToClient(client, __GLX_SIZE_CARD32 * __GLX_FBCONFIG_ATTRIBS_LENGTH,
                       (char *) buf);
@@ -1915,12 +1913,11 @@ DoGetDrawableAttributes(__GLXclientState * cl, XID drawId)
         int length = reply.length;
 
         __GLX_DECLARE_SWAP_VARIABLES;
-        __GLX_DECLARE_SWAP_ARRAY_VARIABLES;
         swaps(&reply.sequenceNumber);
         __GLX_SWAP_INT(&reply.length);
         __GLX_SWAP_INT(&reply.numAttribs);
         WriteToClient(client, sizeof(xGLXGetDrawableAttributesReply), &reply);
-        __GLX_SWAP_INT_ARRAY((int *) attributes, length);
+        SwapLongs(attributes, length);
         WriteToClient(client, length << 2, attributes);
     }
     else {
@@ -2376,12 +2373,11 @@ __glXDisp_QueryExtensionsString(__GLXclientState * cl, GLbyte * pc)
 
     if (client->swapped) {
         __GLX_DECLARE_SWAP_VARIABLES;
-        __GLX_DECLARE_SWAP_ARRAY_VARIABLES;
         swaps(&reply.sequenceNumber);
         __GLX_SWAP_INT(&reply.length);
         __GLX_SWAP_INT(&reply.n);
         WriteToClient(client, sizeof(xGLXQueryExtensionsStringReply), &reply);
-        __GLX_SWAP_INT_ARRAY((int *) buf, length);
+        SwapLongs((CARD32*)buf, length);
         WriteToClient(client, length << 2, buf);
     }
     else {
@@ -2454,7 +2450,6 @@ __glXDisp_QueryServerString(__GLXclientState * cl, GLbyte * pc)
         __GLX_SWAP_INT(&reply.n);
         WriteToClient(client, sizeof(xGLXQueryServerStringReply), &reply);
         /** no swap is needed for an array of chars **/
-        /* __GLX_SWAP_INT_ARRAY((int *)buf, length); */
         WriteToClient(client, length << 2, buf);
     }
     else {

--- a/glx/glxcmdsswap.c
+++ b/glx/glxcmdsswap.c
@@ -263,7 +263,6 @@ __glXDispSwap_CreatePixmap(__GLXclientState * cl, GLbyte * pc)
     CARD32 *attribs;
 
     __GLX_DECLARE_SWAP_VARIABLES;
-    __GLX_DECLARE_SWAP_ARRAY_VARIABLES;
 
     REQUEST_AT_LEAST_SIZE(xGLXCreatePixmapReq);
 
@@ -280,7 +279,7 @@ __glXDispSwap_CreatePixmap(__GLXclientState * cl, GLbyte * pc)
     }
     REQUEST_FIXED_SIZE(xGLXCreatePixmapReq, req->numAttribs << 3);
     attribs = (CARD32 *) (req + 1);
-    __GLX_SWAP_INT_ARRAY(attribs, req->numAttribs << 1);
+    SwapLongs(attribs, req->numAttribs << 1);
 
     return __glXDisp_CreatePixmap(cl, pc);
 }
@@ -352,7 +351,6 @@ __glXDispSwap_CreatePbuffer(__GLXclientState * cl, GLbyte * pc)
     xGLXCreatePbufferReq *req = (xGLXCreatePbufferReq *) pc;
 
     __GLX_DECLARE_SWAP_VARIABLES;
-    __GLX_DECLARE_SWAP_ARRAY_VARIABLES;
     CARD32 *attribs;
 
     REQUEST_AT_LEAST_SIZE(xGLXCreatePbufferReq);
@@ -368,7 +366,7 @@ __glXDispSwap_CreatePbuffer(__GLXclientState * cl, GLbyte * pc)
     }
     REQUEST_FIXED_SIZE(xGLXCreatePbufferReq, req->numAttribs << 3);
     attribs = (CARD32 *) (req + 1);
-    __GLX_SWAP_INT_ARRAY(attribs, req->numAttribs << 1);
+    SwapLongs(attribs, req->numAttribs << 1);
 
     return __glXDisp_CreatePbuffer(cl, pc);
 }
@@ -426,7 +424,6 @@ __glXDispSwap_ChangeDrawableAttributes(__GLXclientState * cl, GLbyte * pc)
     xGLXChangeDrawableAttributesReq *req =
         (xGLXChangeDrawableAttributesReq *) pc;
     __GLX_DECLARE_SWAP_VARIABLES;
-    __GLX_DECLARE_SWAP_ARRAY_VARIABLES;
     CARD32 *attribs;
 
     REQUEST_AT_LEAST_SIZE(xGLXChangeDrawableAttributesReq);
@@ -443,7 +440,7 @@ __glXDispSwap_ChangeDrawableAttributes(__GLXclientState * cl, GLbyte * pc)
         return BadLength;
 
     attribs = (CARD32 *) (req + 1);
-    __GLX_SWAP_INT_ARRAY(attribs, req->numAttribs << 1);
+    SwapLongs(attribs, req->numAttribs << 1);
 
     return __glXDisp_ChangeDrawableAttributes(cl, pc);
 }
@@ -455,7 +452,6 @@ __glXDispSwap_ChangeDrawableAttributesSGIX(__GLXclientState * cl, GLbyte * pc)
     xGLXChangeDrawableAttributesSGIXReq *req =
         (xGLXChangeDrawableAttributesSGIXReq *) pc;
     __GLX_DECLARE_SWAP_VARIABLES;
-    __GLX_DECLARE_SWAP_ARRAY_VARIABLES;
     CARD32 *attribs;
 
     REQUEST_AT_LEAST_SIZE(xGLXChangeDrawableAttributesSGIXReq);
@@ -470,7 +466,7 @@ __glXDispSwap_ChangeDrawableAttributesSGIX(__GLXclientState * cl, GLbyte * pc)
     REQUEST_FIXED_SIZE(xGLXChangeDrawableAttributesSGIXReq,
                        req->numAttribs << 3);
     attribs = (CARD32 *) (req + 1);
-    __GLX_SWAP_INT_ARRAY(attribs, req->numAttribs << 1);
+    SwapLongs(attribs, req->numAttribs << 1);
 
     return __glXDisp_ChangeDrawableAttributesSGIX(cl, pc);
 }
@@ -482,7 +478,6 @@ __glXDispSwap_CreateWindow(__GLXclientState * cl, GLbyte * pc)
     xGLXCreateWindowReq *req = (xGLXCreateWindowReq *) pc;
 
     __GLX_DECLARE_SWAP_VARIABLES;
-    __GLX_DECLARE_SWAP_ARRAY_VARIABLES;
     CARD32 *attribs;
 
     REQUEST_AT_LEAST_SIZE(xGLXCreateWindowReq);
@@ -499,7 +494,7 @@ __glXDispSwap_CreateWindow(__GLXclientState * cl, GLbyte * pc)
     }
     REQUEST_FIXED_SIZE(xGLXCreateWindowReq, req->numAttribs << 3);
     attribs = (CARD32 *) (req + 1);
-    __GLX_SWAP_INT_ARRAY(attribs, req->numAttribs << 1);
+    SwapLongs(attribs, req->numAttribs << 1);
 
     return __glXDisp_CreateWindow(cl, pc);
 }

--- a/glx/single2swap.c
+++ b/glx/single2swap.c
@@ -192,7 +192,7 @@ __glXDispSwap_RenderMode(__GLXclientState * cl, GLbyte * pc)
         }
         retBytes = nitems * __GLX_SIZE_CARD32;
         retBuffer = (GLubyte *) cx->selectBuf;
-        __GLX_SWAP_INT_ARRAY((GLbyte *) retBuffer, nitems);
+        SwapLongs((CARD32*)retBuffer, nitems);
         cx->renderMode = newMode;
         break;
     }

--- a/glx/unpack.h
+++ b/glx/unpack.h
@@ -152,14 +152,6 @@
   	((GLbyte *)(pc))[1] = ((GLbyte *)(pc))[2]; 	\
   	((GLbyte *)(pc))[2] = sw;
 
-#define __GLX_SWAP_INT_ARRAY(pc, count) \
-  	swapPC = ((GLbyte *)(pc));		\
-  	swapEnd = ((GLbyte *)(pc)) + (count)*__GLX_SIZE_INT32;\
-  	while (swapPC < swapEnd) {		\
-	    __GLX_SWAP_INT(swapPC);		\
-	    swapPC += __GLX_SIZE_INT32;		\
-	}
-
 #define __GLX_SWAP_DOUBLE_ARRAY(pc, count) \
   	swapPC = ((GLbyte *)(pc));		\
   	swapEnd = ((GLbyte *)(pc)) + (count)*__GLX_SIZE_FLOAT64;\


### PR DESCRIPTION
We have an optimized function for this, so use it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
