### PR TITLE
Fbdevhw followup

### DIFF
--- a/hw/xfree86/fbdevhw/fbdevhw.c
+++ b/hw/xfree86/fbdevhw/fbdevhw.c
@@ -362,7 +362,7 @@ fbdev_open(int scrnIndex, const char *dev, char **namep)
     }
 
     if (fd == -1) {
-        xf86DrvMsg(scrnIndex, X_ERROR, "open %s: %s\n", dev, strerror(errno));
+        xf86DrvMsg(scrnIndex, X_ERROR, "Unable to find a valid framebuffer device\n");
         return -1;
     }
 

--- a/hw/xfree86/fbdevhw/man/fbdevhw.man
+++ b/hw/xfree86/fbdevhw/man/fbdevhw.man
@@ -14,6 +14,12 @@ module is currently available for linux framebuffer devices.
 is a non-accelerated driver which runs on top of the
 fbdevhw module.  fbdevhw can be used by other drivers too, this
 is usually activated with `Option "UseFBDev"' in the device section.
+.SH CONFIGURATION DETAILS
+Drivers using this module, like fbdev, usually have options
+for setting the desired framebuffer device in xorg.conf.
+For drivers that don't, or if this isn't set in xorg.conf,
+fbdevhw also reads the FRAMEBUFFER environment variable for
+the path to the framebuffer device it should use.
 .SH "SEE ALSO"
 .BR Xorg (@appmansuffix@),
 .BR xorg.conf (@filemansuffix@),


### PR DESCRIPTION
Now that we know the root couse of what this code tried to fix,
we can safely remove it.

Fixes: https://gitlab.freedesktop.org/xorg/driver/xf86-video-fbdev/-/issues/9
Fixes: https://gitlab.freedesktop.org/xorg/xserver/-/commit/fc78bcca21e767697de6ad4d8e03b6728856f613
Fixes: https://gitlab.freedesktop.org/xorg/xserver/-/commit/a8e41a81909ef74faa38ef12ca35c5d83f7c56a5
Fixes: https://gitlab.freedesktop.org/xorg/xserver/-/commit/728b54528d37ffa27b07c9b181c5ed8d2d359379
Fixes: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1798
Fixes: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1826

Also documents the FRAMEBUFFER envvar.

This pr depends on https://github.com/X11Libre/xserver/pull/998