### PR TITLE
dix: dix_priv.h: cast size value on WriteToClient() calls

### DIFF
--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -768,7 +768,7 @@ static inline int __write_reply_hdr_and_rpcbuf(
          swapl(&reply->length);
     }
 
-    WriteToClient(pClient, hdrLen, hdrData);
+    WriteToClient(pClient, (int)hdrLen, hdrData);
     WriteRpcbufToClient(pClient, rpcbuf);
 
     return Success;
@@ -787,7 +787,7 @@ static inline int __write_reply_hdr_simple(
          swapl(&reply->length);
     }
 
-    WriteToClient(pClient, hdrLen, hdrData);
+    WriteToClient(pClient, (int)hdrLen, hdrData);
     return Success;
 }
 


### PR DESCRIPTION
We're trying to use size_t for sizes whereever possible, but WriteToClient()
is part of ABI, so we can't fix it's parameter types - need to explicitly
cast, in order to silence the compiler warnings.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
