### PR TITLE
xquartz: replace malloc() by calloc()

### DIFF
--- a/hw/xquartz/GL/capabilities.c
+++ b/hw/xquartz/GL/capabilities.c
@@ -549,7 +549,7 @@ getGlCapabilities(struct glCapabilities *cap)
             continue;
         }
 
-        conf = malloc(sizeof(*conf));
+        conf = calloc(1, sizeof(*conf));
         if (NULL == conf) {
             FatalError("Unable to allocate memory for OpenGL capabilities\n");
         }

--- a/hw/xquartz/GL/glcontextmodes.c
+++ b/hw/xquartz/GL/glcontextmodes.c
@@ -44,20 +44,17 @@
 #if defined(IN_MINI_GLX)
 #include <stdlib.h>
 #include <string.h>
-#define _mesa_malloc(b) malloc(b)
 #define _mesa_free(m)   free(m)
 #define _mesa_memset memset
 #else
 #ifdef XFree86Server
 #include <os.h>
 #include <string.h>
-#define _mesa_malloc(b) malloc(b)
 #define _mesa_free(m)   free(m)
 #define _mesa_memset memset
 #else
 #include <X11/Xlibint.h>
 #define _mesa_memset memset
-#define _mesa_malloc(b) Xmalloc(b)
 #define _mesa_free(m)   free(m)
 #endif  /* XFree86Server */
 #endif /* !defined(IN_MINI_GLX) */
