### PR TITLE
treewide: drop unnecessary includes of Xi/eglobals.h

### DIFF
--- a/Xext/namespace/hook-receive.c
+++ b/Xext/namespace/hook-receive.c
@@ -8,7 +8,6 @@
 #include "dix/registry_priv.h"
 #include "dix/resource_priv.h"
 #include "Xext/xacestr.h"
-#include "Xi/exglobals.h"
 
 #include "namespace.h"
 #include "hooks.h"

--- a/Xi/allowev.c
+++ b/Xi/allowev.c
@@ -59,7 +59,6 @@ SOFTWARE.
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
 
-#include "exglobals.h"
 #include "allowev.h"
 
 /***********************************************************************

--- a/Xi/chgfctl.c
+++ b/Xi/chgfctl.c
@@ -56,8 +56,6 @@ SOFTWARE.
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XIproto.h>     /* control constants */
 
-#include "exglobals.h"
-
 #include "chgfctl.h"
 
 #define DO_ALL    (-1)

--- a/Xi/closedev.c
+++ b/Xi/closedev.c
@@ -61,7 +61,6 @@ SOFTWARE.
 #include "windowstr.h"          /* window structure  */
 #include "scrnintstr.h"         /* screen structure  */
 #include "XIstubs.h"
-#include "exglobals.h"
 
 #include "closedev.h"
 

--- a/Xi/devbell.c
+++ b/Xi/devbell.c
@@ -55,7 +55,6 @@ SOFTWARE.
 #include "inputstr.h"           /* DeviceIntPtr      */
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XIproto.h>
-#include "exglobals.h"
 
 #include "devbell.h"
 

--- a/Xi/getbmap.c
+++ b/Xi/getbmap.c
@@ -59,7 +59,6 @@ SOFTWARE.
 #include "dix/rpcbuf_priv.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
-#include "exglobals.h"
 
 #include "getbmap.h"
 

--- a/Xi/getdctl.c
+++ b/Xi/getdctl.c
@@ -53,7 +53,6 @@ SOFTWARE.
 #include "dix/rpcbuf_priv.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
-#include "exglobals.h"
 #include "getdctl.h"
 
 static void

--- a/Xi/getfctl.c
+++ b/Xi/getfctl.c
@@ -59,7 +59,6 @@ SOFTWARE.
 #include "dix/rpcbuf_priv.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
-#include "exglobals.h"
 
 #include "getfctl.h"
 

--- a/Xi/getkmap.c
+++ b/Xi/getkmap.c
@@ -59,7 +59,6 @@ SOFTWARE.
 #include "dix/rpcbuf_priv.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
-#include "exglobals.h"
 #include "swaprep.h"
 #include "xkbsrv.h"
 #include "xkbstr.h"

--- a/Xi/getmmap.c
+++ b/Xi/getmmap.c
@@ -59,7 +59,6 @@ SOFTWARE.
 #include "dix/rpcbuf_priv.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
-#include "exglobals.h"
 
 #include "getmmap.h"
 

--- a/Xi/getprop.c
+++ b/Xi/getprop.c
@@ -60,7 +60,6 @@ SOFTWARE.
 
 #include "inputstr.h"           /* DeviceIntPtr      */
 #include "windowstr.h"          /* window structs    */
-#include "exglobals.h"
 #include "swaprep.h"
 #include "getprop.h"
 

--- a/Xi/getselev.c
+++ b/Xi/getselev.c
@@ -61,7 +61,6 @@ SOFTWARE.
 
 #include "inputstr.h"           /* DeviceIntPtr      */
 #include "windowstr.h"          /* window struct     */
-#include "exglobals.h"
 #include "swaprep.h"
 #include "getprop.h"
 #include "getselev.h"

--- a/Xi/getvers.c
+++ b/Xi/getvers.c
@@ -58,7 +58,6 @@ SOFTWARE.
 #include "dix/dix_priv.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
-#include "exevents.h"
 #include "exglobals.h"
 
 #include "getvers.h"

--- a/Xi/grabdevb.c
+++ b/Xi/grabdevb.c
@@ -60,7 +60,6 @@ SOFTWARE.
 
 #include "inputstr.h"           /* DeviceIntPtr      */
 #include "windowstr.h"          /* window structure  */
-#include "exglobals.h"
 #include "xace.h"
 #include "grabdev.h"
 #include "grabdevb.h"

