### PR TITLE
dix: canonical `walkScreenIdx` variable on screen list iterations

### DIFF
--- a/dix/cursor.c
+++ b/dix/cursor.c
@@ -114,8 +114,8 @@ FreeCursor(void *value, XID cid)
 
     BUG_WARN(CursorRefCount(pCurs) < 0);
 
-    for (int nscr = 0; nscr < screenInfo.numScreens; nscr++) {
-        ScreenPtr walkScreen = screenInfo.screens[nscr];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         if (walkScreen->UnrealizeCursor)
             walkScreen->UnrealizeCursor(pDev, walkScreen, pCurs);
     }
@@ -182,8 +182,8 @@ CheckForEmptyMask(CursorBitsPtr bits)
 static int
 RealizeCursorAllScreens(CursorPtr pCurs)
 {
-    for (int nscr = 0; nscr < screenInfo.numScreens; nscr++) {
-        ScreenPtr walkScreen = screenInfo.screens[nscr];
+    for (int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         for (DeviceIntPtr pDev = inputInfo.devices; pDev; pDev = pDev->next) {
             if (DevHasCursor(pDev)) {
                 if (!(*walkScreen->RealizeCursor) (pDev, walkScreen, pCurs)) {
@@ -200,8 +200,8 @@ RealizeCursorAllScreens(CursorPtr pCurs)
                             walkScreen->UnrealizeCursor(pDevIt, walkScreen, pCurs);
                         pDevIt = pDevIt->next;
                     }
-                    while (--nscr >= 0) {
-                        walkScreen = screenInfo.screens[nscr];
+                    while (--walkScreenIdx>= 0) {
+                        walkScreen = screenInfo.screens[walkScreenIdx];
                         /* now unrealize all devices on previous screens */
                         pDevIt = inputInfo.devices;
                         while (pDevIt) {

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -650,10 +650,10 @@ CreateConnectionBlock(void)
     connBlockScreenStart = sizesofar;
     memset(&depth, 0, sizeof(xDepth));
     memset(&visual, 0, sizeof(xVisualType));
-    for (int i = 0; i < screenInfo.numScreens; i++) {
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
         DepthPtr pDepth;
         VisualPtr pVisual;
-        ScreenPtr walkScreen = screenInfo.screens[i];
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
 
         root.windowId = walkScreen->root->drawable.id;
         root.defaultColormap = walkScreen->defColormap;
@@ -3171,8 +3171,8 @@ ProcSetScreenSaver(ClientPtr client)
     REQUEST(xSetScreenSaverReq);
     REQUEST_SIZE_MATCH(xSetScreenSaverReq);
 
-    for (int i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         int rc = XaceHookScreensaverAccess(client, walkScreen, DixSetAttrAccess);
         if (rc != Success)
             return rc;
@@ -3228,8 +3228,8 @@ ProcGetScreenSaver(ClientPtr client)
 {
     REQUEST_SIZE_MATCH(xReq);
 
-    for (int i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         int rc = XaceHookScreensaverAccess(client, walkScreen, DixGetAttrAccess);
         if (rc != Success)
             return rc;
@@ -3744,8 +3744,8 @@ SendConnSetup(ClientPtr client, const char *reason)
         numScreens = ((xConnSetup *) ConnectionInfo)->numRoots;
 #endif /* XINERAMA */
 
-    for (int i = 0; i < numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         xDepth *pDepth;
         WindowPtr pRoot = walkScreen->root;
 

--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -338,8 +338,8 @@ doOpenFont(ClientPtr client, OFclosurePtr c)
     pfont->refcnt++;
     if (pfont->refcnt == 1) {
         UseFPE(pfont->fpe);
-        for (int i = 0; i < screenInfo.numScreens; i++) {
-            ScreenPtr walkScreen = screenInfo.screens[i];
+        for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
             if (walkScreen->RealizeFont) {
                 if (!(*walkScreen->RealizeFont) (walkScreen, pfont)) {
                     CloseFont(pfont, (Font) 0);

--- a/dix/dixutils.c
+++ b/dix/dixutils.c
@@ -343,14 +343,14 @@ BlockHandler(void *pTimeout)
         if (!handlers[i].deleted)
             (*handlers[i].BlockHandler) (handlers[i].blockData, pTimeout);
 
-    for (int i = 0; i < screenInfo.numGPUScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.gpuscreens[i];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numGPUScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.gpuscreens[walkScreenIdx];
         if (walkScreen->BlockHandler)
             walkScreen->BlockHandler(walkScreen, pTimeout);
     }
 
-    for (int i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         if (walkScreen->BlockHandler)
             walkScreen->BlockHandler(walkScreen, pTimeout);
     }
@@ -378,13 +378,13 @@ void
 WakeupHandler(int result)
 {
     ++inHandler;
-    for (int i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         if (walkScreen->WakeupHandler)
             walkScreen->WakeupHandler(walkScreen, result);
     }
-    for (int i = 0; i < screenInfo.numGPUScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.gpuscreens[i];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numGPUScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.gpuscreens[walkScreenIdx];
         if (walkScreen->WakeupHandler)
             walkScreen->WakeupHandler(walkScreen, result);
     }

--- a/dix/enterleave.c
+++ b/dix/enterleave.c
@@ -1240,8 +1240,8 @@ CoreFocusPointerRootNoneSwitch(DeviceIntPtr dev,
         nscreens = 1;
 #endif /* XINERAMA */
 
-    for (int i = 0; i < nscreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < nscreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         WindowPtr root = walkScreen->root;
         if (!HasOtherPointer(root, GetMaster(dev, POINTER_OR_FLOAT)) &&
             !FirstFocusChild(root)) {
@@ -1263,7 +1263,6 @@ CoreFocusPointerRootNoneSwitch(DeviceIntPtr dev,
             if (B == PointerRootWin)
                 CoreFocusInNotifyPointerEvents(dev, root, None, mode, TRUE);
         }
-
     }
 }
 
@@ -1301,8 +1300,8 @@ CoreFocusToPointerRootOrNone(DeviceIntPtr dev, WindowPtr A,
     /* NullWindow means we include the root window */
     CoreFocusOutEvents(dev, A, NullWindow, mode, NotifyNonlinearVirtual);
 
-    for (int i = 0; i < nscreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < nscreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         WindowPtr root = walkScreen->root;
         if (!HasFocus(root) && !FirstFocusChild(root)) {
             CoreFocusEvent(dev, FocusIn, mode,
@@ -1329,8 +1328,8 @@ CoreFocusFromPointerRootOrNone(DeviceIntPtr dev,
         nscreens = 1;
 #endif /* XINERAMA */
 
-    for (int i = 0; i < nscreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < nscreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         WindowPtr root = walkScreen->root;
         if (!HasFocus(root) && !FirstFocusChild(root)) {
             /* If pointer was on PointerRootWin and changes to NoneWin, and
@@ -1429,8 +1428,8 @@ DeviceFocusEvents(DeviceIntPtr dev, WindowPtr from, WindowPtr to, int mode)
                                      NotifyPointer);
             }
             /* Notify all the roots */
-            for (int i = 0; i < nscreens; i++) {
-                ScreenPtr walkScreen = screenInfo.screens[i];
+            for (unsigned int walkScreenIdx = 0; walkScreenIdx < nscreens; walkScreenIdx++) {
+                ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
                 DeviceFocusEvent(dev, XI_FocusOut, mode, out, walkScreen->root);
             }
         }
@@ -1447,8 +1446,8 @@ DeviceFocusEvents(DeviceIntPtr dev, WindowPtr from, WindowPtr to, int mode)
                                  NotifyNonlinearVirtual);
         }
         /* Notify all the roots */
-        for (int i = 0; i < nscreens; i++) {
-            ScreenPtr walkScreen = screenInfo.screens[i];
+        for (unsigned int walkScreenIdx = 0; walkScreenIdx < nscreens; walkScreenIdx++) {
+            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
             DeviceFocusEvent(dev, XI_FocusIn, mode, in, walkScreen->root);
         }
         if (to == PointerRootWin) {
@@ -1466,8 +1465,8 @@ DeviceFocusEvents(DeviceIntPtr dev, WindowPtr from, WindowPtr to, int mode)
                                      InputDevCurrentRootWindow(dev), mode,
                                      NotifyPointer);
             }
-            for (int i = 0; i < nscreens; i++) {
-                ScreenPtr walkScreen = screenInfo.screens[i];
+            for (unsigned int walkScreenIdx = 0; walkScreenIdx < nscreens; walkScreenIdx++) {
+                ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
                 DeviceFocusEvent(dev, XI_FocusOut, mode, out, walkScreen->root);
             }
             if (to->parent != NullWindow)

--- a/dix/inpututils.c
+++ b/dix/inpututils.c
@@ -842,8 +842,8 @@ update_desktop_dimensions(void)
     int x1 = INT_MAX, y1 = INT_MAX;     /* top-left */
     int x2 = INT_MIN, y2 = INT_MIN;     /* bottom-right */
 
-    for (int i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
 
         x1 = min(x1, walkScreen->x);
         y1 = min(y1, walkScreen->y);

--- a/dix/main.c
+++ b/dix/main.c
@@ -201,16 +201,16 @@ dix_main(int argc, char *argv[], char *envp[])
         InitExtensions(argc, argv);
         LogMessageVerb(X_INFO, 1, "Extensions initialized\n");
 
-        for (int i = 0; i < screenInfo.numGPUScreens; i++) {
-            ScreenPtr walkScreen = screenInfo.gpuscreens[i];
+        for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numGPUScreens; walkScreenIdx++) {
+            ScreenPtr walkScreen = screenInfo.gpuscreens[walkScreenIdx];
             if (!PixmapScreenInit(walkScreen))
                 FatalError("failed to create screen pixmap properties");
             if (!dixScreenRaiseCreateResources(walkScreen))
                 FatalError("failed to create screen resources");
         }
 
-        for (int i = 0; i < screenInfo.numScreens; i++) {
-            ScreenPtr walkScreen = screenInfo.screens[i];
+        for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
 
             if (!PixmapScreenInit(walkScreen))
                 FatalError("failed to create screen pixmap properties");
@@ -247,8 +247,8 @@ dix_main(int argc, char *argv[], char *envp[])
             PanoramiXConsolidate();
 #endif /* XINERAMA */
 
-        for (int i = 0; i < screenInfo.numScreens; i++) {
-            ScreenPtr walkScreen = screenInfo.screens[i];
+        for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
             InitRootWindow(walkScreen->root);
             CallCallbacks(&PostInitRootWindowCallback, walkScreen);
         }
@@ -313,8 +313,8 @@ dix_main(int argc, char *argv[], char *envp[])
 
         InputThreadFini();
 
-        for (int i = 0; i < screenInfo.numScreens; i++) {
-            ScreenPtr walkScreen = screenInfo.screens[i];
+        for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
             walkScreen->root = NullWindow;
         }
 
@@ -322,17 +322,21 @@ dix_main(int argc, char *argv[], char *envp[])
 
         CloseDownEvents();
 
-        for (int i = screenInfo.numGPUScreens - 1; i >= 0; i--) {
-            ScreenPtr walkScreen = screenInfo.gpuscreens[i];
-            dixFreeScreen(walkScreen);
-            screenInfo.numGPUScreens = i;
+        if (screenInfo.numGPUScreens > 0) {
+            for (int walkScreenIdx = screenInfo.numGPUScreens - 1; walkScreenIdx >= 0; walkScreenIdx--) {
+                ScreenPtr walkScreen = screenInfo.gpuscreens[walkScreenIdx];
+                dixFreeScreen(walkScreen);
+                screenInfo.numGPUScreens = walkScreenIdx;
+            }
         }
         memset(&screenInfo.gpuscreens, 0, sizeof(screenInfo.gpuscreens));
 
-        for (int i = screenInfo.numScreens - 1; i >= 0; i--) {
-            ScreenPtr walkScreen = screenInfo.screens[i];
-            dixFreeScreen(walkScreen);
-            screenInfo.numScreens = i;
+        if (screenInfo.numScreens > 0) {
+            for (int walkScreenIdx = screenInfo.numScreens - 1; walkScreenIdx >= 0; walkScreenIdx--) {
+                ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+                dixFreeScreen(walkScreen);
+                screenInfo.numScreens = walkScreenIdx;
+            }
         }
         memset(&screenInfo.screens, 0, sizeof(screenInfo.screens));
 

--- a/dix/privates.c
+++ b/dix/privates.c
@@ -211,13 +211,13 @@ fixupOneScreen(ScreenPtr pScreen, FixupFunc fixup, unsigned bytes)
 static Bool
 fixupScreens(FixupFunc fixup, unsigned bytes)
 {
-    for (int s = 0; s < screenInfo.numScreens; s++) {
-        ScreenPtr walkScreen = screenInfo.screens[s];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         if (!fixupOneScreen (walkScreen, fixup, bytes))
             return FALSE;
     }
-    for (int s = 0; s < screenInfo.numGPUScreens; s++) {
-        ScreenPtr walkScreen = screenInfo.gpuscreens[s];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numGPUScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.gpuscreens[walkScreenIdx];
         if (!fixupOneScreen (walkScreen, fixup, bytes))
             return FALSE;
     }
@@ -249,8 +249,8 @@ fixupExtensions(FixupFunc fixup, unsigned bytes)
 static Bool
 fixupDefaultColormaps(FixupFunc fixup, unsigned bytes)
 {
-    for (int s = 0; s < screenInfo.numScreens; s++) {
-        ScreenPtr walkScreen = screenInfo.screens[s];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         ColormapPtr cmap;
         dixLookupResourceByType((void **) &cmap,
                                 walkScreen->defColormap, X11_RESTYPE_COLORMAP,
@@ -300,12 +300,12 @@ static void
 grow_screen_specific_set(DevPrivateType type, unsigned bytes)
 {
     /* Update offsets for all screen-specific keys */
-    for (int s = 0; s < screenInfo.numScreens; s++) {
-        ScreenPtr walkScreen = screenInfo.screens[s];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         grow_private_set(&walkScreen->screenSpecificPrivates[type], bytes);
     }
-    for (int s = 0; s < screenInfo.numGPUScreens; s++) {
-        ScreenPtr walkScreen = screenInfo.gpuscreens[s];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numGPUScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.gpuscreens[walkScreenIdx];
         grow_private_set(&walkScreen->screenSpecificPrivates[type], bytes);
     }
 }

--- a/dix/property.c
+++ b/dix/property.c
@@ -130,16 +130,17 @@ notifyVRRMode(ClientPtr pClient, WindowPtr pWindow, int state, PropertyPtr pProp
 #ifdef XINERAMA
     if (!noPanoramiXExtension) {
         PanoramiXRes *win;
-        int rc, j;
+        int rc;
 
         rc = dixLookupResourceByType((void **) &win, pWindow->drawable.id, XRT_WINDOW,
                                      pClient, DixWriteAccess);
         if (rc != Success)
             goto no_panoramix;
 
-        FOR_NSCREENS_BACKWARD(j) {
+        int walkScreenIdx;
+        FOR_NSCREENS_BACKWARD(walkScreenIdx) {
             WindowPtr pWin;
-            rc = dixLookupWindow(&pWin, win->info[j].id, pClient, DixSetPropAccess);
+            rc = dixLookupWindow(&pWin, win->info[walkScreenIdx].id, pClient, DixSetPropAccess);
             if (rc == Success)
                 setVRRMode(pWin, mode);
         }

--- a/dix/window.c
+++ b/dix/window.c
@@ -396,9 +396,9 @@ PrintWindowTree(void)
     int depth;
     WindowPtr pWin;
 
-    for (int scrnum = 0; scrnum < screenInfo.numScreens; scrnum++) {
-        ScreenPtr walkScreen = screenInfo.screens[scrnum];
-        ErrorF("[dix] Dumping windows for screen %d (pixmap %x):\n", scrnum,
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+        ErrorF("[dix] Dumping windows for screen %d (pixmap %x):\n", walkScreenIdx,
                (unsigned) walkScreen->GetScreenPixmap(walkScreen)->drawable.id);
         pWin = walkScreen->root;
         depth = 1;
@@ -2993,7 +2993,7 @@ SendVisibilityNotify(WindowPtr pWin)
     if (!noPanoramiXExtension) {
         PanoramiXRes *win;
         WindowPtr pWin2;
-        int rc, i, Scrnum;
+        int rc, Scrnum;
 
         Scrnum = pWin->drawable.pScreen->myNum;
 
@@ -3003,21 +3003,23 @@ SendVisibilityNotify(WindowPtr pWin)
             return;
 
         switch (visibility) {
-        case VisibilityUnobscured:
-        FOR_NSCREENS_BACKWARD(i) {
-            if (i == Scrnum)
+        case VisibilityUnobscured: {
+        int walkScreenIdx;
+        FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+            if (walkScreenIdx == Scrnum)
                 continue;
 
-            rc = dixLookupWindow(&pWin2, win->info[i].id, serverClient,
+            rc = dixLookupWindow(&pWin2, win->info[walkScreenIdx].id, serverClient,
                                  DixWriteAccess);
 
             if (rc == Success) {
                 if (pWin2->visibility == VisibilityPartiallyObscured)
                     return;
 
-                if (!i)
+                if (!walkScreenIdx)
                     pWin = pWin2;
             }
+        }
         }
             break;
         case VisibilityPartiallyObscured:
@@ -3028,23 +3030,25 @@ SendVisibilityNotify(WindowPtr pWin)
                     pWin = pWin2;
             }
             break;
-        case VisibilityFullyObscured:
-        FOR_NSCREENS_BACKWARD(i) {
-            if (i == Scrnum)
+        case VisibilityFullyObscured: {
+        int walkScreenIdx;
+        FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+            if (walkScreenIdx == Scrnum)
                 continue;
 
-            rc = dixLookupWindow(&pWin2, win->info[i].id, serverClient,
+            rc = dixLookupWindow(&pWin2, win->info[walkScreenIdx].id, serverClient,
                                  DixWriteAccess);
 
             if (rc == Success) {
                 if (pWin2->visibility != VisibilityFullyObscured)
                     return;
 
-                if (!i)
+                if (!walkScreenIdx)
                     pWin = pWin2;
             }
         }
             break;
+        }
         }
 
         win->u.win.visibility = visibility;
@@ -3080,15 +3084,15 @@ dixSaveScreens(ClientPtr client, int on, int mode)
             type = SCREEN_SAVER_CYCLE;
     }
 
-    for (int i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         int rc = XaceHookScreensaverAccess(client, walkScreen,
                       DixShowAccess | DixHideAccess);
         if (rc != Success)
             return rc;
     }
-    for (int i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
 
         if (on == SCREEN_SAVER_FORCER)
             walkScreen->SaveScreen(walkScreen, on);


### PR DESCRIPTION
When iterating screen lists, consistently use the same variable name
`walkScreenIdx` for holding current screen index everywhere.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
