### PR TITLE
Xi: inline SProcXChangeDeviceControl()

### DIFF
--- a/Xi/chgdctl.c
+++ b/Xi/chgdctl.c
@@ -67,37 +67,6 @@ SOFTWARE.
 
 /***********************************************************************
  *
- * This procedure changes the control attributes for an extension device,
- * for clients on machines with a different byte ordering than the server.
- *
- */
-
-int _X_COLD
-SProcXChangeDeviceControl(ClientPtr client)
-{
-    xDeviceCtl *ctl;
-
-    REQUEST(xChangeDeviceControlReq);
-    REQUEST_AT_LEAST_EXTRA_SIZE(xChangeDeviceControlReq, sizeof(xDeviceCtl));
-    swaps(&stuff->control);
-    ctl = (xDeviceCtl *) &stuff[1];
-    swaps(&ctl->control);
-    swaps(&ctl->length);
-    switch (stuff->control) {
-    case DEVICE_ABS_CALIB:
-    case DEVICE_ABS_AREA:
-    case DEVICE_CORE:
-    case DEVICE_ENABLE:
-    case DEVICE_RESOLUTION:
-        /* hmm. beer. *drool* */
-        break;
-
-    }
-    return (ProcXChangeDeviceControl(client));
-}
-
-/***********************************************************************
- *
  * Change the control attributes.
  *
  */
@@ -105,6 +74,16 @@ SProcXChangeDeviceControl(ClientPtr client)
 int
 ProcXChangeDeviceControl(ClientPtr client)
 {
+    REQUEST(xChangeDeviceControlReq);
+    REQUEST_AT_LEAST_EXTRA_SIZE(xChangeDeviceControlReq, sizeof(xDeviceCtl));
+
+    if (client->swapped) {
+        swaps(&stuff->control);
+        xDeviceCtl *ctl = (xDeviceCtl *) &stuff[1];
+        swaps(&ctl->control);
+        swaps(&ctl->length);
+    }
+
     unsigned len;
     int i, status, ret = BadValue;
     DeviceIntPtr dev;
@@ -112,9 +91,6 @@ ProcXChangeDeviceControl(ClientPtr client)
     AxisInfoPtr a;
     CARD32 *resolution;
     xDeviceEnableCtl *e;
-
-    REQUEST(xChangeDeviceControlReq);
-    REQUEST_AT_LEAST_EXTRA_SIZE(xChangeDeviceControlReq, sizeof(xDeviceCtl));
 
     len = client->req_len - bytes_to_int32(sizeof(xChangeDeviceControlReq));
     ret = dixLookupDevice(&dev, stuff->deviceid, client, DixManageAccess);

--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -420,7 +420,7 @@ SProcIDispatch(ClientPtr client)
         case X_GetDeviceControl:
             return ProcXGetDeviceControl(client);
         case X_ChangeDeviceControl:
-            return SProcXChangeDeviceControl(client);
+            return ProcXChangeDeviceControl(client);
         /* XI 1.5 */
         case X_ListDeviceProperties:
             return ProcXListDeviceProperties(client);

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -69,7 +69,6 @@ int ProcXUngrabDeviceButton(ClientPtr client);
 int ProcXUngrabDevice(ClientPtr client);
 int ProcXUngrabDeviceKey(ClientPtr client);
 
-int SProcXChangeDeviceControl(ClientPtr client);
 int SProcXChangeDeviceDontPropagateList(ClientPtr client);
 int SProcXChangeFeedbackControl(ClientPtr client);
 int SProcXGetDeviceDontPropagateList(ClientPtr  client);

--- a/test/xi1/protocol-xchangedevicecontrol.c
+++ b/test/xi1/protocol-xchangedevicecontrol.c
@@ -78,7 +78,7 @@ request_ChangeDeviceControl(ClientPtr client, xChangeDeviceControlReq * req,
     swaps(&ctl->length);
     swaps(&ctl->control);
     /* XXX: swap other contents of ctl, depending on type */
-    rc = SProcXChangeDeviceControl(&client_request);
+    rc = ProcXChangeDeviceControl(&client_request);
     assert(rc == error);
 }
 


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