@@ -431,14 +428,13 @@ _gl_context_modes_create(unsigned count, size_t minimum_size)
 
     next = &base;
     for (i = 0; i < count; i++) {
-        *next = (__GLcontextModes *)_mesa_malloc(size);
+        *next = calloc(1, size);
         if (*next == NULL) {
             _gl_context_modes_destroy(base);
             base = NULL;
             break;
         }
 
-        (void)_mesa_memset(*next, 0, size);
         (*next)->visualID = GLX_DONT_CARE;
         (*next)->visualType = GLX_DONT_CARE;
         (*next)->visualRating = GLX_NONE;

--- a/hw/xquartz/GL/indirect.c
+++ b/hw/xquartz/GL/indirect.c
@@ -551,7 +551,7 @@ __glXAquaScreenCreateDrawable(ClientPtr client,
 {
     __GLXAquaDrawable *glxPriv;
 
-    glxPriv = malloc(sizeof *glxPriv);
+    glxPriv = calloc(1, sizeof *glxPriv);
 
     if (glxPriv == NULL)
         return NULL;

--- a/hw/xquartz/applewm.c
+++ b/hw/xquartz/applewm.c
@@ -241,7 +241,7 @@ ProcAppleWMSelectInput(register ClientPtr client)
         }
 
         /* build the entry */
-        pNewEvent = (WMEventPtr)malloc(sizeof(WMEventRec));
+        pNewEvent = calloc(1, sizeof(WMEventRec));
         if (!pNewEvent)
             return BadAlloc;
         pNewEvent->next = 0;
@@ -262,7 +262,7 @@ ProcAppleWMSelectInput(register ClientPtr client)
          * done through the resource database.
          */
         if (i != Success || !pHead) {
-            pHead = (WMEventPtr *)malloc(sizeof(WMEventPtr));
+            pHead = calloc(1, sizeof(WMEventPtr));
             if (!pHead ||
                 !AddResource(eventResource, EventType, (void *)pHead)) {
                 FreeResource(clientResource, X11_RESTYPE_NONE);
@@ -363,16 +363,15 @@ ProcAppleWMReenableUpdate(register ClientPtr client)
 static int
 ProcAppleWMSetWindowMenu(register ClientPtr client)
 {
-    const char *bytes, **items;
-    char *shortcuts;
+    const char *bytes;
     int max_len, nitems, i, j;
     REQUEST(xAppleWMSetWindowMenuReq);
 
     REQUEST_AT_LEAST_SIZE(xAppleWMSetWindowMenuReq);
 
     nitems = stuff->nitems;
-    items = malloc(sizeof(char *) * nitems);
-    shortcuts = malloc(sizeof(char) * nitems);
+    char **items = calloc(nitems, sizeof(char *));
+    char *shortcuts = calloc(nitems, sizeof(char));
 
     if (!items || !shortcuts) {
         free(items);

--- a/hw/xquartz/darwin.c
+++ b/hw/xquartz/darwin.c
@@ -189,7 +189,6 @@ DarwinScreenInit(ScreenPtr pScreen, int argc, char **argv)
     int dpi;
     static int foundIndex = 0;
     Bool ret;
-    DarwinFramebufferPtr dfb;
 
     if (!dixRegisterPrivateKey(&darwinScreenKeyRec, PRIVATE_SCREEN, 0))
         return FALSE;
@@ -203,7 +202,7 @@ DarwinScreenInit(ScreenPtr pScreen, int argc, char **argv)
     }
 
     // allocate space for private per screen storage
-    dfb = malloc(sizeof(DarwinFramebufferRec));
+    DarwinFramebufferPtr  dfb = calloc(1, sizeof(DarwinFramebufferRec));
 
     // SCREEN_PRIV(pScreen) = dfb;
     dixSetPrivate(&pScreen->devPrivates, darwinScreenKey, dfb);

--- a/hw/xquartz/keysym2ucs.c
+++ b/hw/xquartz/keysym2ucs.c
@@ -879,7 +879,7 @@ ucs2keysym(long ucs)
     int mid;
 
     if (reverse_keysymtab == NULL) {
-        reverse_keysymtab = malloc(sizeof(keysymtab));
+        reverse_keysymtab = calloc(1, sizeof(keysymtab));
         memcpy(reverse_keysymtab, keysymtab, sizeof(keysymtab));
 
         qsort(reverse_keysymtab,

--- a/hw/xquartz/mach-startup/bundle-main.c
+++ b/hw/xquartz/mach-startup/bundle-main.c
@@ -528,7 +528,6 @@ setup_console_redirect(const char *bundle_id)
 static void
 setup_env(void)
 {
-    char *temp;
     const char *pds = NULL;
     const char *disp = getenv("DISPLAY");
     size_t len;
@@ -559,7 +558,7 @@ setup_env(void)
     setenv("X11_PREFS_DOMAIN", server_bootstrap_name, 1);
 
     len = strlen(server_bootstrap_name);
-    bundle_id_prefix = malloc(sizeof(char) * (len - 3));
+    bundle_id_prefix = calloc((len-3), sizeof(char));
     if (!bundle_id_prefix) {
         ErrorF("X11.app: Memory allocation error.\n");
         exit(1);
@@ -582,7 +581,7 @@ setup_env(void)
                     "X11.app: Detected old style launchd DISPLAY, please update xinit.\n");
             }
             else {
-                temp = (char *)malloc(sizeof(char) * len);
+                char *temp = calloc(len, sizeof(char));
                 if (!temp) {
                     ErrorF(
                         "X11.app: Memory allocation error creating space for socket name test.\n");
@@ -613,7 +612,7 @@ setup_env(void)
     ensure_path(X11BINDIR);
 
     /* cd $HOME */
-    temp = getenv("HOME");
+    char *temp = getenv("HOME");
     if (temp != NULL && temp[0] != '\0')
         chdir(temp);
 }
@@ -781,14 +780,14 @@ command_from_prefs(const char *key, const char *default_value)
         CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
         CFRelease(cfDefaultValue);
 
-        command = (char *)malloc(len * sizeof(char));
+        command = calloc(len, sizeof(char));
         if (!command)
             goto command_from_prefs_out;
         strcpy(command, default_value);
     }
     else {
         int len = CFStringGetLength((CFStringRef)PlistRef) + 1;
-        command = (char *)malloc(len * sizeof(char));
+        command = calloc(len, sizeof(char));
         if (!command)
             goto command_from_prefs_out;
         CFStringGetCString((CFStringRef)PlistRef, command, len,

--- a/hw/xquartz/quartz.c
+++ b/hw/xquartz/quartz.c
@@ -533,7 +533,7 @@ QuartzCopyDisplayIDs(ScreenPtr pScreen,
     free(pQuartzScreen->displayIDs);
     if (displayCount) {
         size_t size = displayCount * sizeof(CGDirectDisplayID);
-        pQuartzScreen->displayIDs = malloc(size);
+        pQuartzScreen->displayIDs = calloc(1, size);
         memcpy(pQuartzScreen->displayIDs, displayIDs, size);
     }
     else {

--- a/hw/xquartz/quartzStartup.c
+++ b/hw/xquartz/quartzStartup.c
@@ -81,7 +81,7 @@ create_thread(void *func, void *arg)
 void
 QuartzInitServer(int argc, char **argv, char **envp)
 {
-    struct arg *args = (struct arg *)malloc(sizeof(struct arg));
+    struct arg *args = calloc(1, sizeof(struct arg));
     if (!args)
         FatalError("Could not allocate memory.\n");
 

--- a/hw/xquartz/xpr/dri.c
+++ b/hw/xquartz/xpr/dri.c
@@ -265,7 +265,7 @@ CreateSurfaceForWindow(ScreenPtr pScreen, WindowPtr pWin,
         xp_window_changes wc;
 
         /* allocate a DRI Window Private record */
-        if (!(pDRIDrawablePriv = malloc(sizeof(*pDRIDrawablePriv)))) {
+        if (!(pDRIDrawablePriv = calloc(1, sizeof(*pDRIDrawablePriv)))) {
             return NULL;
         }
 
@@ -681,7 +681,6 @@ DRICreatePixmap(ScreenPtr pScreen, Drawable id,
                 DrawablePtr pDrawable, char *path,
                 size_t pathmax)
 {
-    DRIPixmapBufferPtr shared;
     PixmapPtr pPix;
 
     if (pDrawable->type != DRAWABLE_PIXMAP)
@@ -689,7 +688,7 @@ DRICreatePixmap(ScreenPtr pScreen, Drawable id,
 
     pPix = (PixmapPtr)pDrawable;
 
-    shared = malloc(sizeof(*shared));
+    DRIPixmapBufferPtr shared = calloc(1, sizeof(*shared));
     if (NULL == shared) {
         FatalError("failed to allocate DRIPixmapBuffer in %s\n", __func__);
     }

--- a/hw/xquartz/xpr/x-list.c
+++ b/hw/xquartz/xpr/x-list.c
@@ -87,10 +87,9 @@ X_PFX(list_prepend) (x_list * lst, void *data) {
     pthread_mutex_lock(&freelist_lock);
 
     if (freelist == NULL) {
-        x_list_block *b;
         int i;
 
-        b = malloc(sizeof(x_list_block));
+        x_list_block *b = calloc(1, sizeof(x_list_block));
         assert(b != NULL);
 
         for (i = 0; i < NODES_PER_BLOCK - 1; i++)

--- a/hw/xquartz/xpr/xprCursor.c
+++ b/hw/xquartz/xpr/xprCursor.c
@@ -93,7 +93,7 @@ load_cursor(CursorPtr src, int screen)
         const uint32_t *be_data = (uint32_t *)src->bits->argb;
         unsigned i;
         rowbytes = src->bits->width * sizeof(CARD32);
-        data = malloc(rowbytes * src->bits->height);
+        data = calloc(rowbytes, src->bits->height);
         free_data = TRUE;
         if (!data) {
             FatalError("Failed to allocate memory in %s\n", __func__);
@@ -119,7 +119,7 @@ load_cursor(CursorPtr src, int screen)
 
         /* round up to 8 pixel boundary so we can convert whole bytes */
         rowbytes = ((src->bits->width * 4) + 31) & ~31;
-        data = malloc(rowbytes * src->bits->height);
+        data = calloc(rowbytes, src->bits->height);
         free_data = TRUE;
         if (!data) {
             FatalError("Failed to allocate memory in %s\n", __func__);

--- a/hw/xquartz/xpr/xprScreen.c
+++ b/hw/xquartz/xpr/xprScreen.c
@@ -199,7 +199,6 @@ xprAddPseudoramiXScreens(int *x, int *y, int *width, int *height,
                          ScreenPtr pScreen)
 {
     CGDisplayCount i, displayCount;
-    CGDirectDisplayID *displayList = NULL;
     CGRect unionRect = CGRectNull, frame;
 
     // Find all the CoreGraphics displays
@@ -224,7 +223,7 @@ xprAddPseudoramiXScreens(int *x, int *y, int *width, int *height,
     if (CGDisplayIsCaptured(kCGDirectMainDisplay))
         displayCount = 1;
 
-    displayList = malloc(displayCount * sizeof(CGDirectDisplayID));
+    CGDirectDisplayID *displayList = calloc(displayCount, sizeof(CGDirectDisplayID));
     if (!displayList)
         FatalError("Unable to allocate memory for list of displays.\n");
     CGGetActiveDisplayList(displayCount, displayList, &displayCount);


### PR DESCRIPTION
It's in general safer to clear out all the memory on allocation,
in order to prevent potential leaks or undefined behaviour on
uninitialized data.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
