### PR TITLE
Xinerama: lambda-esque macro for walking Xinerama screens

### DIFF
--- a/Xext/panoramiX.h
+++ b/Xext/panoramiX.h
@@ -40,6 +40,8 @@ Equipment Corporation.
 #include <X11/Xmd.h>
 #include <X11/extensions/panoramiXproto.h>
 
+#include "include/scrnintstr.h" /* for screenInfo */
+
 #include "gcstruct.h"
 #include "dixstruct.h"
 
@@ -65,6 +67,52 @@ typedef struct {
         char raw_data[4];
     } u;
 } PanoramiXRes;
+
+/*
+ * macro for looping over all screens (up to `PanoramiXNumScreens`).
+ * Makes a new scopes and declares `walkScreenIdx` as the current screen's
+ * index number as well as `walkScreen` as poiner to current ScreenRec
+ *
+ * @param __LAMBDA__ the code to be executed in each iteration step.
+ */
+#define XINERAMA_FOR_EACH_SCREEN_FORWARD(__LAMBDA__) \
+    do { \
+        for (unsigned walkScreenIdx = 0; walkScreenIdx < PanoramiXNumScreens; walkScreenIdx++) { \
+            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx]; \
+            (void)walkScreen; \
+            __LAMBDA__; \
+        } \
+    } while (0);
+
+/*
+ * just like XINERAMA_FOR_EACH_SCREEN_FORWARD(), but skipping the first
+ * screen (which is the frontend to the client)
+ *
+ * @param __LAMBDA__ the code to be executed in each iteration step.
+ */
+#define XINERAMA_FOR_EACH_SCREEN_FORWARD_SKIP0(__LAMBDA__) \
+    do { \
+        for (unsigned walkScreenIdx = 1; walkScreenIdx < PanoramiXNumScreens; walkScreenIdx++) { \
+            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx]; \
+            (void)walkScreen; \
+            __LAMBDA__; \
+        } \
+    } while (0);
+
+/*
+ * like XINERAMA_FOR_EACH_SCREEN_FORWARD(), but traveling backwards.
+ *
+ * @param __LAMBDA__ the code to be executed in each iteration step.
+ */
+#define XINERAMA_FOR_EACH_SCREEN_BACKWARD(__LAMBDA__) \
+    do { \
+        for (unsigned __walkidx = PanoramiXNumScreens; __walkidx > 0; __walkidx--) { \
+            unsigned walkScreenIdx = __walkidx - 1; \
+            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx]; \
+            (void)walkScreen; \
+            __LAMBDA__; \
+        } \
+    } while (0);
 
 #define FOR_NSCREENS_FORWARD(j) for(j = 0; j < PanoramiXNumScreens; j++)
 #define FOR_NSCREENS_FORWARD_SKIP(j) for(j = 1; j < PanoramiXNumScreens; j++)

--- a/Xext/panoramiXprocs.c
+++ b/Xext/panoramiXprocs.c
@@ -134,9 +134,7 @@ PanoramiXCreateWindow(ClientPtr client)
     parentIsRoot = (stuff->parent == screenInfo.screens[0]->root->drawable.id)
         || (stuff->parent == screenInfo.screens[0]->screensaver.wid);
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->wid = newWin->info[walkScreenIdx].id;
         stuff->parent = parent->info[walkScreenIdx].id;
         if (parentIsRoot) {
@@ -154,7 +152,7 @@ PanoramiXCreateWindow(ClientPtr client)
         result = (*SavedProcVector[X_CreateWindow]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     if (result == Success)
         AddResource(newWin->info[0].id, XRT_WINDOW, newWin);
@@ -224,8 +222,7 @@ PanoramiXChangeWindowAttributes(ClientPtr client)
         }
     }
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->window = win->info[walkScreenIdx].id;
         if (backPix)
             *((CARD32 *) &stuff[1] + pback_offset) = backPix->info[walkScreenIdx].id;
@@ -234,7 +231,7 @@ PanoramiXChangeWindowAttributes(ClientPtr client)
         if (cmap)
             *((CARD32 *) &stuff[1] + cmap_offset) = cmap->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_ChangeWindowAttributes]) (client);
-    }
+    });
 
     return result;
 }
@@ -254,13 +251,12 @@ PanoramiXDestroyWindow(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->id = win->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_DestroyWindow]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     /* Since ProcDestroyWindow is using FreeResource, it will free
        our resource for us on the last pass through the loop above */
@@ -283,13 +279,12 @@ PanoramiXDestroySubwindows(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->id = win->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_DestroySubwindows]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     /* DestroySubwindows is using FreeResource which will free
        our resources for us on the last pass through the loop above */
