### PR TITLE
xkb: ProcXkbGetKbdByName(): use return code of X_SEND_REPLY_WITH_RPCBUF()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -5915,7 +5915,7 @@ ProcXkbGetKbdByName(ClientPtr client)
         x_rpcbuf_write_rpcbuf_pad(&rpcbuf, &childbuf);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    status = X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 
     if (loaded) {
         XkbDescPtr old_xkb;
@@ -5973,7 +5973,7 @@ ProcXkbGetKbdByName(ClientPtr client)
     XkbSetCauseXkbReq(&cause, X_kbGetKbdByName, client);
     XkbUpdateAllDeviceIndicators(NULL, &cause);
 
-    return Success;
+    return status;
 }
 
 /***====================================================================***/


### PR DESCRIPTION
The macro will automatically return BadAlloc if the buffer is broken,
otherwise Success. Thus, we don't need extra prior rpcbuf check.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
