### PR TITLE
Xi: inline SProcXGrabDeviceKey()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -380,7 +380,7 @@ SProcIDispatch(ClientPtr client)
         case X_UngrabDevice:
             return ProcXUngrabDevice(client);
         case X_GrabDeviceKey:
-            return SProcXGrabDeviceKey(client);
+            return ProcXGrabDeviceKey(client);
         case X_UngrabDeviceKey:
             return SProcXUngrabDeviceKey(client);
         case X_GrabDeviceButton:

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -75,7 +75,6 @@ int SProcXGetDeviceMotionEvents(ClientPtr client);
 int SProcXGetExtensionVersion(ClientPtr client);
 int SProcXGetSelectedExtensionEvents(ClientPtr client);
 int SProcXGrabDeviceButton(ClientPtr client);
-int SProcXGrabDeviceKey(ClientPtr client);
 int SProcXIAllowEvents(ClientPtr client);
 int SProcXIBarrierReleasePointer(ClientPtr client);
 int SProcXIGetClientPointer(ClientPtr client);


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
