### PR TITLE
xfree86: use screenInfo insead of pointer passed to InitOutput()

### DIFF
--- a/hw/xfree86/common/xf86Init.c
+++ b/hw/xfree86/common/xf86Init.c
@@ -284,7 +284,7 @@ xf86EnsureRANDR(ScreenPtr pScreen)
  *      collecting the pixmap formats.
  */
 void
-InitOutput(ScreenInfo * pScreenInfo, int argc, char **argv)
+InitOutput(ScreenInfo *unused, int argc, char **argv)
 {
     int i, j, k, scr_index;
     const char **modulelist;
@@ -592,16 +592,16 @@ InitOutput(ScreenInfo * pScreenInfo, int argc, char **argv)
         AddCallback(&RootWindowFinalizeCallback, AddSeatId, SeatId);
 
     /*
-     * Use the previously collected parts to setup pScreenInfo
+     * Use the previously collected parts to setup screenInfo
      */
 
-    pScreenInfo->imageByteOrder = xf86Screens[0]->imageByteOrder;
-    pScreenInfo->bitmapScanlinePad = xf86Screens[0]->bitmapScanlinePad;
-    pScreenInfo->bitmapScanlineUnit = xf86Screens[0]->bitmapScanlineUnit;
-    pScreenInfo->bitmapBitOrder = xf86Screens[0]->bitmapBitOrder;
-    pScreenInfo->numPixmapFormats = numFormats;
+    screenInfo.imageByteOrder = xf86Screens[0]->imageByteOrder;
+    screenInfo.bitmapScanlinePad = xf86Screens[0]->bitmapScanlinePad;
+    screenInfo.bitmapScanlineUnit = xf86Screens[0]->bitmapScanlineUnit;
+    screenInfo.bitmapBitOrder = xf86Screens[0]->bitmapBitOrder;
+    screenInfo.numPixmapFormats = numFormats;
     for (i = 0; i < numFormats; i++)
-        pScreenInfo->formats[i] = formats[i];
+        screenInfo.formats[i] = formats[i];
 
     /* Make sure the server's VT is active */
 


### PR DESCRIPTION
We only have one global screenInfo struct ever, and many other parts of the
Xserver can only operate on global screenInfo, so it's time to phase out
this extra pointer. Once the same has done on the other DDXes, it will
be dropped from InitOutput()'s parameter list.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
