### PR TITLE
shm: use embedded private instead of pointer

### DIFF
--- a/Xext/shm.c
+++ b/Xext/shm.c
@@ -97,6 +97,7 @@ in this Software without prior written authorization from The Open Group.
 
 
 typedef struct _ShmScrPrivateRec {
+    Bool initialized;
     ShmFuncsPtr shmFuncs;
 } ShmScrPrivateRec;
 
@@ -198,9 +199,9 @@ static void
 ShmScreenClose(CallbackListPtr *pcbl, ScreenPtr pScreen, void *unused)
 {
     ShmScrPrivateRec *screen_priv = ShmGetScreenPriv(pScreen);
-
-    dixSetPrivate(&pScreen->devPrivates, shmScrPrivateKey, NULL);
-    free(screen_priv);
+    if (screen_priv->initialized) {
+        screen_priv->initialized = FALSE;
+    }
 }
 
 static ShmScrPrivateRec *
@@ -208,10 +209,8 @@ ShmInitScreenPriv(ScreenPtr pScreen)
 {
     ShmScrPrivateRec *screen_priv = ShmGetScreenPriv(pScreen);
 
-    if (!screen_priv) {
-        screen_priv = calloc(1, sizeof(ShmScrPrivateRec));
-        dixSetPrivate(&pScreen->devPrivates, shmScrPrivateKey, screen_priv);
-        dixScreenHookClose(pScreen, ShmScreenClose);
+    if (!screen_priv->initialized) {
+        screen_priv->initialized = TRUE;
     }
     return screen_priv;
 }
@@ -219,7 +218,7 @@ ShmInitScreenPriv(ScreenPtr pScreen)
 static Bool
 ShmRegisterPrivates(void)
 {
-    if (!dixRegisterPrivateKey(&shmScrPrivateKeyRec, PRIVATE_SCREEN, 0))
+    if (!dixRegisterPrivateKey(&shmScrPrivateKeyRec, PRIVATE_SCREEN, sizeof(ShmScrPrivateRec)))
         return FALSE;
     if (!dixRegisterPrivateKey(&shmPixmapPrivateKeyRec, PRIVATE_PIXMAP, 0))
         return FALSE;


### PR DESCRIPTION
The private struct is pretty small and it needs to be allocated anyways,
so save an extra allocation by directly embedding it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
