### PR TITLE
dix: replace XACE_SERVER_ACCESS by direct callback

### DIFF
--- a/Xext/namespace/hook-server.c
+++ b/Xext/namespace/hook-server.c
@@ -4,6 +4,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/registry_priv.h"
+#include "dix/server_priv.h"
 #include "Xext/xacestr.h"
 
 #include "namespace.h"
@@ -11,7 +12,7 @@
 
 void hookServerAccess(CallbackListPtr *pcbl, void *unused, void *calldata)
 {
-    XNS_HOOK_HEAD(XaceServerAccessRec);
+    XNS_HOOK_HEAD(ServerAccessCallbackParam);
 
     if (subj->ns->superPower)
         goto pass;

--- a/Xext/namespace/namespace.c
+++ b/Xext/namespace/namespace.c
@@ -7,6 +7,7 @@
 #include "dix/extension_priv.h"
 #include "dix/property_priv.h"
 #include "dix/selection_priv.h"
+#include "dix/server_priv.h"
 #include "include/os.h"
 #include "miext/extinit_priv.h"
 #include "Xext/xacestr.h"
@@ -37,13 +38,13 @@ NamespaceExtensionInit(void)
           AddCallback(&SelectionFilterCallback, hookSelectionFilter, NULL) &&
           AddCallback(&ExtensionAccessCallback, hookExtAccess, NULL) &&
           AddCallback(&ExtensionDispatchCallback, hookExtDispatch, NULL) &&
+          AddCallback(&ServerAccessCallback, hookServerAccess, NULL) &&
           XaceRegisterCallback(XACE_CLIENT_ACCESS, hookClient, NULL) &&
           XaceRegisterCallback(XACE_DEVICE_ACCESS, hookDevice, NULL) &&
           XaceRegisterCallback(XACE_PROPERTY_ACCESS, hookPropertyAccess, NULL) &&
           XaceRegisterCallback(XACE_RECEIVE_ACCESS, hookReceive, NULL) &&
           XaceRegisterCallback(XACE_RESOURCE_ACCESS, hookResourceAccess, NULL) &&
-          XaceRegisterCallback(XACE_SEND_ACCESS, hookSend, NULL) &&
-          XaceRegisterCallback(XACE_SERVER_ACCESS, hookServerAccess, NULL)))
+          XaceRegisterCallback(XACE_SEND_ACCESS, hookSend, NULL)))
         FatalError("NamespaceExtensionInit: allocation failure\n");
 
     /* Do the serverClient */

--- a/Xext/security.c
+++ b/Xext/security.c
@@ -35,6 +35,7 @@ in this Software without prior written authorization from The Open Group.
 #include "dix/registry_priv.h"
 #include "dix/request_priv.h"
 #include "dix/resource_priv.h"
+#include "dix/server_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/audit.h"
 #include "os/auth.h"
