### PR TITLE
xfixes: inline request swapping

### DIFF
--- a/xfixes/disconnect.c
+++ b/xfixes/disconnect.c
@@ -68,20 +68,12 @@ ProcXFixesSetClientDisconnectMode(ClientPtr client)
     REQUEST(xXFixesSetClientDisconnectModeReq);
     REQUEST_SIZE_MATCH(xXFixesSetClientDisconnectModeReq);
 
+    if (client->swapped)
+        swapl(&stuff->disconnect_mode);
+
     pDisconnect->disconnect_mode = stuff->disconnect_mode;
 
     return Success;
-}
-
-int _X_COLD
-SProcXFixesSetClientDisconnectMode(ClientPtr client)
-{
-    REQUEST(xXFixesSetClientDisconnectModeReq);
-    REQUEST_SIZE_MATCH(xXFixesSetClientDisconnectModeReq);
-
-    swapl(&stuff->disconnect_mode);
-
-    return ProcXFixesSetClientDisconnectMode(client);
 }
 
 int

--- a/xfixes/region.c
+++ b/xfixes/region.c
@@ -77,8 +77,13 @@ ProcXFixesCreateRegion(ClientPtr client)
     RegionPtr pRegion;
 
     REQUEST(xXFixesCreateRegionReq);
-
     REQUEST_AT_LEAST_SIZE(xXFixesCreateRegionReq);
+
+    if (client->swapped) {
+        swapl(&stuff->region);
+        SwapRestS(stuff);
+    }
+
     LEGAL_NEW_RESOURCE(stuff->region, client);
 
     things = (client->req_len << 2) - sizeof(xXFixesCreateRegionReq);
@@ -95,16 +100,6 @@ ProcXFixesCreateRegion(ClientPtr client)
     return Success;
 }
 
