### PR TITLE
dbe: DbeExtensionInit() don't reuse walk variable differently

### DIFF
--- a/dbe/dbe.c
+++ b/dbe/dbe.c
@@ -1236,11 +1236,9 @@ DbeExtensionInit(void)
              */
 
             for (int j = 0; j < i; j++) {
-                walkScreen = screenInfo.screens[j];
-                free(dixLookupPrivate(&walkScreen->devPrivates,
-                                      dbeScreenPrivKey));
-                dixSetPrivate(&walkScreen->devPrivates,
-                              dbeScreenPrivKey, NULL);
+                ScreenPtr pScreen = screenInfo.screens[j];
+                free(dixLookupPrivate(&pScreen->devPrivates, dbeScreenPrivKey));
+                dixSetPrivate(&pScreen->devPrivates, dbeScreenPrivKey, NULL);
             }
             return;
         }


### PR DESCRIPTION
The code is easier to understand when we don't reuse existing variables
for entirely different things.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
