### PR TITLE
render: consolidate byte-swapping in ProcRenderReferenceGlyphSet()

### DIFF
--- a/render/render.c
+++ b/render/render.c
@@ -104,7 +104,6 @@ static int SProcRenderTrapezoids(ClientPtr pClient);
 static int SProcRenderTriangles(ClientPtr pClient);
 static int SProcRenderTriStrip(ClientPtr pClient);
 static int SProcRenderTriFan(ClientPtr pClient);
-static int SProcRenderReferenceGlyphSet(ClientPtr pClient);
 static int SProcRenderFreeGlyphSet(ClientPtr pClient);
 static int SProcRenderAddGlyphs(ClientPtr pClient);
 static int SProcRenderFreeGlyphs(ClientPtr pClient);
@@ -177,7 +176,7 @@ int (*SProcRenderVector[RenderNumberRequests]) (ClientPtr) = {
         _not_implemented, /* SProcRenderColorTriangles */
         _not_implemented, /* SProcRenderTransform */
         ProcRenderCreateGlyphSet,
-        SProcRenderReferenceGlyphSet,
+        ProcRenderReferenceGlyphSet,
         SProcRenderFreeGlyphSet,
         SProcRenderAddGlyphs,
         _not_implemented, /* SProcRenderAddGlyphsFromPicture */
@@ -878,8 +877,12 @@ ProcRenderReferenceGlyphSet(ClientPtr client)
     int rc;
 
     REQUEST(xRenderReferenceGlyphSetReq);
-
     REQUEST_SIZE_MATCH(xRenderReferenceGlyphSetReq);
+
+    if (client->swapped) {
+        swapl(&stuff->gsid);
+        swapl(&stuff->existing);
+    }
 
     LEGAL_NEW_RESOURCE(stuff->gsid, client);
 
@@ -2046,16 +2049,6 @@ SProcRenderTriFan(ClientPtr client)
     swaps(&stuff->ySrc);
     SwapRestL(stuff);
     return ProcRenderTriFan(client);
-}
-
-static int _X_COLD
-SProcRenderReferenceGlyphSet(ClientPtr client)
-{
-    REQUEST(xRenderReferenceGlyphSetReq);
-    REQUEST_SIZE_MATCH(xRenderReferenceGlyphSetReq);
-    swapl(&stuff->gsid);
-    swapl(&stuff->existing);
-    return ProcRenderReferenceGlyphSet(client);
 }
 
 static int _X_COLD


### PR DESCRIPTION
No need for extra functions and call tables for the few trivial lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
