### PR TITLE
Xi: inline SProcXSendExtensionEvent()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -412,7 +412,7 @@ SProcIDispatch(ClientPtr client)
         case X_QueryDeviceState:
             return ProcXQueryDeviceState(client);
         case X_SendExtensionEvent:
-            return SProcXSendExtensionEvent(client);
+            return ProcXSendExtensionEvent(client);
         case X_DeviceBell:
             return ProcXDeviceBell(client);
         case X_SetDeviceValuators:

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -90,7 +90,6 @@ int SProcXISelectEvents(ClientPtr client);
 int SProcXISetClientPointer(ClientPtr client);
 int SProcXISetFocus(ClientPtr client);
 int SProcXIWarpPointer(ClientPtr client);
-int SProcXSendExtensionEvent(ClientPtr client);
 int SProcXSetDeviceFocus(ClientPtr client);
 int SProcXUngrabDeviceButton(ClientPtr client);
 int SProcXUngrabDeviceKey(ClientPtr client);


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
