### PR TITLE
xkb: inline SProcXkbGetNames()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -3735,11 +3735,16 @@ XkbAssembleNames(ClientPtr client, XkbDescPtr xkb, xkbGetNamesReply rep, x_rpcbu
 int
 ProcXkbGetNames(ClientPtr client)
 {
-    DeviceIntPtr dev;
-    XkbDescPtr xkb;
-
     REQUEST(xkbGetNamesReq);
     REQUEST_SIZE_MATCH(xkbGetNamesReq);
+
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swapl(&stuff->which);
+    }
+
+    DeviceIntPtr dev;
+    XkbDescPtr xkb;
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;
@@ -4180,13 +4185,21 @@ _XkbSetNames(ClientPtr client, DeviceIntPtr dev, xkbSetNamesReq * stuff)
 int
 ProcXkbSetNames(ClientPtr client)
 {
+    REQUEST(xkbSetNamesReq);
+    REQUEST_AT_LEAST_SIZE(xkbSetNamesReq);
+
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swaps(&stuff->virtualMods);
+        swapl(&stuff->which);
+        swapl(&stuff->indicators);
+        swaps(&stuff->totalKTLevelNames);
+    }
+
     DeviceIntPtr dev;
     CARD32 *tmp;
     Atom bad;
     int rc;
-
-    REQUEST(xkbSetNamesReq);
-    REQUEST_AT_LEAST_SIZE(xkbSetNamesReq);
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -306,29 +306,6 @@ SProcXkbSetNamedIndicator(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbGetNames(ClientPtr client)
-{
-    REQUEST(xkbGetNamesReq);
-    REQUEST_SIZE_MATCH(xkbGetNamesReq);
-    swaps(&stuff->deviceSpec);
-    swapl(&stuff->which);
-    return ProcXkbGetNames(client);
-}
-
-static int _X_COLD
-SProcXkbSetNames(ClientPtr client)
-{
-    REQUEST(xkbSetNamesReq);
-    REQUEST_AT_LEAST_SIZE(xkbSetNamesReq);
-    swaps(&stuff->deviceSpec);
-    swaps(&stuff->virtualMods);
-    swapl(&stuff->which);
-    swapl(&stuff->indicators);
-    swaps(&stuff->totalKTLevelNames);
-    return ProcXkbSetNames(client);
-}
-
-static int _X_COLD
 SProcXkbGetGeometry(ClientPtr client)
 {
     REQUEST(xkbGetGeometryReq);
@@ -463,9 +440,9 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbSetNamedIndicator:
         return SProcXkbSetNamedIndicator(client);
     case X_kbGetNames:
-        return SProcXkbGetNames(client);
+        return ProcXkbGetNames(client);
     case X_kbSetNames:
-        return SProcXkbSetNames(client);
+        return ProcXkbSetNames(client);
     case X_kbGetGeometry:
         return SProcXkbGetGeometry(client);
     case X_kbSetGeometry:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
