### PR TITLE
os: move `enum ExitCode` into private header

### DIFF
--- a/hw/xfree86/common/xf86_priv.h
+++ b/hw/xfree86/common/xf86_priv.h
@@ -5,6 +5,7 @@
 #ifndef _XSERVER_XF86_PRIV_H
 #define _XSERVER_XF86_PRIV_H
 
+#include "os/osdep.h"
 #include "xf86.h"
 
 extern Bool xf86DoConfigure;

--- a/include/os.h
+++ b/include/os.h
@@ -213,13 +213,6 @@ typedef struct {
 /* stuff for FlushCallback */
 extern _X_EXPORT CallbackListPtr FlushCallback;
 
-enum ExitCode {
-    EXIT_NO_ERROR = 0,
-    EXIT_ERR_ABORT = 1,
-    EXIT_ERR_CONFIGURE = 2,
-    EXIT_ERR_DRIVERS = 3,
-};
-
 extern _X_EXPORT int
 TimeSinceLastInputEvent(void);
 

--- a/os/ddx_priv.h
+++ b/os/ddx_priv.h
@@ -5,7 +5,8 @@
 #ifndef _XSERVER_OS_DDX_PRIV_H
 #define _XSERVER_OS_DDX_PRIV_H
 
-#include "os.h"
+#include "include/os.h"
+#include "os/osdep.h"
 
 /* callbacks of the DDX, which are called by DIX or OS layer.
    DDX's need to implement these in order to handle DDX specific things.

--- a/os/log_priv.h
+++ b/os/log_priv.h
@@ -5,7 +5,7 @@
 #ifndef __XORG_OS_LOGGING_H
 #define __XORG_OS_LOGGING_H
 
-#include "include/os.h"
+#include "os/osdep.h"
 
 /**
  * @brief initialize logging and open log files

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -234,4 +234,11 @@ static inline size_t x_safe_strlen(const char *str) {
     return (str ? strlen(str) : 0);
 }
 
+enum ExitCode {
+    EXIT_NO_ERROR = 0,
+    EXIT_ERR_ABORT = 1,
+    EXIT_ERR_CONFIGURE = 2,
+    EXIT_ERR_DRIVERS = 3,
+};
+
 #endif                          /* _OSDEP_H_ */


### PR DESCRIPTION
Not used by any external drivers, so no need to keep it public.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
