### PR TITLE
composite: fix missing includes of extinit.h

### DIFF
--- a/composite/compinit.c
+++ b/composite/compinit.c
@@ -46,6 +46,7 @@
 #include "dix/colormap_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/screen_hooks_priv.h"
+#include "include/extinit.h"
 #include "os/osdep.h"
 
 #include "compint.h"

--- a/composite/compoverlay.c
+++ b/composite/compoverlay.c
@@ -44,9 +44,9 @@
 #include <dix-config.h>
 #include <X11/Xmd.h>
 
-#include "Xext/panoramiXsrv.h"
-
 #include "dix/window_priv.h"
+#include "include/extinit.h"
+#include "Xext/panoramiXsrv.h"
 
 #include "compint.h"
 #include "xace.h"

--- a/composite/compwindow.c
+++ b/composite/compwindow.c
@@ -45,6 +45,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/resource_priv.h"
+#include "include/extinit.h"
 #include "os/osdep.h"
 #include "Xext/panoramiXsrv.h"
 


### PR DESCRIPTION
Don't rely on this file just being included indirectly by somebody else
just by accident.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
