### PR TITLE
modesetting: Only paint as much of the cursor image as needed

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -59,6 +59,8 @@
 
 #include "driver.h"
 
+#define MAX(a,b) ((a) > (b) ? (a) : (b))
+
 static Bool drmmode_xf86crtc_resize(ScrnInfoPtr scrn, int width, int height);
 static PixmapPtr drmmode_create_pixmap_header(ScreenPtr pScreen, int width, int height,
                                               int depth, int bitsPerPixel, int devKind,
@@ -1878,15 +1880,29 @@ drmmode_cursor_get_pitch(drmmode_crtc_private_ptr drmmode_crtc, int idx)
 
 static void
 drmmode_paint_cursor(CARD32 * restrict cursor, int cursor_pitch, int cursor_width, int cursor_height,
-                     const CARD32 * restrict image, int image_width, int image_height)
+                     const CARD32 * restrict image, int image_width, int image_height,
+                     drmmode_crtc_private_ptr restrict drmmode_crtc, int glyph_width, int glyph_height)
 {
-    if (cursor_width == image_width && cursor_pitch == cursor_width) {
-        /* we can speed things up in this case */
-        memcpy(cursor, image, cursor_width * cursor_height * sizeof(*cursor));
+    int width_todo;
+    int height_todo;
+
+    if (drmmode_crtc->cursor_glyph_width == 0 &&
+        drmmode_crtc->cursor_glyph_height == 0) {
+        /* If this is the first time we paint the cursor, assume the entire cursor buffer is dirty */
+        width_todo = cursor_width;
+        height_todo = cursor_height;
     } else {
-        for (int i = 0; i < cursor_height; i++) {
-            memcpy(cursor + i * cursor_pitch, image + i * image_width, cursor_width * sizeof(*cursor));    /* cpu_to_le32(image[i]); */
-        }
+        /* Paint only what we need to */
+        width_todo = MAX(drmmode_crtc->cursor_glyph_width, glyph_width);
+        height_todo = MAX(drmmode_crtc->cursor_glyph_height, glyph_height);
+    }
+
+    /* remember the size of the current cursor glyph */
+    drmmode_crtc->cursor_glyph_width = glyph_width;
+    drmmode_crtc->cursor_glyph_height = glyph_height;
+
+    for (int i = 0; i < height_todo; i++) {
+        memcpy(cursor + i * cursor_pitch, image + i * image_width, width_todo * sizeof(*cursor));    /* cpu_to_le32(image[i]); */
     }
 }
 
@@ -1942,7 +1958,8 @@ drmmode_load_cursor_argb_check(xf86CrtcPtr crtc, CARD32 *image)
 
     /* cursor should be mapped already */
     drmmode_paint_cursor(drmmode_cursor.bo->ptr, cursor_pitch, width, height,
-                         image, max_width, max_height);
+                         image, max_width, max_height,
+                         drmmode_crtc, cursor->bits->width, cursor->bits->height);
 
     /* set cursor width and height here for drmmode_show_cursor */
     drmmode_crtc->cursor_width = width;

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.h
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.h
@@ -247,6 +247,8 @@ typedef struct {
     Bool use_gamma_lut;
 
     int* cursor_pitches;
+    uint32_t cursor_glyph_width;
+    uint32_t cursor_glyph_height;
 } drmmode_crtc_private_rec, *drmmode_crtc_private_ptr;
 
 typedef struct {


### PR DESCRIPTION
We often use very large cursor sizes, compared to the sizes of the curor glyphs, e.g. 64x64 cursors and 16x16 or smaller glyphs.

This patch makes is so that we only paint the size of the new cursor glyph and clear the old one if needed, instead of painting the entire cursor buffer, which is often far larger than the glyphs.