### PR TITLE
glx: use DeleteCallbackList() for callback list destruction

### DIFF
--- a/dix/callback_priv.h
+++ b/dix/callback_priv.h
@@ -19,6 +19,7 @@ void DeleteCallbackManager(void);
  *
  * @param pcbl pointer to the list head (CallbackListPtr)
  */
+_X_EXPORT /* only for GLX module */
 void DeleteCallbackList(CallbackListPtr *pcbl);
 
 #endif /* _XSERVER_CALLBACK_PRIV_H */

--- a/glx/vndext.c
+++ b/glx/vndext.c
@@ -40,6 +40,7 @@
 #include <GL/glxproto.h>
 #include "vndservervendor.h"
 
+#include "dix/callback_priv.h"
 #include "dix/dix_priv.h"
 #include "miext/extinit_priv.h"
 
@@ -47,8 +48,7 @@ Bool noGlxExtension = FALSE;
 
 ExtensionEntry *GlxExtensionEntry;
 int GlxErrorBase = 0;
-static CallbackListRec vndInitCallbackList;
-static CallbackListPtr vndInitCallbackListPtr = &vndInitCallbackList;
+static CallbackListPtr vndInitCallbackListPtr = NULL;
 static DevPrivateKeyRec glvXGLVScreenPrivKey;
 static DevPrivateKeyRec glvXGLVClientPrivKey;
 
@@ -209,11 +209,7 @@ GLXReset(ExtensionEntry *extEntry)
     GlxMappingReset();
 
     if ((dispatchException & DE_TERMINATE) == DE_TERMINATE) {
-        while (vndInitCallbackList.list != NULL) {
-            CallbackPtr next = vndInitCallbackList.list->next;
-            free(vndInitCallbackList.list);
-            vndInitCallbackList.list = next;
-        }
+        DeleteCallbackList(&vndInitCallbackListPtr);
     }
 }
 


### PR DESCRIPTION
We already have a function for callback list deletion, so use this one
instead of doing it manually.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
