### PR TITLE
include: misc.h: drop duplicate definition of CallbackListPtr

### DIFF
--- a/Xext/xace.h
+++ b/Xext/xace.h
@@ -24,6 +24,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define XACE_MINOR_VERSION		0
 
 #include "dix/selection_priv.h"
+#include "include/callback.h"
 
 #include "extnsionst.h"
 #include "pixmap.h"

--- a/include/callback.h
+++ b/include/callback.h
@@ -56,11 +56,7 @@ SOFTWARE.
  *  callback manager stuff
  */
 
-#ifndef _XTYPEDEF_CALLBACKLISTPTR
-typedef struct _CallbackList *CallbackListPtr;  /* also in misc.h */
-
-#define _XTYPEDEF_CALLBACKLISTPTR
-#endif
+typedef struct _CallbackList *CallbackListPtr;
 
 typedef void (*CallbackProcPtr) (CallbackListPtr *, void *, void *);
 

--- a/include/dixstruct.h
+++ b/include/dixstruct.h
@@ -24,6 +24,10 @@ SOFTWARE.
 #ifndef DIXSTRUCT_H
 #define DIXSTRUCT_H
 
+#include <X11/Xmd.h>
+
+#include "callback.h"
+
 #include "client.h"
 #include "dix.h"
 #include "resource.h"
@@ -31,7 +35,6 @@ SOFTWARE.
 #include "gc.h"
 #include "pixmap.h"
 #include "privates.h"
-#include <X11/Xmd.h>
 
 /*
  * 	direct-mapped hash table, used by resource manager to store

--- a/include/misc.h
+++ b/include/misc.h
@@ -115,12 +115,6 @@ typedef int XRetCode;
 #define FALSE 0
 #endif
 
-#ifndef _XTYPEDEF_CALLBACKLISTPTR
-typedef struct _CallbackList *CallbackListPtr;  /* also in dix.h */
-
-#define _XTYPEDEF_CALLBACKLISTPTR
-#endif
-
 typedef struct _xReq *xReqPtr;
 
 #include "os.h"                 /* for ALLOCATE_LOCAL and DEALLOCATE_LOCAL */

--- a/include/os.h
+++ b/include/os.h
@@ -47,7 +47,9 @@ SOFTWARE.
 #ifndef OS_H
 #define OS_H
 
+#include "callback.h"
 #include "misc.h"
+
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdlib.h>


### PR DESCRIPTION
This type is already defined in `include/callback.h` - anybody who wants it
most likely needs that include file, too.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
