### PR TITLE
xkb: inline SProcXkbGetNamedIndicator()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -3255,13 +3255,20 @@ ProcXkbSetIndicatorMap(ClientPtr client)
 int
 ProcXkbGetNamedIndicator(ClientPtr client)
 {
+    REQUEST(xkbGetNamedIndicatorReq);
+    REQUEST_SIZE_MATCH(xkbGetNamedIndicatorReq);
+
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swaps(&stuff->ledClass);
+        swaps(&stuff->ledID);
+        swapl(&stuff->indicator);
+    }
+
     DeviceIntPtr dev;
     register int i = 0;
     XkbSrvLedInfoPtr sli;
     XkbIndicatorMapPtr map = NULL;
-
-    REQUEST(xkbGetNamedIndicatorReq);
-    REQUEST_SIZE_MATCH(xkbGetNamedIndicatorReq);
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -280,18 +280,6 @@ SProcXkbSetIndicatorMap(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbGetNamedIndicator(ClientPtr client)
-{
-    REQUEST(xkbGetNamedIndicatorReq);
-    REQUEST_SIZE_MATCH(xkbGetNamedIndicatorReq);
-    swaps(&stuff->deviceSpec);
-    swaps(&stuff->ledClass);
-    swaps(&stuff->ledID);
-    swapl(&stuff->indicator);
-    return ProcXkbGetNamedIndicator(client);
-}
-
-static int _X_COLD
 SProcXkbSetNamedIndicator(ClientPtr client)
 {
     REQUEST(xkbSetNamedIndicatorReq);
@@ -459,7 +447,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbSetIndicatorMap:
         return SProcXkbSetIndicatorMap(client);
     case X_kbGetNamedIndicator:
-        return SProcXkbGetNamedIndicator(client);
+        return ProcXkbGetNamedIndicator(client);
     case X_kbSetNamedIndicator:
         return SProcXkbSetNamedIndicator(client);
     case X_kbGetNames:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
