### PR TITLE
dix: move request/response related functions to new request_priv.h header

### DIFF
--- a/Xext/bigreq.c
+++ b/Xext/bigreq.c
@@ -33,6 +33,7 @@ from The Open Group.
 #include <X11/extensions/bigreqsproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "miext/extinit_priv.h"
 
 #include "misc.h"

--- a/Xext/damage/damageext.c
+++ b/Xext/damage/damageext.c
@@ -27,6 +27,7 @@
 #include <X11/extensions/damageproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "include/pixmapstr.h"
 #include "miext/extinit_priv.h"
 #include "os/client_priv.h"

--- a/Xext/dpms.c
+++ b/Xext/dpms.c
@@ -33,6 +33,7 @@ Equipment Corporation.
 #include <X11/extensions/dpmsproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/screensaver.h"
 #include "Xext/geext_priv.h"

--- a/Xext/geext.c
+++ b/Xext/geext.c
@@ -29,6 +29,7 @@
 #include <X11/extensions/geproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "miext/extinit_priv.h"
 #include "Xext/geext_priv.h"
 

--- a/Xext/panoramiX.c
+++ b/Xext/panoramiX.c
@@ -32,6 +32,7 @@ Equipment Corporation.
 #include <X11/extensions/panoramiXproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "dix/screen_hooks_priv.h"

--- a/Xext/panoramiXprocs.c
+++ b/Xext/panoramiXprocs.c
@@ -32,6 +32,7 @@ Equipment Corporation.
 #include <X11/Xproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "dix/screenint_priv.h"
 #include "os/osdep.h"

--- a/Xext/saver.c
+++ b/Xext/saver.c
@@ -36,6 +36,7 @@ in this Software without prior written authorization from the X Consortium.
 #include "dix/colormap_priv.h"
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/window_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/osdep.h"

--- a/Xext/security.c
+++ b/Xext/security.c
@@ -32,6 +32,7 @@ in this Software without prior written authorization from The Open Group.
 
 #include "dix/dix_priv.h"
 #include "dix/registry_priv.h"
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/audit.h"

--- a/Xext/shape.c
+++ b/Xext/shape.c
@@ -33,6 +33,7 @@ in this Software without prior written authorization from The Open Group.
 
 #include "dix/dix_priv.h"
 #include "dix/gc_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "dix/window_priv.h"
 #include "miext/extinit_priv.h"

--- a/Xext/shm.c
+++ b/Xext/shm.c
@@ -43,6 +43,7 @@ in this Software without prior written authorization from The Open Group.
 #include <X11/Xfuncproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/screenint_priv.h"
 #include "dix/screen_hooks_priv.h"
 #include "miext/extinit_priv.h"

--- a/Xext/sync.c
+++ b/Xext/sync.c
@@ -59,6 +59,7 @@ PERFORMANCE OF THIS SOFTWARE.
 #include <X11/extensions/syncproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/bug_priv.h"
 #include "os/osdep.h"

--- a/Xext/vidmode.c
+++ b/Xext/vidmode.c
@@ -38,6 +38,7 @@ from Kaleb S. KEITHLEY
 #include <X11/extensions/xf86vmproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "os/log_priv.h"
 #include "os/osdep.h"

--- a/Xext/xcmisc.c
+++ b/Xext/xcmisc.c
@@ -34,6 +34,7 @@ from The Open Group.
 #include <X11/extensions/xcmiscproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "miext/extinit_priv.h"

--- a/Xext/xf86bigfont.c
+++ b/Xext/xf86bigfont.c
@@ -56,6 +56,7 @@
 #include <X11/fonts/libxfont2.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "miext/extinit_priv.h"
 
 #include "misc.h"

--- a/Xext/xres.c
+++ b/Xext/xres.c
@@ -13,6 +13,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/registry_priv.h"
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "os/client_priv.h"
 #include "miext/extinit_priv.h"

--- a/Xext/xselinux_ext.c
+++ b/Xext/xselinux_ext.c
@@ -21,6 +21,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/property_priv.h"
+#include "dix/request_priv.h"
 #include "dix/selection_priv.h"
 #include "miext/extinit_priv.h"
 

--- a/Xext/xtest.c
+++ b/Xext/xtest.c
@@ -39,6 +39,7 @@
 #include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
 #include "dix/inpututils_priv.h"
