### PR TITLE
dix: unexport screen saver parameters

### DIFF
--- a/Xext/dpms.c
+++ b/Xext/dpms.c
@@ -34,6 +34,7 @@ Equipment Corporation.
 
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
+#include "dix/screensaver_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/screensaver.h"
 #include "Xext/geext_priv.h"

--- a/Xext/saver.c
+++ b/Xext/saver.c
@@ -37,6 +37,7 @@ in this Software without prior written authorization from the X Consortium.
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
+#include "dix/screensaver_priv.h"
 #include "dix/window_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/osdep.h"

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -114,6 +114,7 @@ Equipment Corporation.
 #include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/screensaver_priv.h"
 #include "dix/selection_priv.h"
 #include "dix/window_priv.h"
 #include "include/resource.h"

--- a/dix/main.c
+++ b/dix/main.c
@@ -92,6 +92,7 @@ Equipment Corporation.
 #include "dix/input_priv.h"
 #include "dix/gc_priv.h"
 #include "dix/registry_priv.h"
+#include "dix/screensaver_priv.h"
 #include "dix/selection_priv.h"
 #include "os/audit.h"
 #include "os/auth.h"

--- a/dix/screensaver_priv.h
+++ b/dix/screensaver_priv.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef _XSERVER_DIX_SCREENSAVER_PRIV_H
+#define _XSERVER_DIX_SCREENSAVER_PRIV_H
+
+#include <X11/Xdefs.h>
+#include <X11/Xmd.h>
+
+extern CARD32 defaultScreenSaverTime;
+extern CARD32 defaultScreenSaverInterval;
+extern CARD32 ScreenSaverTime;
+extern CARD32 ScreenSaverInterval;
+extern Bool screenSaverSuspended;
+
+#endif /* _XSERVER_DIX_SCREENSAVER_PRIV_H */

--- a/hw/xfree86/common/xf86Config.c
+++ b/hw/xfree86/common/xf86Config.c
@@ -51,6 +51,7 @@
 #include <grp.h>
 
 #include "dix/resource_priv.h"
+#include "dix/screensaver_priv.h"
 #include "os/log_priv.h"
 #include "os/osdep.h"
 #include "xkb/xkbsrv_priv.h"

--- a/hw/xwin/winblock.c
+++ b/hw/xwin/winblock.c
@@ -31,6 +31,9 @@
 #ifdef HAVE_XWIN_CONFIG_H
 #include <xwin-config.h>
 #endif
+
+#include "dix/screensaver_priv.h"
+
 #include "win.h"
 #include "winmsg.h"
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -11,15 +11,6 @@
 
 /* Global X server variables that are visible to mi, dix, os, and ddx */
 
-extern _X_EXPORT CARD32 defaultScreenSaverTime;
-extern _X_EXPORT CARD32 defaultScreenSaverInterval;
-extern _X_EXPORT CARD32 ScreenSaverTime;
-extern _X_EXPORT CARD32 ScreenSaverInterval;
-
-#ifdef SCREENSAVER
-extern _X_EXPORT Bool screenSaverSuspended;
-#endif
-
 extern _X_EXPORT const char *defaultFontPath;
 extern _X_EXPORT int monitorResolution;
 extern _X_EXPORT int defaultColorVisualClass;

--- a/os/WaitFor.c
+++ b/os/WaitFor.c
@@ -63,6 +63,7 @@ SOFTWARE.
 #include <X11/X.h>
 
 #include "dix/dix_priv.h"
+#include "dix/screensaver_priv.h"
 #include "os/busfault.h"
 #include "os/client_priv.h"
 #include "os/screensaver.h"

--- a/os/utils.c
+++ b/os/utils.c
@@ -96,6 +96,7 @@ OR PERFORMANCE OF THIS SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
+#include "dix/screensaver_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/audit.h"
 #include "os/auth.h"


### PR DESCRIPTION
Not used by any external drivers, so no need to keep them in public
SDK headers. Since they're never used by drivers, it's effectively
not an ABI change, so can safely be done within ABI-25.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