-int _X_COLD
-SProcXFixesCreateRegion(ClientPtr client)
-{
-    REQUEST(xXFixesCreateRegionReq);
-    REQUEST_AT_LEAST_SIZE(xXFixesCreateRegionReq);
-    swapl(&stuff->region);
-    SwapRestS(stuff);
-    return ProcXFixesCreateRegion(client);
-}
-
 int
 ProcXFixesCreateRegionFromBitmap(ClientPtr client)
 {
@@ -113,8 +108,13 @@ ProcXFixesCreateRegionFromBitmap(ClientPtr client)
     int rc;
 
     REQUEST(xXFixesCreateRegionFromBitmapReq);
-
     REQUEST_SIZE_MATCH(xXFixesCreateRegionFromBitmapReq);
+
+    if (client->swapped) {
+        swapl(&stuff->region);
+        swapl(&stuff->bitmap);
+    }
+
     LEGAL_NEW_RESOURCE(stuff->region, client);
 
     rc = dixLookupResourceByType((void **) &pPixmap, stuff->bitmap, X11_RESTYPE_PIXMAP,
@@ -137,16 +137,6 @@ ProcXFixesCreateRegionFromBitmap(ClientPtr client)
     return Success;
 }
 
-int _X_COLD
-SProcXFixesCreateRegionFromBitmap(ClientPtr client)
-{
-    REQUEST(xXFixesCreateRegionFromBitmapReq);
-    REQUEST_SIZE_MATCH(xXFixesCreateRegionFromBitmapReq);
-    swapl(&stuff->region);
-    swapl(&stuff->bitmap);
-    return ProcXFixesCreateRegionFromBitmap(client);
-}
-
 int
 ProcXFixesCreateRegionFromWindow(ClientPtr client)
 {
@@ -156,8 +146,13 @@ ProcXFixesCreateRegionFromWindow(ClientPtr client)
     int rc;
 
     REQUEST(xXFixesCreateRegionFromWindowReq);
-
     REQUEST_SIZE_MATCH(xXFixesCreateRegionFromWindowReq);
+
+    if (client->swapped) {
+        swapl(&stuff->region);
+        swapl(&stuff->window);
+    }
+
     LEGAL_NEW_RESOURCE(stuff->region, client);
     rc = dixLookupResourceByType((void **) &pWin, stuff->window, X11_RESTYPE_WINDOW,
                                  client, DixGetAttrAccess);
@@ -194,16 +189,6 @@ ProcXFixesCreateRegionFromWindow(ClientPtr client)
     return Success;
 }
 
-int _X_COLD
-SProcXFixesCreateRegionFromWindow(ClientPtr client)
-{
-    REQUEST(xXFixesCreateRegionFromWindowReq);
-    REQUEST_SIZE_MATCH(xXFixesCreateRegionFromWindowReq);
-    swapl(&stuff->region);
-    swapl(&stuff->window);
-    return ProcXFixesCreateRegionFromWindow(client);
-}
-
 int
 ProcXFixesCreateRegionFromGC(ClientPtr client)
 {
@@ -212,8 +197,13 @@ ProcXFixesCreateRegionFromGC(ClientPtr client)
     int rc;
 
     REQUEST(xXFixesCreateRegionFromGCReq);
-
     REQUEST_SIZE_MATCH(xXFixesCreateRegionFromGCReq);
+
+    if (client->swapped) {
+        swapl(&stuff->region);
+        swapl(&stuff->gc);
+    }
+
     LEGAL_NEW_RESOURCE(stuff->region, client);
 
     rc = dixLookupGC(&pGC, stuff->gc, client, DixGetAttrAccess);
@@ -235,16 +225,6 @@ ProcXFixesCreateRegionFromGC(ClientPtr client)
     return Success;
 }
 
-int _X_COLD
-SProcXFixesCreateRegionFromGC(ClientPtr client)
-{
-    REQUEST(xXFixesCreateRegionFromGCReq);
-    REQUEST_SIZE_MATCH(xXFixesCreateRegionFromGCReq);
-    swapl(&stuff->region);
-    swapl(&stuff->gc);
-    return ProcXFixesCreateRegionFromGC(client);
-}
-
 int
 ProcXFixesCreateRegionFromPicture(ClientPtr client)
 {
@@ -252,8 +232,13 @@ ProcXFixesCreateRegionFromPicture(ClientPtr client)
     PicturePtr pPicture;
 
     REQUEST(xXFixesCreateRegionFromPictureReq);
-
     REQUEST_SIZE_MATCH(xXFixesCreateRegionFromPictureReq);
+
+    if (client->swapped) {
+        swapl(&stuff->region);
+        swapl(&stuff->picture);
+    }
+
     LEGAL_NEW_RESOURCE(stuff->region, client);
 
     VERIFY_PICTURE(pPicture, stuff->picture, client, DixGetAttrAccess);
@@ -275,16 +260,6 @@ ProcXFixesCreateRegionFromPicture(ClientPtr client)
     return Success;
 }
 
-int _X_COLD
-SProcXFixesCreateRegionFromPicture(ClientPtr client)
-{
-    REQUEST(xXFixesCreateRegionFromPictureReq);
-    REQUEST_SIZE_MATCH(xXFixesCreateRegionFromPictureReq);
-    swapl(&stuff->region);
-    swapl(&stuff->picture);
-    return ProcXFixesCreateRegionFromPicture(client);
-}
-
 int
 ProcXFixesDestroyRegion(ClientPtr client)
 {
@@ -292,18 +267,13 @@ ProcXFixesDestroyRegion(ClientPtr client)
     RegionPtr pRegion;
 
     REQUEST_SIZE_MATCH(xXFixesDestroyRegionReq);
+
+    if (client->swapped)
+        swapl(&stuff->region);
+
     VERIFY_REGION(pRegion, stuff->region, client, DixWriteAccess);
     FreeResource(stuff->region, X11_RESTYPE_NONE);
     return Success;
-}
-
-int _X_COLD
-SProcXFixesDestroyRegion(ClientPtr client)
-{
-    REQUEST(xXFixesDestroyRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesDestroyRegionReq);
-    swapl(&stuff->region);
-    return ProcXFixesDestroyRegion(client);
 }
 
 int
@@ -313,8 +283,13 @@ ProcXFixesSetRegion(ClientPtr client)
     RegionPtr pRegion, pNew;
 
     REQUEST(xXFixesSetRegionReq);
-
     REQUEST_AT_LEAST_SIZE(xXFixesSetRegionReq);
+
+    if (client->swapped) {
+        swapl(&stuff->region);
+        SwapRestS(stuff);
+    }
+
     VERIFY_REGION(pRegion, stuff->region, client, DixWriteAccess);
 
     things = (client->req_len << 2) - sizeof(xXFixesCreateRegionReq);
@@ -333,16 +308,6 @@ ProcXFixesSetRegion(ClientPtr client)
     return Success;
 }
 
