### PR TITLE
Xext: xvmc: use x_rpcbuf_t

### DIFF
--- a/Xext/sync.c
+++ b/Xext/sync.c
@@ -1315,8 +1315,7 @@ ProcSyncListSystemCounters(ClientPtr client)
         swapl(&reply.nCounters);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 /*


### PR DESCRIPTION
Use x_rpcbuf_t for reply payload assembly.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
