### PR TITLE
xkb: inline SProcXkbGetControls()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -684,11 +684,14 @@ ProcXkbLatchLockState(ClientPtr client)
 int
 ProcXkbGetControls(ClientPtr client)
 {
-    XkbControlsPtr xkb;
-    DeviceIntPtr dev;
-
     REQUEST(xkbGetControlsReq);
     REQUEST_SIZE_MATCH(xkbGetControlsReq);
+
+    if (client->swapped)
+        swaps(&stuff->deviceSpec);
+
+    XkbControlsPtr xkb;
+    DeviceIntPtr dev;
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -163,15 +163,6 @@ SProcXkbLatchLockState(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbGetControls(ClientPtr client)
-{
-    REQUEST(xkbGetControlsReq);
-    REQUEST_SIZE_MATCH(xkbGetControlsReq);
-    swaps(&stuff->deviceSpec);
-    return ProcXkbGetControls(client);
-}
-
-static int _X_COLD
 SProcXkbSetControls(ClientPtr client)
 {
     REQUEST(xkbSetControlsReq);
@@ -441,7 +432,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbLatchLockState:
         return SProcXkbLatchLockState(client);
     case X_kbGetControls:
-        return SProcXkbGetControls(client);
+        return ProcXkbGetControls(client);
     case X_kbSetControls:
         return SProcXkbSetControls(client);
     case X_kbGetMap:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
