### PR TITLE
dix: fix parameter types of SetClipRects()

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -1612,7 +1612,7 @@ ProcSetDashes(ClientPtr client)
 int
 ProcSetClipRectangles(ClientPtr client)
 {
-    int nr, result;
+    int result;
     GCPtr pGC;
 
     REQUEST(xSetClipRectanglesReq);
@@ -1627,12 +1627,12 @@ ProcSetClipRectangles(ClientPtr client)
     if (result != Success)
         return result;
 
-    nr = (client->req_len << 2) - sizeof(xSetClipRectanglesReq);
+    size_t nr = (client->req_len << 2) - sizeof(xSetClipRectanglesReq);
     if (nr & 4)
         return BadLength;
     nr >>= 3;
     return SetClipRects(pGC, stuff->xOrigin, stuff->yOrigin,
-                        nr, (xRectangle *) &stuff[1], (int) stuff->ordering);
+                        nr, (xRectangle *) &stuff[1], stuff->ordering);
 }
 
 int

--- a/dix/gc.c
+++ b/dix/gc.c
@@ -984,8 +984,8 @@ VerifyRectOrder(int nrects, xRectangle *prects, int ordering)
 }
 
 int
-SetClipRects(GCPtr pGC, int xOrigin, int yOrigin, int nrects,
-             xRectangle *prects, int ordering)
+SetClipRects(GCPtr pGC, INT16 xOrigin, INT16 yOrigin, size_t nrects,
+             xRectangle *prects, BYTE ordering)
 {
     int newct, size;
 

--- a/dix/gc_priv.h
+++ b/dix/gc_priv.h
@@ -33,10 +33,10 @@ int SetDashes(GCPtr pGC, unsigned offset, unsigned ndash, unsigned char *pdash);
 int VerifyRectOrder(int nrects, xRectangle *prects, int ordering);
 
 int SetClipRects(GCPtr pGC,
-                int xOrigin,
-                int yOrigin,
-                int nrects,
+                INT16 xOrigin,
+                INT16 yOrigin,
+                size_t nrects,
                 xRectangle *prects,
-                int ordering);
+                BYTE ordering);
 
 #endif /* _XSERVER_DIX_GC_PRIV_H */


### PR DESCRIPTION
Use the X11 protocol types where possible and fix signedness warnings.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
