### PR TITLE
[need-backport] glx: fix wrong swapped encoding in __glXDisp_QueryExtensionsString()

### DIFF
--- a/glx/glxcmds.c
+++ b/glx/glxcmds.c
@@ -2355,7 +2355,6 @@ __glXDisp_QueryExtensionsString(__GLXclientState * cl, GLbyte * pc)
         swapl(&reply.length);
         swapl(&reply.n);
         WriteToClient(client, sizeof(xGLXQueryExtensionsStringReply), &reply);
-        SwapLongs((CARD32*)buf, length);
         WriteToClient(client, length << 2, buf);
     }
     else {


### PR DESCRIPTION
The name string is supposed to be transmitted as-is, not swapped in
4-byte chunks.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
