### PR TITLE
dix: move struct _WorkQueue definition into dixutil.c

### DIFF
--- a/dix/dixutils.c
+++ b/dix/dixutils.c
@@ -469,6 +469,13 @@ InitBlockAndWakeupHandlers(void)
  * sleeps for input.
  */
 
+typedef struct _WorkQueue {
+    struct _WorkQueue *next;
+    Bool (*function) (ClientPtr pClient, void *closure);
+    ClientPtr client;
+    void *closure;
+} *WorkQueuePtr;
+
 WorkQueuePtr workQueue;
 static WorkQueuePtr *workQueueLast = &workQueue;
 

--- a/include/dix.h
+++ b/include/dix.h
@@ -98,8 +98,6 @@ typedef struct _Client *ClientPtr;
 #define _XTYPEDEF_CLIENTPTR
 #endif
 
-typedef struct _WorkQueue *WorkQueuePtr;
-
 extern _X_EXPORT ClientPtr clients[MAXCLIENTS];
 extern _X_EXPORT ClientPtr serverClient;
 extern _X_EXPORT int currentMaxClients;

--- a/include/dixstruct.h
+++ b/include/dixstruct.h
@@ -115,15 +115,6 @@ typedef struct _Client {
     int req_fds;
 } ClientRec;
 
-typedef struct _WorkQueue {
-    struct _WorkQueue *next;
-    Bool (*function) (ClientPtr /* pClient */ ,
-                      void *    /* closure */
-        );
-    ClientPtr client;
-    void *closure;
-} WorkQueueRec;
-
 extern _X_EXPORT TimeStamp currentTime;
 
 extern _X_EXPORT int


### PR DESCRIPTION
It's only used inside dixutil.c, nowhere else, especially not drivers,
so no need to keep it in public SDK. Safe for ABI-25.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