@@ -767,7 +768,7 @@ SecurityExtension(CallbackListPtr *pcbl, void *unused, void *calldata)
 static void
 SecurityServer(CallbackListPtr *pcbl, void *unused, void *calldata)
 {
-    XaceServerAccessRec *rec = calldata;
+    ServerAccessCallbackParam *rec = calldata;
     SecurityStateRec *subj, *obj;
     Mask requested = rec->access_mode;
     Mask allowed = SecurityServerMask;
@@ -968,6 +969,7 @@ SecurityResetProc(ExtensionEntry * extEntry)
     DeleteCallback(&ClientStateCallback, SecurityClientState, NULL);
     DeleteCallback(&ExtensionAccessCallback, SecurityExtension, NULL);
     DeleteCallback(&ExtensionDispatchCallback, SecurityExtension, NULL);
+    DeleteCallback(&ServerAccessCallback, SecurityServer, NULL);
 
     XaceDeleteCallback(XACE_RESOURCE_ACCESS, SecurityResource, NULL);
     XaceDeleteCallback(XACE_DEVICE_ACCESS, SecurityDevice, NULL);
@@ -975,7 +977,6 @@ SecurityResetProc(ExtensionEntry * extEntry)
     XaceDeleteCallback(XACE_SEND_ACCESS, SecuritySend, NULL);
     XaceDeleteCallback(XACE_RECEIVE_ACCESS, SecurityReceive, NULL);
     XaceDeleteCallback(XACE_CLIENT_ACCESS, SecurityClient, NULL);
-    XaceDeleteCallback(XACE_SERVER_ACCESS, SecurityServer, NULL);
 }
 
 /* SecurityExtensionInit
@@ -1016,6 +1017,7 @@ SecurityExtensionInit(void)
     ret &= AddCallback(&ClientStateCallback, SecurityClientState, NULL);
     ret &= AddCallback(&ExtensionAccessCallback, SecurityExtension, NULL);
     ret &= AddCallback(&ExtensionDispatchCallback, SecurityExtension, NULL);
+    ret &= AddCallback(&ServerAccessCallback, SecurityServer, NULL);
 
     ret &= XaceRegisterCallback(XACE_RESOURCE_ACCESS, SecurityResource, NULL);
     ret &= XaceRegisterCallback(XACE_DEVICE_ACCESS, SecurityDevice, NULL);
@@ -1023,7 +1025,6 @@ SecurityExtensionInit(void)
     ret &= XaceRegisterCallback(XACE_SEND_ACCESS, SecuritySend, NULL);
     ret &= XaceRegisterCallback(XACE_RECEIVE_ACCESS, SecurityReceive, NULL);
     ret &= XaceRegisterCallback(XACE_CLIENT_ACCESS, SecurityClient, NULL);
-    ret &= XaceRegisterCallback(XACE_SERVER_ACCESS, SecurityServer, NULL);
 
     if (!ret)
         FatalError("SecurityExtensionSetup: Failed to register callbacks\n");

--- a/Xext/xace.c
+++ b/Xext/xace.c
@@ -90,13 +90,6 @@ int XaceHookClientAccess(ClientPtr client, ClientPtr target, Mask access_mode)
     return rec.status;
 }
 
-int XaceHookServerAccess(ClientPtr client, Mask access_mode)
-{
-    XaceServerAccessRec rec = { client, access_mode, Success };
-    CallCallbacks(&XaceHooks[XACE_SERVER_ACCESS], &rec);
-    return rec.status;
-}
-
 int XaceHookScreenAccess(ClientPtr client, ScreenPtr screen, Mask access_mode)
 {
     XaceScreenAccessRec rec = { client, screen, access_mode, Success };

--- a/Xext/xace.h
+++ b/Xext/xace.h
@@ -44,7 +44,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define XACE_SEND_ACCESS		5
 #define XACE_RECEIVE_ACCESS		6
 #define XACE_CLIENT_ACCESS		7
-#define XACE_SERVER_ACCESS		9
 #define XACE_SELECTION_ACCESS		10
 #define XACE_SCREEN_ACCESS		11
 #define XACE_SCREENSAVER_ACCESS		12
@@ -77,7 +76,6 @@ int XaceHookSendAccess(ClientPtr client, DeviceIntPtr dev, WindowPtr win,
                        xEventPtr ev, int count);
 int XaceHookReceiveAccess(ClientPtr client, WindowPtr win, xEventPtr ev, int count);
 int XaceHookClientAccess(ClientPtr client, ClientPtr target, Mask access_mode);
-int XaceHookServerAccess(ClientPtr client, Mask access_mode);
 int XaceHookScreenAccess(ClientPtr client, ScreenPtr screen, Mask access_mode);
 int XaceHookScreensaverAccess(ClientPtr client, ScreenPtr screen, Mask access_mode);
 

--- a/Xext/xacestr.h
+++ b/Xext/xacestr.h
@@ -86,13 +86,6 @@ typedef struct {
     int status;
 } XaceClientAccessRec;
 
-/* XACE_SERVER_ACCESS */
-typedef struct {
-    ClientPtr client;
-    Mask access_mode;
-    int status;
-} XaceServerAccessRec;
-
 /* XACE_SELECTION_ACCESS */
 typedef struct {
     ClientPtr client;

--- a/Xext/xselinux_hooks.c
+++ b/Xext/xselinux_hooks.c
@@ -38,6 +38,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "dix/registry_priv.h"
 #include "dix/resource_priv.h"
 #include "dix/selection_priv.h"
+#include "dix/server_priv.h"
 #include "os/client_priv.h"
 
 #include "inputstr.h"
@@ -732,7 +733,7 @@ SELinuxClient(CallbackListPtr *pcbl, void *unused, void *calldata)
 static void
 SELinuxServer(CallbackListPtr *pcbl, void *unused, void *calldata)
 {
-    XaceServerAccessRec *rec = calldata;
+    ServerAccessCallbackParam *rec = calldata;
     SELinuxSubjectRec *subj;
     SELinuxObjectRec *obj;
     SELinuxAuditRec auditdata = {.client = rec->client };
@@ -833,6 +834,7 @@ SELinuxFlaskReset(void)
     DeleteCallback(&ResourceStateCallback, SELinuxResourceState, NULL);
     DeleteCallback(&ExtensionAccessCallback, SELinuxExtension, NULL);
     DeleteCallback(&ExtensionDispatchCallback, SELinuxExtension, NULL);
+    DeleteCallback(&ServerAccessCallback, SELinuxServer, NULL);
 
     XaceDeleteCallback(XACE_RESOURCE_ACCESS, SELinuxResource, NULL);
     XaceDeleteCallback(XACE_DEVICE_ACCESS, SELinuxDevice, NULL);
@@ -840,7 +842,6 @@ SELinuxFlaskReset(void)
     XaceDeleteCallback(XACE_SEND_ACCESS, SELinuxSend, NULL);
     XaceDeleteCallback(XACE_RECEIVE_ACCESS, SELinuxReceive, NULL);
     XaceDeleteCallback(XACE_CLIENT_ACCESS, SELinuxClient, NULL);
-    XaceDeleteCallback(XACE_SERVER_ACCESS, SELinuxServer, NULL);
     XaceDeleteCallback(XACE_SELECTION_ACCESS, SELinuxSelection, NULL);
     XaceDeleteCallback(XACE_SCREEN_ACCESS, SELinuxScreen, NULL);
     XaceDeleteCallback(XACE_SCREENSAVER_ACCESS, SELinuxScreen, truep);
@@ -927,6 +928,7 @@ SELinuxFlaskInit(void)
     ret &= AddCallback(&ResourceStateCallback, SELinuxResourceState, NULL);
     ret &= AddCallback(&ExtensionAccessCallback, SELinuxExtension, NULL);
     ret &= AddCallback(&ExtensionDispatchCallback, SELinuxExtension, NULL);
+    ret &= AddCallback(&ServerAccessCallback, SELinuxServer, NULL);
 
     ret &= XaceRegisterCallback(XACE_RESOURCE_ACCESS, SELinuxResource, NULL);
     ret &= XaceRegisterCallback(XACE_DEVICE_ACCESS, SELinuxDevice, NULL);
@@ -934,7 +936,6 @@ SELinuxFlaskInit(void)
     ret &= XaceRegisterCallback(XACE_SEND_ACCESS, SELinuxSend, NULL);
     ret &= XaceRegisterCallback(XACE_RECEIVE_ACCESS, SELinuxReceive, NULL);
     ret &= XaceRegisterCallback(XACE_CLIENT_ACCESS, SELinuxClient, NULL);
-    ret &= XaceRegisterCallback(XACE_SERVER_ACCESS, SELinuxServer, NULL);
     ret &= XaceRegisterCallback(XACE_SELECTION_ACCESS, SELinuxSelection, NULL);
     ret &= XaceRegisterCallback(XACE_SCREEN_ACCESS, SELinuxScreen, NULL);
     ret &= XaceRegisterCallback(XACE_SCREENSAVER_ACCESS, SELinuxScreen, truep);

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -115,6 +115,7 @@ Equipment Corporation.
 #include "dix/resource_priv.h"
 #include "dix/screenint_priv.h"
 #include "dix/selection_priv.h"
+#include "dix/server_priv.h"
 #include "dix/window_priv.h"
 #include "include/resource.h"
 #include "miext/extinit_priv.h"
@@ -172,7 +173,9 @@ static int nextFreeClientID;    /* always MIN free client ID */
 
 static int nClients;            /* number of authorized clients */
 
-CallbackListPtr ClientStateCallback;
+CallbackListPtr ClientStateCallback = NULL;
+CallbackListPtr ServerAccessCallback = NULL;
+
 OsTimerPtr dispatchExceptionTimer;
 
 /* dispatchException & isItTimeToYield must be declared volatile since they
@@ -3280,7 +3283,7 @@ ProcListHosts(ClientPtr client)
     REQUEST_SIZE_MATCH(xListHostsReq);
 
     /* untrusted clients can't list hosts */
-    result = XaceHookServerAccess(client, DixReadAccess);
+    result = dixCallServerAccessCallback(client, DixReadAccess);
     if (result != Success)
         return result;
 
@@ -3409,7 +3412,7 @@ ProcGetFontPath(ClientPtr client)
     /* REQUEST (xReq); */
     REQUEST_SIZE_MATCH(xReq);
 
-    int rc = XaceHookServerAccess(client, DixGetAttrAccess);
+    int rc = dixCallServerAccessCallback(client, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 

--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -62,6 +62,7 @@ Equipment Corporation.
 #include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/server_priv.h"
 #include "include/swaprep.h"
 #include "os/auth.h"
 #include "os/log_priv.h"
@@ -788,7 +789,7 @@ ListFonts(ClientPtr client, unsigned char *pattern, unsigned length,
     if (length > XLFDMAXFONTNAMELEN)
         return BadAlloc;
 
-    access = XaceHookServerAccess(client, DixGetAttrAccess);
+    access = dixCallServerAccessCallback(client, DixGetAttrAccess);
     if (access != Success)
         return access;
 
@@ -1066,7 +1067,7 @@ StartListFontsWithInfo(ClientPtr client, int length, unsigned char *pattern,
     if (length > XLFDMAXFONTNAMELEN)
         return BadAlloc;
 
-    access = XaceHookServerAccess(client, DixGetAttrAccess);
+    access = dixCallServerAccessCallback(client, DixGetAttrAccess);
     if (access != Success)
         return access;
 
@@ -1688,7 +1689,7 @@ SetFontPathElements(int npaths, unsigned char *paths, int *bad, Bool persist)
 int
 SetFontPath(ClientPtr client, int npaths, unsigned char *paths)
 {
-    int err = XaceHookServerAccess(client, DixManageAccess);
+    int err = dixCallServerAccessCallback(client, DixManageAccess);
 
     if (err != Success)
         return err;
@@ -1777,7 +1778,7 @@ GetFontPath(ClientPtr client, int *count, int *length, unsigned char **result)
     int len;
     FontPathElementPtr fpe;
 
-    access = XaceHookServerAccess(client, DixGetAttrAccess);
+    access = dixCallServerAccessCallback(client, DixGetAttrAccess);
     if (access != Success)
         return access;
 

--- a/dix/server_priv.h
+++ b/dix/server_priv.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef _XSERVER_DIX_SERVER_PRIV_H
+#define _XSERVER_DIX_SERVER_PRIV_H
+
+#include "include/callback.h"
+#include "include/dix.h"
+
+typedef struct {
+    ClientPtr client;
+    Mask access_mode;
+    int status;
+} ServerAccessCallbackParam;
+
+extern CallbackListPtr ServerAccessCallback;
+
+static inline int dixCallServerAccessCallback(ClientPtr client, Mask access_mode)
+{
+    ServerAccessCallbackParam rec = { client, access_mode, Success };
+    CallCallbacks(&ServerAccessCallback, &rec);
+    return rec.status;
+}
+
+#endif /* _XSERVER_DIX_SERVER_PRIV_H */

--- a/os/access.c
+++ b/os/access.c
@@ -92,6 +92,7 @@ SOFTWARE.
 #include <errno.h>
 #include <sys/types.h>
 
+#include "dix/server_priv.h"
 #include "os/xhostname.h"
 
 #ifndef WIN32
@@ -1262,7 +1263,7 @@ AuthorizedClient(ClientPtr client)
         return Success;
 
     /* untrusted clients can't change host access */
-    rc = XaceHookServerAccess(client, DixManageAccess);
+    rc = dixCallServerAccessCallback(client, DixManageAccess);
     if (rc != Success)
         return rc;
 

--- a/os/connection.c
+++ b/os/connection.c
@@ -92,6 +92,7 @@ SOFTWARE.
 #endif                          /* WIN32 */
 
 #include "dix/dix_priv.h"
+#include "dix/server_priv.h"
 #include "os/audit.h"
 #include "os/auth.h"
 #include "os/client_priv.h"
@@ -871,7 +872,7 @@ OnlyListenToOneClient(ClientPtr client)
 {
     int rc;
 
-    rc = XaceHookServerAccess(client, DixGrabAccess);
+    rc = dixCallServerAccessCallback(client, DixGrabAccess);
     if (rc != Success)
         return rc;
 

--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -35,6 +35,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
+#include "dix/server_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/osdep.h"
 #include "xkb/xkbfmisc_priv.h"
@@ -6677,7 +6678,7 @@ ProcXkbSetDebuggingFlags(ClientPtr client)
     REQUEST(xkbSetDebuggingFlagsReq);
     REQUEST_AT_LEAST_SIZE(xkbSetDebuggingFlagsReq);
 
-    rc = XaceHookServerAccess(client, DixDebugAccess);
+    rc = dixCallServerAccessCallback(client, DixDebugAccess);
     if (rc != Success)
         return rc;
 


### PR DESCRIPTION
Move the callbacks directly into DIX, since it's actually core infrastructure.
Also simplifying the whole machinery, by just using a simpel CallbackListPtr.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