+#include "dix/request_priv.h"
 #include "mi/mi_priv.h"
 #include "mi/mipointer_priv.h"
 #include "miext/extinit_priv.h"

--- a/Xext/xvdisp.c
+++ b/Xext/xvdisp.c
@@ -32,6 +32,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/rpcbuf_priv.h"
+#include "dix/request_priv.h"
 #include "dix/screenint_priv.h"
 #include "Xext/xvdix_priv.h"
 #include "Xext/panoramiX.h"

--- a/Xext/xvmc.c
+++ b/Xext/xvmc.c
@@ -10,6 +10,7 @@
 #include <X11/extensions/XvMCproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/screen_hooks_priv.h"
 #include "miext/extinit_priv.h"
 #include "Xext/xvdix_priv.h"

--- a/Xi/chgdctl.c
+++ b/Xi/chgdctl.c
@@ -58,6 +58,7 @@ SOFTWARE.
 #include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "Xi/handlers.h"
 

--- a/Xi/getbmap.c
+++ b/Xi/getbmap.c
@@ -56,6 +56,7 @@ SOFTWARE.
 #include <X11/extensions/XIproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "Xi/handlers.h"
 

--- a/Xi/getdctl.c
+++ b/Xi/getdctl.c
@@ -50,6 +50,7 @@ SOFTWARE.
 #include <X11/extensions/XIproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "Xi/handlers.h"
 

--- a/Xi/getfctl.c
+++ b/Xi/getfctl.c
@@ -56,6 +56,7 @@ SOFTWARE.
 #include <X11/extensions/XIproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "Xi/handlers.h"
 

--- a/Xi/getfocus.c
+++ b/Xi/getfocus.c
@@ -56,6 +56,7 @@ SOFTWARE.
 #include <X11/extensions/XIproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "windowstr.h"          /* focus struct      */

--- a/Xi/getkmap.c
+++ b/Xi/getkmap.c
@@ -56,6 +56,7 @@ SOFTWARE.
 #include <X11/extensions/XIproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "Xi/handlers.h"
 

--- a/Xi/getmmap.c
+++ b/Xi/getmmap.c
@@ -57,6 +57,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/rpcbuf_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */

--- a/Xi/getprop.c
+++ b/Xi/getprop.c
@@ -56,6 +56,7 @@ SOFTWARE.
 #include <X11/extensions/XIproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "Xi/handlers.h"
 

--- a/Xi/getselev.c
+++ b/Xi/getselev.c
@@ -57,6 +57,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/resource_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "Xi/handlers.h"
 

--- a/Xi/getvers.c
+++ b/Xi/getvers.c
@@ -56,6 +56,7 @@ SOFTWARE.
 #include <X11/extensions/XIproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */

--- a/Xi/grabdev.c
+++ b/Xi/grabdev.c
@@ -56,6 +56,7 @@ SOFTWARE.
 #include <X11/extensions/XIproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */

--- a/Xi/gtmotion.c
+++ b/Xi/gtmotion.c
@@ -57,6 +57,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "Xi/handlers.h"
 

--- a/Xi/listdev.c
+++ b/Xi/listdev.c
@@ -59,6 +59,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "Xi/handlers.h"
 

--- a/Xi/opendev.c
+++ b/Xi/opendev.c
@@ -57,6 +57,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "Xi/handlers.h"
 

--- a/Xi/queryst.c
+++ b/Xi/queryst.c
@@ -40,6 +40,7 @@ from The Open Group.
 #include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "Xi/handlers.h"
 

--- a/Xi/setbmap.c
+++ b/Xi/setbmap.c
@@ -57,6 +57,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */

--- a/Xi/setdval.c
+++ b/Xi/setdval.c
@@ -57,6 +57,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "Xi/handlers.h"
 

--- a/Xi/setmmap.c
+++ b/Xi/setmmap.c
@@ -58,6 +58,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */

--- a/Xi/setmode.c
+++ b/Xi/setmode.c
@@ -57,6 +57,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "Xi/handlers.h"
 

--- a/Xi/xigetclientpointer.c
+++ b/Xi/xigetclientpointer.c
@@ -31,6 +31,7 @@
 #include <X11/extensions/XI2proto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */

--- a/Xi/xigrabdev.c
+++ b/Xi/xigrabdev.c
@@ -37,6 +37,7 @@
 #include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
 #include "dix/inpututils_priv.h"
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "Xi/handlers.h"
 

