### PR TITLE
xfree86: common: move out private definitions from xf86platformBus.h

### DIFF
--- a/hw/xfree86/common/xf86Bus.c
+++ b/hw/xfree86/common/xf86Bus.c
@@ -48,6 +48,7 @@
 
 #include "xf86Bus.h"
 #include "xf86sbusBus_priv.h"
+#include "xf86platformBus_priv.h"
 
 #include "xf86_OSproc.h"
 #ifdef XSERVER_LIBPCIACCESS

--- a/hw/xfree86/common/xf86Events.c
+++ b/hw/xfree86/common/xf86Events.c
@@ -72,6 +72,7 @@
 #include "xf86Priv.h"
 #include "xf86_os_support.h"
 #include "xf86_OSlib.h"
+#include "xf86platformBus_priv.h"
 
 #ifdef XFreeXDGA
 #include "dgaproc.h"

--- a/hw/xfree86/common/xf86Option.c
+++ b/hw/xfree86/common/xf86Option.c
@@ -44,7 +44,7 @@
 #include "xf86Xinput.h"
 #include "xf86Optrec.h"
 #include "xf86Parser.h"
-#include "xf86platformBus.h" /* For OutputClass functions */
+#include "xf86platformBus_priv.h"
 #include "optionstr.h"
 
 static Bool ParseOptionValue(int scrnIndex, XF86OptionPtr options,

--- a/hw/xfree86/common/xf86platformBus.c
+++ b/hw/xfree86/common/xf86platformBus.c
@@ -53,7 +53,7 @@
 #include "xf86str.h"
 #include "xf86Bus.h"
 #include "Pci.h"
-#include "xf86platformBus.h"
+#include "xf86platformBus_priv.h"
 #include "xf86Xinput_priv.h"
 #include "xf86Config.h"
 #include "xf86Crtc.h"

--- a/hw/xfree86/common/xf86platformBus.h
+++ b/hw/xfree86/common/xf86platformBus.h
@@ -37,27 +37,8 @@ struct xf86_platform_device {
 #define XF86_PDEV_PAUSED        0x04
 
 #ifdef XSERVER_PLATFORM_BUS
-int xf86platformProbe(void);
-int xf86platformProbeDev(DriverPtr drvp);
-int xf86platformAddGPUDevices(DriverPtr drvp);
-void xf86MergeOutputClassOptions(int entityIndex, void **options);
-void xf86PlatformScanPciDev(void);
-const char *xf86PlatformFindHotplugDriver(int dev_index);
-
 extern int xf86_num_platform_devices;
 extern struct xf86_platform_device *xf86_platform_devices;
-
-extern int
-xf86_add_platform_device(struct OdevAttributes *attribs, Bool unowned);
-extern int
-xf86_remove_platform_device(int dev_index);
-extern Bool
-xf86_get_platform_device_unowned(int index);
-
-extern int
-xf86platformAddDevice(const char *driver_name, int index);
-extern void
-xf86platformRemoveDevice(int index);
 
 static inline struct OdevAttributes *
 xf86_platform_device_odev_attributes(struct xf86_platform_device *device)
@@ -121,14 +102,6 @@ _xf86_get_platform_device_int_attrib(struct xf86_platform_device *device, int at
 
 extern _X_EXPORT Bool
 xf86PlatformDeviceCheckBusID(struct xf86_platform_device *device, const char *busid);
-
-extern void xf86platformVTProbe(void);
-extern void xf86platformPrimary(void);
-
-#else
-
-static inline int xf86platformAddGPUDevices(DriverPtr drvp) { return FALSE; }
-static inline void xf86MergeOutputClassOptions(int index, void **options) {}
 
 #endif
 

--- a/hw/xfree86/common/xf86platformBus_priv.h
+++ b/hw/xfree86/common/xf86platformBus_priv.h
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef _XSERVER_XF86_PLATFORM_BUS_PRIV_H
+#define _XSERVER_XF86_PLATFORM_BUS_PRIV_H
+
+#include "xf86platformBus.h"
+
+#ifdef XSERVER_PLATFORM_BUS
+
+int xf86platformProbe(void);
+int xf86platformProbeDev(DriverPtr drvp);
+int xf86platformAddGPUDevices(DriverPtr drvp);
+void xf86MergeOutputClassOptions(int entityIndex, void **options);
+void xf86PlatformScanPciDev(void);
+const char *xf86PlatformFindHotplugDriver(int dev_index);
+
+int xf86_add_platform_device(struct OdevAttributes *attribs, Bool unowned);
+int xf86_remove_platform_device(int dev_index);
+Bool xf86_get_platform_device_unowned(int index);
+
+int xf86platformAddDevice(const char *driver_name, int index);
+void xf86platformRemoveDevice(int index);
+
+void xf86platformVTProbe(void);
+void xf86platformPrimary(void);
+
+#else /* XSERVER_PLATFORM_BUS */
+
+static inline int xf86platformAddGPUDevices(DriverPtr drvp) { return FALSE; }
+static inline void xf86MergeOutputClassOptions(int index, void **options) {}
+
+#endif /* XSERVER_PLATFORM_BUS */
+
+#endif /* _XSERVER_XF86_PLATFORM_BUS_PRIV_H */

--- a/hw/xfree86/os-support/shared/drm_platform.c
+++ b/hw/xfree86/os-support/shared/drm_platform.c
@@ -17,7 +17,7 @@
 
 #include "xf86_priv.h"
 #include "xf86_os_support.h"
-#include "xf86platformBus.h"
+#include "xf86platformBus_priv.h"
 #include "xf86Bus.h"
 
 #include "../linux/systemd-logind.h"


### PR DESCRIPTION
Private definitions should not pollute public / SDK headers.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
