### PR TITLE
xf86AutoConfig: Enabled autoselction of the scfb driver for DragonFlyBSD.

### DIFF
--- a/hw/xfree86/common/xf86AutoConfig.c
+++ b/hw/xfree86/common/xf86AutoConfig.c
@@ -303,7 +303,7 @@ listPossibleVideoDrivers(XF86MatchedDrivers *md)
 #if defined(__linux__)
     xf86AddMatchedDriver(md, "fbdev");
 #endif
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__DragonFly__)
     xf86AddMatchedDriver(md, "scfb");
 #endif
 


### PR DESCRIPTION
scfb driver is the native frame-buffer driver used on both FreeBSD and DragonFlyBSD,
It was not enabled as a fallback on DragonFlyBSD, so enabled it.

The driver:
https://github.com/rayddteam/xf86-video-scfb
Signed-off-by: b-aaz <b-aazbsd@proton.me>