### PR TITLE
Xi: inline SProcXChangeDeviceKeyMapping()

### DIFF
--- a/Xi/chgkmap.c
+++ b/Xi/chgkmap.c
@@ -63,26 +63,6 @@ SOFTWARE.
 
 /***********************************************************************
  *
- * This procedure swaps the request when the client and
- * server have different byte orderings.
- *
- */
-
-int _X_COLD
-SProcXChangeDeviceKeyMapping(ClientPtr client)
-{
-    unsigned int count;
-
-    REQUEST(xChangeDeviceKeyMappingReq);
-    REQUEST_AT_LEAST_SIZE(xChangeDeviceKeyMappingReq);
-    count = stuff->keyCodes * stuff->keySymsPerKeyCode;
-    REQUEST_FIXED_SIZE(xChangeDeviceKeyMappingReq, count * sizeof(CARD32));
-    SwapLongs((CARD32 *) (&stuff[1]), count);
-    return (ProcXChangeDeviceKeyMapping(client));
-}
-
-/***********************************************************************
- *
  * Change the device key mapping.
  *
  */
@@ -90,16 +70,18 @@ SProcXChangeDeviceKeyMapping(ClientPtr client)
 int
 ProcXChangeDeviceKeyMapping(ClientPtr client)
 {
-    int ret;
-    unsigned len;
-    DeviceIntPtr dev;
-    unsigned int count;
-
     REQUEST(xChangeDeviceKeyMappingReq);
     REQUEST_AT_LEAST_SIZE(xChangeDeviceKeyMappingReq);
 
-    count = stuff->keyCodes * stuff->keySymsPerKeyCode;
+    unsigned count = stuff->keyCodes * stuff->keySymsPerKeyCode;
     REQUEST_FIXED_SIZE(xChangeDeviceKeyMappingReq, count * sizeof(CARD32));
+
+    if (client->swapped)
+        SwapLongs((CARD32 *) (&stuff[1]), count);
+
+    int ret;
+    unsigned len;
+    DeviceIntPtr dev;
 
     ret = dixLookupDevice(&dev, stuff->deviceid, client, DixManageAccess);
     if (ret != Success)

--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -400,7 +400,7 @@ SProcIDispatch(ClientPtr client)
         case X_GetDeviceKeyMapping:
             return ProcXGetDeviceKeyMapping(client);
         case X_ChangeDeviceKeyMapping:
-            return SProcXChangeDeviceKeyMapping(client);
+            return ProcXChangeDeviceKeyMapping(client);
         case X_GetDeviceModifierMapping:
             return ProcXGetDeviceModifierMapping(client);
         case X_SetDeviceModifierMapping:

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -72,7 +72,6 @@ int ProcXUngrabDeviceKey(ClientPtr client);
 int SProcXAllowDeviceEvents(ClientPtr client);
 int SProcXChangeDeviceControl(ClientPtr client);
 int SProcXChangeDeviceDontPropagateList(ClientPtr client);
-int SProcXChangeDeviceKeyMapping(ClientPtr client);
 int SProcXChangeDeviceProperty(ClientPtr client);
 int SProcXChangeFeedbackControl(ClientPtr client);
 int SProcXDeleteDeviceProperty(ClientPtr client);


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