@@ -312,13 +307,12 @@ PanoramiXChangeSaveSet(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->window = win->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_ChangeSaveSet]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -350,9 +344,7 @@ PanoramiXReparentWindow(ClientPtr client)
     parentIsRoot = (stuff->parent == screenInfo.screens[0]->root->drawable.id)
         || (stuff->parent == screenInfo.screens[0]->screensaver.wid);
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->window = win->info[walkScreenIdx].id;
         stuff->parent = parent->info[walkScreenIdx].id;
         if (parentIsRoot) {
@@ -362,7 +354,7 @@ PanoramiXReparentWindow(ClientPtr client)
         result = (*SavedProcVector[X_ReparentWindow]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -382,13 +374,12 @@ PanoramiXMapWindow(ClientPtr client)
     if (result != Success)
         return result;
 
-    unsigned int walkScreenIdx;
-    FOR_NSCREENS_FORWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_FORWARD({
         stuff->id = win->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_MapWindow]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -408,13 +399,12 @@ PanoramiXMapSubwindows(ClientPtr client)
     if (result != Success)
         return result;
 
-    unsigned int walkScreenIdx;
-    FOR_NSCREENS_FORWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_FORWARD({
         stuff->id = win->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_MapSubwindows]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -434,13 +424,12 @@ PanoramiXUnmapWindow(ClientPtr client)
     if (result != Success)
         return result;
 
-    unsigned int walkScreenIdx;
-    FOR_NSCREENS_FORWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_FORWARD({
         stuff->id = win->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_UnmapWindow]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -460,13 +449,12 @@ PanoramiXUnmapSubwindows(ClientPtr client)
     if (result != Success)
         return result;
 
-    unsigned int walkScreenIdx;
-    FOR_NSCREENS_FORWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_FORWARD({
         stuff->id = win->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_UnmapSubwindows]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -527,9 +515,7 @@ PanoramiXConfigureWindow(ClientPtr client)
 
     /* have to go forward or you get expose events before
        ConfigureNotify events */
-    unsigned int walkScreenIdx;
-    FOR_NSCREENS_FORWARD(walkScreenIdx) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    XINERAMA_FOR_EACH_SCREEN_FORWARD({
         stuff->window = win->info[walkScreenIdx].id;
         if (sib)
             *((CARD32 *) &stuff[1] + sib_offset) = sib->info[walkScreenIdx].id;
@@ -540,7 +526,7 @@ PanoramiXConfigureWindow(ClientPtr client)
         result = (*SavedProcVector[X_ConfigureWindow]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -560,13 +546,12 @@ PanoramiXCirculateWindow(ClientPtr client)
     if (result != Success)
         return result;
 
-    unsigned int walkScreenIdx;
-    FOR_NSCREENS_FORWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_FORWARD({
         stuff->window = win->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_CirculateWindow]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -729,14 +714,13 @@ PanoramiXCreatePixmap(ClientPtr client)
     newPix->u.pix.shared = FALSE;
     panoramix_setup_ids(newPix, client, stuff->pid);
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->pid = newPix->info[walkScreenIdx].id;
         stuff->drawable = refDraw->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_CreatePixmap]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     if (result == Success)
         AddResource(newPix->info[0].id, XRT_PIXMAP, newPix);
@@ -763,13 +747,12 @@ PanoramiXFreePixmap(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->id = pix->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_FreePixmap]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     /* Since ProcFreePixmap is using FreeResource, it will free
        our resource for us on the last pass through the loop above */
@@ -837,8 +820,7 @@ PanoramiXCreateGC(ClientPtr client)
     newGC->type = XRT_GC;
     panoramix_setup_ids(newGC, client, stuff->gc);
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->gc = newGC->info[walkScreenIdx].id;
         stuff->drawable = refDraw->info[walkScreenIdx].id;
         if (tile)
@@ -850,7 +832,7 @@ PanoramiXCreateGC(ClientPtr client)
         result = (*SavedProcVector[X_CreateGC]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     if (result == Success)
         AddResource(newGC->info[0].id, XRT_GC, newGC);
@@ -912,8 +894,7 @@ PanoramiXChangeGC(ClientPtr client)
         }
     }
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->gc = gc->info[walkScreenIdx].id;
         if (tile)
             *((CARD32 *) &stuff[1] + tile_offset) = tile->info[walkScreenIdx].id;
@@ -924,7 +905,7 @@ PanoramiXChangeGC(ClientPtr client)
         result = (*SavedProcVector[X_ChangeGC]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -949,14 +930,13 @@ PanoramiXCopyGC(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->srcGC = srcGC->info[walkScreenIdx].id;
         stuff->dstGC = dstGC->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_CopyGC]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -976,13 +956,12 @@ PanoramiXSetDashes(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->gc = gc->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_SetDashes]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -1002,13 +981,12 @@ PanoramiXSetClipRectangles(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->gc = gc->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_SetClipRectangles]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -1028,13 +1006,12 @@ PanoramiXFreeGC(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->id = gc->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_FreeGC]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     /* Since ProcFreeGC is using FreeResource, it will free
        our resource for us on the last pass through the loop above */
@@ -1062,9 +1039,7 @@ PanoramiXClearToBackground(ClientPtr client)
     y = stuff->y;
     isRoot = win->u.win.root;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->window = win->info[walkScreenIdx].id;
         if (isRoot) {
             stuff->x = x - walkScreen->x;
@@ -1073,7 +1048,7 @@ PanoramiXClearToBackground(ClientPtr client)
         result = (*SavedProcVector[X_ClearArea]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -1141,8 +1116,7 @@ PanoramiXCopyArea(ClientPtr client)
         char *data;
         int pitch, rc;
 
-        int walkScreenIdx;
-        FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+        XINERAMA_FOR_EACH_SCREEN_BACKWARD({
             rc = dixLookupDrawable(drawables + walkScreenIdx, src->info[walkScreenIdx].id, client, 0,
                                    DixGetAttrAccess);
             if (rc != Success)
@@ -1151,7 +1125,7 @@ PanoramiXCopyArea(ClientPtr client)
                                                   drawables[walkScreenIdx]->width,
                                                   drawables[walkScreenIdx]->height,
                                                   IncludeInferiors);
-        }
+        });
 
         pitch = PixmapBytePad(width, drawables[0]->depth);
         if (!(data = calloc(height, pitch)))
@@ -1160,7 +1134,7 @@ PanoramiXCopyArea(ClientPtr client)
         XineramaGetImageData(drawables, srcx, srcy, width, height, ZPixmap, ~0,
                              data, pitch, srcIsRoot);
 
-        FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+        XINERAMA_FOR_EACH_SCREEN_BACKWARD({
             stuff->gc = gc->info[walkScreenIdx].id;
             VALIDATE_DRAWABLE_AND_GC(dst->info[walkScreenIdx].id, pDst, DixWriteAccess);
             if (drawables[0]->depth != pDst->depth) {
@@ -1173,7 +1147,7 @@ PanoramiXCopyArea(ClientPtr client)
                                    width, height, 0, ZPixmap, data);
             if (dstShared)
                 break;
-        }
+        });
         free(data);
 
         if (pGC && pGC->graphicsExposures) {
@@ -1196,8 +1170,7 @@ PanoramiXCopyArea(ClientPtr client)
             RegionInit(&rgn, &sourceBox, 1);
 
             /* subtract the (screen-space) clips of the source drawables */
-            FOR_NSCREENS_BACKWARD(walkScreenIdx) {
-                ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+            XINERAMA_FOR_EACH_SCREEN_BACKWARD({
                 RegionPtr sd;
 
                 if (pGC->subWindowMode == IncludeInferiors)
@@ -1215,7 +1188,7 @@ PanoramiXCopyArea(ClientPtr client)
 
                 if (pGC->subWindowMode == IncludeInferiors)
                     RegionDestroy(sd);
-            }
+            });
 
             /* -dx/-dy to get back to dest-relative, plus request offsets */
             RegionTranslate(&rgn, -dx + dstx, -dy + dsty);
@@ -1236,9 +1209,7 @@ PanoramiXCopyArea(ClientPtr client)
 
         RegionNull(&totalReg);
 
-        int walkScreenIdx;
-        FOR_NSCREENS_BACKWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+        XINERAMA_FOR_EACH_SCREEN_BACKWARD({
             RegionPtr pRgn;
 
             stuff->dstDrawable = dst->info[walkScreenIdx].id;
@@ -1284,7 +1255,7 @@ PanoramiXCopyArea(ClientPtr client)
 
             if (dstShared)
                 break;
-        }
+        });
 
         if (pGC->graphicsExposures) {
             Bool overlap;
@@ -1349,9 +1320,7 @@ PanoramiXCopyPlane(ClientPtr client)
 
     RegionNull(&totalReg);
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         RegionPtr pRgn;
 
         stuff->dstDrawable = dst->info[walkScreenIdx].id;
@@ -1399,7 +1368,7 @@ PanoramiXCopyPlane(ClientPtr client)
 
         if (dstShared)
             break;
-    }
+    });
 
     if (pGC->graphicsExposures) {
         Bool overlap;
@@ -1446,9 +1415,7 @@ PanoramiXPolyPoint(ClientPtr client)
 
         memcpy((char *) origPts, (char *) &stuff[1], npoint * sizeof(xPoint));
 
-        unsigned int walkScreenIdx;
-        FOR_NSCREENS_FORWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+        XINERAMA_FOR_EACH_SCREEN_FORWARD({
             if (walkScreenIdx)
                 memcpy(&stuff[1], origPts, npoint * sizeof(xPoint));
 
@@ -1474,7 +1441,8 @@ PanoramiXPolyPoint(ClientPtr client)
             result = (*SavedProcVector[X_PolyPoint]) (client);
             if (result != Success)
                 break;
-        }
+        });
+
         free(origPts);
         return result;
     }
@@ -1514,9 +1482,7 @@ PanoramiXPolyLine(ClientPtr client)
             return BadAlloc;
         memcpy((char *) origPts, (char *) &stuff[1], npoint * sizeof(xPoint));
 
-        unsigned int walkScreenIdx;
-        FOR_NSCREENS_FORWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+        XINERAMA_FOR_EACH_SCREEN_FORWARD({
             if (walkScreenIdx)
                 memcpy(&stuff[1], origPts, npoint * sizeof(xPoint));
 
@@ -1542,7 +1508,8 @@ PanoramiXPolyLine(ClientPtr client)
             result = (*SavedProcVector[X_PolyLine]) (client);
             if (result != Success)
                 break;
-        }
+        });
+
         free(origPts);
         return result;
     }
@@ -1586,9 +1553,7 @@ PanoramiXPolySegment(ClientPtr client)
             return BadAlloc;
         memcpy((char *) origSegs, (char *) &stuff[1], nsegs * sizeof(xSegment));
 
-        unsigned int walkScreenIdx;
-        FOR_NSCREENS_FORWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+        XINERAMA_FOR_EACH_SCREEN_FORWARD({
             if (walkScreenIdx) /* skip on screen #0 */
                 memcpy(&stuff[1], origSegs, nsegs * sizeof(xSegment));
 
@@ -1613,7 +1578,8 @@ PanoramiXPolySegment(ClientPtr client)
             result = (*SavedProcVector[X_PolySegment]) (client);
             if (result != Success)
                 break;
-        }
+        });
+
         free(origSegs);
         return result;
     }
@@ -1658,10 +1624,7 @@ PanoramiXPolyRectangle(ClientPtr client)
         memcpy((char *) origRecs, (char *) &stuff[1],
                nrects * sizeof(xRectangle));
 
-        unsigned int walkScreenIdx;
-        FOR_NSCREENS_FORWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
-
+        XINERAMA_FOR_EACH_SCREEN_FORWARD({
             if (walkScreenIdx) /* skip on screen #0 */
                 memcpy(&stuff[1], origRecs, nrects * sizeof(xRectangle));
 
@@ -1684,7 +1647,8 @@ PanoramiXPolyRectangle(ClientPtr client)
             result = (*SavedProcVector[X_PolyRectangle]) (client);
             if (result != Success)
                 break;
-        }
+        });
+
         free(origRecs);
         return result;
     }
