### PR TITLE
dix: add callback before ClientRec is being destroyed

### DIFF
--- a/dix/client.c
+++ b/dix/client.c
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#include <dix-config.h>
+
+#include <stddef.h>
+
+#include "include/callback.h"
+
+CallbackListPtr ClientDestroyCallback = NULL;

--- a/dix/client_priv.h
+++ b/dix/client_priv.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef _XSERVER_DIX_CLIENT_PRIV_H
+#define _XSERVER_DIX_CLIENT_PRIV_H
+
+#include "include/callback.h"
+
+/*
+ * called right before ClientRec is about to be destroyed,
+ * after resources have been freed. argument is ClientPtr
+ */
+extern CallbackListPtr ClientDestroyCallback;
+
+#endif /* _XSERVER_DIX_CLIENT_PRIV_H */

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -103,6 +103,7 @@ Equipment Corporation.
 #include <X11/fonts/fontstruct.h>
 #include <X11/fonts/libxfont2.h>
 
+#include "dix/client_priv.h"
 #include "dix/colormap_priv.h"
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
@@ -3546,6 +3547,7 @@ CloseDownClient(ClientPtr client)
         TouchListenerGone(client->clientAsMask);
         GestureListenerGone(client->clientAsMask);
         FreeClientResources(client);
+        CallCallbacks(&ClientDestroyCallback, client);
         /* Disable client ID tracking. This must be done after
          * ClientStateCallback. */
         ReleaseClientIds(client);

--- a/dix/meson.build
+++ b/dix/meson.build
@@ -1,5 +1,6 @@
 srcs_dix = [
     'atom.c',
+    'client.c',
     'colormap.c',
     'color.c',
     'cursor.c',

--- a/os/client_priv.h
+++ b/os/client_priv.h
@@ -3,8 +3,8 @@
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  * Copyright © 2010 Nokia Corporation and/or its subsidiary(-ies).
  */
-#ifndef _XSERVER_DIX_CLIENT_PRIV_H
-#define _XSERVER_DIX_CLIENT_PRIV_H
+#ifndef _XSERVER_OS_CLIENT_PRIV_H
+#define _XSERVER_OS_CLIENT_PRIV_H
 
 #include <sys/types.h>
 #include <X11/Xdefs.h>


### PR DESCRIPTION
Existing client-state hook isn't sufficient for this, and so easy to
be extended cleanly (*1). Adding a new callback is trivial and cheap,
so preferring this way, instead of trying to tweak the existing hook
for something it's never been designed for.

*1) see discussion here: https://github.com/X11Libre/xserver/pull/1077

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
