### PR TITLE
composite: ProcCompositeGetOverlayWindow(): declare `cs` when needed

### DIFF
--- a/composite/compext.c
+++ b/composite/compext.c
@@ -776,7 +776,6 @@ ProcCompositeGetOverlayWindow(ClientPtr client)
     xCompositeGetOverlayWindowReply rep;
     WindowPtr pWin;
     ScreenPtr pScreen;
-    CompScreenPtr cs;
     CompOverlayClientPtr pOc;
     int rc;
     PanoramiXRes *win, *overlayWin = NULL;
@@ -787,7 +786,7 @@ ProcCompositeGetOverlayWindow(ClientPtr client)
         return rc;
     }
 
-    cs = GetCompScreen(dixGetFirstScreenPtr());
+    CompScreenPtr cs = GetCompScreen(dixGetFirstScreenPtr());
     if (!cs->pOverlayWin) {
         if (!(overlayWin = calloc(1, sizeof(PanoramiXRes))))
             return BadAlloc;


### PR DESCRIPTION
it's cleaner to declare variables where they're assigned first.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
