### PR TITLE
dbe: replace dbeScreenPrivKey and dbeWindowPrivKey macros

### DIFF
--- a/dbe/dbe.c
+++ b/dbe/dbe.c
@@ -236,7 +236,7 @@ ProcDbeAllocateBackBufferName(ClientPtr client)
             pDbeWindowPriv->IDs[i] = DBE_FREE_ID_ELEMENT;
 
         /* Actually connect the window priv to the window. */
-        dixSetPrivate(&pWin->devPrivates, dbeWindowPrivKey, pDbeWindowPriv);
+        dixSetPrivate(&pWin->devPrivates, &dbeWindowPrivKeyRec, pDbeWindowPriv);
     } else {
         /* A buffer is already associated with the window.
          * Add the new buffer ID to the array, reallocating the array memory
@@ -327,7 +327,7 @@ ProcDbeAllocateBackBufferName(ClientPtr client)
     return status;
 
  out_free:
-    dixSetPrivate(&pWin->devPrivates, dbeWindowPrivKey, NULL);
+    dixSetPrivate(&pWin->devPrivates, &dbeWindowPrivKeyRec, NULL);
     free(pDbeWindowPriv);
     return status;
 
@@ -919,7 +919,7 @@ DbeWindowPrivDelete(void *pDbeWinPriv, XID id)
 
     if (pDbeWindowPriv->nBufferIDs == 0) {
         /* Reset the DBE window priv pointer. */
-        dixSetPrivate(&pDbeWindowPriv->pWindow->devPrivates, dbeWindowPrivKey,
+        dixSetPrivate(&pDbeWindowPriv->pWindow->devPrivates, &dbeWindowPrivKeyRec,
                       NULL);
 
         /* We are done with the window priv. */
@@ -1039,13 +1039,13 @@ DbeExtensionInit(void)
 
             for (int j = 0; j < walkScreenIdx; j++) {
                 ScreenPtr pScreen = screenInfo.screens[j];
-                free(dixLookupPrivate(&pScreen->devPrivates, dbeScreenPrivKey));
-                dixSetPrivate(&pScreen->devPrivates, dbeScreenPrivKey, NULL);
+                free(dixLookupPrivate(&pScreen->devPrivates, &dbeScreenPrivKeyRec));
+                dixSetPrivate(&pScreen->devPrivates, &dbeScreenPrivKeyRec, NULL);
             }
             return;
         }
 
-        dixSetPrivate(&walkScreen->devPrivates, dbeScreenPrivKey, pDbeScreenPriv);
+        dixSetPrivate(&walkScreen->devPrivates, &dbeScreenPrivKeyRec, pDbeScreenPriv);
 
         {
             /* We don't have DDX support for DBE anymore */
@@ -1085,8 +1085,8 @@ DbeExtensionInit(void)
 
         for (int i = 0; i < screenInfo.numScreens; i++) {
             ScreenPtr walkScreen = screenInfo.screens[i];
-            free(dixLookupPrivate(&walkScreen->devPrivates, dbeScreenPrivKey));
-            dixSetPrivate(&walkScreen->devPrivates, dbeScreenPrivKey, NULL);
+            free(dixLookupPrivate(&walkScreen->devPrivates, &dbeScreenPrivKeyRec));
+            dixSetPrivate(&walkScreen->devPrivates, &dbeScreenPrivKeyRec, NULL);
         }
         return;
     }

--- a/dbe/dbestruct.h
+++ b/dbe/dbestruct.h
@@ -53,7 +53,7 @@ typedef struct {
 /* DEFINES */
 
 #define DBE_SCREEN_PRIV(pScreen) ((DbeScreenPrivPtr) \
-    dixLookupPrivate(&(pScreen)->devPrivates, dbeScreenPrivKey))
+    dixLookupPrivate(&(pScreen)->devPrivates, &dbeScreenPrivKeyRec))
 
 #define DBE_SCREEN_PRIV_FROM_DRAWABLE(pDrawable) \
     DBE_SCREEN_PRIV((pDrawable)->pScreen)
@@ -71,7 +71,7 @@ typedef struct {
     DBE_SCREEN_PRIV((pGC)->pScreen)
 
 #define DBE_WINDOW_PRIV(pWin) ((DbeWindowPrivPtr) \
-    dixLookupPrivate(&(pWin)->devPrivates, dbeWindowPrivKey))
+    dixLookupPrivate(&(pWin)->devPrivates, &dbeWindowPrivKeyRec))
 
 /* Initial size of the buffer ID array in the window priv. */
 #define DBE_INIT_MAX_IDS	2

--- a/dbe/midbe.h
+++ b/dbe/midbe.h
@@ -39,12 +39,7 @@
 extern Bool miDbeInit(ScreenPtr pScreen, DbeScreenPrivPtr pDbeScreenPriv);
 
 extern DevPrivateKeyRec dbeScreenPrivKeyRec;
-
-#define dbeScreenPrivKey (&dbeScreenPrivKeyRec)
-
 extern DevPrivateKeyRec dbeWindowPrivKeyRec;
-
-#define dbeWindowPrivKey (&dbeWindowPrivKeyRec)
 
 extern RESTYPE dbeDrawableResType;
 extern RESTYPE dbeWindowPrivResType;


### PR DESCRIPTION
No need for the extra macros, we can just use the corresponding
structs directly.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
