### PR TITLE
Xi: move VPC define into the only source using it

### DIFF
--- a/Xi/listdev.c
+++ b/Xi/listdev.c
@@ -70,6 +70,8 @@ SOFTWARE.
 #include "xkbstr.h"
 #include "listdev.h"
 
+#define VPC        20              /* Max # valuators per chunk */
+
 /***********************************************************************
  *
  * This procedure calculates the size of the information to be returned

--- a/Xi/listdev.h
+++ b/Xi/listdev.h
@@ -25,8 +25,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #ifndef LISTDEV_H
 #define LISTDEV_H 1
 
-#define VPC	20              /* Max # valuators per chunk */
-
 int ProcXListInputDevices(ClientPtr     /* client */
     );
 


### PR DESCRIPTION
Only used inside listdev.c, so no need to have it within a header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
