### PR TITLE
dix: make ProcBadRequest() static

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -716,12 +716,6 @@ CreateConnectionBlock(void)
 }
 
 int
-ProcBadRequest(ClientPtr client)
-{
-    return BadRequest;
-}
-
-int
 ProcCreateWindow(ClientPtr client)
 {
     WindowPtr pParent, pWin;

--- a/dix/tables.c
+++ b/dix/tables.c
@@ -59,6 +59,12 @@ SOFTWARE.
 #include "swaprep.h"
 #include "swapreq.h"
 
+static int
+ProcBadRequest(ClientPtr client)
+{
+    return BadRequest;
+}
+
 int (*InitialVector[3]) (ClientPtr /* client */) = {
     0,
     ProcInitialConnection,

--- a/include/dixstruct.h
+++ b/include/dixstruct.h
@@ -156,7 +156,4 @@ extern _X_EXPORT int (*SwappedProcVector[256]) (ClientPtr /*client */ );
 /* fixme: still needed by (public) dix.h */
 extern ReplySwapPtr ReplySwapVector[256];
 
-extern _X_EXPORT int
-ProcBadRequest(ClientPtr /*client */ );
-
 #endif                          /* DIXSTRUCT_H */


### PR DESCRIPTION
Nobody outside tables.c is actually using it, so can be static.

The function used to be _X_EXPORT'ed, but there's no indication that any
external driver (not even proprietary NVidia) ever using it, so we can
get away w/o ABI version bump.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