@@ -1728,10 +1692,7 @@ PanoramiXPolyArc(ClientPtr client)
             return BadAlloc;
         memcpy((char *) origArcs, (char *) &stuff[1], narcs * sizeof(xArc));
 
-        unsigned int walkScreenIdx;
-        FOR_NSCREENS_FORWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
-
+        XINERAMA_FOR_EACH_SCREEN_FORWARD({
             if (walkScreenIdx) /* skip screen #0 */
                 memcpy(&stuff[1], origArcs, narcs * sizeof(xArc));
 
@@ -1753,7 +1714,8 @@ PanoramiXPolyArc(ClientPtr client)
             result = (*SavedProcVector[X_PolyArc]) (client);
             if (result != Success)
                 break;
-        }
+        });
+
         free(origArcs);
         return result;
     }
@@ -1795,10 +1757,7 @@ PanoramiXFillPoly(ClientPtr client)
         memcpy((char *) locPts, (char *) &stuff[1],
                count * sizeof(DDXPointRec));
 
-        unsigned int walkScreenIdx;
-        FOR_NSCREENS_FORWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
-
+        XINERAMA_FOR_EACH_SCREEN_FORWARD({
             if (walkScreenIdx) /* skip screen #0 */
                 memcpy(&stuff[1], locPts, count * sizeof(DDXPointRec));
 
@@ -1823,7 +1782,8 @@ PanoramiXFillPoly(ClientPtr client)
             result = (*SavedProcVector[X_FillPoly]) (client);
             if (result != Success)
                 break;
-        }
+        });
+
         free(locPts);
         return result;
     }
@@ -1867,10 +1827,7 @@ PanoramiXPolyFillRectangle(ClientPtr client)
         memcpy((char *) origRects, (char *) &stuff[1],
                things * sizeof(xRectangle));
 
-        unsigned int walkScreenIdx;
-        FOR_NSCREENS_FORWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
-
+        XINERAMA_FOR_EACH_SCREEN_FORWARD({
             if (walkScreenIdx) /* skip screen #0 */
                 memcpy(&stuff[1], origRects, things * sizeof(xRectangle));
 
@@ -1893,7 +1850,8 @@ PanoramiXPolyFillRectangle(ClientPtr client)
             result = (*SavedProcVector[X_PolyFillRectangle]) (client);
             if (result != Success)
                 break;
-        }
+        });
+
         free(origRects);
         return result;
     }
@@ -1937,10 +1895,7 @@ PanoramiXPolyFillArc(ClientPtr client)
             return BadAlloc;
         memcpy((char *) origArcs, (char *) &stuff[1], narcs * sizeof(xArc));
 
-        unsigned int walkScreenIdx;
-        FOR_NSCREENS_FORWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
-
+        XINERAMA_FOR_EACH_SCREEN_FORWARD({
             if (walkScreenIdx) /* skip screen #0 */
                 memcpy(&stuff[1], origArcs, narcs * sizeof(xArc));
 
@@ -1963,7 +1918,8 @@ PanoramiXPolyFillArc(ClientPtr client)
             result = (*SavedProcVector[X_PolyFillArc]) (client);
             if (result != Success)
                 break;
-        }
+        });
+
         free(origArcs);
         return result;
     }
@@ -2000,10 +1956,7 @@ PanoramiXPutImage(ClientPtr client)
     orig_x = stuff->dstX;
     orig_y = stuff->dstY;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
-
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         if (isRoot) {
             stuff->dstX = orig_x - walkScreen->x;
             stuff->dstY = orig_y - walkScreen->y;
@@ -2013,7 +1966,8 @@ PanoramiXPutImage(ClientPtr client)
         result = (*SavedProcVector[X_PutImage]) (client);
         if (result != Success)
             break;
-    }
+    });
+
     return result;
 }
 