-int _X_COLD
-SProcXFixesSetRegion(ClientPtr client)
-{
-    REQUEST(xXFixesSetRegionReq);
-    REQUEST_AT_LEAST_SIZE(xXFixesSetRegionReq);
-    swapl(&stuff->region);
-    SwapRestS(stuff);
-    return ProcXFixesSetRegion(client);
-}
-
 int
 ProcXFixesCopyRegion(ClientPtr client)
 {
@@ -350,6 +315,11 @@ ProcXFixesCopyRegion(ClientPtr client)
 
     REQUEST(xXFixesCopyRegionReq);
     REQUEST_SIZE_MATCH(xXFixesCopyRegionReq);
+
+    if (client->swapped) {
+        swapl(&stuff->source);
+        swapl(&stuff->destination);
+    }
 
     VERIFY_REGION(pSource, stuff->source, client, DixReadAccess);
     VERIFY_REGION(pDestination, stuff->destination, client, DixWriteAccess);
@@ -360,24 +330,20 @@ ProcXFixesCopyRegion(ClientPtr client)
     return Success;
 }
 
-int _X_COLD
-SProcXFixesCopyRegion(ClientPtr client)
-{
-    REQUEST(xXFixesCopyRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesCopyRegionReq);
-    swapl(&stuff->source);
-    swapl(&stuff->destination);
-    return ProcXFixesCopyRegion(client);
-}
-
 int
 ProcXFixesCombineRegion(ClientPtr client)
 {
     RegionPtr pSource1, pSource2, pDestination;
 
     REQUEST(xXFixesCombineRegionReq);
-
     REQUEST_SIZE_MATCH(xXFixesCombineRegionReq);
+
+    if (client->swapped) {
+        swapl(&stuff->source1);
+        swapl(&stuff->source2);
+        swapl(&stuff->destination);
+    }
+
     VERIFY_REGION(pSource1, stuff->source1, client, DixReadAccess);
     VERIFY_REGION(pSource2, stuff->source2, client, DixReadAccess);
     VERIFY_REGION(pDestination, stuff->destination, client, DixWriteAccess);
@@ -400,17 +366,6 @@ ProcXFixesCombineRegion(ClientPtr client)
     return Success;
 }
 
-int _X_COLD
-SProcXFixesCombineRegion(ClientPtr client)
-{
-    REQUEST(xXFixesCombineRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesCombineRegionReq);
-    swapl(&stuff->source1);
-    swapl(&stuff->source2);
-    swapl(&stuff->destination);
-    return ProcXFixesCombineRegion(client);
-}
-
 int
 ProcXFixesInvertRegion(ClientPtr client)
 {
@@ -418,8 +373,17 @@ ProcXFixesInvertRegion(ClientPtr client)
     BoxRec bounds;
 
     REQUEST(xXFixesInvertRegionReq);
-
     REQUEST_SIZE_MATCH(xXFixesInvertRegionReq);
+
+    if (client->swapped) {
+        swapl(&stuff->source);
+        swaps(&stuff->x);
+        swaps(&stuff->y);
+        swaps(&stuff->width);
+        swaps(&stuff->height);
+        swapl(&stuff->destination);
+    }
+
     VERIFY_REGION(pSource, stuff->source, client, DixReadAccess);
     VERIFY_REGION(pDestination, stuff->destination, client, DixWriteAccess);
 
@@ -442,43 +406,24 @@ ProcXFixesInvertRegion(ClientPtr client)
     return Success;
 }
 
-int _X_COLD
-SProcXFixesInvertRegion(ClientPtr client)
-{
-    REQUEST(xXFixesInvertRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesInvertRegionReq);
-    swapl(&stuff->source);
-    swaps(&stuff->x);
-    swaps(&stuff->y);
-    swaps(&stuff->width);
-    swaps(&stuff->height);
-    swapl(&stuff->destination);
-    return ProcXFixesInvertRegion(client);
-}
-
 int
 ProcXFixesTranslateRegion(ClientPtr client)
 {
     RegionPtr pRegion;
 
     REQUEST(xXFixesTranslateRegionReq);
-
     REQUEST_SIZE_MATCH(xXFixesTranslateRegionReq);
+
+    if (client->swapped) {
+        swapl(&stuff->region);
+        swaps(&stuff->dx);
+        swaps(&stuff->dy);
+    }
+
     VERIFY_REGION(pRegion, stuff->region, client, DixWriteAccess);
 
     RegionTranslate(pRegion, stuff->dx, stuff->dy);
     return Success;
-}
-
-int _X_COLD
-SProcXFixesTranslateRegion(ClientPtr client)
-{
-    REQUEST(xXFixesTranslateRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesTranslateRegionReq);
-    swapl(&stuff->region);
-    swaps(&stuff->dx);
-    swaps(&stuff->dy);
-    return ProcXFixesTranslateRegion(client);
 }
 
 int
