### PR TITLE
Xi: inline SProcXChangeDeviceDontPropagateList()

### DIFF
--- a/Xi/chgprop.c
+++ b/Xi/chgprop.c
@@ -67,25 +67,6 @@ SOFTWARE.
 
 /***********************************************************************
  *
- * This procedure returns the extension version.
- *
- */
-
-int _X_COLD
-SProcXChangeDeviceDontPropagateList(ClientPtr client)
-{
-    REQUEST(xChangeDeviceDontPropagateListReq);
-    REQUEST_AT_LEAST_SIZE(xChangeDeviceDontPropagateListReq);
-    swapl(&stuff->window);
-    swaps(&stuff->count);
-    REQUEST_FIXED_SIZE(xChangeDeviceDontPropagateListReq,
-                       stuff->count * sizeof(CARD32));
-    SwapLongs((CARD32 *) (&stuff[1]), stuff->count);
-    return (ProcXChangeDeviceDontPropagateList(client));
-}
-
-/***********************************************************************
- *
  * This procedure changes the dont-propagate list for the specified window.
  *
  */
@@ -93,18 +74,24 @@ SProcXChangeDeviceDontPropagateList(ClientPtr client)
 int
 ProcXChangeDeviceDontPropagateList(ClientPtr client)
 {
+    REQUEST(xChangeDeviceDontPropagateListReq);
+    REQUEST_AT_LEAST_SIZE(xChangeDeviceDontPropagateListReq);
+
+    if (client->swapped) {
+        swapl(&stuff->window);
+        swaps(&stuff->count);
+    }
+
+    REQUEST_FIXED_SIZE(xChangeDeviceDontPropagateListReq,
+                       stuff->count * sizeof(CARD32));
+
+    if (client->swapped)
+        SwapLongs((CARD32 *) (&stuff[1]), stuff->count);
+
     int i, rc;
     WindowPtr pWin;
     struct tmask tmp[EMASKSIZE];
     OtherInputMasks *others;
-
-    REQUEST(xChangeDeviceDontPropagateListReq);
-    REQUEST_AT_LEAST_SIZE(xChangeDeviceDontPropagateListReq);
-
-    if (client->req_len !=
-        bytes_to_int32(sizeof(xChangeDeviceDontPropagateListReq)) +
-        stuff->count)
-        return BadLength;
 
     rc = dixLookupWindow(&pWin, stuff->window, client, DixSetAttrAccess);
     if (rc != Success)

--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -366,7 +366,7 @@ SProcIDispatch(ClientPtr client)
         case X_GetSelectedExtensionEvents:
             return SProcXGetSelectedExtensionEvents(client);
         case X_ChangeDeviceDontPropagateList:
-            return SProcXChangeDeviceDontPropagateList(client);
+            return ProcXChangeDeviceDontPropagateList(client);
         case X_GetDeviceDontPropagateList:
             return SProcXGetDeviceDontPropagateList(client);
         case X_GetDeviceMotionEvents:

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -69,7 +69,6 @@ int ProcXUngrabDeviceButton(ClientPtr client);
 int ProcXUngrabDevice(ClientPtr client);
 int ProcXUngrabDeviceKey(ClientPtr client);
 
-int SProcXChangeDeviceDontPropagateList(ClientPtr client);
 int SProcXGetDeviceDontPropagateList(ClientPtr  client);
 int SProcXGetDeviceMotionEvents(ClientPtr client);
 int SProcXGetExtensionVersion(ClientPtr client);


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
