### PR TITLE
Xi: inline SProcXSelectExtensionEvent()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -362,7 +362,7 @@ SProcIDispatch(ClientPtr client)
         case X_SetDeviceMode:
             return ProcXSetDeviceMode(client);
         case X_SelectExtensionEvent:
-            return SProcXSelectExtensionEvent(client);
+            return ProcXSelectExtensionEvent(client);
         case X_GetSelectedExtensionEvents:
             return SProcXGetSelectedExtensionEvents(client);
         case X_ChangeDeviceDontPropagateList:

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -96,7 +96,6 @@ int SProcXISetClientPointer(ClientPtr client);
 int SProcXISetFocus(ClientPtr client);
 int SProcXIUngrabDevice(ClientPtr client);
 int SProcXIWarpPointer(ClientPtr client);
-int SProcXSelectExtensionEvent(ClientPtr client);
 int SProcXSendExtensionEvent(ClientPtr client);
 int SProcXSetDeviceFocus(ClientPtr client);
 int SProcXUngrabDeviceButton(ClientPtr client);


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
