### PR TITLE
randr: Xi: use return value of X_SEND_REPLY_SIMPLE()

### DIFF
--- a/randr/rrproperty.c
+++ b/randr/rrproperty.c
@@ -690,11 +690,10 @@ sendout:
         swapl(&rep.nItems);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
-
     if (prop && stuff->delete && (rep.bytesAfter == 0)) {     /* delete the Property */
         *prev = prop->next;
         RRDestroyOutputProperty(prop);
     }
-    return Success;
+
+    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
 }


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
