### PR TITLE
dix: drop obsolete SGenericReply()

### DIFF
--- a/dix/swaprep.c
+++ b/dix/swaprep.c
@@ -59,14 +59,6 @@ static void SwapFontInfo(xQueryFontReply * pr);
 
 static void SwapCharInfo(xCharInfo * pInfo);
 
-/* Extra-small reply */
-void _X_COLD
-SGenericReply(ClientPtr pClient, int size, xGenericReply * pRep)
-{
-    swaps(&pRep->sequenceNumber);
-    WriteToClient(pClient, size, pRep);
-}
-
 static void _X_COLD
 SwapCharInfo(xCharInfo * pInfo)
 {

--- a/include/swaprep.h
+++ b/include/swaprep.h
@@ -28,10 +28,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 void SwapFont(xQueryFontReply * pr, Bool hasGlyphs);
 
-extern void SGenericReply(ClientPtr /* pClient */ ,
-                          int /* size */ ,
-                          xGenericReply * /* pRep */ );
-
 extern void SErrorEvent(xError * /* from */ ,
                         xError * /* to */ );
 


### PR DESCRIPTION
Not used anywhere, neither exported, so no need to keep it around
any longer.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
