### PR TITLE
xace: drop obsolete/unused XaceAuditRec

### DIFF
--- a/Xext/xacestr.h
+++ b/Xext/xacestr.h
@@ -132,11 +132,4 @@ typedef struct {
     int count;
 } XaceKeyAvailRec;
 
-/* XACE_AUDIT_BEGIN */
-/* XACE_AUDIT_END */
-typedef struct {
-    ClientPtr client;
-    int requestResult;
-} XaceAuditRec;
-
 #endif                          /* _XACESTR_H */


### PR DESCRIPTION
This struct isn't used anymore for almost a decade, just a left over from
audit hooks removal, back in 2016.

Fixes: 6cb34816afa95d9214199c363f9b4bb5ecbae77b
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
