### PR TITLE
dix: rpcbuf: x_rpcbuf_write_counted_string_pad() silence size mismatch warning

### DIFF
--- a/dix/rpcbuf_priv.h
+++ b/dix/rpcbuf_priv.h
@@ -352,7 +352,7 @@ static inline void x_rpcbuf_write_counted_string_pad(
         x_rpcbuf_t *rpcbuf, const char *str)
 {
     if (str) {
-        CARD16 len = strlen(str);
+        CARD16 len = (CARD16)strlen(str); /* 64k should really be enough */
         x_rpcbuf_write_CARD16(rpcbuf, len);
         x_rpcbuf_write_CARD8s(rpcbuf, (CARD8*)str, len);
         x_rpcbuf_pad(rpcbuf);


### PR DESCRIPTION
strlen() returns an size_t, but the string lengths here is limited to 16bit,
so we need to explictly cast, in order to shut down compiler warning.
Strings longer than 64k really shouldn't ever happen.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
