### PR TITLE
dix: unexport ResourceStateCallback (not used by drivers)

### DIFF
--- a/dix/resource_priv.h
+++ b/dix/resource_priv.h
@@ -7,6 +7,7 @@
 
 #include <X11/Xdefs.h>
 
+#include "include/callback.h"
 #include "include/dix.h"
 #include "include/resource.h"
 
@@ -155,5 +156,20 @@ void GetXIDRange(int client,
                  Bool server,
                  XID *minp,
                  XID *maxp);
+
+/* Resource state callback */
+extern CallbackListPtr ResourceStateCallback;
+
+typedef enum {
+    ResourceStateAdding,
+    ResourceStateFreeing
+} ResourceState;
+
+typedef struct {
+    ResourceState state;
+    XID id;
+    RESTYPE type;
+    void *value;
+} ResourceStateInfoRec;
 
 #endif /* _XSERVER_DIX_RESOURCE_PRIV_H */

--- a/include/resource.h
+++ b/include/resource.h
@@ -46,6 +46,9 @@ SOFTWARE.
 
 #ifndef RESOURCE_H
 #define RESOURCE_H 1
+
+#include "callback.h"
+
 #include "misc.h"
 #include "dixaccess.h"
 
@@ -102,20 +105,6 @@ typedef uint32_t RESTYPE;
 extern _X_EXPORT unsigned int ResourceClientBits(void);
 
 #define BAD_RESOURCE 0xe0000000
-
-/* Resource state callback */
-extern _X_EXPORT CallbackListPtr ResourceStateCallback;
-
-typedef enum { ResourceStateAdding,
-    ResourceStateFreeing
-} ResourceState;
-
-typedef struct {
-    ResourceState state;
-    XID id;
-    RESTYPE type;
-    void *value;
-} ResourceStateInfoRec;
 
 typedef int (*DeleteType) (void *value,
                            XID id);


### PR DESCRIPTION
Only used by Xselinux extension, not by any drivers, so no need to
keep it exported.

Since it's never been used by drivers at all, it's effectively no ABI change,
so can safely be done within ABI-25.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
