### PR TITLE
dix: use xorg_list saveSet list

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -3734,6 +3734,7 @@ InitClient(ClientPtr client, int i, void *ospriv)
     client->index = i;
     xorg_list_init(&client->ready);
     xorg_list_init(&client->output_pending);
+    xorg_list_init(&client->saveSets);
     client->clientAsMask = ((Mask) i) << CLIENTOFFSET;
     client->closeDownMode = i ? DestroyAll : RetainPermanent;
     client->requestVector = InitialVector;

--- a/dix/dixutils.c
+++ b/dix/dixutils.c
@@ -89,6 +89,7 @@ Author:  Adobe Systems Incorporated
 #include "dix/client_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/resource_priv.h"
+#include "dix/saveset_priv.h"
 #include "dix/screenint_priv.h"
 #include "include/misc.h"
 
@@ -250,50 +251,35 @@ XRetCode
 AlterSaveSetForClient(ClientPtr client, WindowPtr pWin, unsigned mode,
                       Bool toRoot, Bool map)
 {
-    unsigned numnow;
-    SaveSetElt *pTmp = NULL;
-    int j;
+    if (mode == SetModeDelete) {
+        SaveSetEntry *walk, *tmp;
+        xorg_list_for_each_entry_safe(walk, tmp, &client->saveSets, entry) {
+            if (walk->windowPtr == pWin) {
+                xorg_list_del(&(walk->entry));
+                free(walk);
+            }
+        }
+        return Success;
+    }
 
-    numnow = client->numSaved;
-    j = 0;
-    if (numnow) {
-        pTmp = client->saveSet;
-        while ((j < numnow) && (SaveSetWindow(pTmp[j]) != (void *) pWin))
-            j++;
-    }
     if (mode == SetModeInsert) {
-        if (j < numnow)         /* duplicate */
-            return Success;
-        numnow++;
-        pTmp = (SaveSetElt *) realloc(client->saveSet, sizeof(*pTmp) * numnow);
-        if (!pTmp)
+        SaveSetEntry *walk;
+        xorg_list_for_each_entry(walk, &client->saveSets, entry) {
+            if (walk->windowPtr == pWin)
+                return Success; /* duplicate */
+        }
+
+        SaveSetEntry *newent = calloc(1, sizeof(SaveSetEntry));
+        if (!newent)
             return BadAlloc;
-        client->saveSet = pTmp;
-        client->numSaved = numnow;
-        SaveSetAssignWindow(client->saveSet[numnow - 1], pWin);
-        SaveSetAssignToRoot(client->saveSet[numnow - 1], toRoot);
-        SaveSetAssignMap(client->saveSet[numnow - 1], map);
+
+        newent->windowPtr = pWin;
+        newent->toRoot = toRoot;
+        newent->map = map;
+        xorg_list_add(&newent->entry, &client->saveSets);
         return Success;
     }
-    else if ((mode == SetModeDelete) && (j < numnow)) {
-        while (j < numnow - 1) {
-            pTmp[j] = pTmp[j + 1];
-            j++;
-        }
-        numnow--;
-        if (numnow) {
-            pTmp =
-                (SaveSetElt *) realloc(client->saveSet, sizeof(*pTmp) * numnow);
-            if (pTmp)
-                client->saveSet = pTmp;
-        }
-        else {
-            free(client->saveSet);
-            client->saveSet = (SaveSetElt *) NULL;
-        }
-        client->numSaved = numnow;
-        return Success;
-    }
+
     return Success;
 }
 
@@ -304,9 +290,7 @@ DeleteWindowFromAnySaveSet(WindowPtr pWin)
 
     for (int i = 0; i < currentMaxClients; i++) {
         client = clients[i];
-        if (client && client->numSaved)
-            (void) AlterSaveSetForClient(client, pWin, SetModeDelete, FALSE,
-                                         TRUE);
+        (void) AlterSaveSetForClient(client, pWin, SetModeDelete, FALSE, TRUE);
     }
 }
 

--- a/dix/saveset_priv.h
+++ b/dix/saveset_priv.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef _XSERVER_DIX_SAVESET_PRIV_H
+#define _XSERVER_DIX_SAVESET_PRIV_H
+
+#include <stdbool.h>
+
+#include "include/list.h"
+#include "include/window.h"
+
+typedef struct {
+    struct xorg_list entry;
+    WindowPtr windowPtr;
+    bool toRoot;
+    bool map;
+} SaveSetEntry;
+
+#endif /*_XSERVER_DIX_SAVESET_PRIV_H */

