### PR TITLE
xquartz: prepare DarwinAdjustScreenOrigins() for new screen iterators

### DIFF
--- a/hw/xquartz/darwin.c
+++ b/hw/xquartz/darwin.c
@@ -583,25 +583,21 @@ CloseInput(void)
  */
 void DarwinAdjustScreenOrigins(void)
 {
-    ScreenPtr masterScreen = dixGetMasterScreen();
-
-    int left = masterScreen->x;
-    int top = masterScreen->y;
-
     /* Find leftmost screen. If there's a tie, take the topmost of the two. */
-    for (int i = 1; i < screenInfo.numScreens; i++) {
-        if (screenInfo.screens[i]->x < left ||
-            (screenInfo.screens[i]->x == left &&
-             screenInfo.screens[i]->y < top)) {
-            left = screenInfo.screens[i]->x;
-            top = screenInfo.screens[i]->y;
+    for (unsigned walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+        if (walkScreenIdx == 0) {
+            darwinMainScreenX  = walkScreen->x;
+            darwinMainScreenY = walkScreen->y;
+            continue;
+        }
+        if ((walkScreen->x < darwinMainScreenX) ||
+            ((walkScreen->x == darwinMainScreenX) &&
+             (walkScreen->y < darwinMainScreenY))) {
+            darwinMainScreenX  = walkScreen->x;
+            darwinMainScreenY = walkScreen->y;
         }
     }
-
-    darwinMainScreenX = left;
-    darwinMainScreenY = top;
-
-    DEBUG_LOG("top = %d, left=%d\n", top, left);
 
     /* Shift all screens so that there is a screen whose top left
      * is at X11 (0,0) and at global screen coordinate
@@ -609,12 +605,12 @@ void DarwinAdjustScreenOrigins(void)
      */
 
     if (darwinMainScreenX != 0 || darwinMainScreenY != 0) {
-        for (int i = 0; i < screenInfo.numScreens; i++) {
-            screenInfo.screens[i]->x -= darwinMainScreenX;
-            screenInfo.screens[i]->y -= darwinMainScreenY;
+        for (unsigned walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+            walkScreen->x -= darwinMainScreenX;
+            walkScreen->y -= darwinMainScreenY;
             DEBUG_LOG("Screen %d placed at X11 coordinate (%d,%d).\n",
-                      i, screenInfo.screens[i]->x,
-                      screenInfo.screens[i]->y);
+                      walkScreenIdx, walkScreen->x, walkScreen->y);
         }
     }
 


### PR DESCRIPTION
* the pScreenInfo isn't needed: we're always getting global screenInfo
  passed in here (there's only one, globally, anyways)
* use the common iterator variable names
* handle first and auxillary screens all in the same loop
  (we can just branch by idx)

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
