### PR TITLE
xkb: inline SProcXkbGetIndicatorState()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -3029,11 +3029,14 @@ ProcXkbSetCompatMap(ClientPtr client)
 int
 ProcXkbGetIndicatorState(ClientPtr client)
 {
-    XkbSrvLedInfoPtr sli;
-    DeviceIntPtr dev;
-
     REQUEST(xkbGetIndicatorStateReq);
     REQUEST_SIZE_MATCH(xkbGetIndicatorStateReq);
+
+    if (client->swapped)
+        swaps(&stuff->deviceSpec);
+
+    XkbSrvLedInfoPtr sli;
+    DeviceIntPtr dev;
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -251,15 +251,6 @@ SProcXkbSetCompatMap(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbGetIndicatorState(ClientPtr client)
-{
-    REQUEST(xkbGetIndicatorStateReq);
-    REQUEST_SIZE_MATCH(xkbGetIndicatorStateReq);
-    swaps(&stuff->deviceSpec);
-    return ProcXkbGetIndicatorState(client);
-}
-
-static int _X_COLD
 SProcXkbGetIndicatorMap(ClientPtr client)
 {
     REQUEST(xkbGetIndicatorMapReq);
@@ -453,7 +444,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbSetCompatMap:
         return SProcXkbSetCompatMap(client);
     case X_kbGetIndicatorState:
-        return SProcXkbGetIndicatorState(client);
+        return ProcXkbGetIndicatorState(client);
     case X_kbGetIndicatorMap:
         return SProcXkbGetIndicatorMap(client);
     case X_kbSetIndicatorMap:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
