### PR TITLE
xkb: inline SProcXkbGetCompatMap()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -2764,6 +2764,12 @@ ProcXkbGetCompatMap(ClientPtr client)
     REQUEST(xkbGetCompatMapReq);
     REQUEST_SIZE_MATCH(xkbGetCompatMapReq);
 
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swaps(&stuff->firstSI);
+        swaps(&stuff->nSI);
+    }
+
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;
 

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -229,17 +229,6 @@ SProcXkbSetMap(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbGetCompatMap(ClientPtr client)
-{
-    REQUEST(xkbGetCompatMapReq);
-    REQUEST_SIZE_MATCH(xkbGetCompatMapReq);
-    swaps(&stuff->deviceSpec);
-    swaps(&stuff->firstSI);
-    swaps(&stuff->nSI);
-    return ProcXkbGetCompatMap(client);
-}
-
-static int _X_COLD
 SProcXkbSetCompatMap(ClientPtr client)
 {
     REQUEST(xkbSetCompatMapReq);
@@ -449,7 +438,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbSetMap:
         return SProcXkbSetMap(client);
     case X_kbGetCompatMap:
-        return SProcXkbGetCompatMap(client);
+        return ProcXkbGetCompatMap(client);
     case X_kbSetCompatMap:
         return SProcXkbSetCompatMap(client);
     case X_kbGetIndicatorState:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
