### PR TITLE
xfree86: dga: use canonical loop index in DGAClientStateChange()

### DIFF
--- a/hw/xfree86/common/xf86DGA.c
+++ b/hw/xfree86/common/xf86DGA.c
@@ -1306,19 +1306,18 @@ static void
 DGAClientStateChange(CallbackListPtr *pcbl, void *nulldata, void *calldata)
 {
     NewClientInfoRec *pci = (NewClientInfoRec *) calldata;
-    int i;
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        if (pci->client && (DGA_GETCLIENT(i) == pci->client)) {
+    for (int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        if (pci->client && (DGA_GETCLIENT(walkScreenIdx) == pci->client)) {
             if ((pci->client->clientState == ClientStateGone) ||
                 (pci->client->clientState == ClientStateRetained))
             {
                 XDGAModeRec mode;
                 PixmapPtr pPix;
 
-                DGA_SETCLIENT(i, NULL);
-                DGASelectInput(i, NULL, 0);
-                DGASetMode(i, 0, &mode, &pPix);
+                DGA_SETCLIENT(walkScreenIdx, NULL);
+                DGASelectInput(walkScreenIdx, NULL, 0);
+                DGASetMode(walkScreenIdx, 0, &mode, &pPix);
 
                 if (--DGACallbackRefCount == 0)
                     DeleteCallback(&ClientStateCallback, DGAClientStateChange, NULL);


### PR DESCRIPTION
Naming all index variables on looping over screens `walkScreenIdx`,
in order to make transition to upcoming generic screen walk macros easier.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
