### PR TITLE
Xi: inline SProcXGrabDevice()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -376,7 +376,7 @@ SProcIDispatch(ClientPtr client)
         case X_ChangePointerDevice:
             return ProcXChangePointerDevice(client);
         case X_GrabDevice:
-            return SProcXGrabDevice(client);
+            return ProcXGrabDevice(client);
         case X_UngrabDevice:
             return SProcXUngrabDevice(client);
         case X_GrabDeviceKey:

--- a/Xi/grabdev.c
+++ b/Xi/grabdev.c
@@ -68,31 +68,6 @@ extern int ExtEventIndex;
 
 /***********************************************************************
  *
- * Swap the request if the requestor has a different byte order than us.
- *
- */
-
-int _X_COLD
-SProcXGrabDevice(ClientPtr client)
-{
-    REQUEST(xGrabDeviceReq);
-    REQUEST_AT_LEAST_SIZE(xGrabDeviceReq);
-
-    swapl(&stuff->grabWindow);
-    swapl(&stuff->time);
-    swaps(&stuff->event_count);
-
-    if (client->req_len !=
-        bytes_to_int32(sizeof(xGrabDeviceReq)) + stuff->event_count)
-        return BadLength;
-
-    SwapLongs((CARD32 *) (&stuff[1]), stuff->event_count);
-
-    return (ProcXGrabDevice(client));
-}
-
-/***********************************************************************
- *
  * Grab an extension device.
  *
  */
@@ -100,17 +75,26 @@ SProcXGrabDevice(ClientPtr client)
 int
 ProcXGrabDevice(ClientPtr client)
 {
-    int rc;
-    DeviceIntPtr dev;
-    GrabMask mask;
-    struct tmask tmp[EMASKSIZE];
-
     REQUEST(xGrabDeviceReq);
     REQUEST_AT_LEAST_SIZE(xGrabDeviceReq);
+
+    if (client->swapped) {
+        swapl(&stuff->grabWindow);
+        swapl(&stuff->time);
+        swaps(&stuff->event_count);
+    }
 
     if (client->req_len !=
         bytes_to_int32(sizeof(xGrabDeviceReq)) + stuff->event_count)
         return BadLength;
+
+    if (client->swapped)
+        SwapLongs((CARD32 *) (&stuff[1]), stuff->event_count);
+
+    int rc;
+    DeviceIntPtr dev;
+    GrabMask mask;
+    struct tmask tmp[EMASKSIZE];
 
     xGrabDeviceReply rep = {
         .RepType = X_GrabDevice,

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -77,7 +77,6 @@ int SProcXGetDeviceMotionEvents(ClientPtr client);
 int SProcXGetExtensionVersion(ClientPtr client);
 int SProcXGetSelectedExtensionEvents(ClientPtr client);
 int SProcXGrabDeviceButton(ClientPtr client);
-int SProcXGrabDevice(ClientPtr client);
 int SProcXGrabDeviceKey(ClientPtr client);
 int SProcXIAllowEvents(ClientPtr client);
 int SProcXIBarrierReleasePointer(ClientPtr client);


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