--- a/Xi/xipassivegrab.c
+++ b/Xi/xipassivegrab.c
@@ -39,6 +39,7 @@
 #include "dix/exevents_priv.h"
 #include "dix/inpututils_priv.h"
 #include "dix/rpcbuf_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */

--- a/Xi/xiproperty.c
+++ b/Xi/xiproperty.c
@@ -36,6 +36,7 @@
 #include "dix/exevents_priv.h"
 #include "dix/extension_priv.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "Xi/handlers.h"
 

--- a/Xi/xiquerydevice.c
+++ b/Xi/xiquerydevice.c
@@ -38,6 +38,7 @@
 #include "dix/exevents_priv.h"
 #include "dix/input_priv.h"
 #include "dix/inpututils_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "os/fmt.h"
 #include "Xi/handlers.h"

--- a/Xi/xiquerypointer.c
+++ b/Xi/xiquerypointer.c
@@ -41,6 +41,7 @@
 #include "dix/exevents_priv.h"
 #include "dix/input_priv.h"
 #include "dix/inpututils_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "dix/screenint_priv.h"
 #include "os/fmt.h"

--- a/Xi/xiqueryversion.c
+++ b/Xi/xiqueryversion.c
@@ -37,6 +37,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
+#include "dix/request_priv.h"
 #include "os/fmt.h"
 #include "Xi/handlers.h"
 

--- a/Xi/xiselectev.c
+++ b/Xi/xiselectev.c
@@ -30,6 +30,7 @@
 #include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
 #include "dix/inpututils_priv.h"
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "Xi/handlers.h"
 

--- a/Xi/xisetdevfocus.c
+++ b/Xi/xisetdevfocus.c
@@ -34,6 +34,7 @@
 #include <X11/extensions/XI2proto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */

--- a/composite/compext.c
+++ b/composite/compext.c
@@ -44,6 +44,7 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/screenint_priv.h"
 #include "miext/extinit_priv.h"
 #include "Xext/panoramiXsrv.h"

--- a/dbe/dbe.c
+++ b/dbe/dbe.c
@@ -40,6 +40,7 @@
 #include <X11/Xproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "dix/screen_hooks_priv.h"
 #include "miext/extinit_priv.h"

--- a/dix/devices.c
+++ b/dix/devices.c
@@ -60,6 +60,7 @@ SOFTWARE.
 #include "dix/exevents_priv.h"
 #include "dix/input_priv.h"
 #include "dix/ptrveloc_priv.h"
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "dix/screenint_priv.h"
 #include "mi/mi_priv.h"

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -110,6 +110,7 @@ Equipment Corporation.
 #include "dix/input_priv.h"
 #include "dix/gc_priv.h"
 #include "dix/registry_priv.h"
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "dix/screenint_priv.h"
 #include "dix/selection_priv.h"

