### PR TITLE
xace: drop unused XACE_AUTH_AVAIL

### DIFF
--- a/Xext/xace.c
+++ b/Xext/xace.c
@@ -130,13 +130,6 @@ int XaceHookScreensaverAccess(ClientPtr client, ScreenPtr screen, Mask access_mo
     return rec.status;
 }
 
-int XaceHookAuthAvail(ClientPtr client, XID authId)
-{
-    XaceAuthAvailRec rec = { client, authId };
-    CallCallbacks(&XaceHooks[XACE_AUTH_AVAIL], &rec);
-    return Success;
-}
-
 int XaceHookKeyAvail(xEventPtr ev, DeviceIntPtr dev, int count)
 {
     XaceKeyAvailRec rec = { ev, dev, count };

--- a/Xext/xace.h
+++ b/Xext/xace.h
@@ -49,7 +49,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define XACE_SELECTION_ACCESS		10
 #define XACE_SCREEN_ACCESS		11
 #define XACE_SCREENSAVER_ACCESS		12
-#define XACE_AUTH_AVAIL			13
 #define XACE_KEY_AVAIL			14
 #define XACE_NUM_HOOKS			15
 
@@ -90,7 +89,6 @@ int XaceHookExtAccess(ClientPtr client, ExtensionEntry *ext);
 int XaceHookServerAccess(ClientPtr client, Mask access_mode);
 int XaceHookScreenAccess(ClientPtr client, ScreenPtr screen, Mask access_mode);
 int XaceHookScreensaverAccess(ClientPtr client, ScreenPtr screen, Mask access_mode);
-int XaceHookAuthAvail(ClientPtr client, XID authId);
 int XaceHookKeyAvail(xEventPtr ev, DeviceIntPtr dev, int count);
 
 /* Register / unregister a callback for a given hook. */

--- a/Xext/xacestr.h
+++ b/Xext/xacestr.h
@@ -119,12 +119,6 @@ typedef struct {
     int status;
 } XaceScreenAccessRec;
 
-/* XACE_AUTH_AVAIL */
-typedef struct {
-    ClientPtr client;
-    XID authId;
-} XaceAuthAvailRec;
-
 /* XACE_KEY_AVAIL */
 typedef struct {
     xEventPtr event;

--- a/os/connection.c
+++ b/os/connection.c
@@ -588,8 +588,6 @@ ClientAuthorized(ClientPtr client,
     XdmcpOpenDisplay(priv->fd);
 #endif                          /* XDMCP */
 
-    XaceHookAuthAvail(client, auth_id);
-
     /* At this point, if the client is authorized to change the access control
      * list, we should getpeername() information, and add the client to
      * the selfhosts list.  It's not really the host machine, but the


### PR DESCRIPTION
Not used anymore for almost two decades, so no need to keep it.

Fixes: eafaf40fb3368ca7e4cf48336fdb7a6c9f536bfa
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
