### PR TITLE
Xi: inline SProcXUngrabDevice()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -378,7 +378,7 @@ SProcIDispatch(ClientPtr client)
         case X_GrabDevice:
             return SProcXGrabDevice(client);
         case X_UngrabDevice:
-            return SProcXUngrabDevice(client);
+            return ProcXUngrabDevice(client);
         case X_GrabDeviceKey:
             return SProcXGrabDeviceKey(client);
         case X_UngrabDeviceKey:

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -100,7 +100,6 @@ int SProcXSelectExtensionEvent(ClientPtr client);
 int SProcXSendExtensionEvent(ClientPtr client);
 int SProcXSetDeviceFocus(ClientPtr client);
 int SProcXUngrabDeviceButton(ClientPtr client);
-int SProcXUngrabDevice(ClientPtr client);
 int SProcXUngrabDeviceKey(ClientPtr client);
 
 #endif /* _XSERVER_XI_HANDLERS_H */

--- a/Xi/ungrdev.c
+++ b/Xi/ungrdev.c
@@ -62,21 +62,6 @@ SOFTWARE.
 
 /***********************************************************************
  *
- * Handle requests from a client with a different byte order.
- *
- */
-
-int _X_COLD
-SProcXUngrabDevice(ClientPtr client)
-{
-    REQUEST(xUngrabDeviceReq);
-    REQUEST_SIZE_MATCH(xUngrabDeviceReq);
-    swapl(&stuff->time);
-    return (ProcXUngrabDevice(client));
-}
-
-/***********************************************************************
- *
  * Release a grab of an extension device.
  *
  */
@@ -84,13 +69,16 @@ SProcXUngrabDevice(ClientPtr client)
 int
 ProcXUngrabDevice(ClientPtr client)
 {
+    REQUEST(xUngrabDeviceReq);
+    REQUEST_SIZE_MATCH(xUngrabDeviceReq);
+
+    if (client->swapped)
+        swapl(&stuff->time);
+
     DeviceIntPtr dev;
     GrabPtr grab;
     TimeStamp time;
     int rc;
-
-    REQUEST(xUngrabDeviceReq);
-    REQUEST_SIZE_MATCH(xUngrabDeviceReq);
 
     rc = dixLookupDevice(&dev, stuff->deviceid, client, DixGetAttrAccess);
     if (rc != Success)


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
