### PR TITLE
xfree86: loader: search module dirs only once

### DIFF
--- a/hw/xfree86/loader/loadmod.c
+++ b/hw/xfree86/loader/loadmod.c
@@ -177,20 +177,11 @@ LoaderSetPath(const char *path)
 static const char *stdSubdirs[] = {
     // first try loading from per-ABI subdir
     XORG_MODULE_ABI_TAG "/",
-    XORG_MODULE_ABI_TAG "/input/",
-    XORG_MODULE_ABI_TAG "/drivers/",
-    XORG_MODULE_ABI_TAG "/extensions/",
     // next try loading from legacy xlibre-25.0 ABI subdir
     // TODO remove this in version 26
     "xlibre-25.0/",
-    "xlibre-25.0/input/",
-    "xlibre-25.0/drivers/",
-    "xlibre-25.0/extensions/",
     // now try loading from legacy / unversioned directories
     "",
-    "input/",
-    "drivers/",
-    "extensions/",
     NULL
 };
 


### PR DESCRIPTION
Only specify the top module directories since the loader is recursing
into the subdirectories either way.

Fixes: #991
Signed-off-by: callmetango <callmetango@users.noreply.github.com>
