### PR TITLE
config: untwist config backend prototypes

### DIFF
--- a/config/config-backends.h
+++ b/config/config-backends.h
@@ -32,20 +32,4 @@
 void remove_devices(const char *backend, const char *config_info);
 BOOL device_is_duplicate(const char *config_info);
 
-#ifdef CONFIG_UDEV
-int config_udev_pre_init(void);
-int config_udev_init(void);
-void config_udev_fini(void);
-#elif defined(CONFIG_HAL)
-int config_hal_init(void);
-void config_hal_fini(void);
-#elif defined(CONFIG_WSCONS)
-int config_wscons_init(void);
-void config_wscons_fini(void);
-#endif
-
-#ifdef CONFIG_UDEV_KMS
-void config_udev_odev_probe(config_odev_probe_proc_ptr probe_callback);
-#endif
-
 #endif /* XSERVER_CONFIG_BACKENDS_H */

--- a/config/config-hal.h
+++ b/config/config-hal.h
@@ -1,0 +1,16 @@
+#ifndef _XSERVER_CONFIG_HAL_H
+#define _XSERVER_CONFIG_HAL_H
+
+#ifdef CONFIG_HAL
+
+int config_hal_init(void);
+void config_hal_fini(void);
+
+#else
+
+static inline int config_hal_init(void) { return 1; }
+static inline void config_hal_fini(void) {}
+
+#endif
+
+#endif /* _XSERVER_CONFIG_HAL_H */

--- a/config/config-udev.h
+++ b/config/config-udev.h
@@ -1,0 +1,21 @@
+#ifndef _XSERVER_CONFIG_UDEV_H
+#define _XSERVER_CONFIG_UDEV_H
+
+#ifdef CONFIG_UDEV
+
+#include "config/hotplug_priv.h"
+
+int config_udev_init(void);
+void config_udev_fini(void);
+int config_udev_pre_init(void);
+void config_udev_odev_probe(config_odev_probe_proc_ptr probe_callback);
+
+#else
+
+static inline int config_udev_init(void) { return 1; }
+static inline void config_udev_fini(void) {}
+static inline int config_udev_pre_init(void) { return 1; }
+
+#endif
+
+#endif /* _XSERVER_CONFIG_UDEV_H */

--- a/config/config-wscons.h
+++ b/config/config-wscons.h
@@ -1,0 +1,16 @@
+#ifndef _XSERVER_CONFIG_WSCONS_H
+#define _XSERVER_CONFIG_WSCONS_H
+
+#ifdef CONFIG_WSCONS
+
+int config_wscons_init(void);
+void config_wscons_fini(void);
+
+#else
+
+static inline int config_wscons_init(void) { return 1; }
+static inline void config_wscons_fini(void) {}
+
+#endif
+
+#endif /* _XSERVER_CONFIG_WSCONS_H */

--- a/config/config.c
+++ b/config/config.c
@@ -27,6 +27,9 @@
 
 #include <unistd.h>
 
+#include "config/config-hal.h"
+#include "config/config-udev.h"
+#include "config/config-wscons.h"
 #include "config/hotplug_priv.h"
 
 #include "os.h"
@@ -38,37 +41,27 @@
 void
 config_pre_init(void)
 {
-#ifdef CONFIG_UDEV
     if (!config_udev_pre_init())
         ErrorF("[config] failed to pre-init udev\n");
-#endif
 }
 
 void
 config_init(void)
 {
-#ifdef CONFIG_UDEV
     if (!config_udev_init())
         ErrorF("[config] failed to initialise udev\n");
-#elif defined(CONFIG_HAL)
     if (!config_hal_init())
         ErrorF("[config] failed to initialise HAL\n");
-#elif defined(CONFIG_WSCONS)
     if (!config_wscons_init())
         ErrorF("[config] failed to initialise wscons\n");
-#endif
 }
 
 void
 config_fini(void)
 {
-#if defined(CONFIG_UDEV)
     config_udev_fini();
-#elif defined(CONFIG_HAL)
     config_hal_fini();
-#elif defined(CONFIG_WSCONS)
     config_wscons_fini();
-#endif
 }
 
 void

--- a/config/hal.c
+++ b/config/hal.c
@@ -31,6 +31,7 @@
 #include <dbus/dbus.h>
 #include <hal/libhal.h>
 
+#include "config/config-hal.h"
 #include "config/hotplug_priv.h"
 #include "config/dbus-core.h"
 #include "os/fmt.h"

--- a/config/udev.c
+++ b/config/udev.c
@@ -29,6 +29,7 @@
 #include <ctype.h>
 #include <unistd.h>
 
+#include "config/config-udev.h"
 #include "dix/settings_priv.h"
 #include "config/hotplug_priv.h"
 #include "os/fmt.h"

--- a/config/wscons.c
+++ b/config/wscons.c
@@ -36,7 +36,8 @@
 #include "input.h"
 #include "inputstr.h"
 #include "os.h"
-#include "config-backends.h"
+
+#include "config/config-wscons.h"
 
 #define WSCONS_KBD_DEVICE "/dev/wskbd"
 #define WSCONS_MOUSE_PREFIX "/dev/wsmouse"


### PR DESCRIPTION
* split the prototypes of individual backends into separate headers
* always define the functions (possibly empty) to cut down ifdef wood

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
