### PR TITLE
xace: drop never used XACE_KEY_AVAIL

### DIFF
--- a/Xext/xace.c
+++ b/Xext/xace.c
@@ -137,13 +137,6 @@ int XaceHookAuthAvail(ClientPtr client, XID authId)
     return Success;
 }
 
-int XaceHookKeyAvail(xEventPtr ev, DeviceIntPtr dev, int count)
-{
-    XaceKeyAvailRec rec = { ev, dev, count };
-    CallCallbacks(&XaceHooks[XACE_KEY_AVAIL], &rec);
-    return Success;
-}
-
 /* XaceHookIsSet
  *
  * Utility function to determine whether there are any callbacks listening on a

--- a/Xext/xace.h
+++ b/Xext/xace.h
@@ -50,8 +50,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define XACE_SCREEN_ACCESS		11
 #define XACE_SCREENSAVER_ACCESS		12
 #define XACE_AUTH_AVAIL			13
-#define XACE_KEY_AVAIL			14
-#define XACE_NUM_HOOKS			15
+#define XACE_NUM_HOOKS			14
 
 extern CallbackListPtr XaceHooks[XACE_NUM_HOOKS];
 
@@ -91,7 +90,6 @@ int XaceHookServerAccess(ClientPtr client, Mask access_mode);
 int XaceHookScreenAccess(ClientPtr client, ScreenPtr screen, Mask access_mode);
 int XaceHookScreensaverAccess(ClientPtr client, ScreenPtr screen, Mask access_mode);
 int XaceHookAuthAvail(ClientPtr client, XID authId);
-int XaceHookKeyAvail(xEventPtr ev, DeviceIntPtr dev, int count);
 
 /* Register / unregister a callback for a given hook. */
 

--- a/Xext/xacestr.h
+++ b/Xext/xacestr.h
@@ -125,13 +125,6 @@ typedef struct {
     XID authId;
 } XaceAuthAvailRec;
 
-/* XACE_KEY_AVAIL */
-typedef struct {
-    xEventPtr event;
-    DeviceIntPtr keybd;
-    int count;
-} XaceKeyAvailRec;
-
 /* XACE_AUDIT_BEGIN */
 /* XACE_AUDIT_END */
 typedef struct {

--- a/Xi/exevents.c
+++ b/Xi/exevents.c
@@ -1883,18 +1883,6 @@ ProcessDeviceEvent(InternalEvent *ev, DeviceIntPtr device)
         break;
     }
 
-    /* send KeyPress and KeyRelease events to XACE plugins */
-    if (XaceHookIsSet(XACE_KEY_AVAIL) &&
-            (event->type == ET_KeyPress || event->type == ET_KeyRelease)) {
-        xEvent *core;
-        int count;
-
-        if (EventToCore(ev, &core, &count) == Success && count > 0) {
-            XaceHookKeyAvail(core, device, 0);
-            free(core);
-        }
-    }
-
     if (DeviceEventCallback && !syncEvents.playingEvents) {
         DeviceEventInfoRec eventinfo;
         SpritePtr pSprite = device->spriteInfo->sprite;


### PR DESCRIPTION
This hook was never used, so no need to keep around something that's
really not used anywhere.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
