### PR TITLE
dix: fix ClientRec->numSaved to unsigned

### DIFF
--- a/dix/dixutils.c
+++ b/dix/dixutils.c
@@ -248,7 +248,7 @@ XRetCode
 AlterSaveSetForClient(ClientPtr client, WindowPtr pWin, unsigned mode,
                       Bool toRoot, Bool map)
 {
-    int numnow;
+    unsigned numnow;
     SaveSetElt *pTmp = NULL;
     int j;
 

--- a/dix/window.c
+++ b/dix/window.c
@@ -2918,7 +2918,7 @@ HandleSaveSet(ClientPtr client)
 {
     WindowPtr pParent, pWin;
 
-    for (int j = 0; j < client->numSaved; j++) {
+    for (unsigned j = 0; j < client->numSaved; j++) {
         pWin = SaveSetWindow(client->saveSet[j]);
         if (SaveSetToRoot(client->saveSet[j]))
             pParent = pWin->drawable.pScreen->root;

--- a/include/dixstruct.h
+++ b/include/dixstruct.h
@@ -96,7 +96,7 @@ typedef struct _Client {
     XID errorValue;
     int sequence;
     int ignoreCount;            /* count for Attend/IgnoreClient */
-    int numSaved;
+    unsigned numSaved;          /* amount of windows in saveSet */
     SaveSetElt *saveSet;
     int (**requestVector) (ClientPtr /* pClient */ );
     CARD32 req_len;             /* length of current request */


### PR DESCRIPTION
this field is used a counter, thus should be unsigned, instead of having
dozens of signess warnings or adding casts to suppress them.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
