### PR TITLE
xwin: use screenInfo insead of pointer passed to InitOutput()

### DIFF
--- a/hw/xwin/InitOutput.c
+++ b/hw/xwin/InitOutput.c
@@ -821,15 +821,15 @@ InitOutput(ScreenInfo * pScreenInfo, int argc, char *argv[])
     LoadPreferences();
 
     /* Setup global screen info parameters */
-    pScreenInfo->imageByteOrder = IMAGE_BYTE_ORDER;
-    pScreenInfo->bitmapScanlinePad = BITMAP_SCANLINE_PAD;
-    pScreenInfo->bitmapScanlineUnit = BITMAP_SCANLINE_UNIT;
-    pScreenInfo->bitmapBitOrder = BITMAP_BIT_ORDER;
-    pScreenInfo->numPixmapFormats = ARRAY_SIZE(g_PixmapFormats);
+    screenInfo.imageByteOrder = IMAGE_BYTE_ORDER;
+    screenInfo.bitmapScanlinePad = BITMAP_SCANLINE_PAD;
+    screenInfo.bitmapScanlineUnit = BITMAP_SCANLINE_UNIT;
+    screenInfo.bitmapBitOrder = BITMAP_BIT_ORDER;
+    screenInfo.numPixmapFormats = ARRAY_SIZE(g_PixmapFormats);
 
     /* Describe how we want common pixmap formats padded */
     for (i = 0; i < ARRAY_SIZE(g_PixmapFormats); i++) {
-        pScreenInfo->formats[i] = g_PixmapFormats[i];
+        screenInfo.formats[i] = g_PixmapFormats[i];
     }
 
     /* Load pointers to DirectDraw functions */


### PR DESCRIPTION
We only have one global screenInfo struct ever, and many other parts of the
Xserver can only operate on global screenInfo, so it's time to phase out
this extra pointer. Once the same has done on the other DDXes, it will
be dropped from InitOutput()'s parameter list.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