@@ -2083,23 +2037,19 @@ PanoramiXGetImage(ClientPtr client)
 
     drawables[0] = pDraw;
 
-    unsigned int walkScreenIdx;
-    FOR_NSCREENS_FORWARD(walkScreenIdx) {
-        if (!walkScreenIdx)
-            continue; /* skip screen #0 */
+    XINERAMA_FOR_EACH_SCREEN_FORWARD_SKIP0({
         rc = dixLookupDrawable(drawables + walkScreenIdx,
                                draw->info[walkScreenIdx].id,
                                client, 0,
                                DixGetAttrAccess);
         if (rc != Success)
             return rc;
-    }
-    FOR_NSCREENS_FORWARD(walkScreenIdx) {
-        drawables[walkScreenIdx]->pScreen->SourceValidate(drawables[walkScreenIdx], 0, 0,
-                                              drawables[walkScreenIdx]->width,
-                                              drawables[walkScreenIdx]->height,
-                                              IncludeInferiors);
-    }
+    });
+
+    XINERAMA_FOR_EACH_SCREEN_FORWARD({
+        DrawablePtr d = drawables[walkScreenIdx];
+        d->pScreen->SourceValidate(d, 0, 0, d->width, d->height, IncludeInferiors);
+    });
 
     size_t length;
     if (format == ZPixmap) {
@@ -2215,9 +2165,7 @@ PanoramiXPolyText8(ClientPtr client)
     orig_x = stuff->x;
     orig_y = stuff->y;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->drawable = draw->info[walkScreenIdx].id;
         stuff->gc = gc->info[walkScreenIdx].id;
         if (isRoot) {
@@ -2227,7 +2175,8 @@ PanoramiXPolyText8(ClientPtr client)
         result = (*SavedProcVector[X_PolyText8]) (client);
         if (result != Success)
             break;
-    }
+    });
+
     return result;
 }
 
@@ -2261,10 +2210,7 @@ PanoramiXPolyText16(ClientPtr client)
     orig_x = stuff->x;
     orig_y = stuff->y;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
-
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->drawable = draw->info[walkScreenIdx].id;
         stuff->gc = gc->info[walkScreenIdx].id;
         if (isRoot) {
@@ -2274,7 +2220,8 @@ PanoramiXPolyText16(ClientPtr client)
         result = (*SavedProcVector[X_PolyText16]) (client);
         if (result != Success)
             break;
-    }
+    });
+
     return result;
 }
 
@@ -2308,9 +2255,7 @@ PanoramiXImageText8(ClientPtr client)
     orig_x = stuff->x;
     orig_y = stuff->y;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->drawable = draw->info[walkScreenIdx].id;
         stuff->gc = gc->info[walkScreenIdx].id;
         if (isRoot) {
@@ -2320,7 +2265,8 @@ PanoramiXImageText8(ClientPtr client)
         result = (*SavedProcVector[X_ImageText8]) (client);
         if (result != Success)
             break;
-    }
+    });
+
     return result;
 }
 
@@ -2354,10 +2300,7 @@ PanoramiXImageText16(ClientPtr client)
     orig_x = stuff->x;
     orig_y = stuff->y;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
-
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->drawable = draw->info[walkScreenIdx].id;
         stuff->gc = gc->info[walkScreenIdx].id;
         if (isRoot) {
@@ -2367,7 +2310,8 @@ PanoramiXImageText16(ClientPtr client)
         result = (*SavedProcVector[X_ImageText16]) (client);
         if (result != Success)
             break;
-    }
+    });
+
     return result;
 }
 
@@ -2394,15 +2338,14 @@ PanoramiXCreateColormap(ClientPtr client)
 
     orig_visual = stuff->visual;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->mid = newCmap->info[walkScreenIdx].id;
         stuff->window = win->info[walkScreenIdx].id;
         stuff->visual = PanoramiXTranslateVisualID(walkScreenIdx, orig_visual);
         result = (*SavedProcVector[X_CreateColormap]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     if (result == Success)
         AddResource(newCmap->info[0].id, XRT_COLORMAP, newCmap);
@@ -2429,13 +2372,12 @@ PanoramiXFreeColormap(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->id = cmap->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_FreeColormap]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     /* Since ProcFreeColormap is using FreeResource, it will free
        our resource for us on the last pass through the loop above */
@@ -2467,14 +2409,13 @@ PanoramiXCopyColormapAndFree(ClientPtr client)
     newCmap->type = XRT_COLORMAP;
     panoramix_setup_ids(newCmap, client, stuff->mid);
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->srcCmap = cmap->info[walkScreenIdx].id;
         stuff->mid = newCmap->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_CopyColormapAndFree]) (client);
         if (result != Success)
             break;
-    }
+    });
 
     if (result == Success)
         AddResource(newCmap->info[0].id, XRT_COLORMAP, newCmap);
@@ -2500,13 +2441,13 @@ PanoramiXInstallColormap(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->id = cmap->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_InstallColormap]) (client);
         if (result != Success)
             break;
-    }
+    });
+
     return result;
 }
 
@@ -2526,13 +2467,13 @@ PanoramiXUninstallColormap(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->id = cmap->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_UninstallColormap]) (client);
         if (result != Success)
             break;
-    }
+    });
+
     return result;
 }
 
@@ -2553,13 +2494,13 @@ PanoramiXAllocColor(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->cmap = cmap->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_AllocColor]) (client);
         if (result != Success)
             break;
-    }
+    });
+
     return result;
 }
 
@@ -2580,13 +2521,13 @@ PanoramiXAllocNamedColor(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->cmap = cmap->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_AllocNamedColor]) (client);
         if (result != Success)
             break;
-    }
+    });
+
     return result;
 }
 
@@ -2607,13 +2548,13 @@ PanoramiXAllocColorCells(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->cmap = cmap->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_AllocColorCells]) (client);
         if (result != Success)
             break;
-    }
+    });
+
     return result;
 }
 
@@ -2634,13 +2575,13 @@ PanoramiXAllocColorPlanes(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->cmap = cmap->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_AllocColorPlanes]) (client);
         if (result != Success)
             break;
-    }
+    });
+
     return result;
 }
 
@@ -2661,11 +2602,11 @@ PanoramiXFreeColors(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->cmap = cmap->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_FreeColors]) (client);
-    }
+    });
+
     return result;
 }
 
@@ -2686,13 +2627,13 @@ PanoramiXStoreColors(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->cmap = cmap->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_StoreColors]) (client);
         if (result != Success)
             break;
-    }
+    });
+
     return result;
 }
 
@@ -2713,12 +2654,12 @@ PanoramiXStoreNamedColor(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->cmap = cmap->info[walkScreenIdx].id;
         result = (*SavedProcVector[X_StoreNamedColor]) (client);
         if (result != Success)
             break;
-    }
+    });
+
     return result;
 }

