### PR TITLE
xfree86: platform bus: move raw device list to internal header

### DIFF
--- a/hw/xfree86/common/xf86AutoConfig.c
+++ b/hw/xfree86/common/xf86AutoConfig.c
@@ -41,7 +41,7 @@
 #include "xf86Priv.h"
 #include "xf86_os_support.h"
 #include "xf86_OSlib.h"
-#include "xf86platformBus.h"
+#include "xf86platformBus_priv.h"
 #include "xf86pciBus.h"
 #ifdef __sparc__
 #include "xf86sbusBus_priv.h"

--- a/hw/xfree86/common/xf86Events.c
+++ b/hw/xfree86/common/xf86Events.c
@@ -90,8 +90,6 @@
 #include "dpmsproc.h"
 #endif
 
-#include "xf86platformBus.h"
-
 #include "../os-support/linux/systemd-logind.h"
 
 extern void (*xf86OSPMClose) (void);

--- a/hw/xfree86/common/xf86platformBus.h
+++ b/hw/xfree86/common/xf86platformBus.h
@@ -37,20 +37,9 @@ struct xf86_platform_device {
 #define XF86_PDEV_PAUSED        0x04
 
 #ifdef XSERVER_PLATFORM_BUS
-extern int xf86_num_platform_devices;
-extern struct xf86_platform_device *xf86_platform_devices;
-
 static inline struct OdevAttributes *
 xf86_platform_device_odev_attributes(struct xf86_platform_device *device)
 {
-    return device->attribs;
-}
-
-static inline struct OdevAttributes *
-xf86_platform_odev_attributes(int index)
-{
-    struct xf86_platform_device *device = &xf86_platform_devices[index];
-
     return device->attribs;
 }
 

--- a/hw/xfree86/common/xf86platformBus_priv.h
+++ b/hw/xfree86/common/xf86platformBus_priv.h
@@ -9,6 +9,16 @@
 
 #ifdef XSERVER_PLATFORM_BUS
 
+extern int xf86_num_platform_devices;
+extern struct xf86_platform_device *xf86_platform_devices;
+
+static inline struct OdevAttributes *
+xf86_platform_odev_attributes(int index)
+{
+    struct xf86_platform_device *device = &xf86_platform_devices[index];
+    return device->attribs;
+}
+
 int xf86platformProbe(void);
 int xf86platformProbeDev(DriverPtr drvp);
 int xf86platformAddGPUDevices(DriverPtr drvp);

--- a/hw/xfree86/os-support/linux/systemd-logind.c
+++ b/hw/xfree86/os-support/linux/systemd-logind.c
@@ -38,7 +38,7 @@
 #include "os.h"
 #include "linux.h"
 #include "xf86_priv.h"
-#include "xf86platformBus.h"
+#include "xf86platformBus_priv.h"
 #include "xf86Xinput_priv.h"
 #include "xf86Priv.h"
 #include "globals.h"

--- a/hw/xfree86/os-support/shared/platform_noop.c
+++ b/hw/xfree86/os-support/shared/platform_noop.c
@@ -11,7 +11,7 @@
 
 #include "xf86.h"
 #include "xf86_os_support.h"
-#include "xf86platformBus.h"
+#include "xf86platformBus_priv.h"
 
 Bool
 xf86PlatformDeviceCheckBusID(struct xf86_platform_device *device, const char *busid)


### PR DESCRIPTION
These xf86_num_platform_devices and xf86_platform_devices fields aren't
_X_EXPORTED, so no drivers can use them - and none are trying so.

Thus move them to internal / non-sdk header.

Not an ABI change.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
