### PR TITLE
xkb: inline SProcXkbGetDeviceInfo()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -6181,14 +6181,21 @@ FillDeviceLedFBs(DeviceIntPtr dev, int class, int id, unsigned wantLength,
 int
 ProcXkbGetDeviceInfo(ClientPtr client)
 {
+    REQUEST(xkbGetDeviceInfoReq);
+    REQUEST_SIZE_MATCH(xkbGetDeviceInfoReq);
+
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swaps(&stuff->wanted);
+        swaps(&stuff->ledClass);
+        swaps(&stuff->ledID);
+    }
+
     DeviceIntPtr dev;
     int status;
     unsigned length, nameLen;
     CARD16 ledClass, ledID;
     unsigned wanted;
-
-    REQUEST(xkbGetDeviceInfoReq);
-    REQUEST_SIZE_MATCH(xkbGetDeviceInfoReq);
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -390,18 +390,6 @@ SProcXkbGetKbdByName(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbGetDeviceInfo(ClientPtr client)
-{
-    REQUEST(xkbGetDeviceInfoReq);
-    REQUEST_SIZE_MATCH(xkbGetDeviceInfoReq);
-    swaps(&stuff->deviceSpec);
-    swaps(&stuff->wanted);
-    swaps(&stuff->ledClass);
-    swaps(&stuff->ledID);
-    return ProcXkbGetDeviceInfo(client);
-}
-
-static int _X_COLD
 SProcXkbSetDeviceInfo(ClientPtr client)
 {
     REQUEST(xkbSetDeviceInfoReq);
@@ -477,7 +465,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbGetKbdByName:
         return SProcXkbGetKbdByName(client);
     case X_kbGetDeviceInfo:
-        return SProcXkbGetDeviceInfo(client);
+        return ProcXkbGetDeviceInfo(client);
     case X_kbSetDeviceInfo:
         return SProcXkbSetDeviceInfo(client);
     case X_kbSetDebuggingFlags:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