--- a/Xext/panoramiXsrv.h
+++ b/Xext/panoramiXsrv.h
@@ -51,11 +51,9 @@ static inline void
 panoramix_setup_ids(PanoramiXRes * resource, ClientPtr client, XID base_id)
 {
     resource->info[0].id = base_id;
-    unsigned int walkScreenIdx;
-    FOR_NSCREENS_FORWARD(walkScreenIdx) {
-        if (walkScreenIdx) /* skip screen #0 */
-            resource->info[walkScreenIdx].id = FakeClientID(client->index);
-    }
+    XINERAMA_FOR_EACH_SCREEN_FORWARD_SKIP0({
+        resource->info[walkScreenIdx].id = FakeClientID(client->index);
+    });
 }
 
 #endif                          /* _PANORAMIXSRV_H_ */

--- a/Xext/saver.c
+++ b/Xext/saver.c
@@ -1133,8 +1133,7 @@ ProcScreenSaverSetAttributes(ClientPtr client)
 
         orig_visual = stuff->visualID;
 
-        int walkScreenIdx;
-        FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+        XINERAMA_FOR_EACH_SCREEN_BACKWARD({
             stuff->drawable = draw->info[walkScreenIdx].id;
             if (backPix)
                 *((CARD32 *) &stuff[1] + pback_offset) = backPix->info[walkScreenIdx].id;
@@ -1147,7 +1146,7 @@ ProcScreenSaverSetAttributes(ClientPtr client)
                 stuff->visualID = PanoramiXTranslateVisualID(walkScreenIdx, orig_visual);
 
             status = ScreenSaverSetAttributes(client, stuff);
-        }
+        });
 
         return status;
     }

--- a/Xext/shape.c
+++ b/Xext/shape.c
@@ -311,13 +311,13 @@ ProcShapeRectangles(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->dest = win->info[walkScreenIdx].id;
         result = ShapeRectangles(client, stuff);
         if (result != Success)
             break;
-    }
+    });
+
     return result;
 #else
     return ShapeRectangles(client, stuff);
@@ -425,15 +425,15 @@ ProcShapeMask(ClientPtr client)
     else
         pmap = NULL;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->dest = win->info[walkScreenIdx].id;
         if (pmap)
             stuff->src = pmap->info[walkScreenIdx].id;
         result = ShapeMask(client, stuff);
         if (result != Success)
             break;
-    }
+    });
+
     return result;
 #else
     return ShapeMask(client, stuff);
@@ -557,14 +557,14 @@ ProcShapeCombine(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->dest = win->info[walkScreenIdx].id;
         stuff->src = win2->info[walkScreenIdx].id;
         result = ShapeCombine(client, stuff);
         if (result != Success)
             break;
-    }
+    });
+
     return result;
 #else
     return ShapeCombine(client, stuff);
@@ -628,13 +628,13 @@ ProcShapeOffset(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->dest = win->info[walkScreenIdx].id;
         result = ShapeOffset(client, stuff);
         if (result != Success)
             break;
-    }
+    });
+
     return result;
 #else
     return ShapeOffset(client, stuff);

--- a/Xext/xvdisp.c
+++ b/Xext/xvdisp.c
@@ -1244,14 +1244,13 @@ XineramaXvStopVideo(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         if (port->info[walkScreenIdx].id) {
             stuff->drawable = draw->info[walkScreenIdx].id;
             stuff->port = port->info[walkScreenIdx].id;
             result = SingleXvStopVideo(client);
         }
-    }
+    });
 
     return result;
 }
@@ -1270,13 +1269,13 @@ XineramaXvSetPortAttribute(ClientPtr client)
     if (result != Success)
         return result;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         if (port->info[walkScreenIdx].id) {
             stuff->port = port->info[walkScreenIdx].id;
             result = SingleXvSetPortAttribute(client);
         }
-    }
+    });
+
     return result;
 }
 
@@ -1314,10 +1313,7 @@ XineramaXvShmPutImage(ClientPtr client)
     x = stuff->drw_x;
     y = stuff->drw_y;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
-
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         if (port->info[walkScreenIdx].id) {
             stuff->drawable = draw->info[walkScreenIdx].id;
             stuff->port = port->info[walkScreenIdx].id;
@@ -1332,7 +1328,8 @@ XineramaXvShmPutImage(ClientPtr client)
 
             result = SingleXvShmPutImage(client);
         }
-    }
+    });
+
     return result;
 }
 #else /* CONFIG_MITSHM */
@@ -1369,9 +1366,7 @@ XineramaXvPutImage(ClientPtr client)
     x = stuff->drw_x;
     y = stuff->drw_y;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         if (port->info[walkScreenIdx].id) {
             stuff->drawable = draw->info[walkScreenIdx].id;
             stuff->port = port->info[walkScreenIdx].id;
@@ -1385,7 +1380,8 @@ XineramaXvPutImage(ClientPtr client)
 
             result = SingleXvPutImage(client);
         }
-    }
+    });
+
     return result;
 }
 
@@ -1419,9 +1415,7 @@ XineramaXvPutVideo(ClientPtr client)
     x = stuff->drw_x;
     y = stuff->drw_y;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         if (port->info[walkScreenIdx].id) {
             stuff->drawable = draw->info[walkScreenIdx].id;
             stuff->port = port->info[walkScreenIdx].id;
@@ -1435,7 +1429,8 @@ XineramaXvPutVideo(ClientPtr client)
 
             result = SingleXvPutVideo(client);
         }
-    }
+    });
+
     return result;
 }
 
@@ -1469,9 +1464,7 @@ XineramaXvPutStill(ClientPtr client)
     x = stuff->drw_x;
     y = stuff->drw_y;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         if (port->info[walkScreenIdx].id) {
             stuff->drawable = draw->info[walkScreenIdx].id;
             stuff->port = port->info[walkScreenIdx].id;
@@ -1482,10 +1475,10 @@ XineramaXvPutStill(ClientPtr client)
                 stuff->drw_x -= walkScreen->x;
                 stuff->drw_y -= walkScreen->y;
             }
-
             result = SingleXvPutStill(client);
         }
-    }
+    });
+
     return result;
 }
 
@@ -1570,13 +1563,9 @@ XineramifyXv(void)
         MatchingAdaptors[0] = refAdapt;
         isOverlay = hasOverlay(refAdapt);
 
-        int walkScreenIdx;
-        FOR_NSCREENS_FORWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
-            if (!walkScreenIdx)
-                continue; /* skip screen #0 */
+        XINERAMA_FOR_EACH_SCREEN_FORWARD_SKIP0({
             MatchingAdaptors[walkScreenIdx] = matchAdaptor(walkScreen, refAdapt, isOverlay);
-        }
+        });
 
         /* now create a resource for each port */
         for (int j = 0; j < refAdapt->nPorts; j++) {
@@ -1585,12 +1574,13 @@ XineramifyXv(void)
             if (!port)
                 break;
 
-            FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+            XINERAMA_FOR_EACH_SCREEN_BACKWARD({
                 if (MatchingAdaptors[walkScreenIdx] && (MatchingAdaptors[walkScreenIdx]->nPorts > j))
                     port->info[walkScreenIdx].id = MatchingAdaptors[walkScreenIdx]->base_id + j;
                 else
                     port->info[walkScreenIdx].id = 0;
-            }
+            });
+
             AddResource(port->info[0].id, XvXRTPort, port);
         }
     }

