### PR TITLE
xfree86: drop XF86XvScreenKey field

### DIFF
--- a/hw/xfree86/common/xf86xv.c
+++ b/hw/xfree86/common/xf86xv.c
@@ -109,15 +109,13 @@ static DevPrivateKeyRec XF86XVWindowKeyRec;
 
 #define XF86XVWindowKey (&XF86XVWindowKeyRec)
 
-/* dixmain.c XvScreenPtr screen private */
-DevPrivateKey XF86XvScreenKey;
 /** xf86xv.c XF86XVScreenPtr screen private */
 static DevPrivateKeyRec XF86XVScreenPrivateKey;
 
 static unsigned long PortResource = 0;
 
 #define GET_XV_SCREEN(pScreen) \
-    ((XvScreenPtr)dixLookupPrivate(&(pScreen)->devPrivates, XF86XvScreenKey))
+    ((XvScreenPtr)dixLookupPrivate(&(pScreen)->devPrivates, XvGetScreenKey()))
 
 #define GET_XF86XV_SCREEN(pScreen) \
     ((XF86XVScreenPtr)(dixGetPrivate(&pScreen->devPrivates, &XF86XVScreenPrivateKey)))
@@ -242,8 +240,6 @@ xf86XVScreenInit(ScreenPtr pScreen, XF86VideoAdaptorPtr * adaptors, int num)
         return FALSE;
     if (!dixRegisterPrivateKey(&XF86XVScreenPrivateKey, PRIVATE_SCREEN, 0))
         return FALSE;
-
-    XF86XvScreenKey = XvGetScreenKey();
 
     PortResource = XvGetRTPort();
 

--- a/hw/xfree86/common/xf86xvmc.c
+++ b/hw/xfree86/common/xf86xvmc.c
@@ -151,8 +151,7 @@ xf86XvMCScreenInit(ScreenPtr pScreen,
 {
     XvMCAdaptorPtr pAdapt;
     xf86XvMCScreenPtr pScreenPriv;
-    XvScreenPtr pxvs = (XvScreenPtr) dixLookupPrivate(&pScreen->devPrivates,
-                                                      XF86XvScreenKey);
+    XvScreenPtr pxvs = dixLookupPrivate(&pScreen->devPrivates, XvGetScreenKey());
     int i, j;
 
     if (noXvExtension)

--- a/hw/xfree86/common/xf86xvpriv.h
+++ b/hw/xfree86/common/xf86xvpriv.h
@@ -33,8 +33,6 @@
 
 /*** These are DDX layer privates ***/
 
-extern DevPrivateKey XF86XvScreenKey;
-
 typedef struct {
     ClipNotifyProcPtr ClipNotify;
     WindowExposuresProcPtr WindowExposures;


### PR DESCRIPTION
Not used by any drivers anymore, so no need to keep it around any longer.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