@@ -487,24 +432,19 @@ ProcXFixesRegionExtents(ClientPtr client)
     RegionPtr pSource, pDestination;
 
     REQUEST(xXFixesRegionExtentsReq);
-
     REQUEST_SIZE_MATCH(xXFixesRegionExtentsReq);
+
+    if (client->swapped) {
+        swapl(&stuff->source);
+        swapl(&stuff->destination);
+    }
+
     VERIFY_REGION(pSource, stuff->source, client, DixReadAccess);
     VERIFY_REGION(pDestination, stuff->destination, client, DixWriteAccess);
 
     RegionReset(pDestination, RegionExtents(pSource));
 
     return Success;
-}
-
-int _X_COLD
-SProcXFixesRegionExtents(ClientPtr client)
-{
-    REQUEST(xXFixesRegionExtentsReq);
-    REQUEST_SIZE_MATCH(xXFixesRegionExtentsReq);
-    swapl(&stuff->source);
-    swapl(&stuff->destination);
-    return ProcXFixesRegionExtents(client);
 }
 
 int
@@ -516,8 +456,12 @@ ProcXFixesFetchRegion(ClientPtr client)
     int i, nBox;
 
     REQUEST(xXFixesFetchRegionReq);
-
     REQUEST_SIZE_MATCH(xXFixesFetchRegionReq);
+
+    if (client->swapped) {
+        swapl(&stuff->region);
+    }
+
     VERIFY_REGION(pRegion, stuff->region, client, DixReadAccess);
 
     pExtent = RegionExtents(pRegion);
@@ -553,15 +497,6 @@ ProcXFixesFetchRegion(ClientPtr client)
     return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }
 
-int _X_COLD
-SProcXFixesFetchRegion(ClientPtr client)
-{
-    REQUEST(xXFixesFetchRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesFetchRegionReq);
-    swapl(&stuff->region);
-    return ProcXFixesFetchRegion(client);
-}
-
 static int
 PanoramiXFixesSetGCClipRegion(ClientPtr client, xXFixesSetGCClipRegionReq *stuff);
 
@@ -573,6 +508,13 @@ ProcXFixesSetGCClipRegion(ClientPtr client)
 {
     REQUEST(xXFixesSetGCClipRegionReq);
     REQUEST_SIZE_MATCH(xXFixesSetGCClipRegionReq);
+
+    if (client->swapped) {
+        swapl(&stuff->gc);
+        swapl(&stuff->region);
+        swaps(&stuff->xOrigin);
+        swaps(&stuff->yOrigin);
+    }
 
 #ifdef XINERAMA
     if (XFixesUseXinerama)
@@ -608,18 +550,6 @@ SingleXFixesSetGCClipRegion(ClientPtr client, xXFixesSetGCClipRegionReq *stuff)
                                (void *) pRegion, 0);
 
     return Success;
-}
-
-int _X_COLD
-SProcXFixesSetGCClipRegion(ClientPtr client)
-{
-    REQUEST(xXFixesSetGCClipRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesSetGCClipRegionReq);
-    swapl(&stuff->gc);
-    swapl(&stuff->region);
-    swaps(&stuff->xOrigin);
-    swaps(&stuff->yOrigin);
-    return ProcXFixesSetGCClipRegion(client);
 }
 
 typedef RegionPtr (*CreateDftPtr) (WindowPtr pWin);
@@ -704,23 +634,18 @@ ProcXFixesSetWindowShapeRegion(ClientPtr client)
     REQUEST(xXFixesSetWindowShapeRegionReq);
     REQUEST_SIZE_MATCH(xXFixesSetWindowShapeRegionReq);
 