--- a/composite/compext.c
+++ b/composite/compext.c
@@ -580,13 +580,12 @@ ProcCompositeRedirectWindow(ClientPtr client)
         return rc;
     }
 
-    int walkScreenIdx;
-    FOR_NSCREENS_FORWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_FORWARD({
         stuff->window = win->info[walkScreenIdx].id;
         rc = SingleCompositeRedirectWindow(client, stuff);
         if (rc != Success)
             break;
-    }
+    });
 
     return rc;
 #else
@@ -613,13 +612,12 @@ ProcCompositeRedirectSubwindows(ClientPtr client)
         return rc;
     }
 
-    unsigned int walkScreenIdx;
-    FOR_NSCREENS_FORWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_FORWARD({
         stuff->window = win->info[walkScreenIdx].id;
         rc = SingleRedirectSubwindows(client, stuff);
         if (rc != Success)
             break;
-    }
+    });
 
     return rc;
 #else
@@ -646,13 +644,12 @@ ProcCompositeUnredirectWindow(ClientPtr client)
         return rc;
     }
 
-    unsigned int walkScreenIdx;
-    FOR_NSCREENS_FORWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_FORWARD({
         stuff->window = win->info[walkScreenIdx].id;
         rc = SingleCompositeUnredirectWindow(client, stuff);
         if (rc != Success)
             break;
-    }
+    });
 
     return rc;
 #else
@@ -679,13 +676,12 @@ ProcCompositeUnredirectSubwindows(ClientPtr client)
         return rc;
     }
 
-    unsigned int walkScreenIdx;
-    FOR_NSCREENS_FORWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_FORWARD({
         stuff->window = win->info[walkScreenIdx].id;
         rc = SingleCompositeUnredirectSubwindows(client, stuff);
         if (rc != Success)
             break;
-    }
+    });
 
     return rc;
 #else
@@ -724,8 +720,7 @@ ProcCompositeNameWindowPixmap(ClientPtr client)
     newPix->u.pix.shared = FALSE;
     panoramix_setup_ids(newPix, client, stuff->pixmap);
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         rc = dixLookupResourceByType((void **) &pWin, win->info[walkScreenIdx].id,
                                      X11_RESTYPE_WINDOW, client,
                                      DixGetAttrAccess);
@@ -756,7 +751,7 @@ ProcCompositeNameWindowPixmap(ClientPtr client)
             return BadAlloc;
 
         ++pPixmap->refcnt;
-    }
+    });
 
     if (!AddResource(stuff->pixmap, XRT_PIXMAP, (void *) newPix))
         return BadAlloc;
@@ -800,8 +795,7 @@ ProcCompositeGetOverlayWindow(ClientPtr client)
         overlayWin->u.win.root = FALSE;
     }
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         rc = dixLookupResourceByType((void **) &pWin, win->info[walkScreenIdx].id,
                                      X11_RESTYPE_WINDOW, client,
                                      DixGetAttrAccess);
@@ -842,14 +836,13 @@ ProcCompositeGetOverlayWindow(ClientPtr client)
             free(overlayWin);
             return rc;
         }
-    }
+    });
 
     if (overlayWin) {
-        FOR_NSCREENS_BACKWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+        XINERAMA_FOR_EACH_SCREEN_BACKWARD({
             cs = GetCompScreen(walkScreen);
             overlayWin->info[walkScreenIdx].id = cs->pOverlayWin->drawable.id;
-        }
+        });
 
         AddResource(overlayWin->info[0].id, XRT_WINDOW, overlayWin);
     }
@@ -891,8 +884,7 @@ ProcCompositeReleaseOverlayWindow(ClientPtr client)
         return rc;
     }
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         if ((rc = dixLookupResourceByType((void **) &pWin, win->info[walkScreenIdx].id,
                                           XRT_WINDOW, client,
                                           DixUnknownAccess))) {
@@ -910,7 +902,7 @@ ProcCompositeReleaseOverlayWindow(ClientPtr client)
 
         /* The delete function will free the client structure */
         FreeResource(pOc->resource, X11_RESTYPE_NONE);
-    }
+    });
 
     return Success;
 #else

--- a/damageext/damageext.c
+++ b/damageext/damageext.c
@@ -340,8 +340,7 @@ DamageExtSubtractWindowClip(DamageExtPtr pDamageExt)
     if (!ret)
         return NULL;
 
-    unsigned int walkScreenIdx;
-    FOR_NSCREENS_FORWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_FORWARD({
         ScreenPtr screen;
         if (Success != dixLookupWindow(&win, res->info[walkScreenIdx].id, serverClient,
                                        DixReadAccess))
@@ -353,7 +352,7 @@ DamageExtSubtractWindowClip(DamageExtPtr pDamageExt)
         if (!RegionUnion(ret, ret, &win->borderClip))
             goto out;
         RegionTranslate(ret, screen->x, screen->y);
-    }
+    });
 
     return ret;
 
@@ -640,9 +639,7 @@ PanoramiXDamageCreate(ClientPtr client, xDamageCreateReq *stuff)
 
     damage->ext = doDamageCreate(client, &rc, stuff);
     if (rc == Success && draw->type == XRT_WINDOW) {
-        unsigned int walkScreenIdx;
-        FOR_NSCREENS_FORWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+        XINERAMA_FOR_EACH_SCREEN_FORWARD({
             DrawablePtr pDrawable;
             DamagePtr pDamage = DamageCreate(PanoramiXDamageReport,
                                              PanoramiXDamageExtDestroy,
@@ -662,7 +659,7 @@ PanoramiXDamageCreate(ClientPtr client, xDamageCreateReq *stuff)
                 break;
 
             DamageExtRegister(pDrawable, pDamage, walkScreenIdx != 0);
-        }
+        });
     }
 
     if (rc != Success)
@@ -676,13 +673,12 @@ PanoramiXDamageDelete(void *res, XID id)
 {
     PanoramiXDamageRes *damage = res;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         if (damage->damage[walkScreenIdx]) {
             DamageDestroy(damage->damage[walkScreenIdx]);
             damage->damage[walkScreenIdx] = NULL;
         }
-    }
+    });
 
     free(damage);
     return 1;

