### PR TITLE
xkb: inline SProcXkbUseExtension()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -175,9 +175,15 @@ int
 ProcXkbUseExtension(ClientPtr client)
 {
     REQUEST(xkbUseExtensionReq);
+    REQUEST_SIZE_MATCH(xkbUseExtensionReq);
+
+    if (client->swapped) {
+        swaps(&stuff->wantedMajor);
+        swaps(&stuff->wantedMinor);
+    }
+
     int supported;
 
-    REQUEST_SIZE_MATCH(xkbUseExtensionReq);
     if (stuff->wantedMajor != SERVER_XKB_MAJOR_VERSION) {
         /* pre-release version 0.65 is compatible with 1.00 */
         supported = ((SERVER_XKB_MAJOR_VERSION == 1) &&

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -42,16 +42,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
          * REQUEST SWAPPING
          */
 static int _X_COLD
-SProcXkbUseExtension(ClientPtr client)
-{
-    REQUEST(xkbUseExtensionReq);
-    REQUEST_SIZE_MATCH(xkbUseExtensionReq);
-    swaps(&stuff->wantedMajor);
-    swaps(&stuff->wantedMinor);
-    return ProcXkbUseExtension(client);
-}
-
-static int _X_COLD
 SProcXkbSelectEvents(ClientPtr client)
 {
     REQUEST(xkbSelectEventsReq);
@@ -431,7 +421,7 @@ SProcXkbDispatch(ClientPtr client)
     REQUEST(xReq);
     switch (stuff->data) {
     case X_kbUseExtension:
-        return SProcXkbUseExtension(client);
+        return ProcXkbUseExtension(client);
     case X_kbSelectEvents:
         return SProcXkbSelectEvents(client);
     case X_kbBell:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
