### PR TITLE
Xext: namespace: fix NULL derefence on client close

### DIFF
--- a/Xext/namespace/hook-clientstate.c
+++ b/Xext/namespace/hook-clientstate.c
@@ -33,13 +33,23 @@ void hookClientState(CallbackListPtr *pcbl, void *unused, void *calldata)
         break;
 
     case ClientStateRetained:
-        XnamespaceAssignClient(subj, NULL);
         break;
     case ClientStateGone:
-        XnamespaceAssignClient(subj, NULL);
         break;
     default:
         XNS_HOOK_LOG("unknown state =%d\n", client->clientState);
         break;
     }
+}
+
+void hookClientDestroy(CallbackListPtr *pcbl, void *unused, void *calldata)
+{
+    ClientPtr client = calldata;
+    struct XnamespaceClientPriv *subj = XnsClientPriv(client);
+
+    if (!subj)
+        return; /* no XNS devprivate assigned ? */
+
+    XnamespaceAssignClient(subj, NULL);
+    /* the devprivate is embedded, so no free() necessary */
 }

--- a/Xext/namespace/hooks.h
+++ b/Xext/namespace/hooks.h
@@ -26,6 +26,7 @@
 
 void hookClient(CallbackListPtr *pcbl, void *unused, void *calldata);
 void hookClientState(CallbackListPtr *pcbl, void *unused, void *calldata);
+void hookClientDestroy(CallbackListPtr *pcbl, void *unused, void *calldata);
 void hookDevice(CallbackListPtr *pcbl, void *unused, void *calldata);
 void hookExtAccess(CallbackListPtr *pcbl, void *unused, void *calldata);
 void hookExtDispatch(CallbackListPtr *pcbl, void *unused, void *calldata);

--- a/Xext/namespace/namespace.c
+++ b/Xext/namespace/namespace.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <X11/Xmd.h>
 
+#include "dix/client_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/extension_priv.h"
 #include "dix/property_priv.h"
@@ -39,6 +40,7 @@ NamespaceExtensionInit(void)
           AddCallback(&ExtensionAccessCallback, hookExtAccess, NULL) &&
           AddCallback(&ExtensionDispatchCallback, hookExtDispatch, NULL) &&
           AddCallback(&ServerAccessCallback, hookServerAccess, NULL) &&
+          AddCallback(&ClientDestroyCallback, hookClientDestroy, NULL) &&
           XaceRegisterCallback(XACE_CLIENT_ACCESS, hookClient, NULL) &&
           XaceRegisterCallback(XACE_DEVICE_ACCESS, hookDevice, NULL) &&
           XaceRegisterCallback(XACE_PROPERTY_ACCESS, hookPropertyAccess, NULL) &&


### PR DESCRIPTION
Removing the namespace assignment of killed clients in ClientState-hook
is too early - we still need it later. Using the new ClientDestroyCallback
instead.

Closes: https://github.com/X11Libre/xserver/issues/486
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
