### PR TITLE
render: consolidate duplicate Proc* functions

### DIFF
--- a/render/render.c
+++ b/render/render.c
@@ -58,28 +58,28 @@
 Bool noRenderExtension = FALSE;
 Bool usePanoramiX = FALSE;
 
+static int
+_not_implemented(ClientPtr client)
+{
+    return BadImplementation;
+}
+
 static int ProcRenderQueryVersion(ClientPtr pClient);
 static int ProcRenderQueryPictFormats(ClientPtr pClient);
 static int ProcRenderQueryPictIndexValues(ClientPtr pClient);
-static int ProcRenderQueryDithers(ClientPtr pClient);
 static int ProcRenderCreatePicture(ClientPtr pClient);
 static int ProcRenderChangePicture(ClientPtr pClient);
 static int ProcRenderSetPictureClipRectangles(ClientPtr pClient);
 static int ProcRenderFreePicture(ClientPtr pClient);
 static int ProcRenderComposite(ClientPtr pClient);
-static int ProcRenderScale(ClientPtr pClient);
 static int ProcRenderTrapezoids(ClientPtr pClient);
 static int ProcRenderTriangles(ClientPtr pClient);
 static int ProcRenderTriStrip(ClientPtr pClient);
 static int ProcRenderTriFan(ClientPtr pClient);
-static int ProcRenderColorTrapezoids(ClientPtr pClient);
-static int ProcRenderColorTriangles(ClientPtr pClient);
-static int ProcRenderTransform(ClientPtr pClient);
 static int ProcRenderCreateGlyphSet(ClientPtr pClient);
 static int ProcRenderReferenceGlyphSet(ClientPtr pClient);
 static int ProcRenderFreeGlyphSet(ClientPtr pClient);
 static int ProcRenderAddGlyphs(ClientPtr pClient);
-static int ProcRenderAddGlyphsFromPicture(ClientPtr pClient);
 static int ProcRenderFreeGlyphs(ClientPtr pClient);
 static int ProcRenderCompositeGlyphs(ClientPtr pClient);
 static int ProcRenderFillRectangles(ClientPtr pClient);
@@ -131,25 +131,25 @@ int (*ProcRenderVector[RenderNumberRequests]) (ClientPtr) = {
 ProcRenderQueryVersion,
         ProcRenderQueryPictFormats,
         ProcRenderQueryPictIndexValues,
-        ProcRenderQueryDithers,
+        _not_implemented, /* ProcRenderQueryDithers */
         ProcRenderCreatePicture,
         ProcRenderChangePicture,
         ProcRenderSetPictureClipRectangles,
         ProcRenderFreePicture,
         ProcRenderComposite,
-        ProcRenderScale,
+        _not_implemented, /* ProcRenderScale */
         ProcRenderTrapezoids,
         ProcRenderTriangles,
         ProcRenderTriStrip,
         ProcRenderTriFan,
-        ProcRenderColorTrapezoids,
-        ProcRenderColorTriangles,
-        ProcRenderTransform,
+        _not_implemented, /* ProcRenderColorTrapezoids */
+        _not_implemented, /* ProcRenderColorTriangles */
+        _not_implemented, /* ProcRenderTransform */
         ProcRenderCreateGlyphSet,
         ProcRenderReferenceGlyphSet,
         ProcRenderFreeGlyphSet,
         ProcRenderAddGlyphs,
-        ProcRenderAddGlyphsFromPicture,
+        _not_implemented, /* ProcRenderAddGlyphsFromPicture */
         ProcRenderFreeGlyphs,
         ProcRenderCompositeGlyphs,
         ProcRenderCompositeGlyphs,
@@ -169,25 +169,25 @@ int (*SProcRenderVector[RenderNumberRequests]) (ClientPtr) = {
 SProcRenderQueryVersion,
         ProcRenderQueryPictFormats,
         SProcRenderQueryPictIndexValues,
-        ProcRenderQueryDithers,
+        _not_implemented, /* SProcRenderQueryDithers */
         SProcRenderCreatePicture,
         SProcRenderChangePicture,
         SProcRenderSetPictureClipRectangles,
         SProcRenderFreePicture,
         SProcRenderComposite,
-        ProcRenderScale,
+        _not_implemented, /* SProcRenderScale */
         SProcRenderTrapezoids,
         SProcRenderTriangles,
         SProcRenderTriStrip,
         SProcRenderTriFan,
-        ProcRenderColorTrapezoids,
-        ProcRenderColorTriangles,
-        ProcRenderTransform,
+        _not_implemented, /* SProcRenderColorTrapezoids */
+        _not_implemented, /* SProcRenderColorTriangles */
+        _not_implemented, /* SProcRenderTransform */
         SProcRenderCreateGlyphSet,
         SProcRenderReferenceGlyphSet,
         SProcRenderFreeGlyphSet,
         SProcRenderAddGlyphs,
-        ProcRenderAddGlyphsFromPicture,
+        _not_implemented, /* SProcRenderAddGlyphsFromPicture */
         SProcRenderFreeGlyphs,
         SProcRenderCompositeGlyphs,
         SProcRenderCompositeGlyphs,
@@ -516,12 +516,6 @@ ProcRenderQueryPictIndexValues(ClientPtr client)
 }
 
 static int
-ProcRenderQueryDithers(ClientPtr client)
-{
-    return BadImplementation;
-}
-
-static int
 SingleRenderCreatePicture(ClientPtr client)
 {
     PicturePtr pPicture;
@@ -667,12 +661,6 @@ SingleRenderComposite(ClientPtr client)
                      stuff->yMask,
                      stuff->xDst, stuff->yDst, stuff->width, stuff->height);
     return Success;
-}
-
-static int
-ProcRenderScale(ClientPtr client)
-{
-    return BadImplementation;
 }
 
 static int
@@ -829,24 +817,6 @@ SingleRenderTriFan(ClientPtr client)
                         stuff->xSrc, stuff->ySrc,
                         npoints, (xPointFixed *) &stuff[1]);
     return Success;
-}
-
-static int
-ProcRenderColorTrapezoids(ClientPtr client)
-{
-    return BadImplementation;
-}
-
-static int
-ProcRenderColorTriangles(ClientPtr client)
-{
-    return BadImplementation;
-}
-
-static int
-ProcRenderTransform(ClientPtr client)
-{
-    return BadImplementation;
 }
 
 static int
@@ -1153,12 +1123,6 @@ ProcRenderAddGlyphs(ClientPtr client)
     if (glyphsBase != glyphsLocal)
         free(glyphsBase);
     return err;
-}
-
-static int
-ProcRenderAddGlyphsFromPicture(ClientPtr client)
-{
-    return BadImplementation;
 }
 
 static int


### PR DESCRIPTION
dropping lots of duplicate functions which are doing the same like others.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
