### PR TITLE
kdrive: KdCursorOffScreen(): move dx and dy into local scope

### DIFF
--- a/hw/kdrive/src/kinput.c
+++ b/hw/kdrive/src/kinput.c
@@ -2116,7 +2116,6 @@ KdCursorOffScreen(ScreenPtr *ppScreen, int *x, int *y)
 {
     ScreenPtr pScreen = *ppScreen;
     int n;
-    int dx, dy;
     int best_x, best_y;
     int n_best_x, n_best_y;
     CARD32 ms;
@@ -2140,8 +2139,8 @@ KdCursorOffScreen(ScreenPtr *ppScreen, int *x, int *y)
         ScreenPtr walkScreen = screenInfo.screens[n];
         if (walkScreen == pScreen)
             continue;
-        dx = KdScreenOrigin(walkScreen)->x - KdScreenOrigin(pScreen)->x;
-        dy = KdScreenOrigin(walkScreen)->y - KdScreenOrigin(pScreen)->y;
+        int dx = KdScreenOrigin(walkScreen)->x - KdScreenOrigin(pScreen)->x;
+        int dy = KdScreenOrigin(walkScreen)->y - KdScreenOrigin(pScreen)->y;
         if (*x < 0) {
             if (dx < 0 && -dx < best_x) {
                 best_x = -dx;


### PR DESCRIPTION
These are just used locally and always assigned at loop body start,
so it's cleaner to declare them locally inside the loop body.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
