### PR TITLE
meson.build: Enable epoll-shim for DFBSD.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -457,7 +457,7 @@ else
     build_dri2 = get_option('dri2') == 'true'
 endif
 
-if host_machine.system() in ['freebsd', 'openbsd']
+if host_machine.system() in ['freebsd', 'openbsd', 'dragonfly']
    epoll_dep = dependency('epoll-shim')
    epoll_inc = join_paths(epoll_dep.get_variable('prefix'), get_option('includedir'), 'libepoll-shim')
 else


### PR DESCRIPTION
DragonFlyBSD also uses epoll-shim and it is necessary for DRI3.