### PR TITLE
treewide: replace PICT_FORMAT by PIXMAN_FORMAT

### DIFF
--- a/exa/exa_render.c
+++ b/exa/exa_render.c
@@ -904,7 +904,7 @@ exaComposite(CARD8 op,
                    (pSrc->format == pDst->format ||
                     (PIXMAN_FORMAT_COLOR(pDst->format) &&
                      PIXMAN_FORMAT_COLOR(pSrc->format) &&
-                     pDst->format == PICT_FORMAT(PIXMAN_FORMAT_BPP(pSrc->format),
+                     pDst->format == PIXMAN_FORMAT(PIXMAN_FORMAT_BPP(pSrc->format),
                                                  PIXMAN_FORMAT_TYPE(pSrc->format),
                                                  0,
                                                  PIXMAN_FORMAT_R(pSrc->format),

--- a/glamor/glamor_render.c
+++ b/glamor/glamor_render.c
@@ -1553,7 +1553,7 @@ glamor_composite_clipped_region(CARD8 op,
              && (source->format == dest->format
                  || (PIXMAN_FORMAT_COLOR(dest->format)
                      && PIXMAN_FORMAT_COLOR(source->format)
-                     && dest->format == PICT_FORMAT(PIXMAN_FORMAT_BPP(source->format),
+                     && dest->format == PIXMAN_FORMAT(PIXMAN_FORMAT_BPP(source->format),
                                                     PIXMAN_FORMAT_TYPE(source->format),
                                                     0,
                                                     PIXMAN_FORMAT_R(source->format),

--- a/render/picture.c
+++ b/render/picture.c
@@ -174,7 +174,7 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
     formats[nformats].format = PIXMAN_a1;
     formats[nformats].depth = 1;
     nformats++;
-    formats[nformats].format = PICT_FORMAT(BitsPerPixel(8),
+    formats[nformats].format = PIXMAN_FORMAT(BitsPerPixel(8),
                                            PIXMAN_TYPE_A, 8, 0, 0, 0);
     formats[nformats].depth = 8;
     nformats++;
@@ -224,7 +224,7 @@ PictureCreateDefaultFormats(ScreenPtr pScreen, int *nformatp)
                 type = PIXMAN_TYPE_BGRA;
             }
             if (type != PIXMAN_TYPE_OTHER) {
-                format = PICT_FORMAT(bpp, type, 0, r, g, b);
+                format = PIXMAN_FORMAT(bpp, type, 0, r, g, b);
                 addFormat(formats, &nformats, format, depth);
             }
             break;
@@ -658,7 +658,7 @@ PictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats)
             g = Ones(formats[n].direct.greenMask);
             b = Ones(formats[n].direct.blueMask);
         }
-        formats[n].format = PICT_FORMAT(0, type, a, r, g, b);
+        formats[n].format = PIXMAN_FORMAT(0, type, a, r, g, b);
     }
     PictureScreenPtr ps = calloc(1, sizeof(PictureScreenRec));
     if (!ps) {

--- a/render/picturestr.h
+++ b/render/picturestr.h
@@ -121,7 +121,7 @@ typedef union _SourcePict {
 typedef struct _Picture {
     DrawablePtr pDrawable;
     PictFormatPtr pFormat;
-    PictFormatShort format;     /* PICT_FORMAT */
+    PictFormatShort format;     /* PIXMAN_FORMAT */
     int refcnt;
     CARD32 id;
     unsigned int repeat:1;


### PR DESCRIPTION
Try not to use old compat macros anymore, use the real ones instead.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
