### PR TITLE
Xext: geext: drop GEClientPrivateKey

### DIFF
--- a/Xext/geext.c
+++ b/Xext/geext.c
@@ -39,8 +39,6 @@
 
 DevPrivateKeyRec GEClientPrivateKeyRec;
 
-#define GEClientPrivateKey (&GEClientPrivateKeyRec)
-
 /** Struct to keep information about registered extensions */
 typedef struct _GEExtension {
     /** Event swapping routine */
@@ -54,7 +52,7 @@ typedef struct _GEClientInfo {
     CARD32 minor_version;
 } GEClientInfoRec, *GEClientInfoPtr;
 
-#define GEGetClient(pClient)    ((GEClientInfoPtr)(dixLookupPrivate(&((pClient)->devPrivates), GEClientPrivateKey)))
+#define GEGetClient(pClient)    ((GEClientInfoPtr)(dixLookupPrivate(&((pClient)->devPrivates), &GEClientPrivateKeyRec)))
 
 /* Forward declarations */
 static void SGEGenericEvent(xEvent *from, xEvent *to);


### PR DESCRIPTION
Don't need actually need that extra macro, we can just write
&GEClientPrivateKeyRec in those few places.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
