### PR TITLE
treewide: replace PictFormatShort by pixman_format_code_t

### DIFF
--- a/exa/exa_render.c
+++ b/exa/exa_render.c
@@ -176,7 +176,8 @@ exaGetRGBAFromPixel(CARD32 pixel,
                     CARD16 *green,
                     CARD16 *blue,
                     CARD16 *alpha,
-                    PictFormatPtr pFormat, PictFormatShort format)
+                    PictFormatPtr pFormat,
+                    pixman_format_code_t format)
 {
     int rshift, bshift, gshift, ashift;
 

--- a/glamor/glamor_gradient.c
+++ b/glamor/glamor_gradient.c
@@ -820,7 +820,7 @@ glamor_generate_radial_gradient_picture(ScreenPtr screen,
                                         PicturePtr src_picture,
                                         int x_source, int y_source,
                                         int width, int height,
-                                        PictFormatShort format)
+                                        pixman_format_code_t format)
 {
     glamor_screen_private *glamor_priv;
     PicturePtr dst_picture = NULL;
@@ -1125,7 +1125,7 @@ glamor_generate_linear_gradient_picture(ScreenPtr screen,
                                         PicturePtr src_picture,
                                         int x_source, int y_source,
                                         int width, int height,
-                                        PictFormatShort format)
+                                        pixman_format_code_t format)
 {
     glamor_screen_private *glamor_priv;
     PicturePtr dst_picture = NULL;

--- a/glamor/glamor_picture.c
+++ b/glamor/glamor_picture.c
@@ -68,8 +68,8 @@ static void byte_swap_swizzle(GLenum *swizzle)
  */
 static Bool
 glamor_get_tex_format_type_from_pictformat(ScreenPtr pScreen,
-                                           PictFormatShort format,
-                                           PictFormatShort *temp_format,
+                                           pixman_format_code_t format,
+                                           pixman_format_code_t *temp_format,
                                            GLenum *tex_format,
                                            GLenum *tex_type,
                                            GLenum *swizzle)
@@ -237,8 +237,8 @@ glamor_get_tex_format_type_from_pictformat(ScreenPtr pScreen,
  * in-memory pixman image of those bits in a destination format.
  */
 static pixman_image_t *
-glamor_get_converted_image(PictFormatShort dst_format,
-                           PictFormatShort src_format,
+glamor_get_converted_image(pixman_format_code_t dst_format,
+                           pixman_format_code_t src_format,
                            void *src_bits,
                            int src_stride,
                            int w, int h)
@@ -276,7 +276,7 @@ glamor_upload_picture_to_texture(PicturePtr picture)
     ScreenPtr screen = pixmap->drawable.pScreen;
     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
     glamor_pixmap_private *pixmap_priv = glamor_get_pixmap_private(pixmap);
-    PictFormatShort converted_format;
+    pixman_format_code_t converted_format;
     void *bits = pixmap->devPrivate.ptr;
     int stride = pixmap->devKind;
     GLenum format, type;

--- a/glamor/glamor_priv.h
+++ b/glamor/glamor_priv.h
@@ -725,12 +725,12 @@ PicturePtr glamor_generate_linear_gradient_picture(ScreenPtr screen,
                                                    PicturePtr src_picture,
                                                    int x_source, int y_source,
                                                    int width, int height,
-                                                   PictFormatShort format);
+                                                   pixman_format_code_t format);
 PicturePtr glamor_generate_radial_gradient_picture(ScreenPtr screen,
                                                    PicturePtr src_picture,
                                                    int x_source, int y_source,
                                                    int width, int height,
-                                                   PictFormatShort format);
+                                                   pixman_format_code_t format);
 
 /* glamor_triangles.c */
 void glamor_triangles(CARD8 op,

--- a/glamor/glamor_render.c
+++ b/glamor/glamor_render.c
@@ -740,10 +740,12 @@ static const int pict_format_combine_tab[][3] = {
 };
 
 static Bool
-combine_pict_format(PictFormatShort * des, const PictFormatShort src,
-                    const PictFormatShort mask, glamor_program_alpha in_ca)
+combine_pict_format(pixman_format_code_t *des,
+                    const pixman_format_code_t src,
+                    const pixman_format_code_t mask,
+                    glamor_program_alpha in_ca)
 {
-    PictFormatShort new_vis;
+    pixman_format_code_t new_vis;
     int src_type, mask_type, src_bpp;
     int i;
 
@@ -842,7 +844,7 @@ glamor_set_normalize_tcoords_generic(PixmapPtr pixmap,
 static Bool
 glamor_render_format_is_supported(PicturePtr picture)
 {
-    PictFormatShort storage_format;
+    pixman_format_code_t storage_format;
     glamor_screen_private *glamor_priv;
     struct glamor_format *f;
 
@@ -899,14 +901,14 @@ glamor_composite_choose_shader(CARD8 op,
                                struct shader_key *s_key,
                                glamor_composite_shader ** shader,
                                struct blendinfo *op_info,
-                               PictFormatShort *psaved_source_format,
+                               pixman_format_code_t *psaved_source_format,
                                enum ca_state ca_state)
 {
     ScreenPtr screen = dest->pDrawable->pScreen;
     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
     Bool source_needs_upload = FALSE;
     Bool mask_needs_upload = FALSE;
-    PictFormatShort saved_source_format = 0;
+    pixman_format_code_t saved_source_format = 0;
     struct shader_key key;
     GLfloat source_solid_color[4];
     GLfloat mask_solid_color[4];
@@ -1228,7 +1230,7 @@ glamor_composite_with_shader(CARD8 op,
     int dest_x_off, dest_y_off;
     int source_x_off, source_y_off;
     int mask_x_off, mask_y_off;
-    PictFormatShort saved_source_format = 0;
+    pixman_format_code_t saved_source_format = 0;
     float src_matrix[9], mask_matrix[9];
     float *psrc_matrix = NULL, *pmask_matrix = NULL;
     int nrect_max;
@@ -1441,7 +1443,7 @@ glamor_convert_gradient_picture(ScreenPtr screen,
     PicturePtr dst = NULL;
     int error;
     PictFormatPtr pFormat;
-    PictFormatShort format;
+    pixman_format_code_t format;
     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
 
     if (source->pDrawable) {

--- a/render/picturestr.h
+++ b/render/picturestr.h
@@ -121,7 +121,7 @@ typedef union _SourcePict {
 typedef struct _Picture {
     DrawablePtr pDrawable;
     PictFormatPtr pFormat;
-    PictFormatShort format;     /* PIXMAN_FORMAT */
+    pixman_format_code_t format;     /* PIXMAN_FORMAT */
     int refcnt;
     CARD32 id;
     unsigned int repeat:1;


### PR DESCRIPTION
Try not to use old compat macros anymore, use the real ones instead.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
