### PR TITLE
os: unexport XNFreallocarray()

### DIFF
--- a/Xi/exevents.c
+++ b/Xi/exevents.c
@@ -82,6 +82,7 @@ SOFTWARE.
 
 #include "dix/cursor_priv.h"
 #include "os/bug_priv.h"
+#include "os/osdep.h"
 
 #include <X11/X.h>
 #include <X11/Xproto.h>

--- a/hw/xfree86/common/xf86AutoConfig.c
+++ b/hw/xfree86/common/xf86AutoConfig.c
@@ -33,6 +33,8 @@
 #include <xorg-config.h>
 #endif
 
+#include "os/osdep.h"
+
 #include "xf86.h"
 #include "xf86Parser_priv.h"
 #include "xf86tokens.h"

--- a/hw/xfree86/common/xf86Bus.c
+++ b/hw/xfree86/common/xf86Bus.c
@@ -39,6 +39,7 @@
 #include <X11/X.h>
 
 #include "config/hotplug_priv.h"
+#include "os/osdep.h"
 
 #include "os.h"
 #include "xf86_priv.h"

--- a/hw/xfree86/common/xf86Helper.c
+++ b/hw/xfree86/common/xf86Helper.c
@@ -45,6 +45,7 @@
 #include "dix/input_priv.h"
 #include "mi/mi_priv.h"
 #include "os/log_priv.h"
+#include "os/osdep.h"
 
 #include "os.h"
 #include "servermd.h"

--- a/hw/xfree86/common/xf86pciBus.c
+++ b/hw/xfree86/common/xf86pciBus.c
@@ -39,6 +39,7 @@
 #include <X11/X.h>
 
 #include "os/log_priv.h"
+#include "os/osdep.h"
 
 #include "os.h"
 #include "Pci.h"

--- a/hw/xfree86/common/xf86platformBus.c
+++ b/hw/xfree86/common/xf86platformBus.c
@@ -40,6 +40,7 @@
 #include "config/hotplug_priv.h"
 #include "dix/screenint_priv.h"
 #include "randr/randrstr_priv.h"
+#include "os/osdep.h"
 
 #include "os.h"
 #include "../os-support/linux/systemd-logind.h"

--- a/hw/xfree86/i2c/xf86i2c.c
+++ b/hw/xfree86/i2c/xf86i2c.c
@@ -13,6 +13,8 @@
 #include <sys/time.h>
 #include <string.h>
 
+#include "os/osdep.h"
+
 #include "misc.h"
 #include "xf86.h"
 #include "xf86_OSproc.h"

--- a/include/os.h
+++ b/include/os.h
@@ -165,13 +165,6 @@ extern _X_EXPORT void *
 XNFrealloc(void * /*ptr */ , unsigned long /*amount */ );
 
 /*
- * This function reallocarray(3)s passed buffer, terminating the server if
- * there is not enough memory or the arguments overflow when multiplied.
- */
-extern _X_EXPORT void *
-XNFreallocarray(void *ptr, size_t nmemb, size_t size);
-
-/*
  * This function strdup(3)s passed string. The only difference from the library
  * function that it is safe to pass NULL, as NULL will be returned.
  */

--- a/os/alloc.c
+++ b/os/alloc.c
@@ -7,7 +7,8 @@
 
 #include <stdlib.h>
 
-#include "os.h"
+#include "include/os.h"
+#include "os/osdep.h"
 
 void *
 XNFalloc(unsigned long amount)

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -202,6 +202,12 @@ extern Bool CoreDump;
 extern Bool NoListenAll;
 extern Bool AllowByteSwappedClients;
 
+/*
+ * This function reallocarray(3)s passed buffer, terminating the server if
+ * there is not enough memory or the arguments overflow when multiplied.
+ */
+void *XNFreallocarray(void *ptr, size_t nmemb, size_t size);
+
 #if __has_builtin(__builtin_popcountl)
 # define Ones __builtin_popcountl
 #else


### PR DESCRIPTION
Not used by any drivers, no no need to keep it in public SDK.
Since it's not used by drivers, it's effectively not an ABI change,
so can be done within ABI-25.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
