### PR TITLE
os: replace GenerateRandomData() by custom arc4random_buf() on platforms that missing it

### DIFF
--- a/os/mitauth.c
+++ b/os/mitauth.c
@@ -141,20 +141,6 @@ MitRemoveCookie(unsigned short data_length, const char *data)
 
 static char cookie[16];         /* 128 bits */
 
-static void
-GenerateRandomData(int len, char *buf)
-{
-#ifdef HAVE_ARC4RANDOM_BUF
-    arc4random_buf(buf, len);
-#else
-    int fd;
-
-    fd = open("/dev/urandom", O_RDONLY);
-    read(fd, buf, len);
-    close(fd);
-#endif
-}
-
 XID
 MitGenerateCookie(unsigned data_length,
                   const char *data,
@@ -167,7 +153,7 @@ MitGenerateCookie(unsigned data_length,
         if (i >= sizeof(cookie))
             i = 0;
     }
-    GenerateRandomData(sizeof(cookie), cookie);
+    arc4random_buf(cookie, sizeof(cookie));
     XID id = MitAddCookie(sizeof(cookie), cookie);
     if (!id)
         return 0;

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -116,6 +116,16 @@ extern Bool NewOutputPending;
 /* in access.c */
 extern Bool ComputeLocalClient(ClientPtr client);
 
+/* for platforms lacking arc4random_buf() libc function */
+#ifndef HAVE_ARC4RANDOM_BUF
+static inline void arc4random_buf(void *buf, size_t nbytes)
+{
+    int fd = open("/dev/urandom", O_RDONLY);
+    read(fd, buf, nbytes);
+    close(fd);
+}
+#endif /* HAVE_ARC4RANDOM_BUF */
+
 /* OsTimer functions */
 void TimerInit(void);
 


### PR DESCRIPTION
arc4random_buf() is a pretty standard libc function on Unix'oid platforms,
but not all our targets have it, thus we need a fallback there. Currently we
have GenerateRandomData(), which either just wraps arc4random_buf() or provides
some fallback implementation.

For those cases it's easier to just implement missing functions directly
instead of having custom wrapper functions. So, drop GenerateRandomData()
in favor of arc4random_buf() and provide fallback implementation for where
it is missing.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
