### PR TITLE
composite: inline SProc*()'s

### DIFF
--- a/composite/compext.c
+++ b/composite/compext.c
@@ -103,6 +103,11 @@ ProcCompositeQueryVersion(ClientPtr client)
     REQUEST(xCompositeQueryVersionReq);
     REQUEST_SIZE_MATCH(xCompositeQueryVersionReq);
 
+    if (client->swapped) {
+        swapl(&stuff->majorVersion);
+        swapl(&stuff->minorVersion);
+    }
+
     CompositeClientPtr pCompositeClient = GetCompositeClient(client);
 
     xCompositeQueryVersionReply rep = {
@@ -184,11 +189,15 @@ SingleCompositeUnredirectSubwindows(ClientPtr client, xCompositeUnredirectSubwin
 static int
 ProcCompositeCreateRegionFromBorderClip(ClientPtr client)
 {
-    WindowPtr pWin;
-
     REQUEST(xCompositeCreateRegionFromBorderClipReq);
     REQUEST_SIZE_MATCH(xCompositeCreateRegionFromBorderClipReq);
 
+    if (client->swapped) {
+        swapl(&stuff->region);
+        swapl(&stuff->window);
+    }
+
+    WindowPtr pWin;
     VERIFY_WINDOW(pWin, stuff->window, client, DixGetAttrAccess);
     LEGAL_NEW_RESOURCE(stuff->region, client);
 
@@ -362,118 +371,6 @@ ProcCompositeDispatch(ClientPtr client)
     }
 }
 
-static int _X_COLD
-SProcCompositeQueryVersion(ClientPtr client)
-{
-    REQUEST(xCompositeQueryVersionReq);
-    REQUEST_SIZE_MATCH(xCompositeQueryVersionReq);
-    swapl(&stuff->majorVersion);
-    swapl(&stuff->minorVersion);
-    return ProcCompositeQueryVersion(client);
-}
-
-static int _X_COLD
-SProcCompositeRedirectWindow(ClientPtr client)
-{
-    REQUEST(xCompositeRedirectWindowReq);
-    REQUEST_SIZE_MATCH(xCompositeRedirectWindowReq);
-    swapl(&stuff->window);
-    return ProcCompositeRedirectWindow(client);
-}
-
-static int _X_COLD
-SProcCompositeRedirectSubwindows(ClientPtr client)
-{
-    REQUEST(xCompositeRedirectSubwindowsReq);
-    REQUEST_SIZE_MATCH(xCompositeRedirectSubwindowsReq);
-    swapl(&stuff->window);
-    return ProcCompositeRedirectSubwindows(client);
-}
-
-static int _X_COLD
-SProcCompositeUnredirectWindow(ClientPtr client)
-{
-    REQUEST(xCompositeUnredirectWindowReq);
-    REQUEST_SIZE_MATCH(xCompositeUnredirectWindowReq);
-    swapl(&stuff->window);
-    return ProcCompositeUnredirectWindow(client);
-}
-
-static int _X_COLD
-SProcCompositeUnredirectSubwindows(ClientPtr client)
-{
-    REQUEST(xCompositeUnredirectSubwindowsReq);
-    REQUEST_SIZE_MATCH(xCompositeUnredirectSubwindowsReq);
-    swapl(&stuff->window);
-    return ProcCompositeUnredirectSubwindows(client);
-}
-
-static int _X_COLD
-SProcCompositeCreateRegionFromBorderClip(ClientPtr client)
-{
-    REQUEST(xCompositeCreateRegionFromBorderClipReq);
-    REQUEST_SIZE_MATCH(xCompositeCreateRegionFromBorderClipReq);
-    swapl(&stuff->region);
-    swapl(&stuff->window);
-    return ProcCompositeCreateRegionFromBorderClip(client);
-}
-
-static int _X_COLD
-SProcCompositeNameWindowPixmap(ClientPtr client)
-{
-    REQUEST(xCompositeNameWindowPixmapReq);
-    REQUEST_SIZE_MATCH(xCompositeNameWindowPixmapReq);
-    swapl(&stuff->window);
-    swapl(&stuff->pixmap);
-    return ProcCompositeNameWindowPixmap(client);
-}
-
-static int _X_COLD
-SProcCompositeGetOverlayWindow(ClientPtr client)
-{
-    REQUEST(xCompositeGetOverlayWindowReq);
-    REQUEST_SIZE_MATCH(xCompositeGetOverlayWindowReq);
-    swapl(&stuff->window);
-    return ProcCompositeGetOverlayWindow(client);
-}
-
-static int _X_COLD
-SProcCompositeReleaseOverlayWindow(ClientPtr client)
-{
-    REQUEST(xCompositeReleaseOverlayWindowReq);
-    REQUEST_SIZE_MATCH(xCompositeReleaseOverlayWindowReq);
-    swapl(&stuff->window);
-    return ProcCompositeReleaseOverlayWindow(client);
-}
-
-static int _X_COLD
-SProcCompositeDispatch(ClientPtr client)
-{
-    REQUEST(xReq);
-    switch (stuff->data) {
-        case X_CompositeQueryVersion:
-            return SProcCompositeQueryVersion(client);
-        case X_CompositeRedirectWindow:
-            return SProcCompositeRedirectWindow(client);
-        case X_CompositeRedirectSubwindows:
-            return SProcCompositeRedirectSubwindows(client);
-        case X_CompositeUnredirectWindow:
-            return SProcCompositeUnredirectWindow(client);
-        case X_CompositeUnredirectSubwindows:
-            return SProcCompositeUnredirectSubwindows(client);
-        case X_CompositeCreateRegionFromBorderClip:
-            return SProcCompositeCreateRegionFromBorderClip(client);
-        case X_CompositeNameWindowPixmap:
-            return SProcCompositeNameWindowPixmap(client);
-        case X_CompositeGetOverlayWindow:
-            return SProcCompositeGetOverlayWindow(client);
-        case X_CompositeReleaseOverlayWindow:
-            return SProcCompositeReleaseOverlayWindow(client);
-        default:
-            return BadRequest;
-    }
-}
-
 /** @see GetDefaultBytes */
 static SizeType coreGetWindowBytes;
 
@@ -552,7 +449,8 @@ CompositeExtensionInit(void)
     }
 
     extEntry = AddExtension(COMPOSITE_NAME, 0, 0,
-                            ProcCompositeDispatch, SProcCompositeDispatch,
+                            ProcCompositeDispatch,
+                            ProcCompositeDispatch,
                             NULL, StandardMinorOpcode);
     if (!extEntry)
         return;
