### PR TITLE
glx: consolidate retrieval of vendor for screen

### DIFF
--- a/glx/vnd_dispatch_stubs.c
+++ b/glx/vnd_dispatch_stubs.c
@@ -11,6 +11,13 @@
 #define X_GLXCreateContextAttribsARB X_GLXCreateContextAtrribsARB
 #endif
 
+static inline GlxServerVendor *vendorForScreen(ClientPtr pClient, CARD32 screen)
+{
+    if (screen < screenInfo.numScreens)
+        return glxServer.getVendorForScreen(pClient, screenInfo.screens[screen]);
+    return NULL;
+}
+
 static int dispatch_Render(ClientPtr client)
 {
     REQUEST(xGLXRenderReq);
@@ -49,14 +56,12 @@ static int dispatch_CreateContext(ClientPtr client)
 {
     REQUEST(xGLXCreateContextReq);
     CARD32 screen, context;
-    GlxServerVendor *vendor = NULL;
     REQUEST_SIZE_MATCH(*stuff);
     screen = GlxCheckSwap(client, stuff->screen);
     context = GlxCheckSwap(client, stuff->context);
     LEGAL_NEW_RESOURCE(context, client);
-    if (screen < screenInfo.numScreens) {
-        vendor = glxServer.getVendorForScreen(client, screenInfo.screens[screen]);
-    }
+
+    GlxServerVendor *vendor = vendorForScreen(client, screen);
     if (vendor != NULL) {
         int ret;
         if (!glxServer.addXIDMap(context, vendor)) {
@@ -147,14 +152,12 @@ static int dispatch_CreateGLXPixmap(ClientPtr client)
 {
     REQUEST(xGLXCreateGLXPixmapReq);
     CARD32 screen, glxpixmap;
-    GlxServerVendor *vendor = NULL;
     REQUEST_SIZE_MATCH(*stuff);
     screen = GlxCheckSwap(client, stuff->screen);
     glxpixmap = GlxCheckSwap(client, stuff->glxpixmap);
     LEGAL_NEW_RESOURCE(glxpixmap, client);
-    if (screen < screenInfo.numScreens) {
-        vendor = glxServer.getVendorForScreen(client, screenInfo.screens[screen]);
-    }
+
+    GlxServerVendor *vendor = vendorForScreen(client, screen);
     if (vendor != NULL) {
         int ret;
         if (!glxServer.addXIDMap(glxpixmap, vendor)) {
@@ -174,12 +177,10 @@ static int dispatch_GetVisualConfigs(ClientPtr client)
 {
     REQUEST(xGLXGetVisualConfigsReq);
     CARD32 screen;
-    GlxServerVendor *vendor = NULL;
     REQUEST_SIZE_MATCH(*stuff);
     screen = GlxCheckSwap(client, stuff->screen);
-    if (screen < screenInfo.numScreens) {
-        vendor = glxServer.getVendorForScreen(client, screenInfo.screens[screen]);
-    }
+
+    GlxServerVendor *vendor = vendorForScreen(client, screen);
     if (vendor != NULL) {
         int ret;
         ret = glxServer.forwardRequest(vendor, client);
@@ -210,12 +211,10 @@ static int dispatch_QueryExtensionsString(ClientPtr client)
 {
     REQUEST(xGLXQueryExtensionsStringReq);
     CARD32 screen;
-    GlxServerVendor *vendor = NULL;
     REQUEST_SIZE_MATCH(*stuff);
     screen = GlxCheckSwap(client, stuff->screen);
-    if (screen < screenInfo.numScreens) {
-        vendor = glxServer.getVendorForScreen(client, screenInfo.screens[screen]);
-    }
+
+    GlxServerVendor *vendor = vendorForScreen(client, screen);
     if (vendor != NULL) {
         int ret;
         ret = glxServer.forwardRequest(vendor, client);
@@ -229,12 +228,10 @@ static int dispatch_QueryServerString(ClientPtr client)
 {
     REQUEST(xGLXQueryServerStringReq);
     CARD32 screen;
-    GlxServerVendor *vendor = NULL;
     REQUEST_SIZE_MATCH(*stuff);
     screen = GlxCheckSwap(client, stuff->screen);
-    if (screen < screenInfo.numScreens) {
-        vendor = glxServer.getVendorForScreen(client, screenInfo.screens[screen]);
-    }
+
+    GlxServerVendor *vendor = vendorForScreen(client, screen);
     if (vendor != NULL) {
         int ret;
         ret = glxServer.forwardRequest(vendor, client);
@@ -265,14 +262,12 @@ static int dispatch_CreateNewContext(ClientPtr client)
 {
     REQUEST(xGLXCreateNewContextReq);
     CARD32 screen, context;
-    GlxServerVendor *vendor = NULL;
     REQUEST_SIZE_MATCH(*stuff);
     screen = GlxCheckSwap(client, stuff->screen);
     context = GlxCheckSwap(client, stuff->context);
     LEGAL_NEW_RESOURCE(context, client);
-    if (screen < screenInfo.numScreens) {
-        vendor = glxServer.getVendorForScreen(client, screenInfo.screens[screen]);
-    }
+
+    GlxServerVendor *vendor = vendorForScreen(client, screen);
     if (vendor != NULL) {
         int ret;
         if (!glxServer.addXIDMap(context, vendor)) {
@@ -292,14 +287,12 @@ static int dispatch_CreatePbuffer(ClientPtr client)
 {
     REQUEST(xGLXCreatePbufferReq);
     CARD32 screen, pbuffer;
-    GlxServerVendor *vendor = NULL;
     REQUEST_AT_LEAST_SIZE(*stuff);
     screen = GlxCheckSwap(client, stuff->screen);
     pbuffer = GlxCheckSwap(client, stuff->pbuffer);
     LEGAL_NEW_RESOURCE(pbuffer, client);
-    if (screen < screenInfo.numScreens) {
-        vendor = glxServer.getVendorForScreen(client, screenInfo.screens[screen]);
-    }
+
+    GlxServerVendor *vendor = vendorForScreen(client, screen);
     if (vendor != NULL) {
         int ret;
         if (!glxServer.addXIDMap(pbuffer, vendor)) {
@@ -319,14 +312,12 @@ static int dispatch_CreatePixmap(ClientPtr client)
 {
     REQUEST(xGLXCreatePixmapReq);
     CARD32 screen, glxpixmap;
-    GlxServerVendor *vendor = NULL;
     REQUEST_AT_LEAST_SIZE(*stuff);
     screen = GlxCheckSwap(client, stuff->screen);
     glxpixmap = GlxCheckSwap(client, stuff->glxpixmap);
     LEGAL_NEW_RESOURCE(glxpixmap, client);
-    if (screen < screenInfo.numScreens) {
-        vendor = glxServer.getVendorForScreen(client, screenInfo.screens[screen]);
-    }
+
+    GlxServerVendor *vendor = vendorForScreen(client, screen);
     if (vendor != NULL) {
         int ret;
         if (!glxServer.addXIDMap(glxpixmap, vendor)) {
@@ -346,14 +337,12 @@ static int dispatch_CreateWindow(ClientPtr client)
 {
     REQUEST(xGLXCreateWindowReq);
     CARD32 screen, glxwindow;
-    GlxServerVendor *vendor = NULL;
     REQUEST_AT_LEAST_SIZE(*stuff);
     screen = GlxCheckSwap(client, stuff->screen);
     glxwindow = GlxCheckSwap(client, stuff->glxwindow);
     LEGAL_NEW_RESOURCE(glxwindow, client);
-    if (screen < screenInfo.numScreens) {
-        vendor = glxServer.getVendorForScreen(client, screenInfo.screens[screen]);
-    }
+
+    GlxServerVendor *vendor = vendorForScreen(client, screen);
     if (vendor != NULL) {
         int ret;
         if (!glxServer.addXIDMap(glxwindow, vendor)) {
@@ -373,14 +362,12 @@ static int dispatch_CreateContextAttribsARB(ClientPtr client)
 {
     REQUEST(xGLXCreateContextAttribsARBReq);
     CARD32 screen, context;
-    GlxServerVendor *vendor = NULL;
     REQUEST_AT_LEAST_SIZE(*stuff);
     screen = GlxCheckSwap(client, stuff->screen);
     context = GlxCheckSwap(client, stuff->context);
     LEGAL_NEW_RESOURCE(context, client);
-    if (screen < screenInfo.numScreens) {
-        vendor = glxServer.getVendorForScreen(client, screenInfo.screens[screen]);
-    }
+
+    GlxServerVendor *vendor = vendorForScreen(client, screen);
     if (vendor != NULL) {
         int ret;
         if (!glxServer.addXIDMap(context, vendor)) {
@@ -477,12 +464,10 @@ static int dispatch_GetFBConfigs(ClientPtr client)
 {
     REQUEST(xGLXGetFBConfigsReq);
     CARD32 screen;
-    GlxServerVendor *vendor = NULL;
     REQUEST_SIZE_MATCH(*stuff);
     screen = GlxCheckSwap(client, stuff->screen);
-    if (screen < screenInfo.numScreens) {
-        vendor = glxServer.getVendorForScreen(client, screenInfo.screens[screen]);
-    }
+
+    GlxServerVendor *vendor = vendorForScreen(client, screen);
     if (vendor != NULL) {
         int ret;
         ret = glxServer.forwardRequest(vendor, client);


### PR DESCRIPTION
Move the steps for retrieving the vendor object for given screen
into a little helper function.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
