### PR TITLE
os: xtrans: drop unused _XSERVTransBytesReadable()

### DIFF
--- a/os/Xtrans.c
+++ b/os/Xtrans.c
@@ -695,11 +695,6 @@ XtransConnInfo _XSERVTransAccept (XtransConnInfo ciptr, int *status)
     return newciptr;
 }
 
-int _XSERVTransBytesReadable (XtransConnInfo ciptr, BytesReadable_t *pend)
-{
-    return ciptr->transptr->BytesReadable (ciptr, pend);
-}
-
 int _XSERVTransRead (XtransConnInfo ciptr, char *buf, int size)
 {
     return ciptr->transptr->Read (ciptr, buf, size);

--- a/os/Xtrans.h
+++ b/os/Xtrans.h
@@ -103,12 +103,6 @@ typedef	struct {
 } Xtransaddr;
 #endif
 
-#ifdef LONG64
-typedef int BytesReadable_t;
-#else
-typedef long BytesReadable_t;
-#endif
-
 typedef struct _XtransConnInfo *XtransConnInfo;
 
 /*
@@ -201,11 +195,6 @@ int _XSERVTransResetListener (
 XtransConnInfo _XSERVTransAccept (
     XtransConnInfo,	/* ciptr */
     int *		/* status */
-);
-
-int _XSERVTransBytesReadable (
-    XtransConnInfo,	/* ciptr */
-    BytesReadable_t *	/* pend */
 );
 
 int _XSERVTransRead (

--- a/os/Xtransint.h
+++ b/os/Xtransint.h
@@ -170,11 +170,6 @@ typedef struct _Xtransport {
         int *			/* status */
     );
 
-    int	(*BytesReadable)(
-	XtransConnInfo,		/* connection */
-	BytesReadable_t *	/* pend */
-    );
-
     int	(*Read)(
 	XtransConnInfo,		/* connection */
 	char *,			/* buf */

--- a/os/Xtranslcl.c
+++ b/os/Xtranslcl.c
@@ -739,14 +739,6 @@ static XtransConnInfo _XSERVTransLocalAccept(XtransConnInfo ciptr, int *status)
     return newciptr;
 }
 
-static int _XSERVTransLocalBytesReadable(XtransConnInfo ciptr, BytesReadable_t *pend )
-{
-    prmsg(2,"LocalBytesReadable(%p->%d,%p)\n",
-          (void *) ciptr, ciptr->fd, (void *) pend);
-
-    return ioctl(ciptr->fd, FIONREAD, (char *)pend);
-}
-
 static int _XSERVTransLocalRead(XtransConnInfo ciptr, char *buf, int size)
 {
     prmsg(2,"LocalRead(%d,%p,%d)\n", ciptr->fd, (void *) buf, size );
@@ -828,7 +820,6 @@ static Xtransport _XSERVTransLocalFuncs = {
 	_XSERVTransLocalCreateListener,
 	_XSERVTransLocalResetListener,
 	_XSERVTransLocalAccept,
-	_XSERVTransLocalBytesReadable,
 	_XSERVTransLocalRead,
 	_XSERVTransLocalWrite,
 #if XTRANS_SEND_FDS
@@ -854,7 +845,6 @@ static Xtransport _XSERVTransNAMEDFuncs = {
 	_XSERVTransLocalCreateListener,
 	_XSERVTransLocalResetListener,
 	_XSERVTransLocalAccept,
-	_XSERVTransLocalBytesReadable,
 	_XSERVTransLocalRead,
 	_XSERVTransLocalWrite,
 #if XTRANS_SEND_FDS
@@ -877,7 +867,6 @@ static Xtransport _XSERVTransPIPEFuncs = {
 	_XSERVTransLocalCreateListener,
 	_XSERVTransLocalResetListener,
 	_XSERVTransLocalAccept,
-	_XSERVTransLocalBytesReadable,
 	_XSERVTransLocalRead,
 	_XSERVTransLocalWrite,
 #if XTRANS_SEND_FDS

--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -1171,14 +1171,6 @@ static XtransConnInfo _XSERVTransSocketUNIXAccept (
 
 #endif /* UNIXCONN */
 
-static int _XSERVTransSocketBytesReadable (
-    XtransConnInfo ciptr, BytesReadable_t *pend)
-{
-    prmsg (2,"SocketBytesReadable(%p,%d,%p)\n",
-	(void *) ciptr, ciptr->fd, (void *) pend);
-    return ossock_ioctl (ciptr->fd, FIONREAD, pend);
-}
-
 #if XTRANS_SEND_FDS
 
 static void
@@ -1483,7 +1475,6 @@ static Xtransport _XSERVTransSocketTCPFuncs = {
 	_XSERVTransSocketINETCreateListener,
 	NULL,		       			/* ResetListener */
 	_XSERVTransSocketINETAccept,
-	_XSERVTransSocketBytesReadable,
 	_XSERVTransSocketRead,
 	_XSERVTransSocketWrite,
 #if XTRANS_SEND_FDS
@@ -1506,7 +1497,6 @@ static Xtransport _XSERVTransSocketINETFuncs = {
 	_XSERVTransSocketINETCreateListener,
 	NULL,		       			/* ResetListener */
 	_XSERVTransSocketINETAccept,
-	_XSERVTransSocketBytesReadable,
 	_XSERVTransSocketRead,
 	_XSERVTransSocketWrite,
 #if XTRANS_SEND_FDS
@@ -1530,7 +1520,6 @@ static Xtransport _XSERVTransSocketINET6Funcs = {
 	_XSERVTransSocketINETCreateListener,
 	NULL,					/* ResetListener */
 	_XSERVTransSocketINETAccept,
-	_XSERVTransSocketBytesReadable,
 	_XSERVTransSocketRead,
 	_XSERVTransSocketWrite,
 #if XTRANS_SEND_FDS
@@ -1561,7 +1550,6 @@ static Xtransport _XSERVTransSocketLocalFuncs = {
 	_XSERVTransSocketUNIXCreateListener,
 	_XSERVTransSocketUNIXResetListener,
 	_XSERVTransSocketUNIXAccept,
-	_XSERVTransSocketBytesReadable,
 	_XSERVTransSocketRead,
 	_XSERVTransSocketWrite,
 #if XTRANS_SEND_FDS
@@ -1596,7 +1584,6 @@ static Xtransport _XSERVTransSocketUNIXFuncs = {
 	_XSERVTransSocketUNIXCreateListener,
 	_XSERVTransSocketUNIXResetListener,
 	_XSERVTransSocketUNIXAccept,
-	_XSERVTransSocketBytesReadable,
 	_XSERVTransSocketRead,
 	_XSERVTransSocketWrite,
 #if XTRANS_SEND_FDS


### PR DESCRIPTION
Not used anywhere, so no need to keep it around anymore.
Also dropping the BytesReadable vector, which is unused now.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
