### PR TITLE
record: inline SProc*()

### DIFF
--- a/record/record.c
+++ b/record/record.c
@@ -1,4 +1,3 @@
-
 /*
 
 Copyright 1995, 1998  The Open Group
@@ -1822,13 +1821,19 @@ RecordRegisterClients(RecordContextPtr pContext, ClientPtr client,
 static int
 ProcRecordQueryVersion(ClientPtr client)
 {
-    /* REQUEST(xRecordQueryVersionReq); */
+    REQUEST(xRecordQueryVersionReq);
+    REQUEST_SIZE_MATCH(xRecordQueryVersionReq);
+
+    if (client->swapped) {
+        swaps(&stuff->majorVersion);
+        swaps(&stuff->minorVersion);
+    }
+
     xRecordQueryVersionReply rep = {
         .majorVersion = SERVER_RECORD_MAJOR_VERSION,
         .minorVersion = SERVER_RECORD_MINOR_VERSION
     };
 
-    REQUEST_SIZE_MATCH(xRecordQueryVersionReq);
     if (client->swapped) {
         swaps(&rep.majorVersion);
         swaps(&rep.minorVersion);
@@ -1837,14 +1842,24 @@ ProcRecordQueryVersion(ClientPtr client)
     return X_SEND_REPLY_SIMPLE(client, rep);
 }
 