+    if (client->swapped) {
+        swapl(&stuff->dest);
+        swaps(&stuff->xOff);
+        swaps(&stuff->yOff);
+        swapl(&stuff->region);
+    }
+
 #ifdef XINERAMA
     if (XFixesUseXinerama)
         return PanoramiXFixesSetWindowShapeRegion(client, stuff);
 #endif
     return SingleXFixesSetWindowShapeRegion(client, stuff);
-}
-
-int _X_COLD
-SProcXFixesSetWindowShapeRegion(ClientPtr client)
-{
-    REQUEST(xXFixesSetWindowShapeRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesSetWindowShapeRegionReq);
-    swapl(&stuff->dest);
-    swaps(&stuff->xOff);
-    swaps(&stuff->yOff);
-    swapl(&stuff->region);
-    return ProcXFixesSetWindowShapeRegion(client);
 }
 
 static int
@@ -734,6 +659,13 @@ ProcXFixesSetPictureClipRegion(ClientPtr client)
 {
     REQUEST(xXFixesSetPictureClipRegionReq);
     REQUEST_SIZE_MATCH(xXFixesSetPictureClipRegionReq);
+
+    if (client->swapped) {
+        swapl(&stuff->picture);
+        swapl(&stuff->region);
+        swaps(&stuff->xOrigin);
+        swaps(&stuff->yOrigin);
+    }
 
 #ifdef XINERAMA
     if (XFixesUseXinerama)
@@ -758,18 +690,6 @@ SingleXFixesSetPictureClipRegion(ClientPtr client, xXFixesSetPictureClipRegionRe
                                 pRegion);
 }
 
-int _X_COLD
-SProcXFixesSetPictureClipRegion(ClientPtr client)
-{
-    REQUEST(xXFixesSetPictureClipRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesSetPictureClipRegionReq);
-    swapl(&stuff->picture);
-    swapl(&stuff->region);
-    swaps(&stuff->xOrigin);
-    swaps(&stuff->yOrigin);
-    return ProcXFixesSetPictureClipRegion(client);
-}
-
 int
 ProcXFixesExpandRegion(ClientPtr client)
 {
@@ -782,6 +702,16 @@ ProcXFixesExpandRegion(ClientPtr client)
     int i;
 
     REQUEST_SIZE_MATCH(xXFixesExpandRegionReq);
+
+    if (client->swapped) {
+        swapl(&stuff->source);
+        swapl(&stuff->destination);
+        swaps(&stuff->left);
+        swaps(&stuff->right);
+        swaps(&stuff->top);
+        swaps(&stuff->bottom);
+    }
+
     VERIFY_REGION(pSource, stuff->source, client, DixReadAccess);
     VERIFY_REGION(pDestination, stuff->destination, client, DixWriteAccess);
 
@@ -807,20 +737,6 @@ ProcXFixesExpandRegion(ClientPtr client)
         free(pTmp);
     }
     return Success;
-}
-
-int _X_COLD
-SProcXFixesExpandRegion(ClientPtr client)
-{
-    REQUEST(xXFixesExpandRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesExpandRegionReq);
-    swapl(&stuff->source);
-    swapl(&stuff->destination);
-    swaps(&stuff->left);
-    swaps(&stuff->right);
-    swaps(&stuff->top);
-    swaps(&stuff->bottom);
-    return ProcXFixesExpandRegion(client);
 }
 
 #ifdef XINERAMA

--- a/xfixes/saveset.c
+++ b/xfixes/saveset.c
@@ -35,8 +35,11 @@ ProcXFixesChangeSaveSet(ClientPtr client)
     WindowPtr pWin;
 
     REQUEST(xXFixesChangeSaveSetReq);
-
     REQUEST_SIZE_MATCH(xXFixesChangeSaveSetReq);
+
+    if (client->swapped)
+        swapl(&stuff->window);
+
     result = dixLookupWindow(&pWin, stuff->window, client, DixManageAccess);
     if (result != Success)
         return result;
@@ -57,14 +60,4 @@ ProcXFixesChangeSaveSet(ClientPtr client)
     toRoot = (stuff->target == SaveSetRoot);
     map = (stuff->map == SaveSetMap);
     return AlterSaveSetForClient(client, pWin, stuff->mode, toRoot, map);
-}
-
-int _X_COLD
-SProcXFixesChangeSaveSet(ClientPtr client)
-{
-    REQUEST(xXFixesChangeSaveSetReq);
-    REQUEST_SIZE_MATCH(xXFixesChangeSaveSetReq);
-
-    swapl(&stuff->window);
-    return ProcXFixesChangeSaveSet(client);
 }

