### PR TITLE
render: consolidate byte-swapping in ProcRenderFreeGlyphSet()

### DIFF
--- a/render/render.c
+++ b/render/render.c
@@ -103,7 +103,6 @@ static int SProcRenderTrapezoids(ClientPtr pClient);
 static int SProcRenderTriangles(ClientPtr pClient);
 static int SProcRenderTriStrip(ClientPtr pClient);
 static int SProcRenderTriFan(ClientPtr pClient);
-static int SProcRenderFreeGlyphSet(ClientPtr pClient);
 static int SProcRenderAddGlyphs(ClientPtr pClient);
 static int SProcRenderFreeGlyphs(ClientPtr pClient);
 static int SProcRenderCompositeGlyphs(ClientPtr pClient);
@@ -176,7 +175,7 @@ int (*SProcRenderVector[RenderNumberRequests]) (ClientPtr) = {
         _not_implemented, /* SProcRenderTransform */
         ProcRenderCreateGlyphSet,
         ProcRenderReferenceGlyphSet,
-        SProcRenderFreeGlyphSet,
+        ProcRenderFreeGlyphSet,
         SProcRenderAddGlyphs,
         _not_implemented, /* SProcRenderAddGlyphsFromPicture */
         SProcRenderFreeGlyphs,
@@ -903,8 +902,11 @@ ProcRenderFreeGlyphSet(ClientPtr client)
     int rc;
 
     REQUEST(xRenderFreeGlyphSetReq);
-
     REQUEST_SIZE_MATCH(xRenderFreeGlyphSetReq);
+
+    if (client->swapped)
+        swapl(&stuff->glyphset);
+
     rc = dixLookupResourceByType((void **) &glyphSet, stuff->glyphset,
                                  GlyphSetType, client, DixDestroyAccess);
     if (rc != Success) {
@@ -2031,15 +2033,6 @@ SProcRenderTriFan(ClientPtr client)
     swaps(&stuff->ySrc);
     SwapRestL(stuff);
     return ProcRenderTriFan(client);
-}
-
-static int _X_COLD
-SProcRenderFreeGlyphSet(ClientPtr client)
-{
-    REQUEST(xRenderFreeGlyphSetReq);
-    REQUEST_SIZE_MATCH(xRenderFreeGlyphSetReq);
-    swapl(&stuff->glyphset);
-    return ProcRenderFreeGlyphSet(client);
 }
 
 static int _X_COLD


### PR DESCRIPTION
No need for extra functions and call tables for the few trivial lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