--- a/dix/property.c
+++ b/dix/property.c
@@ -137,13 +137,12 @@ notifyVRRMode(ClientPtr pClient, WindowPtr pWindow, int state, PropertyPtr pProp
         if (rc != Success)
             goto no_panoramix;
 
-        int walkScreenIdx;
-        FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+        XINERAMA_FOR_EACH_SCREEN_BACKWARD({
             WindowPtr pWin;
             rc = dixLookupWindow(&pWin, win->info[walkScreenIdx].id, pClient, DixSetPropAccess);
             if (rc == Success)
                 setVRRMode(pWin, mode);
-        }
+        });
     }
     return;
 no_panoramix:

--- a/dix/window.c
+++ b/dix/window.c
@@ -3001,8 +3001,7 @@ SendVisibilityNotify(WindowPtr pWin)
 
         switch (visibility) {
         case VisibilityUnobscured: {
-        int walkScreenIdx;
-        FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+        XINERAMA_FOR_EACH_SCREEN_BACKWARD({
             if (walkScreenIdx == Scrnum)
                 continue;
 
@@ -3016,7 +3015,7 @@ SendVisibilityNotify(WindowPtr pWin)
                 if (!walkScreenIdx)
                     pWin = pWin2;
             }
-        }
+        });
         }
             break;
         case VisibilityPartiallyObscured:
@@ -3028,8 +3027,7 @@ SendVisibilityNotify(WindowPtr pWin)
             }
             break;
         case VisibilityFullyObscured: {
-        int walkScreenIdx;
-        FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+        XINERAMA_FOR_EACH_SCREEN_BACKWARD({
             if (walkScreenIdx == Scrnum)
                 continue;
 
@@ -3043,7 +3041,7 @@ SendVisibilityNotify(WindowPtr pWin)
                 if (!walkScreenIdx)
                     pWin = pWin2;
             }
-        }
+        });
             break;
         }
         }

--- a/render/render.c
+++ b/render/render.c
@@ -2561,14 +2561,13 @@ PanoramiXRenderCreatePicture(ClientPtr client)
     else
         newPict->u.pict.root = FALSE;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->pid = newPict->info[walkScreenIdx].id;
         stuff->drawable = refDraw->info[walkScreenIdx].id;
         result = ProcRenderCreatePicture(client);
         if (result != Success)
             break;
-    }
+    });
 
     if (result == Success)
         AddResource(newPict->info[0].id, XRT_PICTURE, newPict);
@@ -2590,13 +2589,12 @@ PanoramiXRenderChangePicture(ClientPtr client)
 
     VERIFY_XIN_PICTURE(pict, stuff->picture, client, DixWriteAccess);
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->picture = pict->info[walkScreenIdx].id;
         result = ProcRenderChangePicture(client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -2612,13 +2610,12 @@ PanoramiXRenderSetPictureClipRectangles(ClientPtr client)
 
     VERIFY_XIN_PICTURE(pict, stuff->picture, client, DixWriteAccess);
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->picture = pict->info[walkScreenIdx].id;
         result = ProcRenderSetPictureClipRectangles(client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -2634,13 +2631,12 @@ PanoramiXRenderSetPictureTransform(ClientPtr client)
 
     VERIFY_XIN_PICTURE(pict, stuff->picture, client, DixWriteAccess);
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->picture = pict->info[walkScreenIdx].id;
         result = ProcRenderSetPictureTransform(client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -2656,13 +2652,12 @@ PanoramiXRenderSetPictureFilter(ClientPtr client)
 
     VERIFY_XIN_PICTURE(pict, stuff->picture, client, DixWriteAccess);
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->picture = pict->info[walkScreenIdx].id;
         result = ProcRenderSetPictureFilter(client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -2681,13 +2676,12 @@ PanoramiXRenderFreePicture(ClientPtr client)
 
     VERIFY_XIN_PICTURE(pict, stuff->picture, client, DixDestroyAccess);
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->picture = pict->info[walkScreenIdx].id;
         result = ProcRenderFreePicture(client);
         if (result != Success)
             break;
-    }
+    });
 
     /* Since ProcRenderFreePicture is using FreeResource, it will free
        our resource for us on the last pass through the loop above */
@@ -2712,9 +2706,7 @@ PanoramiXRenderComposite(ClientPtr client)
 
     orig = *stuff;
 
-    unsigned int walkScreenIdx;
-    FOR_NSCREENS_FORWARD(walkScreenIdx) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    XINERAMA_FOR_EACH_SCREEN_FORWARD({
         stuff->src = src->info[walkScreenIdx].id;
         if (src->u.pict.root) {
             stuff->xSrc = orig.xSrc - walkScreen->x;
@@ -2735,7 +2727,7 @@ PanoramiXRenderComposite(ClientPtr client)
         result = ProcRenderComposite(client);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -2760,9 +2752,8 @@ PanoramiXRenderCompositeGlyphs(ClientPtr client)
         origElt = *elt;
         xSrc = stuff->xSrc;
         ySrc = stuff->ySrc;
-        unsigned int walkScreenIdx;
-        FOR_NSCREENS_FORWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+
+        XINERAMA_FOR_EACH_SCREEN_FORWARD({
             stuff->src = src->info[walkScreenIdx].id;
             if (src->u.pict.root) {
                 stuff->xSrc = xSrc - walkScreen->x;
@@ -2776,7 +2767,7 @@ PanoramiXRenderCompositeGlyphs(ClientPtr client)
             result = ProcRenderCompositeGlyphs(client);
             if (result != Success)
                 break;
-        }
+        });
     }
 
     return result;
@@ -2797,9 +2788,8 @@ PanoramiXRenderFillRectangles(ClientPtr client)
     extra_len = (client->req_len << 2) - sizeof(xRenderFillRectanglesReq);
     if (extra_len && (extra = calloc(1, extra_len))) {
         memcpy(extra, stuff + 1, extra_len);
-        unsigned int walkScreenIdx;
-        FOR_NSCREENS_FORWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+
+        XINERAMA_FOR_EACH_SCREEN_FORWARD({
             if (walkScreenIdx) /* skip screen #0 */
                 memcpy(stuff + 1, extra, extra_len);
             if (dst->u.pict.root) {
@@ -2821,7 +2811,8 @@ PanoramiXRenderFillRectangles(ClientPtr client)
             result = ProcRenderFillRectangles(client);
             if (result != Success)
                 break;
-        }
+        });
+
         free(extra);
     }
 
@@ -2848,9 +2839,7 @@ PanoramiXRenderTrapezoids(ClientPtr client)
     if (extra_len && (extra = calloc(1, extra_len))) {
         memcpy(extra, stuff + 1, extra_len);
 
-        unsigned int walkScreenIdx;
-        FOR_NSCREENS_FORWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+        XINERAMA_FOR_EACH_SCREEN_FORWARD({
             if (walkScreenIdx) /* skip screen #0 */
                 memcpy(stuff + 1, extra, extra_len);
             if (dst->u.pict.root) {
@@ -2883,7 +2872,7 @@ PanoramiXRenderTrapezoids(ClientPtr client)
 
             if (result != Success)
                 break;
-        }
+        });
 
         free(extra);
     }
@@ -2911,9 +2900,7 @@ PanoramiXRenderTriangles(ClientPtr client)
     if (extra_len && (extra = calloc(1, extra_len))) {
         memcpy(extra, stuff + 1, extra_len);
 
-        unsigned int walkScreenIdx;
-        FOR_NSCREENS_FORWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+        XINERAMA_FOR_EACH_SCREEN_FORWARD({
             if (walkScreenIdx) /* skip screen #0 */
                 memcpy(stuff + 1, extra, extra_len);
             if (dst->u.pict.root) {
@@ -2942,7 +2929,7 @@ PanoramiXRenderTriangles(ClientPtr client)
 
             if (result != Success)
                 break;
-        }
+        });
 
         free(extra);
     }
@@ -2970,9 +2957,7 @@ PanoramiXRenderTriStrip(ClientPtr client)
     if (extra_len && (extra = calloc(1, extra_len))) {
         memcpy(extra, stuff + 1, extra_len);
 
-        unsigned int walkScreenIdx;
-        FOR_NSCREENS_FORWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+        XINERAMA_FOR_EACH_SCREEN_FORWARD({
             if (walkScreenIdx) /* skip screen #0 */
                 memcpy(stuff + 1, extra, extra_len);
             if (dst->u.pict.root) {
@@ -2997,7 +2982,7 @@ PanoramiXRenderTriStrip(ClientPtr client)
 
             if (result != Success)
                 break;
-        }
+        });
 
         free(extra);
     }
@@ -3025,9 +3010,7 @@ PanoramiXRenderTriFan(ClientPtr client)
     if (extra_len && (extra = calloc(1, extra_len))) {
         memcpy(extra, stuff + 1, extra_len);
 
-        unsigned int walkScreenIdx;
-        FOR_NSCREENS_FORWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+        XINERAMA_FOR_EACH_SCREEN_FORWARD({
             if (walkScreenIdx) /* skip screen #0 */
                 memcpy(stuff + 1, extra, extra_len);
             if (dst->u.pict.root) {
@@ -3052,7 +3035,7 @@ PanoramiXRenderTriFan(ClientPtr client)
 
             if (result != Success)
                 break;
-        }
+        });
 
         free(extra);
     }
@@ -3079,9 +3062,7 @@ PanoramiXRenderAddTraps(ClientPtr client)
         x_off = stuff->xOff;
         y_off = stuff->yOff;
 
-        unsigned int walkScreenIdx;
-        FOR_NSCREENS_FORWARD(walkScreenIdx) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+        XINERAMA_FOR_EACH_SCREEN_FORWARD({
             if (walkScreenIdx) /* skip screen #0 */
                 memcpy(stuff + 1, extra, extra_len);
             stuff->picture = picture->info[walkScreenIdx].id;
@@ -3093,7 +3074,8 @@ PanoramiXRenderAddTraps(ClientPtr client)
             result = ProcRenderAddTraps(client);
             if (result != Success)
                 break;
-        }
+        });
+
         free(extra);
     }
 
@@ -3116,13 +3098,12 @@ PanoramiXRenderCreateSolidFill(ClientPtr client)
     panoramix_setup_ids(newPict, client, stuff->pid);
     newPict->u.pict.root = FALSE;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->pid = newPict->info[walkScreenIdx].id;
         result = ProcRenderCreateSolidFill(client);
         if (result != Success)
             break;
-    }
+    });
 
     if (result == Success)
         AddResource(newPict->info[0].id, XRT_PICTURE, newPict);
