### PR TITLE
treewide: drop ScreenInfoPtr parameter from InitOutput()

### DIFF
--- a/dix/main.c
+++ b/dix/main.c
@@ -192,7 +192,7 @@ dix_main(int argc, char *argv[], char *envp[])
         dixResetRegistry();
         InitFonts();
         InitCallbackManager();
-        InitOutput(&screenInfo, argc, argv);
+        InitOutput(argc, argv);
 
         if (screenInfo.numScreens < 1)
             FatalError("no screens found");

--- a/dix/screenint_priv.h
+++ b/dix/screenint_priv.h
@@ -24,6 +24,8 @@ void DetachUnboundGPU(ScreenPtr unbound);
 void AttachOffloadGPU(ScreenPtr pScreen, ScreenPtr newScreen);
 void DetachOffloadGPU(ScreenPtr slave);
 
+void InitOutput(int argc, char **argv);
+
 static inline ScreenPtr dixGetMasterScreen(void) {
     return screenInfo.screens[0];
 }

--- a/doc/Xserver-spec.xml
+++ b/doc/Xserver-spec.xml
@@ -1865,14 +1865,12 @@ insists that these must be the same for all screens on the server.</para>
 <para>
 <blockquote><programlisting>
 
-        InitOutput(pScreenInfo, argc, argv)
-                ScreenInfo *pScreenInfo;
+        InitOutput(argc, argv)
                 int argc;
                 char **argv;
 </programlisting></blockquote>
 Upon initialization, your DDX routine InitOutput() is called by DIX.
-It is passed a pointer to screenInfo to initialize.  It is also passed
-the argc and argv from main() for your server for the command-line
+It is passed the argc and argv from main() for your server for the command-line
 arguments.  These arguments may indicate what or how many screen
 device(s) to use or in what way to use them.  For instance, your
 server command line may allow a "-D" flag followed by the name of the

--- a/hw/kdrive/ephyr/ephyrinit.c
+++ b/hw/kdrive/ephyr/ephyrinit.c
@@ -63,7 +63,7 @@ InitCard(char *name)
 }
 
 void
-InitOutput(ScreenInfo * pScreenInfo, int argc, char **argv)
+InitOutput(int argc, char **argv)
 {
     KdInitOutput(argc, argv);
 }

--- a/hw/vfb/InitOutput.c
+++ b/hw/vfb/InitOutput.c
@@ -1046,7 +1046,7 @@ vfbScreenInit(ScreenPtr pScreen, int argc, char **argv)
 }                               /* end vfbScreenInit */
 
 void
-InitOutput(ScreenInfo *unused, int argc, char **argv)
+InitOutput(int argc, char **argv)
 {
     int i;
     int NumFormats = 0;

--- a/hw/xfree86/common/xf86Init.c
+++ b/hw/xfree86/common/xf86Init.c
@@ -284,7 +284,7 @@ xf86EnsureRANDR(ScreenPtr pScreen)
  *      collecting the pixmap formats.
  */
 void
-InitOutput(ScreenInfo *unused, int argc, char **argv)
+InitOutput(int argc, char **argv)
 {
     int i, j, k, scr_index;
     const char **modulelist;

--- a/hw/xnest/Init.c
+++ b/hw/xnest/Init.c
@@ -65,7 +65,7 @@ Bool noGlxExtension = FALSE;
 #endif
 
 void
-InitOutput(ScreenInfo * screen_info, int argc, char *argv[])
+InitOutput(int argc, char *argv[])
 {
     int i;
 

--- a/hw/xquartz/darwin.c
+++ b/hw/xquartz/darwin.c
@@ -636,7 +636,7 @@ void DarwinAdjustScreenOrigins(void)
  *  SetupScreen function can be called to finalize screen setup.
  */
 void
-InitOutput(ScreenInfo *pScreenInfo, int argc, char **argv)
+InitOutput(int argc, char **argv)
 {
     int i;
 

--- a/hw/xwin/InitOutput.c
+++ b/hw/xwin/InitOutput.c
@@ -786,7 +786,7 @@ ddxUseMsg(void)
  */
 
 void
-InitOutput(ScreenInfo * pScreenInfo, int argc, char *argv[])
+InitOutput(int argc, char *argv[])
 {
     int i;
 

--- a/include/scrnintstr.h
+++ b/include/scrnintstr.h
@@ -732,8 +732,4 @@ typedef struct _ScreenInfo {
 
 extern _X_EXPORT ScreenInfo screenInfo;
 
-extern _X_EXPORT void InitOutput(ScreenInfo * /*pScreenInfo */ ,
-                                 int /*argc */ ,
-                                 char ** /*argv */ );
-
 #endif                          /* SCREENINTSTRUCT_H */


### PR DESCRIPTION
Nobody's using this pointer anymore, everybody's using the global
screenInfo structure.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