--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -701,24 +701,6 @@ static inline ClientPtr dixLookupXIDOwner(XID xid)
 }
 
 /*
- * @brief write rpc buffer to client and then clear it
- *
- * @param pClient the client to write buffer to
- * @param rpcbuf  the buffer whose contents will be written
- * @return the result of WriteToClient() call
- */
-static inline ssize_t WriteRpcbufToClient(ClientPtr pClient,
-                                          x_rpcbuf_t *rpcbuf) {
-    /* explicitly casting between (s)size_t and int - should be safe,
-       since payloads are always small enough to easily fit into int. */
-    ssize_t ret = WriteToClient(pClient,
-                                (int)rpcbuf->wpos,
-                                rpcbuf->buffer);
-    x_rpcbuf_clear(rpcbuf);
-    return ret;
-}
-
-/*
  * @brief make atom from null-terminated string
  *
  * if atom already existing, return the existing Atom ID
@@ -741,76 +723,6 @@ static inline Atom dixAddAtom(const char *name) {
 static inline Atom dixGetAtomID(const char *name) {
     return MakeAtom(name, (unsigned int)strlen(name), FALSE);
 }
-
-/* compute the amount of extra units a reply header needs.
- *
- * all reply header structs are at least the size of xGenericReply
- * we have to count how many units the header is bigger than xGenericReply
- *
- */
-#define X_REPLY_HEADER_UNITS(hdrtype) \
-    (bytes_to_int32((sizeof(hdrtype) - sizeof(xGenericReply))))
-
-static inline int __write_reply_hdr_and_rpcbuf(
-    ClientPtr pClient, void *hdrData, size_t hdrLen, x_rpcbuf_t *rpcbuf)
-{
-    if (rpcbuf->error)
-        return BadAlloc;
-
-    xGenericReply *reply = hdrData;
-    reply->type = X_Reply;
-    reply->length = (bytes_to_int32(hdrLen - sizeof(xGenericReply)))
-                  + x_rpcbuf_wsize_units(rpcbuf);
-    reply->sequenceNumber = (CARD16)pClient->sequence; /* shouldn't go above 64k */
-
-    if (pClient->swapped) {
-         swaps(&reply->sequenceNumber);
-         swapl(&reply->length);
-    }
-
-    WriteToClient(pClient, (int)hdrLen, hdrData);
-    WriteRpcbufToClient(pClient, rpcbuf);
-
-    return Success;
-}
-
-static inline int __write_reply_hdr_simple(
-    ClientPtr pClient, void *hdrData, size_t hdrLen)
-{
-    xGenericReply *reply = hdrData;
-    reply->type = X_Reply;
-    reply->length = (bytes_to_int32(hdrLen - sizeof(xGenericReply)));
-    reply->sequenceNumber = (CARD16)pClient->sequence; /* shouldn't go above 64k */
-
-    if (pClient->swapped) {
-         swaps(&reply->sequenceNumber);
-         swapl(&reply->length);
-    }
-
-    WriteToClient(pClient, (int)hdrLen, hdrData);
-    return Success;
-}
-
-/*
- * send reply with header struct (not pointer!) along with rpcbuf payload
- *
- * @param client      pointer to the client (ClientPtr)
- * @param hdrstruct   the header struct (not pointer, the struct itself!)
- * @param rpcbuf      the rpcbuf to send (not pointer, the struct itself!)
- * return             X11 result code
- */
-#define X_SEND_REPLY_WITH_RPCBUF(client, hdrstruct, rpcbuf) \
-    __write_reply_hdr_and_rpcbuf(client, &(hdrstruct), sizeof(hdrstruct), &(rpcbuf));
-
-/*
- * send reply with header struct (not pointer!) without any payload
- *
- * @param client      pointer to the client (ClientPtr)
- * @param hdrstruct   the header struct (not pointer, the struct itself!)
- * @return            X11 result code (=Success)
- */
-#define X_SEND_REPLY_SIMPLE(client, hdrstruct) \
-    __write_reply_hdr_simple(client, &(hdrstruct), sizeof(hdrstruct));
 
 /*
  * transmit raw event into client's buffer

--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -59,6 +59,7 @@ Equipment Corporation.
 
 #include "dix/dix_priv.h"
 #include "dix/gc_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "dix/screenint_priv.h"
 #include "include/swaprep.h"

--- a/dix/events.c
+++ b/dix/events.c
@@ -127,6 +127,7 @@ Equipment Corporation.
 #include "dix/input_priv.h"
 #include "dix/inpututils_priv.h"
 #include "dix/reqhandlers_priv.h"
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "dix/screenint_priv.h"
 #include "dix/window_priv.h"

--- a/dix/extension.c
+++ b/dix/extension.c
@@ -52,6 +52,7 @@ SOFTWARE.
 #include "dix/dix_priv.h"
 #include "dix/extension_priv.h"
 #include "dix/registry_priv.h"
+#include "dix/request_priv.h"
 
 #include "misc.h"
 #include "dixstruct.h"

--- a/dix/property.c
+++ b/dix/property.c
@@ -52,6 +52,7 @@ SOFTWARE.
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
 #include "dix/property_priv.h"
+#include "dix/request_priv.h"
 #include "dix/window_priv.h"
 #include "Xext/panoramiX.h"
 #include "Xext/panoramiXsrv.h"

--- a/dix/request_priv.h
+++ b/dix/request_priv.h
@@ -1,0 +1,104 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef _XSERVER_DIX_REQUEST_PRIV_H
+#define _XSERVER_DIX_REQUEST_PRIV_H
+
+#include <X11/Xproto.h>
+
+#include "dix/rpcbuf_priv.h" /* x_rpcbuf_t */
+#include "include/dix.h"
+#include "include/dixstruct.h"
+#include "include/misc.h"    /* bytes_to_int32 */
+#include "include/os.h"      /* WriteToClient */
+
+/*
+ * @brief write rpc buffer to client and then clear it
+ *
+ * @param pClient the client to write buffer to
+ * @param rpcbuf  the buffer whose contents will be written
+ * @return the result of WriteToClient() call
+ */
+static inline ssize_t WriteRpcbufToClient(ClientPtr pClient,
+                                          x_rpcbuf_t *rpcbuf) {
+    /* explicitly casting between (s)size_t and int - should be safe,
+       since payloads are always small enough to easily fit into int. */
+    ssize_t ret = WriteToClient(pClient,
+                                (int)rpcbuf->wpos,
+                                rpcbuf->buffer);
+    x_rpcbuf_clear(rpcbuf);
+    return ret;
+}
+
+/* compute the amount of extra units a reply header needs.
+ *
+ * all reply header structs are at least the size of xGenericReply
+ * we have to count how many units the header is bigger than xGenericReply
+ *
+ */
+#define X_REPLY_HEADER_UNITS(hdrtype) \
+    (bytes_to_int32((sizeof(hdrtype) - sizeof(xGenericReply))))
+
+static inline int __write_reply_hdr_and_rpcbuf(
+    ClientPtr pClient, void *hdrData, size_t hdrLen, x_rpcbuf_t *rpcbuf)
+{
+    if (rpcbuf->error)
+        return BadAlloc;
+
+    xGenericReply *reply = hdrData;
+    reply->type = X_Reply;
+    reply->length = (bytes_to_int32(hdrLen - sizeof(xGenericReply)))
+                  + x_rpcbuf_wsize_units(rpcbuf);
+    reply->sequenceNumber = (CARD16)pClient->sequence; /* shouldn't go above 64k */
+
+    if (pClient->swapped) {
+         swaps(&reply->sequenceNumber);
+         swapl(&reply->length);
+    }
+
+    WriteToClient(pClient, (int)hdrLen, hdrData);
+    WriteRpcbufToClient(pClient, rpcbuf);
+
+    return Success;
+}
+
+static inline int __write_reply_hdr_simple(
+    ClientPtr pClient, void *hdrData, size_t hdrLen)
+{
+    xGenericReply *reply = hdrData;
+    reply->type = X_Reply;
+    reply->length = (bytes_to_int32(hdrLen - sizeof(xGenericReply)));
+    reply->sequenceNumber = (CARD16)pClient->sequence; /* shouldn't go above 64k */
+
+    if (pClient->swapped) {
+         swaps(&reply->sequenceNumber);
+         swapl(&reply->length);
+    }
+
+    WriteToClient(pClient, (int)hdrLen, hdrData);
+    return Success;
+}
+
+/*
+ * send reply with header struct (not pointer!) along with rpcbuf payload
+ *
+ * @param client      pointer to the client (ClientPtr)
+ * @param hdrstruct   the header struct (not pointer, the struct itself!)
+ * @param rpcbuf      the rpcbuf to send (not pointer, the struct itself!)
+ * return             X11 result code
+ */
+#define X_SEND_REPLY_WITH_RPCBUF(client, hdrstruct, rpcbuf) \
+    __write_reply_hdr_and_rpcbuf(client, &(hdrstruct), sizeof(hdrstruct), &(rpcbuf));
+
+/*
+ * send reply with header struct (not pointer!) without any payload
+ *
+ * @param client      pointer to the client (ClientPtr)
+ * @param hdrstruct   the header struct (not pointer, the struct itself!)
+ * @return            X11 result code (=Success)
+ */
+#define X_SEND_REPLY_SIMPLE(client, hdrstruct) \
+    __write_reply_hdr_simple(client, &(hdrstruct), sizeof(hdrstruct));
+
+#endif /* _XSERVER_DIX_REQUEST_PRIV_H */

