### PR TITLE
Xext: panoramix: cache screen pointer

### DIFF
--- a/Xext/panoramiX.c
+++ b/Xext/panoramiX.c
@@ -982,10 +982,12 @@ ProcPanoramiXGetScreenSize(ClientPtr client)
     if (rc != Success)
         return rc;
 
+    ScreenPtr pScreen = screenInfo.screens[stuff->screen];
+
     xPanoramiXGetScreenSizeReply reply = {
         /* screen dimensions */
-        .width = screenInfo.screens[stuff->screen]->width,
-        .height = screenInfo.screens[stuff->screen]->height,
+        .width = pScreen->width,
+        .height = pScreen->height,
         .window = stuff->window,
         .screen = stuff->screen
     };


### PR DESCRIPTION
locally cache the screen pointer in local variable.
follow-up commits will use a generic helper function for retrieving it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
