### PR TITLE
xfree86: dri: ProcXF86DRIGetDrawableInfo(): cache screen pointer

### DIFF
--- a/hw/xfree86/dri/xf86dri.c
+++ b/hw/xfree86/dri/xf86dri.c
@@ -353,7 +353,9 @@ ProcXF86DRIGetDrawableInfo(register ClientPtr client)
     if (rc != Success)
         return rc;
 
-    if (!DRIGetDrawableInfo(screenInfo.screens[stuff->screen],
+    ScreenPtr pScreen = screenInfo.screens[stuff->screen];
+
+    if (!DRIGetDrawableInfo(pScreen,
                             pDrawable,
                             (unsigned int *) &rep.drawableTableIndex,
                             (unsigned int *) &rep.drawableTableStamp,
@@ -389,7 +391,6 @@ ProcXF86DRIGetDrawableInfo(register ClientPtr client)
         if (!pClippedRects)
             return BadAlloc;
 
-        ScreenPtr pScreen = screenInfo.screens[stuff->screen];
         int i, j;
 
         for (i = 0, j = 0; i < rep.numClipRects; i++) {


### PR DESCRIPTION
Cache the screen pointer in local variable, instead of fetching it
from global array several times. Follow-up commits will use some
inline helper for that.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
