### PR TITLE
randr: fix missing includes of extinit.h

### DIFF
--- a/randr/rrxinerama.c
+++ b/randr/rrxinerama.c
@@ -74,6 +74,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
+#include "include/extinit.h"
 #include "randr/randrstr_priv.h"
 
 #include "swaprep.h"


### PR DESCRIPTION
Don't rely on this file just being included indirectly by somebody else
just by accident.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
