### PR TITLE
Xvmc: add reply byte-swapping

### DIFF
--- a/Xext/xvmc.c
+++ b/Xext/xvmc.c
@@ -118,6 +118,11 @@ ProcXvMCQueryVersion(ClientPtr client)
     /* REQUEST(xvmcQueryVersionReq); */
     REQUEST_SIZE_MATCH(xvmcQueryVersionReq);
 
+    if (client->swapped) {
+        swapl(&reply.major);
+        swapl(&reply.minor);
+    }
+
     X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 }
@@ -164,6 +169,17 @@ ProcXvMCListSurfaceTypes(ClientPtr client)
             info[i].subpicture_max_height = surface->subpicture_max_height;
             info[i].mc_type = surface->mc_type;
             info[i].flags = surface->flags;
+
+            if (client->swapped) {
+                swapl(&info[i].surface_type_id);
+                swaps(&info[i].chroma_format);
+                swaps(&info[i].max_width);
+                swaps(&info[i].max_height);
+                swaps(&info[i].subpicture_max_width);
+                swaps(&info[i].subpicture_max_height);
+                swapl(&info[i].mc_type);
+                swapl(&info[i].flags);
+            }
         }
     }
 
@@ -173,6 +189,12 @@ ProcXvMCListSurfaceTypes(ClientPtr client)
         .num = num_surfaces,
         .length = bytes_to_int32(sizeof(xvmcSurfaceInfo) * num_surfaces),
     };
+
+    if (client->swapped) {
+        swaps(&reply.sequenceNumber);
+        swapl(&reply.length);
+        swapl(&reply.num);
+    }
 
     WriteToClient(client, sizeof(xvmcListSurfaceTypesReply), &reply);
     WriteToClient(client, sizeof(xvmcSurfaceInfo) * num_surfaces, info);
@@ -266,6 +288,15 @@ ProcXvMCCreateContext(ClientPtr client)
         .flags_return = pContext->flags
     };
 
+    if (client->swapped) {
+        swaps(&reply.sequenceNumber);
+        swapl(&reply.length);
+        swaps(&reply.width_actual);
+        swaps(&reply.height_actual);
+        swapl(&reply.flags_return);
+        SwapLongs(data, dwords);
+    }
+
     WriteToClient(client, sizeof(xvmcCreateContextReply), &reply);
     if (dwords)
         WriteToClient(client, dwords << 2, data);
@@ -340,6 +371,11 @@ ProcXvMCCreateSurface(ClientPtr client)
         .sequenceNumber = client->sequence,
         .length = dwords
     };
+
+    if (client->swapped) {
+        swaps(&reply.sequenceNumber);
+        swapl(&reply.length);
+    }
 
     WriteToClient(client, sizeof(xvmcCreateSurfaceReply), &reply);
     if (dwords)
@@ -468,6 +504,15 @@ ProcXvMCCreateSubpicture(ClientPtr client)
         .component_order[3] = pSubpicture->component_order[3]
     };
 
+    if (client->swapped) {
+        swaps(&reply.sequenceNumber);
+        swapl(&reply.length);
+        swaps(&reply.width_actual);
+        swaps(&reply.height_actual);
+        swaps(&reply.num_palette_entries);
+        swaps(&reply.entry_bytes);
+    }
+
     WriteToClient(client, sizeof(xvmcCreateSubpictureReply), &reply);
     if (dwords)
         WriteToClient(client, dwords << 2, data);
@@ -586,6 +631,22 @@ ProcXvMCListSubpictureTypes(ClientPtr client)
             info[i].vert_v_period = pImage->vert_v_period;
             memcpy(&info[i].comp_order, pImage->component_order, 32);
             info[i].scanline_order = pImage->scanline_order;
+
+            if (client->swapped) {
+                swapl(&info[i].id);
+                swapl(&info[i].red_mask);
+                swapl(&info[i].green_mask);
+                swapl(&info[i].blue_mask);
+                swapl(&info[i].y_sample_bits);
+                swapl(&info[i].u_sample_bits);
+                swapl(&info[i].v_sample_bits);
+                swapl(&info[i].horz_y_period);
+                swapl(&info[i].horz_u_period);
+                swapl(&info[i].horz_v_period);
+                swapl(&info[i].vert_y_period);
+                swapl(&info[i].vert_u_period);
+                swapl(&info[i].vert_v_period);
+            }
         }
     }
 
@@ -596,6 +657,11 @@ ProcXvMCListSubpictureTypes(ClientPtr client)
         .length = bytes_to_int32(num * sizeof(xvImageFormatInfo)),
     };
 
+    if (client->swapped) {
+        swaps(&reply.sequenceNumber);
+        swapl(&reply.length);
+        swapl(&reply.num);
+    }
     WriteToClient(client, sizeof(xvmcListSubpictureTypesReply), &reply);
     WriteToClient(client, sizeof(xvImageFormatInfo) * num, info);
     free(info);
@@ -670,6 +736,17 @@ ProcXvMCGetDRInfo(ClientPtr client)
         shmdt((char *) patternP);
     }
 #endif                          /* HAS_XVMCSHM */
+
+    if (client->swapped) {
+        swaps(&reply.sequenceNumber);
+        swapl(&reply.length);
+        swapl(&reply.major);
+        swapl(&reply.minor);
+        swapl(&reply.patchLevel);
+        swapl(&reply.nameLen);
+        swapl(&reply.busIDLen);
+        swapl(&reply.isLocal);
+    }
 
     WriteToClient(client, sizeof(xvmcGetDRInfoReply), &reply);
     WriteToClient(client, buflen, buf);


### PR DESCRIPTION
In 22 years, nobody ever implemented byte-swapping here.

Fixes: 9508a382f8a9f241dab097d921b6d290c1c3a776
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