--- a/xfixes/select.c
+++ b/xfixes/select.c
@@ -135,6 +135,12 @@ ProcXFixesSelectSelectionInput(ClientPtr client)
     REQUEST(xXFixesSelectSelectionInputReq);
     REQUEST_SIZE_MATCH(xXFixesSelectSelectionInputReq);
 
+    if (client->swapped) {
+        swapl(&stuff->window);
+        swapl(&stuff->selection);
+        swapl(&stuff->eventMask);
+    }
+
     /* allow extensions to intercept */
     SelectionFilterParamRec param = {
         .client = client,
@@ -214,17 +220,6 @@ ProcXFixesSelectSelectionInput(ClientPtr client)
     }
     e->eventMask = stuff->eventMask;
     return Success;
-}
-
-int _X_COLD
-SProcXFixesSelectSelectionInput(ClientPtr client)
-{
-    REQUEST(xXFixesSelectSelectionInputReq);
-    REQUEST_SIZE_MATCH(xXFixesSelectSelectionInputReq);
-    swapl(&stuff->window);
-    swapl(&stuff->selection);
-    swapl(&stuff->eventMask);
-    return ProcXFixesSelectSelectionInput(client);
 }
 
 void _X_COLD

--- a/xfixes/xfixes.c
+++ b/xfixes/xfixes.c
@@ -68,8 +68,12 @@ ProcXFixesQueryVersion(ClientPtr client)
     XFixesClientPtr pXFixesClient = GetXFixesClient(client);
 
     REQUEST(xXFixesQueryVersionReq);
-
     REQUEST_SIZE_MATCH(xXFixesQueryVersionReq);
+
+    if (client->swapped) {
+        swapl(&stuff->majorVersion);
+        swapl(&stuff->minorVersion);
+    }
 
     if (version_compare(stuff->majorVersion, stuff->minorVersion,
                         SERVER_XFIXES_MAJOR_VERSION,
@@ -203,112 +207,6 @@ ProcXFixesDispatch(ClientPtr client)
     }
 }
 
