### PR TITLE
glx: fix missing includes of extinit.h

### DIFF
--- a/glx/extension_string.c
+++ b/glx/extension_string.c
@@ -33,6 +33,8 @@
 
 #include <dix-config.h>
 
+#include "include/extinit.h"
+
 #include "extension_string.h"
 #include "opaque.h"
 

--- a/glx/glxscreens.c
+++ b/glx/glxscreens.c
@@ -36,6 +36,7 @@
 #include <GL/glxtokens.h>
 
 #include "dix/colormap_priv.h"
+#include "include/extinit.h"
 
 #include <windowstr.h>
 #include <os.h>


### PR DESCRIPTION
Don't rely on this file just being included indirectly by somebody else
just by accident.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
