### PR TITLE
pseudoramiX: inline SProc*()

### DIFF
--- a/pseudoramiX/pseudoramiX.c
+++ b/pseudoramiX/pseudoramiX.c
@@ -61,8 +61,6 @@ static void
 PseudoramiXResetProc(ExtensionEntry *extEntry);
 
 static int
-ProcPseudoramiXQueryVersion(ClientPtr client);
-static int
 ProcPseudoramiXGetState(ClientPtr client);
 static int
 ProcPseudoramiXGetScreenCount(ClientPtr client);
@@ -74,21 +72,6 @@ static int
 ProcPseudoramiXQueryScreens(ClientPtr client);
 static int
 ProcPseudoramiXDispatch(ClientPtr client);
-
-static int
-SProcPseudoramiXQueryVersion(ClientPtr client);
-static int
-SProcPseudoramiXGetState(ClientPtr client);
-static int
-SProcPseudoramiXGetScreenCount(ClientPtr client);
-static int
-SProcPseudoramiXGetScreenSize(ClientPtr client);
-static int
-SProcPseudoramiXIsActive(ClientPtr client);
-static int
-SProcPseudoramiXQueryScreens(ClientPtr client);
-static int
-SProcPseudoramiXDispatch(ClientPtr client);
 
 typedef struct {
     int x;
@@ -154,7 +137,7 @@ PseudoramiXExtensionInit(void)
     if (pseudoramiXGeneration != serverGeneration) {
         extEntry = AddExtension(PANORAMIX_PROTOCOL_NAME, 0, 0,
                                 ProcPseudoramiXDispatch,
-                                SProcPseudoramiXDispatch,
+                                ProcPseudoramiXDispatch,
                                 PseudoramiXResetProc,
                                 StandardMinorOpcode);
         if (!extEntry) {
@@ -194,24 +177,19 @@ PseudoramiXResetProc(ExtensionEntry *extEntry)
 
 // was PanoramiX
 static int
-ProcPseudoramiXQueryVersion(ClientPtr client)
-{
-    TRACE;
-
-    return ProcPanoramiXQueryVersion(client);
-}
-
-// was PanoramiX
-static int
 ProcPseudoramiXGetState(ClientPtr client)
 {
     REQUEST(xPanoramiXGetStateReq);
+    REQUEST_SIZE_MATCH(xPanoramiXGetStateReq);
+
+    if (client->swapped)
+        swapl(&stuff->window);
+
     WindowPtr pWin;
     register int rc;
 
     TRACE;
 
-    REQUEST_SIZE_MATCH(xPanoramiXGetStateReq);
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
     if (rc != Success)
         return rc;
@@ -233,12 +211,16 @@ static int
 ProcPseudoramiXGetScreenCount(ClientPtr client)
 {
     REQUEST(xPanoramiXGetScreenCountReq);
+    REQUEST_SIZE_MATCH(xPanoramiXGetScreenCountReq);
+
+    if (client->swapped)
+        swapl(&stuff->window);
+
     WindowPtr pWin;
     register int rc;
 
     TRACE;
 
-    REQUEST_SIZE_MATCH(xPanoramiXGetScreenCountReq);
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
     if (rc != Success)
         return rc;
@@ -260,12 +242,17 @@ static int
 ProcPseudoramiXGetScreenSize(ClientPtr client)
 {
     REQUEST(xPanoramiXGetScreenSizeReq);
+    REQUEST_SIZE_MATCH(xPanoramiXGetScreenSizeReq);
+
+    if (client->swapped) {
+        swapl(&stuff->window);
+        swapl(&stuff->screen);
+    }
+
     WindowPtr pWin;
     register int rc;
 
     TRACE;
-
-    REQUEST_SIZE_MATCH(xPanoramiXGetScreenSizeReq);
 
     if (stuff->screen >= pseudoramiXNumScreens)
       return BadMatch;
@@ -353,7 +340,7 @@ ProcPseudoramiXDispatch(ClientPtr client)
     TRACE;
     switch (stuff->data) {
     case X_PanoramiXQueryVersion:
-        return ProcPseudoramiXQueryVersion(client);
+        return ProcPanoramiXQueryVersion(client);
 
     case X_PanoramiXGetState:
         return ProcPseudoramiXGetState(client);
@@ -369,89 +356,6 @@ ProcPseudoramiXDispatch(ClientPtr client)
 
     case X_XineramaQueryScreens:
         return ProcPseudoramiXQueryScreens(client);
-    }
-    return BadRequest;
-}
-
-static int
-SProcPseudoramiXQueryVersion(ClientPtr client)
-{
-    TRACE;
-
-    REQUEST_SIZE_MATCH(xPanoramiXQueryVersionReq);
-    return ProcPseudoramiXQueryVersion(client);
-}
-
-static int
-SProcPseudoramiXGetState(ClientPtr client)
-{
-    TRACE;
-
-    REQUEST_SIZE_MATCH(xPanoramiXGetStateReq);
-    return ProcPseudoramiXGetState(client);
-}
-
-static int
-SProcPseudoramiXGetScreenCount(ClientPtr client)
-{
-    TRACE;
-
-    REQUEST_SIZE_MATCH(xPanoramiXGetScreenCountReq);
-    return ProcPseudoramiXGetScreenCount(client);
-}
-
-static int
-SProcPseudoramiXGetScreenSize(ClientPtr client)
-{
-    TRACE;
-
-    REQUEST_SIZE_MATCH(xPanoramiXGetScreenSizeReq);
-    return ProcPseudoramiXGetScreenSize(client);
-}
-
-static int
-SProcPseudoramiXIsActive(ClientPtr client)
-{
-    TRACE;
-
-    REQUEST_SIZE_MATCH(xXineramaIsActiveReq);
-    return ProcPseudoramiXIsActive(client);
-}
-
-static int
-SProcPseudoramiXQueryScreens(ClientPtr client)
-{
-    TRACE;
-
-    REQUEST_SIZE_MATCH(xXineramaQueryScreensReq);
-    return ProcPseudoramiXQueryScreens(client);
-}
-
-static int
-SProcPseudoramiXDispatch(ClientPtr client)
-{
-    REQUEST(xReq);
-
-    TRACE;
-
-    switch (stuff->data) {
-    case X_PanoramiXQueryVersion:
-        return SProcPseudoramiXQueryVersion(client);
-
-    case X_PanoramiXGetState:
-        return SProcPseudoramiXGetState(client);
-
-    case X_PanoramiXGetScreenCount:
-        return SProcPseudoramiXGetScreenCount(client);
-
-    case X_PanoramiXGetScreenSize:
-        return SProcPseudoramiXGetScreenSize(client);
-
-    case X_XineramaIsActive:
-        return SProcPseudoramiXIsActive(client);
-
-    case X_XineramaQueryScreens:
-        return SProcPseudoramiXQueryScreens(client);
     }
     return BadRequest;
 }


### PR DESCRIPTION
The few LoC for the bytes-wapping are so trivial that we can easily
inline them instead of having a whole bunch of extra functions.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
