### PR TITLE
dix: replace XACE_EXT_ACCESS and XACE_EXT_DISPATCH by direct callback

### DIFF
--- a/Xext/namespace/hook-ext-access.c
+++ b/Xext/namespace/hook-ext-access.c
@@ -13,7 +13,7 @@
 /* called on X_QueryExtension */
 void hookExtAccess(CallbackListPtr *pcbl, void *unused, void *calldata)
 {
-    XNS_HOOK_HEAD(XaceExtAccessRec);
+    XNS_HOOK_HEAD(ExtensionAccessCallbackParam);
 
     /* root NS has super powers */
     if (subj->ns->superPower)

--- a/Xext/namespace/hook-ext-dispatch.c
+++ b/Xext/namespace/hook-ext-dispatch.c
@@ -20,7 +20,7 @@
 
 void hookExtDispatch(CallbackListPtr *pcbl, void *unused, void *calldata)
 {
-    XNS_HOOK_HEAD(XaceExtAccessRec);
+    XNS_HOOK_HEAD(ExtensionAccessCallbackParam);
 
     /* root NS has super powers */
     if (subj->ns->superPower)

--- a/Xext/namespace/namespace.c
+++ b/Xext/namespace/namespace.c
@@ -4,6 +4,7 @@
 #include <X11/Xmd.h>
 
 #include "dix/dix_priv.h"
+#include "dix/extension_priv.h"
 #include "dix/property_priv.h"
 #include "dix/selection_priv.h"
 #include "include/os.h"
@@ -34,10 +35,10 @@ NamespaceExtensionInit(void)
           AddCallback(&PostInitRootWindowCallback, hookInitRootWindow, NULL) &&
           AddCallback(&PropertyFilterCallback, hookWindowProperty, NULL) &&
           AddCallback(&SelectionFilterCallback, hookSelectionFilter, NULL) &&
+          AddCallback(&ExtensionAccessCallback, hookExtAccess, NULL) &&
+          AddCallback(&ExtensionDispatchCallback, hookExtDispatch, NULL) &&
           XaceRegisterCallback(XACE_CLIENT_ACCESS, hookClient, NULL) &&
           XaceRegisterCallback(XACE_DEVICE_ACCESS, hookDevice, NULL) &&
-          XaceRegisterCallback(XACE_EXT_DISPATCH, hookExtDispatch, NULL) &&
-          XaceRegisterCallback(XACE_EXT_ACCESS, hookExtAccess, NULL) &&
           XaceRegisterCallback(XACE_PROPERTY_ACCESS, hookPropertyAccess, NULL) &&
           XaceRegisterCallback(XACE_RECEIVE_ACCESS, hookReceive, NULL) &&
           XaceRegisterCallback(XACE_RESOURCE_ACCESS, hookResourceAccess, NULL) &&

--- a/Xext/security.c
+++ b/Xext/security.c
@@ -31,6 +31,7 @@ in this Software without prior written authorization from The Open Group.
 #include <X11/Xfuncproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/extension_priv.h"
 #include "dix/registry_priv.h"
 #include "dix/resource_priv.h"
 #include "miext/extinit_priv.h"
@@ -742,7 +743,7 @@ denied:
 static void
 SecurityExtension(CallbackListPtr *pcbl, void *unused, void *calldata)
 {
-    XaceExtAccessRec *rec = calldata;
+    ExtensionAccessCallbackParam *rec = calldata;
     SecurityStateRec *subj;
     int i = 0;
 
@@ -964,15 +965,15 @@ SecurityResetProc(ExtensionEntry * extEntry)
 {
     /* Unregister callbacks */
     DeleteCallback(&ClientStateCallback, SecurityClientState, NULL);
+    DeleteCallback(&ExtensionAccessCallback, SecurityExtension, NULL);
+    DeleteCallback(&ExtensionDispatchCallback, SecurityExtension, NULL);
 
-    XaceDeleteCallback(XACE_EXT_DISPATCH, SecurityExtension, NULL);
     XaceDeleteCallback(XACE_RESOURCE_ACCESS, SecurityResource, NULL);
     XaceDeleteCallback(XACE_DEVICE_ACCESS, SecurityDevice, NULL);
     XaceDeleteCallback(XACE_PROPERTY_ACCESS, SecurityProperty, NULL);
     XaceDeleteCallback(XACE_SEND_ACCESS, SecuritySend, NULL);
     XaceDeleteCallback(XACE_RECEIVE_ACCESS, SecurityReceive, NULL);
     XaceDeleteCallback(XACE_CLIENT_ACCESS, SecurityClient, NULL);
-    XaceDeleteCallback(XACE_EXT_ACCESS, SecurityExtension, NULL);
     XaceDeleteCallback(XACE_SERVER_ACCESS, SecurityServer, NULL);
 }
 
@@ -1012,15 +1013,15 @@ SecurityExtensionInit(void)
 
     /* Register callbacks */
     ret &= AddCallback(&ClientStateCallback, SecurityClientState, NULL);
+    ret &= AddCallback(&ExtensionAccessCallback, SecurityExtension, NULL);
+    ret &= AddCallback(&ExtensionDispatchCallback, SecurityExtension, NULL);
 
-    ret &= XaceRegisterCallback(XACE_EXT_DISPATCH, SecurityExtension, NULL);
     ret &= XaceRegisterCallback(XACE_RESOURCE_ACCESS, SecurityResource, NULL);
     ret &= XaceRegisterCallback(XACE_DEVICE_ACCESS, SecurityDevice, NULL);
     ret &= XaceRegisterCallback(XACE_PROPERTY_ACCESS, SecurityProperty, NULL);
     ret &= XaceRegisterCallback(XACE_SEND_ACCESS, SecuritySend, NULL);
     ret &= XaceRegisterCallback(XACE_RECEIVE_ACCESS, SecurityReceive, NULL);
     ret &= XaceRegisterCallback(XACE_CLIENT_ACCESS, SecurityClient, NULL);
-    ret &= XaceRegisterCallback(XACE_EXT_ACCESS, SecurityExtension, NULL);
     ret &= XaceRegisterCallback(XACE_SERVER_ACCESS, SecurityServer, NULL);
 
     if (!ret)

--- a/Xext/xace.c
+++ b/Xext/xace.c
@@ -35,18 +35,6 @@ CallbackListPtr XaceHooks[XACE_NUM_HOOKS] = { 0 };
 /* Special-cased hook functions.  Called by Xserver.
  */
 int
-XaceHookDispatch0(ClientPtr client, int major)
-{
-    /* Call the extension dispatch hook */
-    ExtensionEntry *ext = GetExtensionEntry(major);
-    XaceExtAccessRec erec = { client, ext, DixUseAccess, Success };
-    if (ext)
-        CallCallbacks(&XaceHooks[XACE_EXT_DISPATCH], &erec);
-    /* On error, pretend extension doesn't exist */
-    return (erec.status == Success) ? Success : BadRequest;
-}
-
-int
 XaceHookPropertyAccess(ClientPtr client, WindowPtr pWin,
                        PropertyPtr *ppProp, Mask access_mode)
 {
@@ -99,13 +87,6 @@ int XaceHookClientAccess(ClientPtr client, ClientPtr target, Mask access_mode)
 {
     XaceClientAccessRec rec = { client, target, access_mode, Success };
     CallCallbacks(&XaceHooks[XACE_CLIENT_ACCESS], &rec);
-    return rec.status;
-}
-
-int XaceHookExtAccess(ClientPtr client, ExtensionEntry *ext)
-{
-    XaceExtAccessRec rec = { client, ext, DixGetAttrAccess, Success };
-    CallCallbacks(&XaceHooks[XACE_EXT_ACCESS], &rec);
     return rec.status;
 }
 

--- a/Xext/xace.h
+++ b/Xext/xace.h
@@ -37,14 +37,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /* security hooks */
 /* Constants used to identify the available security hooks
  */
-#define XACE_EXT_DISPATCH		1
 #define XACE_RESOURCE_ACCESS		2
 #define XACE_DEVICE_ACCESS		3
 #define XACE_PROPERTY_ACCESS		4
 #define XACE_SEND_ACCESS		5
 #define XACE_RECEIVE_ACCESS		6
 #define XACE_CLIENT_ACCESS		7
-#define XACE_EXT_ACCESS			8
 #define XACE_SERVER_ACCESS		9
 #define XACE_SELECTION_ACCESS		10
 #define XACE_SCREEN_ACCESS		11
@@ -66,12 +64,6 @@ int XaceHookIsSet(int hook);
 
 /* Special-cased hook functions
  */
-int XaceHookDispatch0(ClientPtr ptr, int major);
-#define XaceHookDispatch(c, m) \
-    ((XaceHooks[XACE_EXT_DISPATCH] && (m) >= EXTENSION_BASE) ? \
-    XaceHookDispatch0((c), (m)) : \
-    Success)
-
 int XaceHookPropertyAccess(ClientPtr ptr, WindowPtr pWin, PropertyPtr *ppProp,
                            Mask access_mode);
 int XaceHookSelectionAccess(ClientPtr ptr, Selection ** ppSel, Mask access_mode);
@@ -86,7 +78,6 @@ int XaceHookSendAccess(ClientPtr client, DeviceIntPtr dev, WindowPtr win,
                        xEventPtr ev, int count);
 int XaceHookReceiveAccess(ClientPtr client, WindowPtr win, xEventPtr ev, int count);
 int XaceHookClientAccess(ClientPtr client, ClientPtr target, Mask access_mode);
-int XaceHookExtAccess(ClientPtr client, ExtensionEntry *ext);
 int XaceHookServerAccess(ClientPtr client, Mask access_mode);
 int XaceHookScreenAccess(ClientPtr client, ScreenPtr screen, Mask access_mode);
 int XaceHookScreensaverAccess(ClientPtr client, ScreenPtr screen, Mask access_mode);

--- a/Xext/xacestr.h
+++ b/Xext/xacestr.h
@@ -86,15 +86,6 @@ typedef struct {
     int status;
 } XaceClientAccessRec;
 
-/* XACE_EXT_DISPATCH */
-/* XACE_EXT_ACCESS */
-typedef struct {
-    ClientPtr client;
-    ExtensionEntry *ext;
-    Mask access_mode;
-    int status;
-} XaceExtAccessRec;
-
 /* XACE_SERVER_ACCESS */
 typedef struct {
     ClientPtr client;

--- a/Xext/xselinux_hooks.c
+++ b/Xext/xselinux_hooks.c
@@ -33,6 +33,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <X11/Xfuncproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/extension_priv.h"
 #include "dix/input_priv.h"
 #include "dix/registry_priv.h"
 #include "dix/resource_priv.h"
@@ -454,7 +455,7 @@ SELinuxReceive(CallbackListPtr *pcbl, void *unused, void *calldata)
 static void
 SELinuxExtension(CallbackListPtr *pcbl, void *unused, void *calldata)
 {
-    XaceExtAccessRec *rec = calldata;
+    ExtensionAccessCallbackParam *rec = calldata;
     SELinuxSubjectRec *subj, *serv;
     SELinuxObjectRec *obj;
     SELinuxAuditRec auditdata = {.client = rec->client };
@@ -830,15 +831,15 @@ SELinuxFlaskReset(void)
     /* Unregister callbacks */
     DeleteCallback(&ClientStateCallback, SELinuxClientState, NULL);
     DeleteCallback(&ResourceStateCallback, SELinuxResourceState, NULL);
+    DeleteCallback(&ExtensionAccessCallback, SELinuxExtension, NULL);
+    DeleteCallback(&ExtensionDispatchCallback, SELinuxExtension, NULL);
 
-    XaceDeleteCallback(XACE_EXT_DISPATCH, SELinuxExtension, NULL);
     XaceDeleteCallback(XACE_RESOURCE_ACCESS, SELinuxResource, NULL);
     XaceDeleteCallback(XACE_DEVICE_ACCESS, SELinuxDevice, NULL);
     XaceDeleteCallback(XACE_PROPERTY_ACCESS, SELinuxProperty, NULL);
     XaceDeleteCallback(XACE_SEND_ACCESS, SELinuxSend, NULL);
     XaceDeleteCallback(XACE_RECEIVE_ACCESS, SELinuxReceive, NULL);
     XaceDeleteCallback(XACE_CLIENT_ACCESS, SELinuxClient, NULL);
-    XaceDeleteCallback(XACE_EXT_ACCESS, SELinuxExtension, NULL);
     XaceDeleteCallback(XACE_SERVER_ACCESS, SELinuxServer, NULL);
     XaceDeleteCallback(XACE_SELECTION_ACCESS, SELinuxSelection, NULL);
     XaceDeleteCallback(XACE_SCREEN_ACCESS, SELinuxScreen, NULL);
@@ -924,15 +925,15 @@ SELinuxFlaskInit(void)
     /* Register callbacks */
     ret &= AddCallback(&ClientStateCallback, SELinuxClientState, NULL);
     ret &= AddCallback(&ResourceStateCallback, SELinuxResourceState, NULL);
+    ret &= AddCallback(&ExtensionAccessCallback, SELinuxExtension, NULL);
+    ret &= AddCallback(&ExtensionDispatchCallback, SELinuxExtension, NULL);
 
-    ret &= XaceRegisterCallback(XACE_EXT_DISPATCH, SELinuxExtension, NULL);
     ret &= XaceRegisterCallback(XACE_RESOURCE_ACCESS, SELinuxResource, NULL);
     ret &= XaceRegisterCallback(XACE_DEVICE_ACCESS, SELinuxDevice, NULL);
     ret &= XaceRegisterCallback(XACE_PROPERTY_ACCESS, SELinuxProperty, NULL);
     ret &= XaceRegisterCallback(XACE_SEND_ACCESS, SELinuxSend, NULL);
     ret &= XaceRegisterCallback(XACE_RECEIVE_ACCESS, SELinuxReceive, NULL);
     ret &= XaceRegisterCallback(XACE_CLIENT_ACCESS, SELinuxClient, NULL);
-    ret &= XaceRegisterCallback(XACE_EXT_ACCESS, SELinuxExtension, NULL);
     ret &= XaceRegisterCallback(XACE_SERVER_ACCESS, SELinuxServer, NULL);
     ret &= XaceRegisterCallback(XACE_SELECTION_ACCESS, SELinuxSelection, NULL);
     ret &= XaceRegisterCallback(XACE_SCREEN_ACCESS, SELinuxScreen, NULL);

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -106,6 +106,7 @@ Equipment Corporation.
 #include "dix/colormap_priv.h"
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
+#include "dix/extension_priv.h"
 #include "dix/input_priv.h"
 #include "dix/gc_priv.h"
 #include "dix/registry_priv.h"
@@ -541,7 +542,16 @@ Dispatch(void)
                 if (result < 0 || result > (maxBigRequestSize << 2))
                     result = BadLength;
                 else {
-                    result = XaceHookDispatch(client, client->majorOp);
+                    result = Success;
+                    /* On extension requests, call the extension dispatch hook */
+                    if ((client->majorOp >= EXTENSION_BASE) && ExtensionDispatchCallback) {
+                        ExtensionEntry *ext = GetExtensionEntry(client->majorOp);
+                        if (ext) {
+                            ExtensionAccessCallbackParam erec = { client, ext, DixUseAccess, Success };
+                            CallCallbacks(&ExtensionDispatchCallback, &erec);
+                            result = erec.status;
+                        }
+                    }
                     if (result == Success) {
                         currentClient = client;
                         result =

--- a/dix/extension.c
+++ b/dix/extension.c
@@ -64,6 +64,9 @@ SOFTWARE.
 
 #define LAST_ERROR 255
 
+CallbackListPtr ExtensionAccessCallback = NULL;
+CallbackListPtr ExtensionDispatchCallback = NULL;
+
 static ExtensionEntry **extensions = (ExtensionEntry **) NULL;
 
 int lastEvent = EXTENSION_EVENT_BASE;
@@ -273,8 +276,12 @@ ExtensionAvailable(ClientPtr client, ExtensionEntry *ext)
 {
     if (!ext)
         return FALSE;
-    if (XaceHookExtAccess(client, ext) != Success)
+
+    ExtensionAccessCallbackParam rec = { client, ext, DixGetAttrAccess, Success };
+    CallCallbacks(&ExtensionAccessCallback, &rec);
+    if (rec.status != Success)
         return FALSE;
+
     if (!ext->base)
         return FALSE;
     return TRUE;

--- a/dix/extension_priv.h
+++ b/dix/extension_priv.h
@@ -5,7 +5,9 @@
 #ifndef _XSERVER_EXTENSION_PRIV_H
 #define _XSERVER_EXTENSION_PRIV_H
 
-#include "misc.h"
+#include "include/callback.h"
+#include "include/extnsionst.h"
+#include "include/misc.h"
 
 #define EXTENSION_MAJOR_APPLE_WM            (EXTENSION_BASE + 0)
 #define EXTENSION_MAJOR_APPLE_DRI           (EXTENSION_BASE + 1)
@@ -45,5 +47,15 @@
 #define EXTENSION_MAJOR_XVMC                (EXTENSION_BASE + 35)
 
 #define RESERVED_EXTENSIONS                 38
+
+typedef struct {
+    ClientPtr client;
+    ExtensionEntry *ext;
+    Mask access_mode;
+    int status;
+} ExtensionAccessCallbackParam;
+
+extern CallbackListPtr ExtensionAccessCallback;
+extern CallbackListPtr ExtensionDispatchCallback;
 
 #endif /* _XSERVER_EXTENSION_PRIV_H */


### PR DESCRIPTION
Move the callbacks directly into DIX, since it's actually core infrastructure.
Also simplifying the whole machinery, by just using a simpel CallbackListPtr.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