--- a/dix/selection.c
+++ b/dix/selection.c
@@ -47,6 +47,7 @@ SOFTWARE.
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/selection_priv.h"
 
 #include "windowstr.h"

--- a/dix/window.c
+++ b/dix/window.c
@@ -106,6 +106,7 @@ Equipment Corporation.
 #include "dix/input_priv.h"
 #include "dix/inpututils_priv.h"
 #include "dix/property_priv.h"
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "dix/screenint_priv.h"
 #include "dix/selection_priv.h"

--- a/dri3/dri3_request.c
+++ b/dri3/dri3_request.c
@@ -24,6 +24,7 @@
 #include <unistd.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "os/client_priv.h"
 
 #include "dri3_priv.h"

--- a/glx/glxcmds.c
+++ b/glx/glxcmds.c
@@ -37,6 +37,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/resource_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "os/bug_priv.h"
 

--- a/glx/indirect_program.c
+++ b/glx/indirect_program.c
@@ -30,6 +30,8 @@
  */
 #include <dix-config.h>
 
+#include "dix/request_priv.h"
+
 #include "glxserver.h"
 #include "glxext.h"
 #include "misc.h"

--- a/glx/indirect_texture_compression.c
+++ b/glx/indirect_texture_compression.c
@@ -24,6 +24,8 @@
  */
 #include <dix-config.h>
 
