### PR TITLE
dix: ValidateGC(): fix serialNumber assignment

### DIFF
--- a/dix/gc.c
+++ b/dix/gc.c
@@ -77,7 +77,7 @@ ValidateGC(DrawablePtr pDraw, GCPtr pGC)
 {
     (*pGC->funcs->ValidateGC) (pGC, pGC->stateChanges, pDraw);
     pGC->stateChanges = 0;
-    pGC->serialNumber = pDraw->serialNumber;
+    pGC->serialNumber = (unsigned)pDraw->serialNumber;
 }
 
 /*


### PR DESCRIPTION
GC's serialNumber field is unsigned int, but DrawableRec's is unsigned long,
so we need to typecast.

It would be better if they all had the same type, but we can't change them easily,
as that might cause ABI break.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
