### PR TITLE
Xi: ProcXCloseDevice(): compactify the loop a bit

### DIFF
--- a/Xi/closedev.c
+++ b/Xi/closedev.c
@@ -140,10 +140,8 @@ ProcXCloseDevice(ClientPtr client)
 
     for (i = 0; i < screenInfo.numScreens; i++) {
         ScreenPtr walkScreen = screenInfo.screens[i];
-        WindowPtr pWin = walkScreen->root;
-        DeleteDeviceEvents(d, pWin, client);
-        WindowPtr p1 = pWin->firstChild;
-        DeleteEventsFromChildren(d, p1, client);
+        DeleteDeviceEvents(d, walkScreen->root, client);
+        DeleteEventsFromChildren(d, walkScreen->root->firstChild, client);
     }
 
     return Success;


### PR DESCRIPTION
In preparation of upcoming screen iterator macros, compactify the
loop body a little bit. This function is so cold that it's not
really worth caching the screen's root window pointer.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
