### PR TITLE
xwin: fix missing includes of extinit.h

### DIFF
--- a/hw/xwin/winscrinit.c
+++ b/hw/xwin/winscrinit.c
@@ -36,6 +36,7 @@
 #include <xwin-config.h>
 #endif
 
+#include "include/extinit.h"
 #include "mi/mi_priv.h"
 
 #include "win.h"


### PR DESCRIPTION
Don't rely on this file just being included indirectly by somebody else
just by accident.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