+static int _X_COLD
+SwapCreateRegister(ClientPtr client, xRecordRegisterClientsReq * stuff);
+
 static int
 ProcRecordCreateContext(ClientPtr client)
 {
     REQUEST(xRecordCreateContextReq);
+    REQUEST_AT_LEAST_SIZE(xRecordCreateContextReq);
+
+    if (client->swapped) {
+        int rc = SwapCreateRegister(client, (void *) stuff);
+        if (rc != Success)
+            return rc;
+    }
+
     RecordContextPtr *ppNewAllContexts = NULL;
     int err = BadAlloc;
 
-    REQUEST_AT_LEAST_SIZE(xRecordCreateContextReq);
     LEGAL_NEW_RESOURCE(stuff->context, client);
 
     RecordContextPtr pContext = calloc(1, sizeof(RecordContextRec));
@@ -1889,11 +1904,16 @@ ProcRecordCreateContext(ClientPtr client)
 static int
 ProcRecordRegisterClients(ClientPtr client)
 {
-    RecordContextPtr pContext;
-
     REQUEST(xRecordRegisterClientsReq);
-
     REQUEST_AT_LEAST_SIZE(xRecordRegisterClientsReq);
+
+    if (client->swapped) {
+        int rc = SwapCreateRegister(client, (void *) stuff);
+        if (rc != Success)
+            return rc;
+    }
+
+    RecordContextPtr pContext;
     VERIFY_CONTEXT(pContext, stuff->context, client);
 
     return RecordRegisterClients(pContext, client, stuff);
@@ -1902,15 +1922,22 @@ ProcRecordRegisterClients(ClientPtr client)
 static int
 ProcRecordUnregisterClients(ClientPtr client)
 {
+    REQUEST(xRecordUnregisterClientsReq);
+    REQUEST_AT_LEAST_SIZE(xRecordUnregisterClientsReq);
+
+    if (client->swapped) {
+        swapl(&stuff->context);
+        swapl(&stuff->nClients);
+        SwapRestL(stuff);
+    }
+
     RecordContextPtr pContext;
     int err;
 
-    REQUEST(xRecordUnregisterClientsReq);
     XID *pCanonClients;
     int nClients;
     int i;
 
-    REQUEST_AT_LEAST_SIZE(xRecordUnregisterClientsReq);
     if (INT_MAX / 4 < stuff->nClients ||
         (client->req_len << 2) - SIZEOF(xRecordUnregisterClientsReq) !=
         4 * stuff->nClients)
@@ -2127,9 +2154,13 @@ RecordSwapRanges(xRecordRange * pRanges, int nRanges)
 static int
 ProcRecordGetContext(ClientPtr client)
 {
-    RecordContextPtr pContext;
-
     REQUEST(xRecordGetContextReq);
+    REQUEST_SIZE_MATCH(xRecordGetContextReq);
+
+    if (client->swapped)
+        swapl(&stuff->context);
+
+    RecordContextPtr pContext;
     xRecordGetContextReply rep;
     RecordClientsAndProtocolPtr pRCAP;
     int nRCAPs = 0;
@@ -2139,7 +2170,6 @@ ProcRecordGetContext(ClientPtr client)
     int err;
     CARD32 nClients, length;
 
-    REQUEST_SIZE_MATCH(xRecordGetContextReq);
     VERIFY_CONTEXT(pContext, stuff->context, client);
 
     /* how many RCAPs are there on this context? */
@@ -2279,13 +2309,16 @@ ProcRecordGetContext(ClientPtr client)
 static int
 ProcRecordEnableContext(ClientPtr client)
 {
-    RecordContextPtr pContext;
-
     REQUEST(xRecordEnableContextReq);
+    REQUEST_SIZE_MATCH(xRecordEnableContextReq);
+
+    if (client->swapped)
+        swapl(&stuff->context);
+
+    RecordContextPtr pContext;
     int i;
     RecordClientsAndProtocolPtr pRCAP;
 
-    REQUEST_SIZE_MATCH(xRecordGetContextReq);
     VERIFY_CONTEXT(pContext, stuff->context, client);
     if (pContext->pRecordingClient)
         return BadMatch;        /* already enabled */
@@ -2390,11 +2423,13 @@ RecordDisableContext(RecordContextPtr pContext)
 static int
 ProcRecordDisableContext(ClientPtr client)
 {
-    RecordContextPtr pContext;
-
     REQUEST(xRecordDisableContextReq);
-
     REQUEST_SIZE_MATCH(xRecordDisableContextReq);
+
+    if (client->swapped)
+        swapl(&stuff->context);
+
+    RecordContextPtr pContext;
     VERIFY_CONTEXT(pContext, stuff->context, client);
     RecordDisableContext(pContext);
     return Success;
@@ -2451,11 +2486,13 @@ RecordDeleteContext(void *value, XID id)
 static int
 ProcRecordFreeContext(ClientPtr client)
 {
-    RecordContextPtr pContext;
-
     REQUEST(xRecordFreeContextReq);
-
     REQUEST_SIZE_MATCH(xRecordFreeContextReq);
+
+    if (client->swapped)
+        swapl(&stuff->context);
+
+    RecordContextPtr pContext;
     VERIFY_CONTEXT(pContext, stuff->context, client);
     FreeResource(stuff->context, X11_RESTYPE_NONE);
     return Success;
@@ -2489,16 +2526,6 @@ ProcRecordDispatch(ClientPtr client)
 }                               /* ProcRecordDispatch */
 
 static int _X_COLD
-SProcRecordQueryVersion(ClientPtr client)
-{
-    REQUEST(xRecordQueryVersionReq);
-    REQUEST_SIZE_MATCH(xRecordQueryVersionReq);
-    swaps(&stuff->majorVersion);
-    swaps(&stuff->minorVersion);
-    return ProcRecordQueryVersion(client);
-}                               /* SProcRecordQueryVersion */
-
-static int _X_COLD
 SwapCreateRegister(ClientPtr client, xRecordRegisterClientsReq * stuff)
 {
     int i;
@@ -2521,104 +2548,6 @@ SwapCreateRegister(ClientPtr client, xRecordRegisterClientsReq * stuff)
     RecordSwapRanges((xRecordRange *) pClientID, stuff->nRanges);
     return Success;
 }                               /* SwapCreateRegister */
-
-static int _X_COLD
-SProcRecordCreateContext(ClientPtr client)
-{
-    REQUEST(xRecordCreateContextReq);
-    int status;
-
-    REQUEST_AT_LEAST_SIZE(xRecordCreateContextReq);
-    if ((status = SwapCreateRegister(client, (void *) stuff)) != Success)
-        return status;
-    return ProcRecordCreateContext(client);
-}                               /* SProcRecordCreateContext */
-
-static int _X_COLD
-SProcRecordRegisterClients(ClientPtr client)
-{
-    REQUEST(xRecordRegisterClientsReq);
-    int status;
-
-    REQUEST_AT_LEAST_SIZE(xRecordRegisterClientsReq);
-    if ((status = SwapCreateRegister(client, (void *) stuff)) != Success)
-        return status;
-    return ProcRecordRegisterClients(client);
-}                               /* SProcRecordRegisterClients */
-
-static int _X_COLD
-SProcRecordUnregisterClients(ClientPtr client)
-{
-    REQUEST(xRecordUnregisterClientsReq);
-    REQUEST_AT_LEAST_SIZE(xRecordUnregisterClientsReq);
-    swapl(&stuff->context);
-    swapl(&stuff->nClients);
-    SwapRestL(stuff);
-    return ProcRecordUnregisterClients(client);
-}                               /* SProcRecordUnregisterClients */
-
-static int _X_COLD
-SProcRecordGetContext(ClientPtr client)
-{
-    REQUEST(xRecordGetContextReq);
-    REQUEST_SIZE_MATCH(xRecordGetContextReq);
-    swapl(&stuff->context);
-    return ProcRecordGetContext(client);
-}                               /* SProcRecordGetContext */
-
-static int _X_COLD
-SProcRecordEnableContext(ClientPtr client)
-{
-    REQUEST(xRecordEnableContextReq);
-    REQUEST_SIZE_MATCH(xRecordEnableContextReq);
-    swapl(&stuff->context);
-    return ProcRecordEnableContext(client);
-}                               /* SProcRecordEnableContext */
-
-static int _X_COLD
-SProcRecordDisableContext(ClientPtr client)
-{
-    REQUEST(xRecordDisableContextReq);
-    REQUEST_SIZE_MATCH(xRecordDisableContextReq);
-    swapl(&stuff->context);
-    return ProcRecordDisableContext(client);
-}                               /* SProcRecordDisableContext */
-
-static int _X_COLD
-SProcRecordFreeContext(ClientPtr client)
-{
-    REQUEST(xRecordFreeContextReq);
-    REQUEST_SIZE_MATCH(xRecordFreeContextReq);
-    swapl(&stuff->context);
-    return ProcRecordFreeContext(client);
-}                               /* SProcRecordFreeContext */
-
-static int _X_COLD
-SProcRecordDispatch(ClientPtr client)
-{
-    REQUEST(xReq);
-
-    switch (stuff->data) {
-    case X_RecordQueryVersion:
-        return SProcRecordQueryVersion(client);
-    case X_RecordCreateContext:
-        return SProcRecordCreateContext(client);
-    case X_RecordRegisterClients:
-        return SProcRecordRegisterClients(client);
-    case X_RecordUnregisterClients:
-        return SProcRecordUnregisterClients(client);
-    case X_RecordGetContext:
-        return SProcRecordGetContext(client);
-    case X_RecordEnableContext:
-        return SProcRecordEnableContext(client);
-    case X_RecordDisableContext:
-        return SProcRecordDisableContext(client);
-    case X_RecordFreeContext:
-        return SProcRecordFreeContext(client);
-    default:
-        return BadRequest;
-    }
-}                               /* SProcRecordDispatch */
 
 /* RecordConnectionSetupInfo
  *
@@ -2794,7 +2723,7 @@ RecordExtensionInit(void)
         return;
 
     extentry = AddExtension(RECORD_NAME, RecordNumEvents, RecordNumErrors,
-                            ProcRecordDispatch, SProcRecordDispatch,
+                            ProcRecordDispatch, ProcRecordDispatch,
                             RecordCloseDown, StandardMinorOpcode);
     if (!extentry) {
         DeleteCallback(&ClientStateCallback, RecordAClientStateChange, NULL);


### PR DESCRIPTION
The few LoC can be easily inlined into the actual request handlers,
so no need for having a whole bunch of extra functions for that.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
