### PR TITLE
present: unexport symbols not used by drivers

### DIFF
--- a/glx/glxcmds.c
+++ b/glx/glxcmds.c
@@ -39,6 +39,7 @@
 #include "dix/resource_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "os/bug_priv.h"
+#include "present/present_priv.h"
 
 #include "glxserver.h"
 #include <unpack.h>

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -36,6 +36,7 @@
 
 #include "dix/dix_priv.h"
 #include "os/fmt.h"
+#include "present/present_priv.h"
 
 #include "dumb_bo.h"
 #include "inputstr.h"
@@ -51,7 +52,6 @@
 #include <xf86drm.h>
 #include "xf86Crtc.h"
 #include "drmmode_display.h"
-#include "present.h"
 
 #include <cursorstr.h>
 

--- a/os/utils.c
+++ b/os/utils.c
@@ -107,12 +107,13 @@ OR PERFORMANCE OF THIS SOFTWARE.
 #include "os/osdep.h"
 #include "os/serverlock.h"
 #include "os/xhostname.h"
+#include "present/present_priv.h"
 #include "Xext/xf86bigfontsrv.h" /* XF86BigfontCleanup() */
 #include "xkb/xkbsrv_priv.h"
+
 #include "dixstruct.h"
 #include "picture.h"
 #include "miinitext.h"
-#include "present.h"
 #include "dixstruct_priv.h"
 #include "dpmsproc.h"
 

--- a/present/present.c
+++ b/present/present.c
@@ -21,9 +21,9 @@
  */
 #include <dix-config.h>
 
+#include "present/present_priv.h"
 #include "randr/randrstr_priv.h"
 
-#include "present_priv.h"
 #include <gcstruct.h>
 
 uint32_t

--- a/present/present.h
+++ b/present/present.h
@@ -158,22 +158,4 @@ present_event_notify(uint64_t event_id, uint64_t ust, uint64_t msc);
 extern _X_EXPORT Bool
 present_screen_init(ScreenPtr screen, present_screen_info_ptr info);
 
-extern _X_EXPORT void
-present_check_flips(WindowPtr window);
-
-typedef void (*present_complete_notify_proc)(WindowPtr window,
-                                             CARD8 kind,
-                                             CARD8 mode,
-                                             CARD32 serial,
-                                             uint64_t ust,
-                                             uint64_t msc);
-
-extern _X_EXPORT void
-present_register_complete_notify(present_complete_notify_proc proc);
-
-extern _X_EXPORT Bool
-present_can_window_flip(WindowPtr window);
-
-extern _X_EXPORT uint32_t FakeScreenFps;
-
 #endif /* _PRESENT_H_ */

--- a/present/present_event.c
+++ b/present/present_event.c
@@ -22,9 +22,8 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "present/present_priv.h"
 #include "Xext/geext_priv.h"
-
-#include "present_priv.h"
 
 static RESTYPE present_event_type;
 

--- a/present/present_execute.c
+++ b/present/present_execute.c
@@ -21,8 +21,10 @@
  */
 #include <dix-config.h>
 
-#include "present_priv.h"
 #include <unistd.h>
+
+#include "present/present_priv.h"
+
 #ifdef DRI3
 #include <sys/eventfd.h>
 #endif /* DRI3 */

--- a/present/present_fake.c
+++ b/present/present_fake.c
@@ -21,8 +21,8 @@
  */
 #include <dix-config.h>
 
-#include "present_priv.h"
-#include "list.h"
+#include "include/list.h"
+#include "present/present_priv.h"
 
 static struct xorg_list fake_vblank_queue;
 

--- a/present/present_fence.c
+++ b/present/present_fence.c
@@ -21,7 +21,8 @@
  */
 #include <dix-config.h>
 
-#include "present_priv.h"
+#include "present/present_priv.h"
+
 #include <gcstruct.h>
 #include <misync.h>
 #include <misyncstr.h>

--- a/present/present_priv.h
+++ b/present/present_priv.h
@@ -23,14 +23,16 @@
 #ifndef _PRESENT_PRIV_H_
 #define _PRESENT_PRIV_H_
 
-#include "dix-config.h"
 #include <X11/X.h>
+#include <X11/Xmd.h>
+
+#include "present/present.h"
+
 #include "scrnintstr.h"
 #include "misc.h"
 #include "list.h"
 #include "windowstr.h"
 #include "dixstruct.h"
-#include "present.h"
 #include <syncsdk.h>
 #include <syncsrv.h>
 #include <xfixes.h>
@@ -527,5 +529,23 @@ present_vblank_scrap(present_vblank_ptr vblank);
 
 void
 present_vblank_destroy(present_vblank_ptr vblank);
+
+/* only for in-tree modesetting */ _X_EXPORT
+void present_check_flips(WindowPtr window);
+
+typedef void (*present_complete_notify_proc)(WindowPtr window,
+                                             CARD8 kind,
+                                             CARD8 mode,
+                                             CARD32 serial,
+                                             uint64_t ust,
+                                             uint64_t msc);
+
+/* only for in-tree GLX module */ _X_EXPORT
+void present_register_complete_notify(present_complete_notify_proc proc);
+
+/* only for in-tree modesetting */ _X_EXPORT
+Bool present_can_window_flip(WindowPtr window);
+
+extern uint32_t FakeScreenFps;
 
 #endif /*  _PRESENT_PRIV_H_ */

--- a/present/present_request.c
+++ b/present/present_request.c
@@ -23,8 +23,8 @@
 
 #include "dix/dix_priv.h"
 #include "dri3/dri3_priv.h"
+#include "present/present_priv.h"
 
-#include "present_priv.h"
 #include "randrstr_priv.h"
 #include <protocol-versions.h>
 

--- a/present/present_scmd.c
+++ b/present/present_scmd.c
@@ -21,9 +21,9 @@
  */
 #include <dix-config.h>
 
+#include "present/present_priv.h"
 #include "randr/randrstr_priv.h"
 
-#include "present_priv.h"
 #include <misync.h>
 #include <misyncstr.h>
 

--- a/present/present_screen.c
+++ b/present/present_screen.c
@@ -22,10 +22,8 @@
 #include <dix-config.h>
 
 #include "dix/screen_hooks_priv.h"
-
-#include "present_priv.h"
-
 #include "miext/extinit_priv.h"
+#include "present/present_priv.h"
 
 int present_request;
 DevPrivateKeyRec present_screen_private_key;

--- a/present/present_vblank.c
+++ b/present/present_vblank.c
@@ -21,8 +21,9 @@
  */
 #include <dix-config.h>
 
-#include "present_priv.h"
 #include <unistd.h>
+
+#include "present/present_priv.h"
 
 void
 present_vblank_notify(present_vblank_ptr vblank, CARD8 kind, CARD8 mode, uint64_t ust, uint64_t crtc_msc)


### PR DESCRIPTION
these symbols aren't used by any external drivers (not even proprietary
Nvidia), so no need to keep them exported any longer:

 * present_check_flips
 * present_register_complete_notify
 * present_can_window_flip
 * uint32_t FakeScreenFps

Since it's not any *effective* ABI change, can go into current ABI-25 line.

Note: some functions still need to be _X_EXPORT'ed for in-tree modules, but they're not part of SDK anymore.