@@ -567,6 +465,9 @@ ProcCompositeRedirectWindow(ClientPtr client)
 {
     REQUEST(xCompositeRedirectWindowReq);
     REQUEST_SIZE_MATCH(xCompositeRedirectWindowReq);
+
+    if (client->swapped)
+        swapl(&stuff->window);
 
 #ifdef XINERAMA
     if (!compositeUseXinerama)
@@ -600,6 +501,9 @@ ProcCompositeRedirectSubwindows(ClientPtr client)
     REQUEST(xCompositeRedirectSubwindowsReq);
     REQUEST_SIZE_MATCH(xCompositeRedirectSubwindowsReq);
 
+    if (client->swapped)
+        swapl(&stuff->window);
+
 #ifdef XINERAMA
     if (!compositeUseXinerama)
         return SingleRedirectSubwindows(client, stuff);
@@ -631,6 +535,9 @@ ProcCompositeUnredirectWindow(ClientPtr client)
 {
     REQUEST(xCompositeUnredirectWindowReq);
     REQUEST_SIZE_MATCH(xCompositeUnredirectWindowReq);
+
+    if (client->swapped)
+        swapl(&stuff->window);
 
 #ifdef XINERAMA
     if (!compositeUseXinerama)
@@ -664,6 +571,9 @@ ProcCompositeUnredirectSubwindows(ClientPtr client)
     REQUEST(xCompositeUnredirectSubwindowsReq);
     REQUEST_SIZE_MATCH(xCompositeUnredirectSubwindowsReq);
 
+    if (client->swapped)
+        swapl(&stuff->window);
+
 #ifdef XINERAMA
     if (!compositeUseXinerama)
         return SingleCompositeUnredirectSubwindows(client, stuff);
@@ -695,6 +605,11 @@ ProcCompositeNameWindowPixmap(ClientPtr client)
 {
     REQUEST(xCompositeNameWindowPixmapReq);
     REQUEST_SIZE_MATCH(xCompositeNameWindowPixmapReq);
+
+    if (client->swapped) {
+        swapl(&stuff->window);
+        swapl(&stuff->pixmap);
+    }
 
 #ifdef XINERAMA
     if (!compositeUseXinerama)
@@ -768,6 +683,9 @@ ProcCompositeGetOverlayWindow(ClientPtr client)
 {
     REQUEST(xCompositeGetOverlayWindowReq);
     REQUEST_SIZE_MATCH(xCompositeGetOverlayWindowReq);
+
+    if (client->swapped)
+        swapl(&stuff->window);
 
 #ifdef XINERAMA
     if (!compositeUseXinerama)
@@ -868,6 +786,9 @@ ProcCompositeReleaseOverlayWindow(ClientPtr client)
 {
     REQUEST(xCompositeReleaseOverlayWindowReq);
     REQUEST_SIZE_MATCH(xCompositeReleaseOverlayWindowReq);
+
+    if (client->swapped)
+        swapl(&stuff->window);
 
 #ifdef XINERAMA
     if (!compositeUseXinerama)


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
