### PR TITLE
dbe: DbeResetProc(): locally scope temporary variable

### DIFF
--- a/dbe/dbe.c
+++ b/dbe/dbe.c
@@ -1142,11 +1142,10 @@ static void miDbeWindowDestroy(CallbackListPtr *pcbl, ScreenPtr pScreen, WindowP
 static void
 DbeResetProc(ExtensionEntry * extEntry)
 {
-    DbeScreenPrivPtr pDbeScreenPriv;
 
     for (int i = 0; i < screenInfo.numScreens; i++) {
         ScreenPtr walkScreen = screenInfo.screens[i];
-        pDbeScreenPriv = DBE_SCREEN_PRIV(walkScreen);
+        DbeScreenPrivPtr pDbeScreenPriv = DBE_SCREEN_PRIV(walkScreen);
 
         if (pDbeScreenPriv) {
             dixScreenUnhookWindowDestroy(walkScreen, miDbeWindowDestroy);


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
