### PR TITLE
Xi: inline SProcXChangeFeedbackControl()

### DIFF
--- a/Xi/chgfctl.c
+++ b/Xi/chgfctl.c
@@ -60,22 +60,6 @@ SOFTWARE.
 
 #define DO_ALL    (-1)
 
-/***********************************************************************
- *
- * This procedure changes the control attributes for an extension device,
- * for clients on machines with a different byte ordering than the server.
- *
- */
-
-int _X_COLD
-SProcXChangeFeedbackControl(ClientPtr client)
-{
-    REQUEST(xChangeFeedbackControlReq);
-    REQUEST_AT_LEAST_SIZE(xChangeFeedbackControlReq);
-    swapl(&stuff->mask);
-    return (ProcXChangeFeedbackControl(client));
-}
-
 /******************************************************************************
  *
  * This procedure changes KbdFeedbackClass data.
@@ -420,6 +404,12 @@ ChangeLedFeedback(ClientPtr client, DeviceIntPtr dev, long unsigned int mask,
 int
 ProcXChangeFeedbackControl(ClientPtr client)
 {
+    REQUEST(xChangeFeedbackControlReq);
+    REQUEST_AT_LEAST_SIZE(xChangeFeedbackControlReq);
+
+    if (client->swapped)
+        swapl(&stuff->mask);
+
     unsigned len;
     DeviceIntPtr dev;
     KbdFeedbackPtr k;
@@ -429,9 +419,6 @@ ProcXChangeFeedbackControl(ClientPtr client)
     BellFeedbackPtr b;
     LedFeedbackPtr l;
     int rc;
-
-    REQUEST(xChangeFeedbackControlReq);
-    REQUEST_AT_LEAST_SIZE(xChangeFeedbackControlReq);
 
     len = client->req_len - bytes_to_int32(sizeof(xChangeFeedbackControlReq));
     rc = dixLookupDevice(&dev, stuff->deviceid, client, DixManageAccess);

--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -396,7 +396,7 @@ SProcIDispatch(ClientPtr client)
         case X_GetFeedbackControl:
             return ProcXGetFeedbackControl(client);
         case X_ChangeFeedbackControl:
-            return SProcXChangeFeedbackControl(client);
+            return ProcXChangeFeedbackControl(client);
         case X_GetDeviceKeyMapping:
             return ProcXGetDeviceKeyMapping(client);
         case X_ChangeDeviceKeyMapping:

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -71,7 +71,6 @@ int ProcXUngrabDeviceKey(ClientPtr client);
 
 int SProcXChangeDeviceControl(ClientPtr client);
 int SProcXChangeDeviceDontPropagateList(ClientPtr client);
-int SProcXChangeFeedbackControl(ClientPtr client);
 int SProcXGetDeviceDontPropagateList(ClientPtr  client);
 int SProcXGetDeviceMotionEvents(ClientPtr client);
 int SProcXGetExtensionVersion(ClientPtr client);


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
