### PR TITLE
kdrive: fix missing includes of extinit.h

### DIFF
--- a/hw/kdrive/src/kxv.c
+++ b/hw/kdrive/src/kxv.c
@@ -41,6 +41,7 @@ of the copyright holder.
 #include <X11/extensions/Xvproto.h>
 
 #include "dix/screen_hooks_priv.h"
+#include "include/extinit.h"
 #include "Xext/xvdix_priv.h"
 
 #include "kdrive.h"


### PR DESCRIPTION
Don't rely on this file just being included indirectly by somebody else
just by accident.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
