### PR TITLE
compext: Xi: use return value of X_SEND_REPLY_SIMPLE()

### DIFF
--- a/composite/compext.c
+++ b/composite/compext.c
@@ -122,8 +122,8 @@ ProcCompositeQueryVersion(ClientPtr client)
         swapl(&rep.majorVersion);
         swapl(&rep.minorVersion);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
-    return Success;
+
+    return X_SEND_REPLY_SIMPLE(client, rep);
 }
 
 #define VERIFY_WINDOW(pWindow, wid, client, mode)			\
@@ -301,8 +301,8 @@ SingleCompositeGetOverlayWindow(ClientPtr client, xCompositeGetOverlayWindowReq 
     if (client->swapped) {
         swapl(&rep.overlayWin);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
-    return Success;
+
+    return X_SEND_REPLY_SIMPLE(client, rep);
 }
 
 static int
@@ -856,8 +856,8 @@ ProcCompositeGetOverlayWindow(ClientPtr client)
     if (client->swapped) {
         swapl(&rep.overlayWin);
     }
-    X_SEND_REPLY_SIMPLE(client, rep);
-    return Success;
+
+    return X_SEND_REPLY_SIMPLE(client, rep);
 #else
     return SingleCompositeGetOverlayWindow(client, stuff);
 #endif /* XINERAMA */


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
