### PR TITLE
Xext: shape: inline request swapping

### DIFF
--- a/Xext/shape.c
+++ b/Xext/shape.c
@@ -292,6 +292,13 @@ ProcShapeRectangles(ClientPtr client)
     REQUEST(xShapeRectanglesReq);
     REQUEST_AT_LEAST_SIZE(xShapeRectanglesReq);
 
+    if (client->swapped) {
+        swapl(&stuff->dest);
+        swaps(&stuff->xOff);
+        swaps(&stuff->yOff);
+        SwapRestS(stuff);
+    }
+
 #ifdef XINERAMA
     if (noPanoramiXExtension)
         return ShapeRectangles(client, stuff);
@@ -388,6 +395,13 @@ ProcShapeMask(ClientPtr client)
 {
     REQUEST(xShapeMaskReq);
     REQUEST_SIZE_MATCH(xShapeMaskReq);
+
+    if (client->swapped) {
+        swapl(&stuff->dest);
+        swaps(&stuff->xOff);
+        swaps(&stuff->yOff);
+        swapl(&stuff->src);
+    }
 
 #ifdef XINERAMA
     if (noPanoramiXExtension)
@@ -517,6 +531,13 @@ ProcShapeCombine(ClientPtr client)
     REQUEST(xShapeCombineReq);
     REQUEST_AT_LEAST_SIZE(xShapeCombineReq);
 
+    if (client->swapped) {
+        swapl(&stuff->dest);
+        swaps(&stuff->xOff);
+        swaps(&stuff->yOff);
+        swapl(&stuff->src);
+    }
+
 #ifdef XINERAMA
     if (noPanoramiXExtension)
         return ShapeCombine(client, stuff);
@@ -586,6 +607,12 @@ ProcShapeOffset(ClientPtr client)
     REQUEST(xShapeOffsetReq);
     REQUEST_AT_LEAST_SIZE(xShapeOffsetReq);
 
+    if (client->swapped) {
+        swapl(&stuff->dest);
+        swaps(&stuff->xOff);
+        swaps(&stuff->yOff);
+    }
+
 #ifdef XINERAMA
     PanoramiXRes *win;
     int j, result;
@@ -615,6 +642,9 @@ ProcShapeQueryExtents(ClientPtr client)
 {
     REQUEST(xShapeQueryExtentsReq);
     REQUEST_SIZE_MATCH(xShapeQueryExtentsReq);
+
+    if (client->swapped)
+        swapl(&stuff->window);
 
     WindowPtr pWin;
     int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
@@ -728,6 +758,10 @@ ProcShapeSelectInput(ClientPtr client)
     int rc;
 
     REQUEST_SIZE_MATCH(xShapeSelectInputReq);
+
+    if (client->swapped)
+        swapl(&stuff->window);
+
     rc = dixLookupWindow(&pWin, stuff->window, client, DixReceiveAccess);
     if (rc != Success)
         return rc;
@@ -898,6 +932,10 @@ ProcShapeInputSelected(ClientPtr client)
     int enabled, rc;
 
     REQUEST_SIZE_MATCH(xShapeInputSelectedReq);
+
+    if (client->swapped)
+        swapl(&stuff->window);
+
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
     if (rc != Success)
         return rc;
@@ -932,6 +970,10 @@ ProcShapeGetRectangles(ClientPtr client)
     RegionPtr region;
 
     REQUEST_SIZE_MATCH(xShapeGetRectanglesReq);
+
+    if (client->swapped)
+        swapl(&stuff->window);
+
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
     if (rc != Success)
         return rc;
@@ -1046,117 +1088,6 @@ SShapeNotifyEvent(xShapeNotifyEvent * from, xShapeNotifyEvent * to)
     to->shaped = from->shaped;
 }
 
-static int _X_COLD
-SProcShapeRectangles(ClientPtr client)
-{
-    REQUEST(xShapeRectanglesReq);
-    REQUEST_AT_LEAST_SIZE(xShapeRectanglesReq);
-    swapl(&stuff->dest);
-    swaps(&stuff->xOff);
-    swaps(&stuff->yOff);
-    SwapRestS(stuff);
-    return ProcShapeRectangles(client);
-}
-
-static int _X_COLD
-SProcShapeMask(ClientPtr client)
-{
-    REQUEST(xShapeMaskReq);
-    REQUEST_SIZE_MATCH(xShapeMaskReq);
-    swapl(&stuff->dest);
-    swaps(&stuff->xOff);
-    swaps(&stuff->yOff);
-    swapl(&stuff->src);
-    return ProcShapeMask(client);
-}
-
-static int _X_COLD
-SProcShapeCombine(ClientPtr client)
-{
-    REQUEST(xShapeCombineReq);
-    REQUEST_SIZE_MATCH(xShapeCombineReq);
-    swapl(&stuff->dest);
-    swaps(&stuff->xOff);
-    swaps(&stuff->yOff);
-    swapl(&stuff->src);
-    return ProcShapeCombine(client);
-}
-
-static int _X_COLD
-SProcShapeOffset(ClientPtr client)
-{
-    REQUEST(xShapeOffsetReq);
-    REQUEST_SIZE_MATCH(xShapeOffsetReq);
-    swapl(&stuff->dest);
-    swaps(&stuff->xOff);
-    swaps(&stuff->yOff);
-    return ProcShapeOffset(client);
-}
-
-static int _X_COLD
-SProcShapeQueryExtents(ClientPtr client)
-{
-    REQUEST(xShapeQueryExtentsReq);
-    REQUEST_SIZE_MATCH(xShapeQueryExtentsReq);
-    swapl(&stuff->window);
-    return ProcShapeQueryExtents(client);
-}
-
-static int _X_COLD
-SProcShapeSelectInput(ClientPtr client)
-{
-    REQUEST(xShapeSelectInputReq);
-    REQUEST_SIZE_MATCH(xShapeSelectInputReq);
-    swapl(&stuff->window);
-    return ProcShapeSelectInput(client);
-}
-
-static int _X_COLD
-SProcShapeInputSelected(ClientPtr client)
-{
-    REQUEST(xShapeInputSelectedReq);
-    REQUEST_SIZE_MATCH(xShapeInputSelectedReq);
-    swapl(&stuff->window);
-    return ProcShapeInputSelected(client);
-}
-
-static int _X_COLD
-SProcShapeGetRectangles(ClientPtr client)
-{
-    REQUEST(xShapeGetRectanglesReq);
-    REQUEST_SIZE_MATCH(xShapeGetRectanglesReq);
-    swapl(&stuff->window);
-    return ProcShapeGetRectangles(client);
-}
-
-static int _X_COLD
-SProcShapeDispatch(ClientPtr client)
-{
-    REQUEST(xReq);
-    switch (stuff->data) {
-    case X_ShapeQueryVersion:
-        return ProcShapeQueryVersion(client);
-    case X_ShapeRectangles:
-        return SProcShapeRectangles(client);
-    case X_ShapeMask:
-        return SProcShapeMask(client);
-    case X_ShapeCombine:
-        return SProcShapeCombine(client);
-    case X_ShapeOffset:
-        return SProcShapeOffset(client);
-    case X_ShapeQueryExtents:
-        return SProcShapeQueryExtents(client);
-    case X_ShapeSelectInput:
-        return SProcShapeSelectInput(client);
-    case X_ShapeInputSelected:
-        return SProcShapeInputSelected(client);
-    case X_ShapeGetRectangles:
-        return SProcShapeGetRectangles(client);
-    default:
-        return BadRequest;
-    }
-}
-
 void
 ShapeExtensionInit(void)
 {
@@ -1166,7 +1097,7 @@ ShapeExtensionInit(void)
     ShapeEventType = CreateNewResourceType(ShapeFreeEvents, "ShapeEvent");
     if (ClientType && ShapeEventType &&
         (extEntry = AddExtension(SHAPENAME, ShapeNumberEvents, 0,
-                                 ProcShapeDispatch, SProcShapeDispatch,
+                                 ProcShapeDispatch, ProcShapeDispatch,
                                  NULL, StandardMinorOpcode))) {
         ShapeEventBase = extEntry->eventBase;
         EventSwapVector[ShapeEventBase] = (EventSwapPtr) SShapeNotifyEvent;


### PR DESCRIPTION
It's so trivial that those few lines can easily be inlined into
the actual request handler.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
