### PR TITLE
xkb: inline SProcXkbGetMap()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -1376,6 +1376,13 @@ ProcXkbGetMap(ClientPtr client)
     REQUEST(xkbGetMapReq);
     REQUEST_SIZE_MATCH(xkbGetMapReq);
 
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swaps(&stuff->full);
+        swaps(&stuff->partial);
+        swaps(&stuff->virtualMods);
+    }
+
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;
 

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -203,18 +203,6 @@ SProcXkbSetControls(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbGetMap(ClientPtr client)
-{
-    REQUEST(xkbGetMapReq);
-    REQUEST_SIZE_MATCH(xkbGetMapReq);
-    swaps(&stuff->deviceSpec);
-    swaps(&stuff->full);
-    swaps(&stuff->partial);
-    swaps(&stuff->virtualMods);
-    return ProcXkbGetMap(client);
-}
-
-static int _X_COLD
 SProcXkbSetMap(ClientPtr client)
 {
     REQUEST(xkbSetMapReq);
@@ -445,7 +433,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbSetControls:
         return SProcXkbSetControls(client);
     case X_kbGetMap:
-        return SProcXkbGetMap(client);
+        return ProcXkbGetMap(client);
     case X_kbSetMap:
         return SProcXkbSetMap(client);
     case X_kbGetCompatMap:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
