### PR TITLE
mi: fix missing includes of extinit.h

### DIFF
--- a/mi/miexpose.c
+++ b/mi/miexpose.c
@@ -80,6 +80,7 @@ Equipment Corporation.
 
 #include "dix/dix_priv.h"
 #include "dix/screenint_priv.h"
+#include "include/extinit.h"
 #include "mi/mi_priv.h"
 #include "Xext/panoramiX.h"
 #include "Xext/panoramiXsrv.h"

--- a/mi/mipointer.c
+++ b/mi/mipointer.c
@@ -57,6 +57,7 @@ in this Software without prior written authorization from The Open Group.
 #include   "dix/input_priv.h"
 #include   "dix/inpututils_priv.h"
 #include   "dix/screen_hooks_priv.h"
+#include   "include/extinit.h"
 #include   "mi/mi_priv.h"
 #include   "mi/mipointer_priv.h"
 


### PR DESCRIPTION
Don't rely on this file just being included indirectly by somebody else
just by accident.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
