### PR TITLE
xkb: inline SProcXkbSetGeometry()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -5323,11 +5323,22 @@ _XkbSetGeometry(ClientPtr client, DeviceIntPtr dev, xkbSetGeometryReq * stuff)
 int
 ProcXkbSetGeometry(ClientPtr client)
 {
-    DeviceIntPtr dev;
-    int rc;
-
     REQUEST(xkbSetGeometryReq);
     REQUEST_AT_LEAST_SIZE(xkbSetGeometryReq);
+
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swapl(&stuff->name);
+        swaps(&stuff->widthMM);
+        swaps(&stuff->heightMM);
+        swaps(&stuff->nProperties);
+        swaps(&stuff->nColors);
+        swaps(&stuff->nDoodads);
+        swaps(&stuff->nKeyAliases);
+    }
+
+    DeviceIntPtr dev;
+    int rc;
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -339,22 +339,6 @@ SProcXkbGetGeometry(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbSetGeometry(ClientPtr client)
-{
-    REQUEST(xkbSetGeometryReq);
-    REQUEST_AT_LEAST_SIZE(xkbSetGeometryReq);
-    swaps(&stuff->deviceSpec);
-    swapl(&stuff->name);
-    swaps(&stuff->widthMM);
-    swaps(&stuff->heightMM);
-    swaps(&stuff->nProperties);
-    swaps(&stuff->nColors);
-    swaps(&stuff->nDoodads);
-    swaps(&stuff->nKeyAliases);
-    return ProcXkbSetGeometry(client);
-}
-
-static int _X_COLD
 SProcXkbPerClientFlags(ClientPtr client)
 {
     REQUEST(xkbPerClientFlagsReq);
@@ -469,7 +453,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbGetGeometry:
         return SProcXkbGetGeometry(client);
     case X_kbSetGeometry:
-        return SProcXkbSetGeometry(client);
+        return ProcXkbSetGeometry(client);
     case X_kbPerClientFlags:
         return SProcXkbPerClientFlags(client);
     case X_kbListComponents:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