-static _X_COLD int
-SProcXFixesQueryVersion(ClientPtr client)
-{
-    REQUEST(xXFixesQueryVersionReq);
-    REQUEST_SIZE_MATCH(xXFixesQueryVersionReq);
-
-    swapl(&stuff->majorVersion);
-    swapl(&stuff->minorVersion);
-    return ProcXFixesQueryVersion(client);
-}
-
-static _X_COLD int
-SProcXFixesDispatch(ClientPtr client)
-{
-    REQUEST(xReq);
-    XFixesClientPtr pXFixesClient = GetXFixesClient(client);
-
-    if (pXFixesClient->major_version >= ARRAY_SIZE(version_requests))
-        return BadRequest;
-    if (stuff->data > version_requests[pXFixesClient->major_version])
-        return BadRequest;
-
-    switch (stuff->data) {
-        /*************** Version 1 ******************/
-        case X_XFixesQueryVersion:
-            return SProcXFixesQueryVersion(client);
-        case X_XFixesChangeSaveSet:
-            return SProcXFixesChangeSaveSet(client);
-        case X_XFixesSelectSelectionInput:
-            return SProcXFixesSelectSelectionInput(client);
-        case X_XFixesSelectCursorInput:
-            return SProcXFixesSelectCursorInput(client);
-        case X_XFixesGetCursorImage:
-            return ProcXFixesGetCursorImage(client);
-
-        /*************** Version 2 ******************/
-        case X_XFixesCreateRegion:
-            return SProcXFixesCreateRegion(client);
-        case X_XFixesCreateRegionFromBitmap:
-            return SProcXFixesCreateRegionFromBitmap(client);
-        case X_XFixesCreateRegionFromWindow:
-            return SProcXFixesCreateRegionFromWindow(client);
-        case X_XFixesCreateRegionFromGC:
-            return SProcXFixesCreateRegionFromGC(client);
-        case X_XFixesCreateRegionFromPicture:
-            return SProcXFixesCreateRegionFromPicture(client);
-        case X_XFixesDestroyRegion:
-            return SProcXFixesDestroyRegion(client);
-        case X_XFixesSetRegion:
-            return SProcXFixesSetRegion(client);
-        case X_XFixesCopyRegion:
-            return SProcXFixesCopyRegion(client);
-        case X_XFixesUnionRegion:
-            return SProcXFixesCombineRegion(client);
-        case X_XFixesIntersectRegion:
-            return SProcXFixesCombineRegion(client);
-        case X_XFixesSubtractRegion:
-            return SProcXFixesCombineRegion(client);
-        case X_XFixesInvertRegion:
-            return SProcXFixesInvertRegion(client);
-        case X_XFixesTranslateRegion:
-            return SProcXFixesTranslateRegion(client);
-        case X_XFixesRegionExtents:
-            return SProcXFixesRegionExtents(client);
-        case X_XFixesFetchRegion:
-            return SProcXFixesFetchRegion(client);
-        case X_XFixesSetGCClipRegion:
-            return SProcXFixesSetGCClipRegion(client);
-        case X_XFixesSetWindowShapeRegion:
-            return SProcXFixesSetWindowShapeRegion(client);
-        case X_XFixesSetPictureClipRegion:
-            return SProcXFixesSetPictureClipRegion(client);
-        case X_XFixesSetCursorName:
-            return SProcXFixesSetCursorName(client);
-        case X_XFixesGetCursorName:
-            return SProcXFixesGetCursorName(client);
-        case X_XFixesGetCursorImageAndName:
-            return ProcXFixesGetCursorImageAndName(client);
-        case X_XFixesChangeCursor:
-            return SProcXFixesChangeCursor(client);
-        case X_XFixesChangeCursorByName:
-            return SProcXFixesChangeCursorByName(client);
-
-        /*************** Version 3 ******************/
-        case X_XFixesExpandRegion:
-            return SProcXFixesExpandRegion(client);
-        /*************** Version 4 ******************/
-        case X_XFixesHideCursor:
-            return SProcXFixesHideCursor(client);
-        case X_XFixesShowCursor:
-            return SProcXFixesShowCursor(client);
-        /*************** Version 5 ******************/
-        case X_XFixesCreatePointerBarrier:
-            return SProcXFixesCreatePointerBarrier(client);
-        case X_XFixesDestroyPointerBarrier:
-            return SProcXFixesDestroyPointerBarrier(client);
-        /*************** Version 6 ******************/
-        case X_XFixesSetClientDisconnectMode:
-            return SProcXFixesSetClientDisconnectMode(client);
-        case X_XFixesGetClientDisconnectMode:
-            return ProcXFixesGetClientDisconnectMode(client);
-        default:
-            return BadRequest;
-    }
-}
-
 void
 XFixesExtensionInit(void)
 {
@@ -324,7 +222,7 @@ XFixesExtensionInit(void)
         XFixesClientDisconnectInit() &&
         (extEntry = AddExtension(XFIXES_NAME, XFixesNumberEvents,
                                  XFixesNumberErrors,
-                                 ProcXFixesDispatch, SProcXFixesDispatch,
+                                 ProcXFixesDispatch, ProcXFixesDispatch,
                                  NULL, StandardMinorOpcode)) != 0) {
         XFixesReqCode = (unsigned char) extEntry->base;
         XFixesEventBase = extEntry->eventBase;

--- a/xfixes/xfixesint.h
+++ b/xfixes/xfixesint.h
@@ -75,15 +75,9 @@ typedef struct _XFixesClient {
 int
  ProcXFixesChangeSaveSet(ClientPtr client);
 
-int
- SProcXFixesChangeSaveSet(ClientPtr client);
-
 /* Selection events */
 int
  ProcXFixesSelectSelectionInput(ClientPtr client);
-
-int
- SProcXFixesSelectSelectionInput(ClientPtr client);
 
 void
 
@@ -99,9 +93,6 @@ Bool
 int
  ProcXFixesSelectCursorInput(ClientPtr client);
 
-int
- SProcXFixesSelectCursorInput(ClientPtr client);
-
 void
 
 SXFixesCursorNotifyEvent(xXFixesCursorNotifyEvent * from,
@@ -116,13 +107,7 @@ int
  ProcXFixesSetCursorName(ClientPtr client);
 
 int
- SProcXFixesSetCursorName(ClientPtr client);
-
-int
  ProcXFixesGetCursorName(ClientPtr client);
-
-int
- SProcXFixesGetCursorName(ClientPtr client);
 
 int
  ProcXFixesGetCursorImageAndName(ClientPtr client);
@@ -133,13 +118,7 @@ int
  ProcXFixesChangeCursor(ClientPtr client);
 
 int
- SProcXFixesChangeCursor(ClientPtr client);
-
-int
  ProcXFixesChangeCursorByName(ClientPtr client);
-
-int
- SProcXFixesChangeCursorByName(ClientPtr client);
 
 /* Region objects (Version 2* */
 Bool
@@ -149,103 +128,52 @@ int
  ProcXFixesCreateRegion(ClientPtr client);
 
 int
- SProcXFixesCreateRegion(ClientPtr client);
-
-int
  ProcXFixesCreateRegionFromBitmap(ClientPtr client);
-
-int
- SProcXFixesCreateRegionFromBitmap(ClientPtr client);
 
 int
  ProcXFixesCreateRegionFromWindow(ClientPtr client);
 
 int
- SProcXFixesCreateRegionFromWindow(ClientPtr client);
-
-int
  ProcXFixesCreateRegionFromGC(ClientPtr client);
-
-int
- SProcXFixesCreateRegionFromGC(ClientPtr client);
 
 int
  ProcXFixesCreateRegionFromPicture(ClientPtr client);
 
 int
- SProcXFixesCreateRegionFromPicture(ClientPtr client);
-
-int
  ProcXFixesDestroyRegion(ClientPtr client);
-
-int
- SProcXFixesDestroyRegion(ClientPtr client);
 
 int
  ProcXFixesSetRegion(ClientPtr client);
 
 int
- SProcXFixesSetRegion(ClientPtr client);
-
-int
  ProcXFixesCopyRegion(ClientPtr client);
-
-int
- SProcXFixesCopyRegion(ClientPtr client);
 
 int
  ProcXFixesCombineRegion(ClientPtr client);
 
 int
- SProcXFixesCombineRegion(ClientPtr client);
-
-int
  ProcXFixesInvertRegion(ClientPtr client);
-
-int
- SProcXFixesInvertRegion(ClientPtr client);
 
 int
  ProcXFixesTranslateRegion(ClientPtr client);
 
 int
- SProcXFixesTranslateRegion(ClientPtr client);
-
-int
  ProcXFixesRegionExtents(ClientPtr client);
-
-int
- SProcXFixesRegionExtents(ClientPtr client);
 
 int
  ProcXFixesFetchRegion(ClientPtr client);
 
 int
- SProcXFixesFetchRegion(ClientPtr client);
-
-int
  ProcXFixesSetGCClipRegion(ClientPtr client);
-
-int
- SProcXFixesSetGCClipRegion(ClientPtr client);
 
 int
  ProcXFixesSetWindowShapeRegion(ClientPtr client);
 
 int
- SProcXFixesSetWindowShapeRegion(ClientPtr client);
-
-int
  ProcXFixesSetPictureClipRegion(ClientPtr client);
 
 int
- SProcXFixesSetPictureClipRegion(ClientPtr client);
-
-int
  ProcXFixesExpandRegion(ClientPtr client);
-
-int
- SProcXFixesExpandRegion(ClientPtr client);
 
 /* Cursor Visibility (Version 4) */
 
@@ -253,13 +181,7 @@ int
  ProcXFixesHideCursor(ClientPtr client);
 
 int
- SProcXFixesHideCursor(ClientPtr client);
-
-int
  ProcXFixesShowCursor(ClientPtr client);
-
-int
- SProcXFixesShowCursor(ClientPtr client);
 
 /* Version 5 */
 
@@ -267,13 +189,7 @@ int
  ProcXFixesCreatePointerBarrier(ClientPtr client);
 
 int
- SProcXFixesCreatePointerBarrier(ClientPtr client);
-
-int
  ProcXFixesDestroyPointerBarrier(ClientPtr client);
-
-int
- SProcXFixesDestroyPointerBarrier(ClientPtr client);
 
 /* Version 6 */
 
@@ -285,9 +201,6 @@ int
 
 int
  ProcXFixesGetClientDisconnectMode(ClientPtr client);
-
-int
- SProcXFixesSetClientDisconnectMode(ClientPtr client);
 
 Bool
  XFixesShouldDisconnectClient(ClientPtr client);


### PR DESCRIPTION
It's so trivial that those few lines can easily be inlined into
the actual request handler.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