+#include "dix/request_priv.h"
+
 #include "glxserver.h"
 #include "glxext.h"
 #include "misc.h"

--- a/glx/indirect_util.c
+++ b/glx/indirect_util.c
@@ -31,6 +31,7 @@
 #include <GL/glxproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 
 #include "indirect_size.h"

--- a/glx/single2.c
+++ b/glx/single2.c
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 
 #include "glxserver.h"

--- a/glx/single2swap.c
+++ b/glx/single2swap.c
@@ -30,6 +30,8 @@
 
 #include <dix-config.h>
 
+#include "dix/request_priv.h"
+
 #include "glxserver.h"
 #include "glxutil.h"
 #include "glxext.h"

--- a/glx/singlepix.c
+++ b/glx/singlepix.c
@@ -30,6 +30,8 @@
 
 #include <dix-config.h>
 
+#include "dix/request_priv.h"
+
 #include "glxserver.h"
 #include "glxext.h"
 #include "singlesize.h"

--- a/glx/unpack.h
+++ b/glx/unpack.h
@@ -1,6 +1,8 @@
 #ifndef __GLX_unpack_h__
 #define __GLX_unpack_h__
 
+#include "dix/request_priv.h"
+
 /*
  * SGI FREE SOFTWARE LICENSE B (Version 2.0, Sept. 18, 2008)
  * Copyright (C) 1991-2000 Silicon Graphics, Inc. All Rights Reserved.

--- a/glx/vndcmds.c
+++ b/glx/vndcmds.c
@@ -29,6 +29,8 @@
 
 #include <dix-config.h>
 
+#include "dix/request_priv.h"
+
 #include "hashtable.h"
 #include "vndserver_priv.h"
 #include "vndservervendor.h"

--- a/hw/xfree86/common/xf86DGA.c
+++ b/hw/xfree86/common/xf86DGA.c
@@ -50,6 +50,7 @@
 #include "dix/dix_priv.h"
 #include "dix/eventconvert.h"
 #include "dix/exevents_priv.h"
+#include "dix/request_priv.h"
 #include "dix/screen_hooks_priv.h"
 #include "mi/mi_priv.h"
 

--- a/hw/xfree86/dri/xf86dri.c
+++ b/hw/xfree86/dri/xf86dri.c
@@ -43,6 +43,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <X11/Xproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 
 #include "xf86.h"
 #include "misc.h"

--- a/hw/xfree86/dri2/dri2ext.c
+++ b/hw/xfree86/dri2/dri2ext.c
@@ -40,6 +40,7 @@
 #include <X11/extensions/xfixeswire.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 
 #include "dixstruct.h"
 #include "scrnintstr.h"

--- a/hw/xquartz/applewm.c
+++ b/hw/xquartz/applewm.c
@@ -36,6 +36,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/property_priv.h"
+#include "dix/request_priv.h"
 
 #include "quartz.h"
 

--- a/hw/xquartz/xpr/appledri.c
+++ b/hw/xquartz/xpr/appledri.c
@@ -42,6 +42,7 @@
 #include <X11/Xproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 
 #include "misc.h"
 #include "dixstruct.h"

--- a/hw/xwin/dri/windowsdri.c
+++ b/hw/xwin/dri/windowsdri.c
@@ -27,6 +27,8 @@
 #include <X11/Xproto.h>
 #include <X11/extensions/windowsdristr.h>
 
+#include "dix/request_priv.h"
+
 #include "dixstruct.h"
 #include "extnsionst.h"
 #include "scrnintstr.h"

--- a/present/present_request.c
+++ b/present/present_request.c
@@ -22,6 +22,7 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dri3/dri3_priv.h"
 
 #include "present_priv.h"

--- a/pseudoramiX/pseudoramiX.c
+++ b/pseudoramiX/pseudoramiX.c
@@ -38,6 +38,7 @@
 #include <X11/Xfuncproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "miext/extinit_priv.h"
 
 #include "pseudoramiX.h"

--- a/randr/rrcrtc.c
+++ b/randr/rrcrtc.c
@@ -25,6 +25,7 @@
 #include <X11/Xatom.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "randr/randrstr_priv.h"
 #include "randr/rrdispatch_priv.h"

--- a/randr/rrdispatch.c
+++ b/randr/rrdispatch.c
@@ -22,6 +22,7 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "randr/randrstr_priv.h"
 #include "randr/rrdispatch_priv.h"
 #include "os/fmt.h"

--- a/randr/rrlease.c
+++ b/randr/rrlease.c
@@ -24,6 +24,7 @@
 #include <unistd.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "randr/randrstr_priv.h"
 #include "randr/rrdispatch_priv.h"
 #include "os/client_priv.h"

--- a/randr/rrmode.c
+++ b/randr/rrmode.c
@@ -22,6 +22,7 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "randr/randrstr_priv.h"
 #include "randr/rrdispatch_priv.h"
 

--- a/randr/rrmonitor.c
+++ b/randr/rrmonitor.c
@@ -22,6 +22,7 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "randr/randrstr_priv.h"
 #include "randr/rrdispatch_priv.h"
 

--- a/randr/rroutput.c
+++ b/randr/rroutput.c
@@ -25,6 +25,7 @@
 #include <X11/Xatom.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "randr/randrstr_priv.h"
 #include "randr/rrdispatch_priv.h"
 

--- a/randr/rrproperty.c
+++ b/randr/rrproperty.c
@@ -24,6 +24,7 @@
 #include <X11/Xatom.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "randr/rrdispatch_priv.h"
 
 #include "randrstr_priv.h"

--- a/randr/rrprovider.c
+++ b/randr/rrprovider.c
@@ -27,6 +27,7 @@
 #include <X11/Xatom.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "randr/randrstr_priv.h"
 #include "randr/rrdispatch_priv.h"
 

--- a/randr/rrproviderproperty.c
+++ b/randr/rrproviderproperty.c
@@ -22,6 +22,7 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "randr/randrstr_priv.h"
 #include "randr/rrdispatch_priv.h"
 

--- a/randr/rrscreen.c
+++ b/randr/rrscreen.c
@@ -22,6 +22,7 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "randr/randrstr_priv.h"
 #include "randr/rrdispatch_priv.h"
 

--- a/randr/rrxinerama.c
+++ b/randr/rrxinerama.c
@@ -73,6 +73,7 @@
 #include <X11/extensions/panoramiXproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "randr/randrstr_priv.h"
 
 #include "swaprep.h"

--- a/record/record.c
+++ b/record/record.c
@@ -43,6 +43,7 @@ and Jim Haggerty of Metheus.
 #include "dix/dix_priv.h"
 #include "dix/eventconvert.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "dix/screenint_priv.h"
 #include "miext/extinit_priv.h"

--- a/render/render.c
+++ b/render/render.c
@@ -34,6 +34,7 @@
 #include "dix/colormap_priv.h"
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/screenint_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/osdep.h"

--- a/xfixes/cursor.c
+++ b/xfixes/cursor.c
@@ -47,6 +47,7 @@
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "dix/screen_hooks_priv.h"
 #include "dix/screenint_priv.h"

--- a/xfixes/disconnect.c
+++ b/xfixes/disconnect.c
@@ -45,6 +45,7 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 
 #include "xfixesint.h"
 

--- a/xfixes/region.c
+++ b/xfixes/region.c
@@ -23,6 +23,7 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "dix/window_priv.h"
 #include "render/picturestr_priv.h"

--- a/xfixes/xfixes.c
+++ b/xfixes/xfixes.c
@@ -45,6 +45,7 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/fmt.h"
 

--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -33,6 +33,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <X11/extensions/XKMformat.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/osdep.h"


### PR DESCRIPTION
Move functions/macros dealing with request parsing or reply assembly/write
out of the big dix_priv.h into their own headers. This new header will also
get more of those function/macros soon (yet still in the pipeline).

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
