### PR TITLE
Xi: fix missing includes of extinit.h

### DIFF
--- a/Xi/xiquerypointer.c
+++ b/Xi/xiquerypointer.c
@@ -44,6 +44,7 @@
 #include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "dix/screenint_priv.h"
+#include "include/extinit.h"
 #include "os/fmt.h"
 #include "Xext/panoramiXsrv.h"
 #include "Xi/handlers.h"


### PR DESCRIPTION
Don't rely on this file just being included indirectly by somebody else
just by accident.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
