### PR TITLE
os: move LogPrintMarkers() declaration into private header

### DIFF
--- a/include/os.h
+++ b/include/os.h
@@ -302,8 +302,6 @@ extern _X_EXPORT void
 ErrorF(const char *f, ...)
 _X_ATTRIBUTE_PRINTF(1, 2);
 
-void LogPrintMarkers(void);
-
 extern _X_EXPORT void
 xorg_backtrace(void);
 

--- a/os/log_priv.h
+++ b/os/log_priv.h
@@ -89,4 +89,9 @@ extern int xorgSyslogVerbosity;
  */
 extern const char *xorgSyslogIdent;
 
+/*
+ * print log markers into the log file
+ */
+void LogPrintMarkers(void);
+
 #endif /* __XORG_OS_LOGGING_H */


### PR DESCRIPTION
Not exported, not used by any external modules, so no need to have
that declaration in a public SDK header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
