### PR TITLE
xfree86: os-support: Deal with DFBSD correctly.

### DIFF
--- a/hw/xfree86/os-support/meson.build
+++ b/hw/xfree86/os-support/meson.build
@@ -92,7 +92,7 @@ elif host_machine.system() == 'sunos'
         error('Unknown CPU family for Solaris build')
     endif
 
-elif host_machine.system().endswith('bsd')
+elif host_machine.system().endswith('bsd') or host_machine.system() == 'dragonfly'
     srcs_xorg_os_support += [
         'bsd/bsd_VTsw.c',
         'bsd/bsd_bell.c',
@@ -129,7 +129,7 @@ elif host_machine.system().endswith('bsd')
         endif
     endif
 
-    if host_machine.system() == 'freebsd'
+    if host_machine.system() == 'freebsd' or host_machine.system() == 'dragonfly'
         srcs_xorg_os_support += 'bsd/bsd_kmod.c'
     else
         srcs_xorg_os_support += 'shared/kmod_noop.c'


### PR DESCRIPTION
In DragonFlyBSD the host_machine.system() variable is set to 'dragonfly' and does not end with 'bsd'. Changed a check to correctly detect 'dragonfly' as a member of BSD OSs.

bsd/bsd_kmod.c is used for dealing with kernel modules on FreeBSD, enabled this file for DragonFlyBSD too, because they both have the same APIs in this context.