--- a/dix/window.c
+++ b/dix/window.c
@@ -108,6 +108,7 @@ Equipment Corporation.
 #include "dix/property_priv.h"
 #include "dix/request_priv.h"
 #include "dix/resource_priv.h"
+#include "dix/saveset_priv.h"
 #include "dix/screenint_priv.h"
 #include "dix/screensaver_priv.h"
 #include "dix/selection_priv.h"
@@ -2916,11 +2917,11 @@ UnmapSubwindows(WindowPtr pWin)
 void
 HandleSaveSet(ClientPtr client)
 {
-    WindowPtr pParent, pWin;
-
-    for (unsigned j = 0; j < client->numSaved; j++) {
-        pWin = SaveSetWindow(client->saveSet[j]);
-        if (SaveSetToRoot(client->saveSet[j]))
+    SaveSetEntry *walk, *tmp;
+    xorg_list_for_each_entry_safe(walk, tmp, &client->saveSets, entry) {
+        WindowPtr pParent = NULL;
+        WindowPtr pWin = walk->windowPtr;
+        if (walk->toRoot)
             pParent = pWin->drawable.pScreen->root;
         else
         {
@@ -2931,7 +2932,7 @@ HandleSaveSet(ClientPtr client)
         if (pParent) {
             if (pParent != pWin->parent) {
                 /* unmap first so that ReparentWindow doesn't remap */
-                if (!SaveSetShouldMap(client->saveSet[j]))
+                if (!walk->map)
                     UnmapWindow(pWin, FALSE);
                 ReparentWindow(pWin, pParent,
                                pWin->drawable.x - wBorderWidth(pWin) -
@@ -2941,13 +2942,13 @@ HandleSaveSet(ClientPtr client)
                 if (!pWin->realized && pWin->mapped)
                     pWin->mapped = FALSE;
             }
-            if (SaveSetShouldMap(client->saveSet[j]))
+            if (walk->map)
                 MapWindow(pWin, client);
         }
+
+        xorg_list_del(&walk->entry);
+        free(walk);
     }
-    free(client->saveSet);
-    client->numSaved = 0;
-    client->saveSet = NULL;
 }
 
 /**

--- a/include/dixstruct.h
+++ b/include/dixstruct.h
@@ -59,19 +59,9 @@ typedef enum { ClientStateInitial,
     ClientStateGone
 } ClientState;
 
-typedef struct _saveSet {
-    struct _Window *windowPtr;
-    Bool toRoot;
-    Bool map;
-} SaveSetElt;
-#define SaveSetWindow(ss)   ((ss).windowPtr)
-#define SaveSetToRoot(ss)   ((ss).toRoot)
-#define SaveSetShouldMap(ss)	    ((ss).map)
-#define SaveSetAssignWindow(ss,w)   ((ss).windowPtr = (w))
-#define SaveSetAssignToRoot(ss,tr)  ((ss).toRoot = (tr))
-#define SaveSetAssignMap(ss,m)      ((ss).map = (m))
-
 struct _Client {
+    /* changes in here must be done with great caution, as long as some
+       external drivers might still depend on specific layout */
     void *requestBuffer;
     void *osPrivate;             /* for OS layer, including scheduler */
     struct xorg_list ready;      /* List of clients ready to run */
@@ -92,8 +82,10 @@ struct _Client {
     XID errorValue;
     int sequence;
     int ignoreCount;            /* count for Attend/IgnoreClient */
-    unsigned numSaved;          /* amount of windows in saveSet */
-    SaveSetElt *saveSet;
+
+    int __dummy0;                       /* used to be numSave */
+    void *__dummy1;                     /* used to be saveSet */
+
     int (**requestVector) (ClientPtr /* pClient */ );
     CARD32 req_len;             /* length of current request */
     unsigned int replyBytesRemaining;
@@ -109,6 +101,10 @@ struct _Client {
     DeviceIntPtr clientPtr;
     struct _ClientId *clientIds;
     int req_fds;
+
+    /* driver should NEVER EVER touch anything beyond here */
+
+    struct xorg_list saveSets;
 };
 
 extern _X_EXPORT TimeStamp currentTime;


### PR DESCRIPTION
Simplify saveSet handling by just using trivial `struct xorg_list` instead
of complicated dynamically resized array. Common operations like insert or
remove are much simpler using lists instead of arrays.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
