### PR TITLE
render: consolidate byte-swapping in ProcRenderCreateGlyphSet()

### DIFF
--- a/render/render.c
+++ b/render/render.c
@@ -106,7 +106,6 @@ static int SProcRenderTrapezoids(ClientPtr pClient);
 static int SProcRenderTriangles(ClientPtr pClient);
 static int SProcRenderTriStrip(ClientPtr pClient);
 static int SProcRenderTriFan(ClientPtr pClient);
-static int SProcRenderCreateGlyphSet(ClientPtr pClient);
 static int SProcRenderReferenceGlyphSet(ClientPtr pClient);
 static int SProcRenderFreeGlyphSet(ClientPtr pClient);
 static int SProcRenderAddGlyphs(ClientPtr pClient);
@@ -182,7 +181,7 @@ int (*SProcRenderVector[RenderNumberRequests]) (ClientPtr) = {
         _not_implemented, /* SProcRenderColorTrapezoids */
         _not_implemented, /* SProcRenderColorTriangles */
         _not_implemented, /* SProcRenderTransform */
-        SProcRenderCreateGlyphSet,
+        ProcRenderCreateGlyphSet,
         SProcRenderReferenceGlyphSet,
         SProcRenderFreeGlyphSet,
         SProcRenderAddGlyphs,
@@ -830,8 +829,12 @@ ProcRenderCreateGlyphSet(ClientPtr client)
     int rc, f;
 
     REQUEST(xRenderCreateGlyphSetReq);
-
     REQUEST_SIZE_MATCH(xRenderCreateGlyphSetReq);
+
+    if (client->swapped) {
+        swapl(&stuff->gsid);
+        swapl(&stuff->format);
+    }
 
     LEGAL_NEW_RESOURCE(stuff->gsid, client);
     rc = dixLookupResourceByType((void **) &format, stuff->format,
@@ -2058,16 +2061,6 @@ SProcRenderTriFan(ClientPtr client)
     swaps(&stuff->ySrc);
     SwapRestL(stuff);
     return ProcRenderTriFan(client);
-}
-
-static int _X_COLD
-SProcRenderCreateGlyphSet(ClientPtr client)
-{
-    REQUEST(xRenderCreateGlyphSetReq);
-    REQUEST_SIZE_MATCH(xRenderCreateGlyphSetReq);
-    swapl(&stuff->gsid);
-    swapl(&stuff->format);
-    return ProcRenderCreateGlyphSet(client);
 }
 
 static int _X_COLD


### PR DESCRIPTION
No need for extra functions and call tables for the few trivial lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
