### PR TITLE
os: unexport ReplyCallback

### DIFF
--- a/include/os.h
+++ b/include/os.h
@@ -199,17 +199,6 @@ PrivsElevated(void);
 extern _X_EXPORT int
 GetClientFd(ClientPtr);
 
-/* stuff for ReplyCallback */
-extern _X_EXPORT CallbackListPtr ReplyCallback;
-typedef struct {
-    ClientPtr client;
-    const void *replyData;
-    unsigned long dataLenBytes; /* actual bytes from replyData + pad bytes */
-    unsigned long bytesRemaining;
-    Bool startOfReply;
-    unsigned long padBytes;     /* pad bytes from zeroed array */
-} ReplyInfoRec;
-
 /* stuff for FlushCallback */
 extern _X_EXPORT CallbackListPtr FlushCallback;
 

--- a/os/client_priv.h
+++ b/os/client_priv.h
@@ -10,6 +10,8 @@
 #include <X11/Xdefs.h>
 #include <X11/Xfuncproto.h>
 
+#include "include/callback.h"
+
 /* Client IDs. Use GetClientPid, GetClientCmdName and GetClientCmdArgs
  * instead of accessing the fields directly. */
 struct _ClientId {
@@ -59,5 +61,16 @@ _X_EXPORT void SetCriticalOutputPending(void);
 
 /* exported only for DRI module, but should not be used by external drivers */
 _X_EXPORT void ResetCurrentRequest(struct _Client *client);
+
+/* stuff for ReplyCallback */
+extern CallbackListPtr ReplyCallback;
+typedef struct {
+    ClientPtr client;
+    const void *replyData;
+    unsigned long dataLenBytes; /* actual bytes from replyData + pad bytes */
+    unsigned long bytesRemaining;
+    Bool startOfReply;
+    unsigned long padBytes;     /* pad bytes from zeroed array */
+} ReplyInfoRec;
 
 #endif /* _XSERVER_DIX_CLIENT_PRIV_H */

--- a/os/io.c
+++ b/os/io.c
@@ -82,7 +82,7 @@ SOFTWARE.
 #include "dixstruct.h"
 #include "misc.h"
 
-CallbackListPtr ReplyCallback;
+CallbackListPtr ReplyCallback = NULL;
 CallbackListPtr FlushCallback;
 
 typedef struct _connectionInput {


### PR DESCRIPTION
It's only used by record extension, not used by any drivers at all
(neither FOSS nor proprietary), so it shouldn't be in the public SDK.

Since it's never been used by any driver, it's effectively no ABI change,
so we can safely do this within ABI-25.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
