### PR TITLE
vfb: fix missing includes of extinit.h

### DIFF
--- a/hw/vfb/InitOutput.c
+++ b/hw/vfb/InitOutput.c
@@ -39,6 +39,7 @@ from The Open Group.
 #include "dix/colormap_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/screenint_priv.h"
+#include "include/extinit.h"
 #include "mi/mi_priv.h"
 #include "mi/mipointer_priv.h"
 #include "os/cmdline.h"


### PR DESCRIPTION
Don't rely on this file just being included indirectly by somebody else
just by accident.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
