### PR TITLE
treewide: use inline helper for accessing first screen

### DIFF
--- a/Xext/shm.c
+++ b/Xext/shm.c
@@ -43,6 +43,7 @@ in this Software without prior written authorization from The Open Group.
 #include <X11/Xfuncproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/screenint_priv.h"
 #include "dix/screen_hooks_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/auth.h"
@@ -812,12 +813,12 @@ ProcShmGetImage(ClientPtr client)
             return BadMatch;
     }
     else {
+        ScreenPtr firstScreen = dixGetFirstScreenPtr();
         if (                    /* check for being onscreen */
-               screenInfo.screens[0]->x + pDraw->x + x < 0 ||
-               screenInfo.screens[0]->x + pDraw->x + x + w > PanoramiXPixWidth
-               || screenInfo.screens[0]->y + pDraw->y + y < 0 ||
-               screenInfo.screens[0]->y + pDraw->y + y + h > PanoramiXPixHeight
-               ||
+               firstScreen->x + pDraw->x + x < 0 ||
+               firstScreen->x + pDraw->x + x + w > PanoramiXPixWidth ||
+               firstScreen->y + pDraw->y + y < 0 ||
+               firstScreen->y + pDraw->y + y + h > PanoramiXPixHeight ||
                /* check for being inside of border */
                x < -wBorderWidth((WindowPtr) pDraw) ||
                x + w > wBorderWidth((WindowPtr) pDraw) + (int) pDraw->width ||

--- a/Xext/xvdisp.c
+++ b/Xext/xvdisp.c
@@ -32,6 +32,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/rpcbuf_priv.h"
+#include "dix/screenint_priv.h"
 #include "Xext/xvdix_priv.h"
 #include "Xext/panoramiX.h"
 #include "Xext/panoramiXsrv.h"
@@ -1543,7 +1544,7 @@ void
 XineramifyXv(void)
 {
     XvScreenPtr xvsp0 =
-        dixLookupPrivate(&screenInfo.screens[0]->devPrivates, XvGetScreenKey());
+        dixLookupPrivate(&(dixGetFirstScreenPtr()->devPrivates), XvGetScreenKey());
     XvAdaptorPtr MatchingAdaptors[MAXSCREENS];
     int i;
 

--- a/Xi/xiquerypointer.c
+++ b/Xi/xiquerypointer.c
@@ -42,6 +42,7 @@
 #include "dix/input_priv.h"
 #include "dix/inpututils_priv.h"
 #include "dix/rpcbuf_priv.h"
+#include "dix/screenint_priv.h"
 #include "os/fmt.h"
 #include "Xext/panoramiXsrv.h"
 
@@ -172,11 +173,12 @@ ProcXIQueryPointer(ClientPtr client)
 
 #ifdef XINERAMA
     if (!noPanoramiXExtension) {
-        rep.root_x += double_to_fp1616(screenInfo.screens[0]->x);
-        rep.root_y += double_to_fp1616(screenInfo.screens[0]->y);
+        ScreenPtr firstScreen = dixGetFirstScreenPtr();
+        rep.root_x += double_to_fp1616(firstScreen->x);
+        rep.root_y += double_to_fp1616(firstScreen->y);
         if (stuff->win == rep.root) {
-            rep.win_x += double_to_fp1616(screenInfo.screens[0]->x);
-            rep.win_y += double_to_fp1616(screenInfo.screens[0]->y);
+            rep.win_x += double_to_fp1616(firstScreen->x);
+            rep.win_y += double_to_fp1616(firstScreen->y);
         }
     }
 #endif /* XINERAMA */

--- a/composite/compext.c
+++ b/composite/compext.c
@@ -44,6 +44,7 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/screenint_priv.h"
 #include "miext/extinit_priv.h"
 #include "Xext/panoramiXsrv.h"
 
@@ -786,7 +787,7 @@ ProcCompositeGetOverlayWindow(ClientPtr client)
         return rc;
     }
 
-    cs = GetCompScreen(screenInfo.screens[0]);
+    cs = GetCompScreen(dixGetFirstScreenPtr());
     if (!cs->pOverlayWin) {
         if (!(overlayWin = calloc(1, sizeof(PanoramiXRes))))
             return BadAlloc;
@@ -847,7 +848,7 @@ ProcCompositeGetOverlayWindow(ClientPtr client)
         AddResource(overlayWin->info[0].id, XRT_WINDOW, overlayWin);
     }
 
-    cs = GetCompScreen(screenInfo.screens[0]);
+    cs = GetCompScreen(dixGetFirstScreenPtr());
 
     rep = (xCompositeGetOverlayWindowReply) {
         .overlayWin = cs->pOverlayWin->drawable.id

--- a/dix/devices.c
+++ b/dix/devices.c
@@ -61,6 +61,7 @@ SOFTWARE.
 #include "dix/input_priv.h"
 #include "dix/ptrveloc_priv.h"
 #include "dix/resource_priv.h"
+#include "dix/screenint_priv.h"
 #include "mi/mi_priv.h"
 #include "os/bug_priv.h"
 #include "os/log_priv.h"
@@ -378,9 +379,10 @@ EnableDevice(DeviceIntPtr dev, BOOL sendevent)
         if (InputDevIsMaster(dev)) {
             /* Sprites appear on first root window, so we can hardcode it */
             if (dev->spriteInfo->spriteOwner) {
-                InitializeSprite(dev, screenInfo.screens[0]->root);
+                ScreenPtr firstScreen = dixGetFirstScreenPtr();
+                InitializeSprite(dev, firstScreen->root);
                 /* mode doesn't matter */
-                EnterWindow(dev, screenInfo.screens[0]->root, NotifyAncestor);
+                EnterWindow(dev, firstScreen->root, NotifyAncestor);
             }
             else {
                 other = NextFreePointerDevice();
@@ -589,7 +591,7 @@ int
 ActivateDevice(DeviceIntPtr dev, BOOL sendevent)
 {
     int ret = Success;
-    ScreenPtr pScreen = screenInfo.screens[0];
+    ScreenPtr pScreen = dixGetFirstScreenPtr();
 
     if (!dev || !dev->deviceProc)
         return BadImplementation;
@@ -672,7 +674,7 @@ CorePointerProc(DeviceIntPtr pDev, int what)
     BYTE map[NBUTTONS + 1];
     Atom btn_labels[NBUTTONS] = { 0 };
     Atom axes_labels[NAXES] = { 0 };
-    ScreenPtr scr = screenInfo.screens[0];
+    ScreenPtr scr = dixGetFirstScreenPtr();
 
     switch (what) {
     case DEVICE_INIT:
@@ -987,7 +989,7 @@ FreePendingFrozenDeviceEvents(DeviceIntPtr dev)
 static void
 CloseDevice(DeviceIntPtr dev)
 {
-    ScreenPtr screen = screenInfo.screens[0];
+    ScreenPtr screen = dixGetFirstScreenPtr();
     ClassesPtr classes;
 
     if (!dev)
@@ -1142,7 +1144,7 @@ AbortDevices(void)
 void
 UndisplayDevices(void)
 {
-    ScreenPtr screen = screenInfo.screens[0];
+    ScreenPtr screen = dixGetFirstScreenPtr();
 
     for (DeviceIntPtr dev = inputInfo.devices; dev; dev = dev->next)
         screen->DisplayCursor(dev, screen, NullCursor);
@@ -1184,7 +1186,7 @@ int
 RemoveDevice(DeviceIntPtr dev, BOOL sendevent)
 {
     int ret = BadMatch;
-    ScreenPtr screen = screenInfo.screens[0];
+    ScreenPtr screen = dixGetFirstScreenPtr();
     int deviceid;
     int initialized;
     int flags[MAXDEVICES] = { 0 };
@@ -2632,7 +2634,7 @@ AttachDevice(ClientPtr client, DeviceIntPtr dev, DeviceIntPtr master)
         if (dev->spriteInfo->sprite)
             currentRoot = InputDevCurrentRootWindow(dev);
         else                    /* new device auto-set to floating */
-            currentRoot = screenInfo.screens[0]->root;
+            currentRoot = dixGetFirstScreenPtr()->root;
 
         /* we need to init a fake sprite */
         screen = currentRoot->drawable.pScreen;

--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -60,6 +60,7 @@ Equipment Corporation.
 #include "dix/dix_priv.h"
 #include "dix/gc_priv.h"
 #include "dix/rpcbuf_priv.h"
+#include "dix/screenint_priv.h"
 #include "include/swaprep.h"
 #include "os/auth.h"
 #include "os/log_priv.h"
@@ -1868,7 +1869,7 @@ get_client_resolutions(int *num)
     static struct _FontResolution res;
     ScreenPtr pScreen;
 
-    pScreen = screenInfo.screens[0];
+    pScreen = dixGetFirstScreenPtr();
     res.x_resolution = (pScreen->width * 25.4) / pScreen->mmWidth;
     /*
      * XXX - we'll want this as long as bitmap instances are prevalent

--- a/dix/events.c
+++ b/dix/events.c
@@ -128,6 +128,7 @@ Equipment Corporation.
 #include "dix/inpututils_priv.h"
 #include "dix/reqhandlers_priv.h"
 #include "dix/resource_priv.h"
+#include "dix/screenint_priv.h"
 #include "dix/window_priv.h"
 #include "os/bug_priv.h"
 #include "os/client_priv.h"
@@ -539,8 +540,10 @@ XineramaSetCursorPosition(DeviceIntPtr pDev, int x, int y, Bool generateEvent)
        that screen are. */
 
     pScreen = pSprite->screen;
-    x += screenInfo.screens[0]->x;
-    y += screenInfo.screens[0]->y;
+
+    ScreenPtr firstScreen = dixGetFirstScreenPtr();
+    x += firstScreen->x;
+    y += firstScreen->y;
 
     if (!point_on_screen(pScreen, x, y)) {
         XINERAMA_FOR_EACH_SCREEN_BACKWARD({
@@ -554,8 +557,8 @@ XineramaSetCursorPosition(DeviceIntPtr pDev, int x, int y, Bool generateEvent)
     }
 
     pSprite->screen = pScreen;
-    pSprite->hotPhys.x = x - screenInfo.screens[0]->x;
-    pSprite->hotPhys.y = y - screenInfo.screens[0]->y;
+    pSprite->hotPhys.x = x - firstScreen->x;
+    pSprite->hotPhys.y = y - firstScreen->y;
     x -= pScreen->x;
     y -= pScreen->y;
 
@@ -571,12 +574,14 @@ XineramaConstrainCursor(DeviceIntPtr pDev)
     ScreenPtr pScreen = pSprite->screen;
     BoxRec newBox = pSprite->physLimits;
 
+    ScreenPtr firstScreen = dixGetFirstScreenPtr();
+
     /* Translate the constraining box to the screen
        the sprite is actually on */
-    newBox.x1 += screenInfo.screens[0]->x - pScreen->x;
-    newBox.x2 += screenInfo.screens[0]->x - pScreen->x;
-    newBox.y1 += screenInfo.screens[0]->y - pScreen->y;
-    newBox.y2 += screenInfo.screens[0]->y - pScreen->y;
+    newBox.x1 += firstScreen->x - pScreen->x;
+    newBox.x2 += firstScreen->x - pScreen->x;
+    newBox.y1 += firstScreen->y - pScreen->y;
+    newBox.y2 += firstScreen->y - pScreen->y;
 
     (*pScreen->ConstrainCursor) (pDev, pScreen, &newBox);
 }
@@ -586,7 +591,7 @@ XineramaSetWindowPntrs(DeviceIntPtr pDev, WindowPtr pWin)
 {
     SpritePtr pSprite = pDev->spriteInfo->sprite;
 
-    if (pWin == screenInfo.screens[0]->root) {
+    if (pWin == dixGetFirstScreenPtr()->root) {
         XINERAMA_FOR_EACH_SCREEN_BACKWARD({
             pSprite->windows[walkScreenIdx] = walkScreen->root;
         });
@@ -655,7 +660,7 @@ XineramaConfineCursorToWindow(DeviceIntPtr pDev,
 
     pSprite->confined = FALSE;
     pSprite->confineWin =
-        (pWin == screenInfo.screens[0]->root) ? NullWindow : pWin;
+        (pWin == dixGetFirstScreenPtr()->root) ? NullWindow : pWin;
 
     CheckPhysLimits(pDev, pSprite->current, generateEvents, FALSE, NULL);
 }
@@ -1182,8 +1187,9 @@ EnqueueEvent(InternalEvent *ev, DeviceIntPtr device)
     if (event->type == ET_Motion) {
 #ifdef XINERAMA
         if (!noPanoramiXExtension) {
-            event->root_x += pSprite->screen->x - screenInfo.screens[0]->x;
-            event->root_y += pSprite->screen->y - screenInfo.screens[0]->y;
+            ScreenPtr firstScreen = dixGetFirstScreenPtr();
+            event->root_x += pSprite->screen->x - firstScreen->x;
+            event->root_y += pSprite->screen->y - firstScreen->y;
         }
 #endif /* XINERAMA */
         pSprite->hotPhys.x = event->root_x;
@@ -1233,6 +1239,9 @@ PlayReleasedEvents(void)
     QdEventPtr qe;
     DeviceIntPtr dev;
     DeviceIntPtr pDev;
+#ifdef XINERAMA
+    ScreenPtr firstScreen = dixGetFirstScreenPtr();
+#endif
 
  restart:
     xorg_list_for_each_entry_safe(qe, tmp, &syncEvents.pending, next) {
@@ -1261,9 +1270,9 @@ PlayReleasedEvents(void)
                 case ET_TouchBegin:
                 case ET_TouchUpdate:
                 case ET_TouchEnd:
-                    ev->root_x += screenInfo.screens[0]->x -
+                    ev->root_x += firstScreen->x -
                         pDev->spriteInfo->sprite->screen->x;
-                    ev->root_y += screenInfo.screens[0]->y -
+                    ev->root_y += firstScreen->y -
                         pDev->spriteInfo->sprite->screen->y;
                     break;
                 default:
@@ -3010,12 +3019,13 @@ PointInBorderSize(WindowPtr pWin, int x, int y)
     if (!noPanoramiXExtension &&
         XineramaSetWindowPntrs(inputInfo.pointer, pWin)) {
         SpritePtr pSprite = inputInfo.pointer->spriteInfo->sprite;
+        ScreenPtr firstScreen = dixGetFirstScreenPtr();
 
         XINERAMA_FOR_EACH_SCREEN_FORWARD_SKIP0({
             if (RegionContainsPoint(&pSprite->windows[walkScreenIdx]->borderSize,
-                                    x + screenInfo.screens[0]->x -
+                                    x + firstScreen->x -
                                     walkScreen->x,
-                                    y + screenInfo.screens[0]->y -
+                                    y + firstScreen->y -
                                     walkScreen->y, &box))
                 return TRUE;
         });
@@ -3165,8 +3175,9 @@ CheckMotion(DeviceEvent *ev, DeviceIntPtr pDev)
             /* Motion events entering DIX get translated to Screen 0
                coordinates.  Replayed events have already been
                translated since they've entered DIX before */
-            ev->root_x += pSprite->screen->x - screenInfo.screens[0]->x;
-            ev->root_y += pSprite->screen->y - screenInfo.screens[0]->y;
+            ScreenPtr firstScreen = dixGetFirstScreenPtr();
+            ev->root_x += pSprite->screen->x - firstScreen->x;
+            ev->root_y += pSprite->screen->y - firstScreen->y;
         }
         else
 #endif /* XINERAMA */
@@ -3337,7 +3348,7 @@ InitializeSprite(DeviceIntPtr pDev, WindowPtr pWin)
         pSprite->spriteTrace = NULL;
         pSprite->spriteTraceSize = 0;
         pSprite->spriteTraceGood = 0;
-        pSprite->pEnqueueScreen = screenInfo.screens[0];
+        pSprite->pEnqueueScreen = dixGetFirstScreenPtr();
         pSprite->pDequeueScreen = pSprite->pEnqueueScreen;
     }
     pCursor = RefCursor(pCursor);
@@ -3358,10 +3369,11 @@ InitializeSprite(DeviceIntPtr pDev, WindowPtr pWin)
     }
 #ifdef XINERAMA
     if (!noPanoramiXExtension) {
-        pSprite->hotLimits.x1 = -screenInfo.screens[0]->x;
-        pSprite->hotLimits.y1 = -screenInfo.screens[0]->y;
-        pSprite->hotLimits.x2 = PanoramiXPixWidth - screenInfo.screens[0]->x;
-        pSprite->hotLimits.y2 = PanoramiXPixHeight - screenInfo.screens[0]->y;
+        ScreenPtr firstScreen = dixGetFirstScreenPtr();
+        pSprite->hotLimits.x1 = -firstScreen->x;
+        pSprite->hotLimits.y1 = -firstScreen->y;
+        pSprite->hotLimits.x2 = PanoramiXPixWidth - firstScreen->x;
+        pSprite->hotLimits.y2 = PanoramiXPixHeight - firstScreen->y;
         pSprite->physLimits = pSprite->hotLimits;
         pSprite->confineWin = NullWindow;
         pSprite->hotShape = NullRegion;
@@ -3438,10 +3450,11 @@ UpdateSpriteForScreen(DeviceIntPtr pDev, ScreenPtr pScreen)
 
 #ifdef XINERAMA
     if (!noPanoramiXExtension) {
-        pSprite->hotLimits.x1 = -screenInfo.screens[0]->x;
-        pSprite->hotLimits.y1 = -screenInfo.screens[0]->y;
-        pSprite->hotLimits.x2 = PanoramiXPixWidth - screenInfo.screens[0]->x;
-        pSprite->hotLimits.y2 = PanoramiXPixHeight - screenInfo.screens[0]->y;
+        ScreenPtr firstScreen = dixGetFirstScreenPtr();
+        pSprite->hotLimits.x1 = -firstScreen->x;
+        pSprite->hotLimits.y1 = -firstScreen->y;
+        pSprite->hotLimits.x2 = PanoramiXPixWidth - firstScreen->x;
+        pSprite->hotLimits.y2 = PanoramiXPixHeight - firstScreen->y;
         pSprite->physLimits = pSprite->hotLimits;
         pSprite->screen = pScreen;
     }
@@ -3478,26 +3491,26 @@ NewCurrentScreen(DeviceIntPtr pDev, ScreenPtr newScreen, int x, int y)
     pSprite->hotPhys.y = y;
 #ifdef XINERAMA
     if (!noPanoramiXExtension) {
-        pSprite->hotPhys.x += newScreen->x - screenInfo.screens[0]->x;
-        pSprite->hotPhys.y += newScreen->y - screenInfo.screens[0]->y;
+        ScreenPtr firstScreen = dixGetFirstScreenPtr();
+        pSprite->hotPhys.x += newScreen->x - firstScreen->x;
+        pSprite->hotPhys.y += newScreen->y - firstScreen->y;
         if (newScreen != pSprite->screen) {
             pSprite->screen = newScreen;
             /* Make sure we tell the DDX to update its copy of the screen */
             if (pSprite->confineWin)
                 XineramaConfineCursorToWindow(ptr, pSprite->confineWin, TRUE);
             else
-                XineramaConfineCursorToWindow(ptr, screenInfo.screens[0]->root,
-                                              TRUE);
+                XineramaConfineCursorToWindow(ptr, firstScreen->root, TRUE);
             /* if the pointer wasn't confined, the DDX won't get
                told of the pointer warp so we reposition it here */
             if (!syncEvents.playingEvents)
                 (*pSprite->screen->SetCursorPosition) (ptr,
                                                        pSprite->screen,
                                                        pSprite->hotPhys.x +
-                                                       screenInfo.screens[0]->
+                                                       firstScreen->
                                                        x - pSprite->screen->x,
                                                        pSprite->hotPhys.y +
-                                                       screenInfo.screens[0]->
+                                                       firstScreen->
                                                        y - pSprite->screen->y,
                                                        FALSE);
         }
@@ -3525,8 +3538,10 @@ XineramaPointInWindowIsVisible(WindowPtr pWin, int x, int y)
     if (!XineramaSetWindowPntrs(inputInfo.pointer, pWin))
          return FALSE;
 
-    xoff = x + screenInfo.screens[0]->x;
-    yoff = y + screenInfo.screens[0]->y;
+    ScreenPtr firstScreen = dixGetFirstScreenPtr();
+
+    xoff = x + firstScreen->x;
+    yoff = y + firstScreen->y;
 
     XINERAMA_FOR_EACH_SCREEN_FORWARD_SKIP0({
         pWin = inputInfo.pointer->spriteInfo->sprite->windows[walkScreenIdx];
@@ -3562,6 +3577,8 @@ XineramaWarpPointer(ClientPtr client)
     x = pSprite->hotPhys.x;
     y = pSprite->hotPhys.y;
 
+    ScreenPtr firstScreen = dixGetFirstScreenPtr();
+
     if (stuff->srcWid != None) {
         int winX, winY;
         XID winID = stuff->srcWid;
@@ -3573,9 +3590,9 @@ XineramaWarpPointer(ClientPtr client)
 
         winX = source->drawable.x;
         winY = source->drawable.y;
-        if (source == screenInfo.screens[0]->root) {
-            winX -= screenInfo.screens[0]->x;
-            winY -= screenInfo.screens[0]->y;
+        if (source == firstScreen->root) {
+            winX -= firstScreen->x;
+            winY -= firstScreen->y;
         }
         if (x < winX + stuff->srcX ||
             y < winY + stuff->srcY ||
@@ -3589,9 +3606,9 @@ XineramaWarpPointer(ClientPtr client)
     if (dest) {
         x = dest->drawable.x;
         y = dest->drawable.y;
-        if (dest == screenInfo.screens[0]->root) {
-            x -= screenInfo.screens[0]->x;
-            y -= screenInfo.screens[0]->y;
+        if (dest == firstScreen->root) {
+            x -= firstScreen->x;
+            y -= firstScreen->y;
         }
     }
 
@@ -5356,11 +5373,12 @@ ProcQueryPointer(ClientPtr client)
 
 #ifdef XINERAMA
     if (!noPanoramiXExtension) {
-        rep.rootX += screenInfo.screens[0]->x;
-        rep.rootY += screenInfo.screens[0]->y;
+        ScreenPtr firstScreen = dixGetFirstScreenPtr();
+        rep.rootX += firstScreen->x;
+        rep.rootY += firstScreen->y;
         if (stuff->id == rep.root) {
-            rep.winX += screenInfo.screens[0]->x;
-            rep.winY += screenInfo.screens[0]->y;
+            rep.winX += firstScreen->x;
+            rep.winY += firstScreen->y;
         }
     }
 #endif /* XINERAMA */
@@ -6025,8 +6043,8 @@ WriteEventsToClient(ClientPtr pClient, int count, xEvent *events)
     XkbFilterEvents(pClient, count, events);
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension &&
-        (screenInfo.screens[0]->x || screenInfo.screens[0]->y)) {
+    ScreenPtr firstScreen = dixGetFirstScreenPtr();
+    if (!noPanoramiXExtension && (firstScreen->x || firstScreen->y)) {
         switch (events->u.u.type) {
         case MotionNotify:
         case ButtonPress:
@@ -6042,12 +6060,12 @@ WriteEventsToClient(ClientPtr pClient, int count, xEvent *events)
              */
             count = 1;          /* should always be 1 */
             memcpy(&eventCopy, events, sizeof(xEvent));
-            eventCopy.u.keyButtonPointer.rootX += screenInfo.screens[0]->x;
-            eventCopy.u.keyButtonPointer.rootY += screenInfo.screens[0]->y;
+            eventCopy.u.keyButtonPointer.rootX += firstScreen->x;
+            eventCopy.u.keyButtonPointer.rootY += firstScreen->y;
             if (eventCopy.u.keyButtonPointer.event ==
                 eventCopy.u.keyButtonPointer.root) {
-                eventCopy.u.keyButtonPointer.eventX += screenInfo.screens[0]->x;
-                eventCopy.u.keyButtonPointer.eventY += screenInfo.screens[0]->y;
+                eventCopy.u.keyButtonPointer.eventX += firstScreen->x;
+                eventCopy.u.keyButtonPointer.eventY += firstScreen->y;
             }
             events = &eventCopy;
             break;

--- a/dix/gestures.c
+++ b/dix/gestures.c
@@ -31,6 +31,7 @@
 #include "dix/input_priv.h"
 #include "dix/inpututils_priv.h"
 #include "dix/resource_priv.h"
+#include "dix/screenint_priv.h"
 #include "mi/mi_priv.h"
 #include "os/bug_priv.h"
 
@@ -52,10 +53,12 @@ GestureInitGestureInfo(GestureInfoPtr gi)
     if (!gi->sprite.spriteTrace) {
         return FALSE;
     }
+    ScreenPtr firstScreen = dixGetFirstScreenPtr();
+
     gi->sprite.spriteTraceSize = 32;
-    gi->sprite.spriteTrace[0] = screenInfo.screens[0]->root;
-    gi->sprite.hot.pScreen = screenInfo.screens[0];
-    gi->sprite.hotPhys.pScreen = screenInfo.screens[0];
+    gi->sprite.spriteTrace[0] = firstScreen->root;
+    gi->sprite.hot.pScreen = firstScreen;
+    gi->sprite.hotPhys.pScreen = firstScreen;
 
     return TRUE;
 }

--- a/dix/getevents.c
+++ b/dix/getevents.c
@@ -42,6 +42,7 @@
 
 #include "dix/input_priv.h"
 #include "dix/inpututils_priv.h"
+#include "dix/screenint_priv.h"
 #include "mi/mi_priv.h"
 #include "os/bug_priv.h"
 #include "os/probes_priv.h"
@@ -2119,8 +2120,9 @@ PostSyntheticMotion(DeviceIntPtr pDev,
        will translate from sprite screen to screen 0 upon reentry
        to the DIX layer. */
     if (!noPanoramiXExtension) {
-        x += screenInfo.screens[0]->x - screenInfo.screens[screen]->x;
-        y += screenInfo.screens[0]->y - screenInfo.screens[screen]->y;
+        ScreenPtr firstScreen = dixGetFirstScreenPtr();
+        x += firstScreen->x - screenInfo.screens[screen]->x;
+        y += firstScreen->y - screenInfo.screens[screen]->y;
     }
 #endif /* XINERAMA */
 

--- a/dix/glyphcurs.c
+++ b/dix/glyphcurs.c
@@ -47,6 +47,7 @@ SOFTWARE.
 #include <dix-config.h>
 
 #include "dix/cursor_priv.h"
+#include "dix/screenint_priv.h"
 
 #include "misc.h"
 #include <X11/fonts/fontstruct.h>
@@ -74,7 +75,6 @@ int
 ServerBitsFromGlyph(FontPtr pfont, unsigned ch, CursorMetricPtr cm,
                     unsigned char **ppbits)
 {
-    ScreenPtr pScreen;
     GCPtr pGC;
     xRectangle rect;
     PixmapPtr ppix;
@@ -86,7 +86,7 @@ ServerBitsFromGlyph(FontPtr pfont, unsigned ch, CursorMetricPtr cm,
     char2b[0] = (unsigned char) (ch >> 8);
     char2b[1] = (unsigned char) (ch & 0xff);
 
-    pScreen = screenInfo.screens[0];
+    ScreenPtr pScreen = dixGetFirstScreenPtr();
     pbits = calloc(BitmapBytePad(cm->width), cm->height);
     if (!pbits)
         return BadAlloc;

--- a/dix/screenint_priv.h
+++ b/dix/screenint_priv.h
@@ -8,7 +8,8 @@
 
 #include <X11/Xdefs.h>
 
-#include "screenint.h"
+#include "include/screenint.h"
+#include "include/scrnintstr.h" /* for screenInfo */
 
 typedef Bool (*ScreenInitProcPtr)(ScreenPtr pScreen, int argc, char **argv);
 
@@ -22,5 +23,9 @@ void DetachUnboundGPU(ScreenPtr unbound);
 
 void AttachOffloadGPU(ScreenPtr pScreen, ScreenPtr newScreen);
 void DetachOffloadGPU(ScreenPtr slave);
+
+static inline ScreenPtr dixGetFirstScreenPtr(void) {
+    return screenInfo.screens[0];
+}
 
 #endif /* _XSERVER_DIX_SCREENINT_PRIV_H */

--- a/dix/touch.c
+++ b/dix/touch.c
@@ -33,6 +33,7 @@
 #include "dix/input_priv.h"
 #include "dix/inpututils_priv.h"
 #include "dix/resource_priv.h"
+#include "dix/screenint_priv.h"
 #include "mi/mi_priv.h"
 #include "os/bug_priv.h"
 #include "os/log_priv.h"
@@ -221,9 +222,12 @@ TouchInitTouchPoint(TouchClassPtr t, ValuatorClassPtr v, int index)
         return FALSE;
     }
     ti->sprite.spriteTraceSize = 32;
-    ti->sprite.spriteTrace[0] = screenInfo.screens[0]->root;
-    ti->sprite.hot.pScreen = screenInfo.screens[0];
-    ti->sprite.hotPhys.pScreen = screenInfo.screens[0];
+
+    ScreenPtr firstScreen = dixGetFirstScreenPtr();
+
+    ti->sprite.spriteTrace[0] = firstScreen->root;
+    ti->sprite.hot.pScreen = firstScreen;
+    ti->sprite.hotPhys.pScreen = firstScreen;
 
     ti->client_id = -1;
 

--- a/dix/window.c
+++ b/dix/window.c
@@ -107,6 +107,7 @@ Equipment Corporation.
 #include "dix/inpututils_priv.h"
 #include "dix/property_priv.h"
 #include "dix/resource_priv.h"
+#include "dix/screenint_priv.h"
 #include "dix/selection_priv.h"
 #include "dix/window_priv.h"
 #include "mi/mi_priv.h"         /* miPaintWindow */
@@ -2268,8 +2269,9 @@ ConfigureWindow(WindowPtr pWin, Mask mask, XID *vlist, ClientPtr client)
         event.u.u.detail = (mask & CWStackMode) ? smode : Above;
 #ifdef XINERAMA
         if (!noPanoramiXExtension && (!pParent || !pParent->parent)) {
-            event.u.configureRequest.x += screenInfo.screens[0]->x;
-            event.u.configureRequest.y += screenInfo.screens[0]->y;
+            ScreenPtr firstScreen = dixGetFirstScreenPtr();
+            event.u.configureRequest.x += firstScreen->x;
+            event.u.configureRequest.y += firstScreen->y;
         }
 #endif /* XINERAMA */
         if (MaybeDeliverEventToClient(pParent, &event,
@@ -2351,8 +2353,9 @@ ConfigureWindow(WindowPtr pWin, Mask mask, XID *vlist, ClientPtr client)
         event.u.u.type = ConfigureNotify;
 #ifdef XINERAMA
         if (!noPanoramiXExtension && (!pParent || !pParent->parent)) {
-            event.u.configureNotify.x += screenInfo.screens[0]->x;
-            event.u.configureNotify.y += screenInfo.screens[0]->y;
+            ScreenPtr firstScreen = dixGetFirstScreenPtr();
+            event.u.configureNotify.x += firstScreen->x;
+            event.u.configureNotify.y += firstScreen->y;
         }
 #endif /* XINERAMA */
         DeliverEvents(pWin, &event, 1, NullWindow);
@@ -2496,8 +2499,9 @@ ReparentWindow(WindowPtr pWin, WindowPtr pParent,
     event.u.u.type = ReparentNotify;
 #ifdef XINERAMA
     if (!noPanoramiXExtension && !pParent->parent) {
-        event.u.reparent.x += screenInfo.screens[0]->x;
-        event.u.reparent.y += screenInfo.screens[0]->y;
+        ScreenPtr firstScreen = dixGetFirstScreenPtr();
+        event.u.reparent.x += firstScreen->x;
+        event.u.reparent.y += firstScreen->y;
     }
 #endif /* XINERAMA */
     DeliverEvents(pWin, &event, 1, pParent);

--- a/hw/xfree86/common/xf86Xinput.c
+++ b/hw/xfree86/common/xf86Xinput.c
@@ -61,6 +61,7 @@
 #include "dix/input_priv.h"
 #include "dix/inpututils_priv.h"
 #include "dix/ptrveloc_priv.h"
+#include "dix/screenint_priv.h"
 
 #include "xf86_priv.h"
 #include "xf86Priv.h"
@@ -1525,11 +1526,11 @@ void
 xf86InitValuatorDefaults(DeviceIntPtr dev, int axnum)
 {
     if (axnum == 0) {
-        dev->valuator->axisVal[0] = screenInfo.screens[0]->width / 2;
+        dev->valuator->axisVal[0] = dixGetFirstScreenPtr()->width / 2;
         dev->last.valuators[0] = dev->valuator->axisVal[0];
     }
     else if (axnum == 1) {
-        dev->valuator->axisVal[1] = screenInfo.screens[0]->height / 2;
+        dev->valuator->axisVal[1] = dixGetFirstScreenPtr()->height / 2;
         dev->last.valuators[1] = dev->valuator->axisVal[1];
     }
 }

--- a/hw/xquartz/darwin.c
+++ b/hw/xquartz/darwin.c
@@ -34,6 +34,7 @@
 #include <X11/X.h>
 #include <X11/Xproto.h>
 
+#include "dix/screenint_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/ddx_priv.h"
 #include "os/log_priv.h"
@@ -586,8 +587,10 @@ DarwinAdjustScreenOrigins(ScreenInfo *pScreenInfo)
 {
     int i, left, top;
 
-    left = pScreenInfo->screens[0]->x;
-    top = pScreenInfo->screens[0]->y;
+    ScreenPtr firstScreen = dixGetFirstScreenPtr();
+
+    left = firstScreen->x;
+    top = firstScreen->y;
 
     /* Find leftmost screen. If there's a tie, take the topmost of the two. */
     for (i = 1; i < pScreenInfo->numScreens; i++) {

--- a/hw/xquartz/quartz.c
+++ b/hw/xquartz/quartz.c
@@ -34,6 +34,7 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/screenint_priv.h"
 
 #include "quartzRandR.h"
 #include "inputstr.h"
@@ -251,7 +252,7 @@ QuartzUpdateScreens(void)
         return;
     }
 
-    pScreen = screenInfo.screens[0];
+    pScreen = dixGetFirstScreenPtr();
 
     PseudoramiXResetScreens();
     quartzProcs->AddPseudoramiXScreens(&x, &y, &width, &height, pScreen);

--- a/hw/xquartz/quartzRandR.c
+++ b/hw/xquartz/quartzRandR.c
@@ -33,6 +33,8 @@
 
 #include <dix-config.h>
 
+#include "dix/screenint_priv.h"
+
 #include "quartzRandR.h"
 #include "quartz.h"
 #include "darwin.h"
@@ -424,7 +426,7 @@ _QuartzRandRUpdateFakeModes(ScreenPtr pScreen)
 Bool
 QuartzRandRUpdateFakeModes(BOOL force_update)
 {
-    ScreenPtr pScreen = screenInfo.screens[0];
+    ScreenPtr pScreen = dixGetFirstScreenPtr();
 
     if (ignore_next_fake_mode_update) {
         DEBUG_LOG(
@@ -494,7 +496,7 @@ QuartzRandRSetFakeFullscreen(BOOL state)
 void
 QuartzRandRToggleFullscreen(void)
 {
-    ScreenPtr pScreen = screenInfo.screens[0];
+    ScreenPtr pScreen = dixGetFirstScreenPtr();
     QuartzScreenPtr pQuartzScreen = QUARTZ_PRIV(pScreen);
 
     if (pQuartzScreen->currentMode.ref == NULL) {

--- a/hw/xwin/winkeybd.c
+++ b/hw/xwin/winkeybd.c
@@ -35,6 +35,7 @@
 #include <xwin-config.h>
 #endif
 
+#include "dix/screenint_priv.h"
 #include "mi/mi_priv.h"
 
 #include "win.h"
@@ -256,8 +257,8 @@ winRestoreModeKeyStates(void)
 
     /* Only process events if the rootwindow is mapped. The keyboard events
      * will cause segfaults otherwise */
-    if (screenInfo.screens[0]->root &&
-        screenInfo.screens[0]->root->mapped == FALSE)
+    ScreenPtr firstScreen = dixGetFirstScreenPtr();
+    if (firstScreen->root && firstScreen->root->mapped == FALSE)
         processEvents = FALSE;
 
     /* Force to process all pending events in the mi event queue */

--- a/hw/xwin/winmsgwindow.c
+++ b/hw/xwin/winmsgwindow.c
@@ -26,6 +26,8 @@
 #include <xwin-config.h>
 #endif
 
+#include "dix/screenint_priv.h"
+
 #include "win.h"
 
 /*
@@ -56,7 +58,7 @@ winMsgWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
            has set the DE_TERMINATE flag so exits the msg dispatch loop.
          */
         {
-            ScreenPtr pScreen = screenInfo.screens[0];
+            ScreenPtr pScreen = dixGetFirstScreenPtr();
 
             winScreenPriv(pScreen);
             PostMessage(pScreenPriv->hwndScreen, WM_GIVEUP, 0, 0);

--- a/mi/miexpose.c
+++ b/mi/miexpose.c
@@ -79,6 +79,7 @@ Equipment Corporation.
 #include <X11/Xprotostr.h>
 
 #include "dix/dix_priv.h"
+#include "dix/screenint_priv.h"
 #include "mi/mi_priv.h"
 #include "Xext/panoramiX.h"
 #include "Xext/panoramiXsrv.h"
@@ -327,7 +328,7 @@ miSendExposures(WindowPtr pWin, RegionPtr pRgn, int dx, int dy)
         if (!pWin->parent) {
             x = screenInfo.screens[scrnum]->x;
             y = screenInfo.screens[scrnum]->y;
-            pWin = screenInfo.screens[0]->root;
+            pWin = dixGetFirstScreenPtr()->root;
             realWin = pWin->drawable.id;
         }
         else if (scrnum) {

--- a/record/record.c
+++ b/record/record.c
@@ -44,6 +44,7 @@ and Jim Haggerty of Metheus.
 #include "dix/eventconvert.h"
 #include "dix/input_priv.h"
 #include "dix/resource_priv.h"
+#include "dix/screenint_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/client_priv.h"
 #include "os/osdep.h"
@@ -725,12 +726,13 @@ RecordSendProtocolEvents(RecordClientsAndProtocolPtr pRCAP,
                  pev->u.u.type == ButtonRelease ||
                  pev->u.u.type == KeyPress || pev->u.u.type == KeyRelease)) {
                 int scr = inputInfo.pointer->spriteInfo->sprite->screen->myNum;
+                ScreenPtr firstScreen = dixGetFirstScreenPtr();
 
                 memcpy(&shiftedEvent, pev, sizeof(xEvent));
                 shiftedEvent.u.keyButtonPointer.rootX +=
-                    screenInfo.screens[scr]->x - screenInfo.screens[0]->x;
+                    screenInfo.screens[scr]->x - firstScreen->x;
                 shiftedEvent.u.keyButtonPointer.rootY +=
-                    screenInfo.screens[scr]->y - screenInfo.screens[0]->y;
+                    screenInfo.screens[scr]->y - firstScreen->y;
                 pEvToRecord = &shiftedEvent;
             }
 #endif /* XINERAMA */

--- a/render/filter.c
+++ b/render/filter.c
@@ -25,6 +25,8 @@
 #define  XK_LATIN1
 #include <X11/keysymdef.h>
 
+#include "dix/screenint_priv.h"
+
 #include "misc.h"
 #include "scrnintstr.h"
 #include "os.h"
@@ -329,7 +331,7 @@ SetPictureFilter(PicturePtr pPicture, char *name, int len, xFixed * params,
     if (pPicture->pDrawable != NULL)
         pScreen = pPicture->pDrawable->pScreen;
     else
-        pScreen = screenInfo.screens[0];
+        pScreen = dixGetFirstScreenPtr();
 
     pFilter = PictureFindFilter(pScreen, name, len);
 
@@ -360,7 +362,7 @@ SetPicturePictFilter(PicturePtr pPicture, PictFilterPtr pFilter,
     if (pPicture->pDrawable)
         pScreen = pPicture->pDrawable->pScreen;
     else
-        pScreen = screenInfo.screens[0];
+        pScreen = dixGetFirstScreenPtr();
 
     if (pFilter->ValidateParams) {
         int width, height;

--- a/render/render.c
+++ b/render/render.c
@@ -34,6 +34,7 @@
 #include "dix/colormap_priv.h"
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
+#include "dix/screenint_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/osdep.h"
 #include "Xext/panoramiX.h"
@@ -2555,7 +2556,7 @@ PanoramiXRenderCreatePicture(ClientPtr client)
     panoramix_setup_ids(newPict, client, stuff->pid);
 
     if (refDraw->type == XRT_WINDOW &&
-        stuff->drawable == screenInfo.screens[0]->root->drawable.id) {
+        stuff->drawable == dixGetFirstScreenPtr()->root->drawable.id) {
         newPict->u.pict.root = TRUE;
     }
     else

--- a/test/xi2/protocol-common.c
+++ b/test/xi2/protocol-common.c
@@ -33,6 +33,7 @@
 #include "dix/atom_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
+#include "dix/screenint_priv.h"
 #include "miext/extinit_priv.h"
 #include "xkb/xkbsrv_priv.h"    /* for XkbInitPrivates */
 
@@ -109,9 +110,10 @@ TestPointerProc(DeviceIntPtr pDev, int what)
                    pDev->name);
             return BadAlloc;
         }
-        pDev->valuator->axisVal[0] = screenInfo.screens[0]->width / 2;
+        ScreenPtr firstScreen = dixGetFirstScreenPtr();
+        pDev->valuator->axisVal[0] = firstScreen->width / 2;
         pDev->last.valuators[0] = pDev->valuator->axisVal[0];
-        pDev->valuator->axisVal[1] = screenInfo.screens[0]->height / 2;
+        pDev->valuator->axisVal[1] = firstScreen->height / 2;
         pDev->last.valuators[1] = pDev->valuator->axisVal[1];
 
         /* protocol-xiquerydevice.c relies on these increment */

--- a/xfixes/cursor.c
+++ b/xfixes/cursor.c
@@ -49,6 +49,7 @@
 #include "dix/input_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "dix/screen_hooks_priv.h"
+#include "dix/screenint_priv.h"
 
 #include "xfixesint.h"
 #include "scrnintstr.h"
@@ -618,7 +619,7 @@ ReplaceCursor(CursorPtr pCursor, TestCursorFunc testCursor, void *closure)
         }
     }
     /* this "knows" that WindowHasNewCursor doesn't depend on its argument */
-    WindowHasNewCursor(screenInfo.screens[0]->root);
+    WindowHasNewCursor(dixGetFirstScreenPtr()->root);
 }
 
 static Bool

--- a/xkb/xkbInit.c
+++ b/xkb/xkbInit.c
@@ -39,6 +39,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <X11/Xatom.h>
 #include <X11/extensions/XKMformat.h>
 
+#include "dix/screenint_priv.h"
 #include "os/bug_priv.h"
 #include "os/cmdline.h"
 #include "os/log_priv.h"
@@ -192,7 +193,7 @@ XkbWriteRulesProp(void)
         ErrorF("[xkb] Internal Error! bad size (%d!=%d) for _XKB_RULES_NAMES\n",
                out, len);
     }
-    dixChangeWindowProperty(serverClient, screenInfo.screens[0]->root, name,
+    dixChangeWindowProperty(serverClient, dixGetFirstScreenPtr()->root, name,
                             XA_STRING, 8, PropModeReplace, len, pval, TRUE);
     free(pval);
     return TRUE;


### PR DESCRIPTION
Instead of everybody directly accessing the (internal) screenInfo struct,
let those consumers only interested in first screen use a little helper.

Also caching the value if it's needed several times.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
