### PR TITLE
Xi: inline SProcXIChangeCursor()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -436,7 +436,7 @@ SProcIDispatch(ClientPtr client)
         case X_XIWarpPointer:
             return SProcXIWarpPointer(client);
         case X_XIChangeCursor:
-            return SProcXIChangeCursor(client);
+            return ProcXIChangeCursor(client);
         case X_XIChangeHierarchy:
             return ProcXIChangeHierarchy(client);
         case X_XISetClientPointer:

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -81,7 +81,6 @@ int SProcXGrabDevice(ClientPtr client);
 int SProcXGrabDeviceKey(ClientPtr client);
 int SProcXIAllowEvents(ClientPtr client);
 int SProcXIBarrierReleasePointer(ClientPtr client);
-int SProcXIChangeCursor(ClientPtr client);
 int SProcXIGetClientPointer(ClientPtr client);
 int SProcXIGetFocus(ClientPtr client);
 int SProcXIGetSelectedEvents(ClientPtr client);

--- a/Xi/xichangecursor.c
+++ b/Xi/xichangecursor.c
@@ -54,27 +54,22 @@
  *
  */
 
-int _X_COLD
-SProcXIChangeCursor(ClientPtr client)
-{
-    REQUEST(xXIChangeCursorReq);
-    REQUEST_SIZE_MATCH(xXIChangeCursorReq);
-    swapl(&stuff->win);
-    swapl(&stuff->cursor);
-    swaps(&stuff->deviceid);
-    return (ProcXIChangeCursor(client));
-}
-
 int
 ProcXIChangeCursor(ClientPtr client)
 {
+    REQUEST(xXIChangeCursorReq);
+    REQUEST_SIZE_MATCH(xXIChangeCursorReq);
+
+    if (client->swapped) {
+        swapl(&stuff->win);
+        swapl(&stuff->cursor);
+        swaps(&stuff->deviceid);
+    }
+
     int rc;
     WindowPtr pWin = NULL;
     DeviceIntPtr pDev = NULL;
     CursorPtr pCursor = NULL;
-
-    REQUEST(xXIChangeCursorReq);
-    REQUEST_SIZE_MATCH(xXIChangeCursorReq);
 
     rc = dixLookupDevice(&pDev, stuff->deviceid, client, DixSetAttrAccess);
     if (rc != Success)


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
