### PR TITLE
Xext: xf86bigfont: use retval of X_SEND_REPLY_SIMPLE()

### DIFF
--- a/Xext/xf86bigfont.c
+++ b/Xext/xf86bigfont.c
@@ -281,8 +281,7 @@ ProcXF86BigfontQueryVersion(ClientPtr client)
         swapl(&reply.gid);
         swapl(&reply.signature);
     }
-    X_SEND_REPLY_SIMPLE(client, reply);
-    return Success;
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 static void


### PR DESCRIPTION
In ProcXF86BigfontQueryVersion(), return the retval of the
X_SEND_REPLY_SIMPLE() call.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
