### PR TITLE
include: move CharInfoPtr definition to gcstruct.h

### DIFF
--- a/include/gcstruct.h
+++ b/include/gcstruct.h
@@ -58,6 +58,11 @@ SOFTWARE.
 
 #define GCAllBits ((1 << (GCLastBit + 1)) - 1)
 
+#ifndef _XTYPEDEF_CHARINFOPTR
+typedef struct _CharInfo *CharInfoPtr;  /* also in fonts/include/font.h */
+#define _XTYPEDEF_CHARINFOPTR
+#endif
+
 /*
  * functions which modify the state of the GC
  */

--- a/include/misc.h
+++ b/include/misc.h
@@ -326,17 +326,6 @@ typedef struct _xEvent *xEventPtr;
 typedef struct _xRectangle *xRectanglePtr;
 typedef struct _GrabRec *GrabPtr;
 
-/*  typedefs from other places - duplicated here to minimize the amount
- *  of unnecessary junk that one would normally have to include to get
- *  these symbols defined
- */
-
-#ifndef _XTYPEDEF_CHARINFOPTR
-typedef struct _CharInfo *CharInfoPtr;  /* also in fonts/include/font.h */
-
-#define _XTYPEDEF_CHARINFOPTR
-#endif
-
 typedef unsigned long x_server_generation_t;
 
 extern _X_EXPORT unsigned long globalSerialNumber;


### PR DESCRIPTION
Move it to where it's really needed.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