--- a/Xi/grabdevk.c
+++ b/Xi/grabdevk.c
@@ -60,7 +60,6 @@ SOFTWARE.
 
 #include "inputstr.h"           /* DeviceIntPtr      */
 #include "windowstr.h"          /* window structure  */
-#include "exglobals.h"
 #include "xace.h"
 #include "grabdev.h"
 #include "grabdevk.h"

--- a/Xi/gtmotion.c
+++ b/Xi/gtmotion.c
@@ -60,7 +60,6 @@ SOFTWARE.
 #include "dix/rpcbuf_priv.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
-#include "exglobals.h"
 #include "gtmotion.h"
 
 /***********************************************************************

--- a/Xi/queryst.c
+++ b/Xi/queryst.c
@@ -44,7 +44,6 @@ from The Open Group.
 
 #include "inputstr.h"           /* DeviceIntPtr      */
 #include "windowstr.h"          /* window structure  */
-#include "exglobals.h"
 #include "xkbsrv.h"
 #include "xkbstr.h"
 #include "queryst.h"

--- a/Xi/sendexev.c
+++ b/Xi/sendexev.c
@@ -60,7 +60,6 @@ SOFTWARE.
 #include "inputstr.h"           /* DeviceIntPtr      */
 #include "windowstr.h"          /* Window            */
 #include "extnsionst.h"         /* EventSwapPtr      */
-#include "exglobals.h"
 #include "grabdev.h"
 #include "sendexev.h"
 

--- a/Xi/setbmap.c
+++ b/Xi/setbmap.c
@@ -60,7 +60,6 @@ SOFTWARE.
 
 #include "inputstr.h"           /* DeviceIntPtr      */
 #include "exevents.h"
-#include "exglobals.h"
 #include "setbmap.h"
 
 /***********************************************************************

--- a/Xi/setdval.c
+++ b/Xi/setdval.c
@@ -61,7 +61,6 @@ SOFTWARE.
 
 #include "inputstr.h"           /* DeviceIntPtr      */
 #include "XIstubs.h"
-#include "exglobals.h"
 #include "setdval.h"
 
 /***********************************************************************

--- a/Xi/setmmap.c
+++ b/Xi/setmmap.c
@@ -61,7 +61,6 @@ SOFTWARE.
 
 #include "inputstr.h"           /* DeviceIntPtr      */
 #include "exevents.h"
-#include "exglobals.h"
 #include "setmmap.h"
 
 /***********************************************************************

--- a/Xi/ungrdev.c
+++ b/Xi/ungrdev.c
@@ -58,7 +58,6 @@ SOFTWARE.
 
 #include "inputstr.h"           /* DeviceIntPtr      */
 #include "windowstr.h"          /* window structure  */
-#include "exglobals.h"
 #include "ungrdev.h"
 
 /***********************************************************************

--- a/Xi/xiselectev.c
+++ b/Xi/xiselectev.c
@@ -34,7 +34,6 @@
 
 #include "dixstruct.h"
 #include "windowstr.h"
-#include "exglobals.h"
 #include "xiselectev.h"
 
 /**

--- a/dix/getevents.c
+++ b/dix/getevents.c
@@ -61,7 +61,6 @@
 #include "windowstr.h"
 #include "xkbsrv.h"
 #include "exglobals.h"
-#include "exevents.h"
 #include "extnsionst.h"
 #include "listdev.h"            /* for sizing up DeviceClassesChangedEvent */
 

--- a/hw/xfree86/common/xf86DGA.c
+++ b/hw/xfree86/common/xf86DGA.c
@@ -65,7 +65,6 @@
 #include "micmap.h"
 #include "xkbsrv.h"
 #include "xf86Xinput.h"
-#include "exglobals.h"
 #include "eventstr.h"
 #include "xf86Extensions.h"
 #include "misc.h"

--- a/mi/mieq.c
+++ b/mi/mieq.c
@@ -56,7 +56,6 @@ in this Software without prior written authorization from The Open Group.
 #include   "inputstr.h"
 #include   "mipointer.h"
 #include   "scrnintstr.h"
-#include   "exglobals.h"
 #include   "eventstr.h"
 
 #ifdef DPMSExtension

--- a/xkb/xkbAccessX.c
+++ b/xkb/xkbAccessX.c
@@ -41,7 +41,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "os/log_priv.h"
 #include "xkb/xkbsrv_priv.h"
 
-#include "exglobals.h"
 #include "inputstr.h"
 #include "eventstr.h"
 


### PR DESCRIPTION
Dropping include by sources that don't use anything from this header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
