### PR TITLE
os: log: make LogVHdrMessageVerb() static

### DIFF
--- a/include/os.h
+++ b/include/os.h
@@ -280,12 +280,6 @@ extern _X_EXPORT void
 LogMessage(MessageType type, const char *format, ...)
 _X_ATTRIBUTE_PRINTF(2, 3);
 
-void
-LogVHdrMessageVerb(MessageType type, int verb,
-                   const char *msg_format, va_list msg_args,
-                   const char *hdr_format, va_list hdr_args)
-_X_ATTRIBUTE_PRINTF(3, 0)
-_X_ATTRIBUTE_PRINTF(5, 0);
 extern _X_EXPORT void
 LogHdrMessageVerb(MessageType type, int verb,
                   const char *msg_format, va_list msg_args,

--- a/os/log.c
+++ b/os/log.c
@@ -734,7 +734,14 @@ LogMessage(MessageType type, const char *format, ...)
     va_end(ap);
 }
 
-void
+static void
+LogVHdrMessageVerb(MessageType type, int verb,
+                   const char *msg_format, va_list msg_args,
+                   const char *hdr_format, va_list hdr_args)
+_X_ATTRIBUTE_PRINTF(3, 0)
+_X_ATTRIBUTE_PRINTF(5, 0);
+
+static void
 LogVHdrMessageVerb(MessageType type, int verb, const char *msg_format,
                    va_list msg_args, const char *hdr_format, va_list hdr_args)
 {


### PR DESCRIPTION
Only used inside log.c and not exported, so can be made static.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
