### PR TITLE
Xi: inline SProcXAllowDeviceEvents()

### DIFF
--- a/Xi/allowev.c
+++ b/Xi/allowev.c
@@ -66,30 +66,18 @@ SOFTWARE.
  *
  */
 
-int _X_COLD
-SProcXAllowDeviceEvents(ClientPtr client)
-{
-    REQUEST(xAllowDeviceEventsReq);
-    REQUEST_SIZE_MATCH(xAllowDeviceEventsReq);
-    swapl(&stuff->time);
-    return (ProcXAllowDeviceEvents(client));
-}
-
-/***********************************************************************
- *
- * This procedure allows frozen events to be routed.
- *
- */
-
 int
 ProcXAllowDeviceEvents(ClientPtr client)
 {
+    REQUEST(xAllowDeviceEventsReq);
+    REQUEST_SIZE_MATCH(xAllowDeviceEventsReq);
+
+    if (client->swapped)
+        swapl(&stuff->time);
+
     TimeStamp time;
     DeviceIntPtr thisdev;
     int rc;
-
-    REQUEST(xAllowDeviceEventsReq);
-    REQUEST_SIZE_MATCH(xAllowDeviceEventsReq);
 
     rc = dixLookupDevice(&thisdev, stuff->deviceid, client, DixGetAttrAccess);
     if (rc != Success)

--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -388,7 +388,7 @@ SProcIDispatch(ClientPtr client)
         case X_UngrabDeviceButton:
             return SProcXUngrabDeviceButton(client);
         case X_AllowDeviceEvents:
-            return SProcXAllowDeviceEvents(client);
+            return ProcXAllowDeviceEvents(client);
         case X_GetDeviceFocus:
             return ProcXGetDeviceFocus(client);
         case X_SetDeviceFocus:

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -69,7 +69,6 @@ int ProcXUngrabDeviceButton(ClientPtr client);
 int ProcXUngrabDevice(ClientPtr client);
 int ProcXUngrabDeviceKey(ClientPtr client);
 
-int SProcXAllowDeviceEvents(ClientPtr client);
 int SProcXChangeDeviceControl(ClientPtr client);
 int SProcXChangeDeviceDontPropagateList(ClientPtr client);
 int SProcXChangeDeviceKeyMapping(ClientPtr client);


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
