### PR TITLE
include: misc.h: bytes_to_int32(): use CARD32 as return value

### DIFF
--- a/include/misc.h
+++ b/include/misc.h
@@ -193,10 +193,10 @@ bits_to_bytes(const int bits)
  * @param bytes The minimum number of bytes needed.
  * @return The number of 4-byte units needed to hold bytes.
  */
-static inline int
-bytes_to_int32(const int bytes)
+static inline CARD32
+bytes_to_int32(const size_t bytes)
 {
-    return (((bytes) + 3) >> 2);
+    return (CARD32)(((bytes) + 3) >> 2);
 }
 
 /**


### PR DESCRIPTION
Callers usually need this value as CARD32 (the X11 protocol's native type
of the .length header field), so convert it here in order to reduce
unnecessary compiler warnings.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
