### PR TITLE
xkb: inline SProcXkbListComponents()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -5502,14 +5502,19 @@ GetComponentSpec(ClientPtr client, xkbGetKbdByNameReq *stuff,
 int
 ProcXkbListComponents(ClientPtr client)
 {
+    REQUEST(xkbListComponentsReq);
+    REQUEST_AT_LEAST_SIZE(xkbListComponentsReq);
+
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swaps(&stuff->maxNames);
+    }
+
     DeviceIntPtr dev;
     unsigned len;
     unsigned char *str;
     uint8_t size;
     int i;
-
-    REQUEST(xkbListComponentsReq);
-    REQUEST_AT_LEAST_SIZE(xkbListComponentsReq);
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -369,16 +369,6 @@ SProcXkbPerClientFlags(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbListComponents(ClientPtr client)
-{
-    REQUEST(xkbListComponentsReq);
-    REQUEST_AT_LEAST_SIZE(xkbListComponentsReq);
-    swaps(&stuff->deviceSpec);
-    swaps(&stuff->maxNames);
-    return ProcXkbListComponents(client);
-}
-
-static int _X_COLD
 SProcXkbGetKbdByName(ClientPtr client)
 {
     REQUEST(xkbGetKbdByNameReq);
@@ -473,7 +463,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbPerClientFlags:
         return SProcXkbPerClientFlags(client);
     case X_kbListComponents:
-        return SProcXkbListComponents(client);
+        return ProcXkbListComponents(client);
     case X_kbGetKbdByName:
         return SProcXkbGetKbdByName(client);
     case X_kbGetDeviceInfo:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
