### PR TITLE
Xi: turn XIAllMasks from variable into #define

### DIFF
--- a/Xext/xinput/exglobals.h
+++ b/Xext/xinput/exglobals.h
@@ -51,7 +51,6 @@ extern const Mask DeviceButtonGrabMask;
 extern const Mask DeviceButtonMotionMask;
 extern const Mask DevicePresenceNotifyMask;
 extern const Mask DevicePropertyNotifyMask;
-extern const Mask XIAllMasks;
 
 extern int DeviceValuator;
 extern int DeviceKeyPress;

--- a/Xext/xinput/extinit.c
+++ b/Xext/xinput/extinit.c
@@ -101,7 +101,6 @@ const Mask DeviceButtonGrabMask = (1L << 17);
 const Mask DeviceOwnerGrabButtonMask = (1L << 17);
 const Mask DevicePresenceNotifyMask = (1L << 18);
 const Mask DevicePropertyNotifyMask = (1L << 19);
-const Mask XIAllMasks = (1L << 20) - 1;
 
 int ExtEventIndex;
 

--- a/Xext/xinput/selectev.c
+++ b/Xext/xinput/selectev.c
@@ -66,6 +66,8 @@ SOFTWARE.
 #include "exglobals.h"
 #include "grabdev.h"
 
+#define XIAllMasks ((Mask)((1L << 20) - 1))
+
 static int
 HandleDevicePresenceMask(ClientPtr client, WindowPtr win,
                          XEventClass * cls, CARD16 *count)


### PR DESCRIPTION
No need to have an actual (const) variable for something that can easily
be a #define. And also moving it into the only source file actually
using it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
