### PR TITLE
include: pixmapstr.h: inline PixmapBox() and fix signedness

### DIFF
--- a/include/pixmapstr.h
+++ b/include/pixmapstr.h
@@ -98,22 +98,12 @@ typedef struct _PixmapDirtyUpdate {
 } PixmapDirtyUpdateRec;
 
 static inline void
-PixmapBox(BoxPtr box, PixmapPtr pixmap)
-{
-    box->x1 = 0;
-    box->x2 = pixmap->drawable.width;
-
-    box->y1 = 0;
-    box->y2 = pixmap->drawable.height;
-}
-
-
-static inline void
 PixmapRegionInit(RegionPtr region, PixmapPtr pixmap)
 {
-    BoxRec box;
-
-    PixmapBox(&box, pixmap);
+    BoxRec box = {
+        .x2 = (int16_t)pixmap->drawable.width,
+        .y2 = (int16_t)pixmap->drawable.height,
+    };
     RegionInit(region, &box, 1);
 }
 


### PR DESCRIPTION
Not used anywhere else than just once in this header, so we can directly
inline it. Also adding explicit typecast to silence signedness warning.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
