### PR TITLE
kdrive: use screenInfo insead of pointer passed to InitOutput()

### DIFF
--- a/hw/kdrive/ephyr/ephyrinit.c
+++ b/hw/kdrive/ephyr/ephyrinit.c
@@ -65,7 +65,7 @@ InitCard(char *name)
 void
 InitOutput(ScreenInfo * pScreenInfo, int argc, char **argv)
 {
-    KdInitOutput(pScreenInfo, argc, argv);
+    KdInitOutput(argc, argv);
 }
 
 void

--- a/hw/kdrive/fbdev/fbinit.c
+++ b/hw/kdrive/fbdev/fbinit.c
@@ -59,7 +59,7 @@ InitOutput(ScreenInfo * pScreenInfo, int argc, char **argv)
     if (serverGeneration == 1)
         ephyrExtensionInit();
 
-    KdInitOutput(pScreenInfo, argc, argv);
+    KdInitOutput(argc, argv);
 }
 
 void

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -386,8 +386,7 @@ extern miPointerScreenFuncRec kdPointerScreenFuncs;
 
 void KdSuspend(void);
 
-void KdInitScreen(ScreenInfo * pScreenInfo,
-                  KdScreenInfo * screen, int argc, char **argv);
+void KdInitScreen(KdScreenInfo * screen, int argc, char **argv);
 
 void
  KdDisableScreen(ScreenPtr pScreen);
@@ -450,8 +449,7 @@ Bool KdScreenInit(ScreenPtr pScreen, int argc, char **argv);
 void
  KdInitCard(ScreenInfo * pScreenInfo, KdCardInfo * card, int argc, char **argv);
 
-void
- KdInitOutput(ScreenInfo * pScreenInfo, int argc, char **argv);
+void KdInitOutput(int argc, char **argv);
 
 void
  KdSetSubpixelOrder(ScreenPtr pScreen, Rotation randr);


### PR DESCRIPTION
We only have one global screenInfo struct ever, and many other parts of the
Xserver can only operate on global screenInfo, so it's time to phase out
this extra pointer. Once the same has done on the other DDXes, it will
be dropped from InitOutput()'s parameter list.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