@@ -3148,13 +3129,12 @@ PanoramiXRenderCreateLinearGradient(ClientPtr client)
     panoramix_setup_ids(newPict, client, stuff->pid);
     newPict->u.pict.root = FALSE;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->pid = newPict->info[walkScreenIdx].id;
         result = ProcRenderCreateLinearGradient(client);
         if (result != Success)
             break;
-    }
+    });
 
     if (result == Success)
         AddResource(newPict->info[0].id, XRT_PICTURE, newPict);
@@ -3180,13 +3160,12 @@ PanoramiXRenderCreateRadialGradient(ClientPtr client)
     panoramix_setup_ids(newPict, client, stuff->pid);
     newPict->u.pict.root = FALSE;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->pid = newPict->info[walkScreenIdx].id;
         result = ProcRenderCreateRadialGradient(client);
         if (result != Success)
             break;
-    }
+    });
 
     if (result == Success)
         AddResource(newPict->info[0].id, XRT_PICTURE, newPict);
@@ -3212,13 +3191,12 @@ PanoramiXRenderCreateConicalGradient(ClientPtr client)
     panoramix_setup_ids(newPict, client, stuff->pid);
     newPict->u.pict.root = FALSE;
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->pid = newPict->info[walkScreenIdx].id;
         result = ProcRenderCreateConicalGradient(client);
         if (result != Success)
             break;
-    }
+    });
 
     if (result == Success)
         AddResource(newPict->info[0].id, XRT_PICTURE, newPict);

--- a/xfixes/region.c
+++ b/xfixes/region.c
@@ -753,13 +753,12 @@ PanoramiXFixesSetGCClipRegion(ClientPtr client, xXFixesSetGCClipRegionReq *stuff
         return result;
     }
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->gc = gc->info[walkScreenIdx].id;
         result = SingleXFixesSetGCClipRegion(client, stuff);
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -781,9 +780,7 @@ PanoramiXFixesSetWindowShapeRegion(ClientPtr client, xXFixesSetWindowShapeRegion
     if (win->u.win.root)
         VERIFY_REGION_OR_NONE(reg, stuff->region, client, DixReadAccess);
 
-    unsigned int walkScreenIdx;
-    FOR_NSCREENS_FORWARD(walkScreenIdx) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    XINERAMA_FOR_EACH_SCREEN_FORWARD({
         stuff->dest = win->info[walkScreenIdx].id;
 
         if (reg)
@@ -796,7 +793,7 @@ PanoramiXFixesSetWindowShapeRegion(ClientPtr client, xXFixesSetWindowShapeRegion
 
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }
@@ -818,9 +815,7 @@ PanoramiXFixesSetPictureClipRegion(ClientPtr client, xXFixesSetPictureClipRegion
     if (pict->u.pict.root)
         VERIFY_REGION_OR_NONE(reg, stuff->region, client, DixReadAccess);
 
-    int walkScreenIdx;
-    FOR_NSCREENS_BACKWARD(walkScreenIdx) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         stuff->picture = pict->info[walkScreenIdx].id;
 
         if (reg)
@@ -833,7 +828,7 @@ PanoramiXFixesSetPictureClipRegion(ClientPtr client, xXFixesSetPictureClipRegion
 
         if (result != Success)
             break;
-    }
+    });
 
     return result;
 }


### PR DESCRIPTION
Move the walking loops on Xinerama screens into lambda-esque macros:
the callers look quite like we've been using lambda functions and
closures, but actually are just fancy macro trickery.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
