### PR TITLE
dix: replace XACE_CLIENT_ACCESS by direct callback

### DIFF
--- a/Xext/namespace/hook-client.c
+++ b/Xext/namespace/hook-client.c
@@ -2,6 +2,7 @@
 
 #include <dix-config.h>
 
+#include "dix/client_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/extension_priv.h"
 #include "dix/registry_priv.h"
@@ -20,7 +21,7 @@
 
 void hookClient(CallbackListPtr *pcbl, void *unused, void *calldata)
 {
-    XNS_HOOK_HEAD(XaceClientAccessRec);
+    XNS_HOOK_HEAD(ClientAccessCallbackParam);
     struct XnamespaceClientPriv *obj = XnsClientPriv(param->target);
 
     if (subj->ns->superPower || XnsClientSameNS(subj, obj))

--- a/Xext/namespace/namespace.c
+++ b/Xext/namespace/namespace.c
@@ -41,7 +41,7 @@ NamespaceExtensionInit(void)
           AddCallback(&ExtensionDispatchCallback, hookExtDispatch, NULL) &&
           AddCallback(&ServerAccessCallback, hookServerAccess, NULL) &&
           AddCallback(&ClientDestroyCallback, hookClientDestroy, NULL) &&
-          XaceRegisterCallback(XACE_CLIENT_ACCESS, hookClient, NULL) &&
+          AddCallback(&ClientAccessCallback, hookClient, NULL) &&
           XaceRegisterCallback(XACE_DEVICE_ACCESS, hookDevice, NULL) &&
           XaceRegisterCallback(XACE_PROPERTY_ACCESS, hookPropertyAccess, NULL) &&
           XaceRegisterCallback(XACE_RECEIVE_ACCESS, hookReceive, NULL) &&

--- a/Xext/security.c
+++ b/Xext/security.c
@@ -30,6 +30,7 @@ in this Software without prior written authorization from The Open Group.
 #include <X11/extensions/securproto.h>
 #include <X11/Xfuncproto.h>
 
+#include "dix/client_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/extension_priv.h"
 #include "dix/registry_priv.h"
@@ -787,7 +788,7 @@ SecurityServer(CallbackListPtr *pcbl, void *unused, void *calldata)
 static void
 SecurityClient(CallbackListPtr *pcbl, void *unused, void *calldata)
 {
-    XaceClientAccessRec *rec = calldata;
+    ClientAccessCallbackParam *rec = calldata;
     SecurityStateRec *subj, *obj;
     Mask requested = rec->access_mode;
     Mask allowed = SecurityClientMask;
@@ -970,13 +971,13 @@ SecurityResetProc(ExtensionEntry * extEntry)
     DeleteCallback(&ExtensionAccessCallback, SecurityExtension, NULL);
     DeleteCallback(&ExtensionDispatchCallback, SecurityExtension, NULL);
     DeleteCallback(&ServerAccessCallback, SecurityServer, NULL);
+    DeleteCallback(&ClientAccessCallback, SecurityClient, NULL);
 
     XaceDeleteCallback(XACE_RESOURCE_ACCESS, SecurityResource, NULL);
     XaceDeleteCallback(XACE_DEVICE_ACCESS, SecurityDevice, NULL);
     XaceDeleteCallback(XACE_PROPERTY_ACCESS, SecurityProperty, NULL);
     XaceDeleteCallback(XACE_SEND_ACCESS, SecuritySend, NULL);
     XaceDeleteCallback(XACE_RECEIVE_ACCESS, SecurityReceive, NULL);
-    XaceDeleteCallback(XACE_CLIENT_ACCESS, SecurityClient, NULL);
 }
 
 /* SecurityExtensionInit
@@ -1018,13 +1019,13 @@ SecurityExtensionInit(void)
     ret &= AddCallback(&ExtensionAccessCallback, SecurityExtension, NULL);
     ret &= AddCallback(&ExtensionDispatchCallback, SecurityExtension, NULL);
     ret &= AddCallback(&ServerAccessCallback, SecurityServer, NULL);
+    ret &= AddCallback(&ClientAccessCallback, SecurityClient, NULL);
 
     ret &= XaceRegisterCallback(XACE_RESOURCE_ACCESS, SecurityResource, NULL);
     ret &= XaceRegisterCallback(XACE_DEVICE_ACCESS, SecurityDevice, NULL);
     ret &= XaceRegisterCallback(XACE_PROPERTY_ACCESS, SecurityProperty, NULL);
     ret &= XaceRegisterCallback(XACE_SEND_ACCESS, SecuritySend, NULL);
     ret &= XaceRegisterCallback(XACE_RECEIVE_ACCESS, SecurityReceive, NULL);
-    ret &= XaceRegisterCallback(XACE_CLIENT_ACCESS, SecurityClient, NULL);
 
     if (!ret)
         FatalError("SecurityExtensionSetup: Failed to register callbacks\n");

--- a/Xext/xace.c
+++ b/Xext/xace.c
@@ -83,13 +83,6 @@ int XaceHookReceiveAccess(ClientPtr client, WindowPtr win,
     return rec.status;
 }
 
-int XaceHookClientAccess(ClientPtr client, ClientPtr target, Mask access_mode)
-{
-    XaceClientAccessRec rec = { client, target, access_mode, Success };
-    CallCallbacks(&XaceHooks[XACE_CLIENT_ACCESS], &rec);
-    return rec.status;
-}
-
 int XaceHookScreenAccess(ClientPtr client, ScreenPtr screen, Mask access_mode)
 {
     XaceScreenAccessRec rec = { client, screen, access_mode, Success };

--- a/Xext/xace.h
+++ b/Xext/xace.h
@@ -43,7 +43,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define XACE_PROPERTY_ACCESS		4
 #define XACE_SEND_ACCESS		5
 #define XACE_RECEIVE_ACCESS		6
-#define XACE_CLIENT_ACCESS		7
 #define XACE_SELECTION_ACCESS		10
 #define XACE_SCREEN_ACCESS		11
 #define XACE_SCREENSAVER_ACCESS		12
@@ -75,7 +74,6 @@ int XaceHookDeviceAccess(ClientPtr client, DeviceIntPtr dev, Mask access_mode);
 int XaceHookSendAccess(ClientPtr client, DeviceIntPtr dev, WindowPtr win,
                        xEventPtr ev, int count);
 int XaceHookReceiveAccess(ClientPtr client, WindowPtr win, xEventPtr ev, int count);
-int XaceHookClientAccess(ClientPtr client, ClientPtr target, Mask access_mode);
 int XaceHookScreenAccess(ClientPtr client, ScreenPtr screen, Mask access_mode);
 int XaceHookScreensaverAccess(ClientPtr client, ScreenPtr screen, Mask access_mode);
 

--- a/Xext/xacestr.h
+++ b/Xext/xacestr.h
@@ -78,14 +78,6 @@ typedef struct {
     int status;
 } XaceReceiveAccessRec;
 
-/* XACE_CLIENT_ACCESS */
-typedef struct {
-    ClientPtr client;
-    ClientPtr target;
-    Mask access_mode;
-    int status;
-} XaceClientAccessRec;
-
 /* XACE_SELECTION_ACCESS */
 typedef struct {
     ClientPtr client;

--- a/Xext/xres.c
+++ b/Xext/xres.c
@@ -11,6 +11,7 @@
 #include <X11/Xproto.h>
 #include <X11/extensions/XResproto.h>
 
+#include "dix/client_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/registry_priv.h"
 #include "dix/request_priv.h"
@@ -208,7 +209,7 @@ ProcXResQueryClients(ClientPtr client)
     for (int i = 0; i < currentMaxClients; i++) {
         ClientPtr walkClient = clients[i];
         if (walkClient &&
-            (XaceHookClientAccess(client, walkClient, DixReadAccess) == Success)) {
+            (dixCallClientAccessCallback(client, walkClient, DixReadAccess) == Success)) {
             x_rpcbuf_write_CARD32(&rpcbuf, walkClient->clientAsMask); /* resource_base */
             x_rpcbuf_write_CARD32(&rpcbuf, RESOURCE_ID_MASK);         /* resource_mask */
             num_clients++;
@@ -261,7 +262,7 @@ ProcXResQueryClientResources(ClientPtr client)
     ClientPtr resClient = dixClientForXID(stuff->xid);
 
     if ((!resClient) ||
-        (XaceHookClientAccess(client, resClient, DixReadAccess)
+        (dixCallClientAccessCallback(client, resClient, DixReadAccess)
                               != Success)) {
         client->errorValue = stuff->xid;
         return BadValue;
@@ -320,7 +321,7 @@ ProcXResQueryClientPixmapBytes(ClientPtr client)
 
     ClientPtr owner = dixClientForXID(stuff->xid);
     if ((!owner) ||
-        (XaceHookClientAccess(client, owner, DixReadAccess)
+        (dixCallClientAccessCallback(client, owner, DixReadAccess)
                               != Success)) {
         client->errorValue = stuff->xid;
         return BadValue;
@@ -465,7 +466,7 @@ ConstructClientIds(ClientPtr client,
             int c;
             for (c = 0; c < currentMaxClients; ++c) {
                 if (clients[c] &&
-                    (XaceHookClientAccess(client, clients[c], DixReadAccess)
+                    (dixCallClientAccessCallback(client, clients[c], DixReadAccess)
                                           == Success)) {
                     if (!ConstructClientIdValue(client, clients[c],
                                                 specs[specIdx].mask, ctx)) {
@@ -476,7 +477,7 @@ ConstructClientIds(ClientPtr client,
         } else {
             ClientPtr owner = dixClientForXID(specs[specIdx].client);
             if (owner &&
-                (XaceHookClientAccess(client, owner, DixReadAccess)
+                (dixCallClientAccessCallback(client, owner, DixReadAccess)
                                       == Success)) {
                 if (!ConstructClientIdValue(client, owner,
                                             specs[specIdx].mask, ctx)) {

--- a/Xext/xselinux_hooks.c
+++ b/Xext/xselinux_hooks.c
@@ -32,6 +32,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <X11/Xatom.h>
 #include <X11/Xfuncproto.h>
 
+#include "dix/client_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/extension_priv.h"
 #include "dix/input_priv.h"
@@ -715,7 +716,7 @@ SELinuxScreen(CallbackListPtr *pcbl, void *is_saver, void *calldata)
 static void
 SELinuxClient(CallbackListPtr *pcbl, void *unused, void *calldata)
 {
-    XaceClientAccessRec *rec = calldata;
+    ClientAccessCallbackParam *rec = calldata;
     SELinuxSubjectRec *subj;
     SELinuxObjectRec *obj;
     SELinuxAuditRec auditdata = {.client = rec->client };
@@ -835,13 +836,13 @@ SELinuxFlaskReset(void)
     DeleteCallback(&ExtensionAccessCallback, SELinuxExtension, NULL);
     DeleteCallback(&ExtensionDispatchCallback, SELinuxExtension, NULL);
     DeleteCallback(&ServerAccessCallback, SELinuxServer, NULL);
+    DeleteCallback(&ClientAccessCallback, SELinuxClient, NULL);
 
     XaceDeleteCallback(XACE_RESOURCE_ACCESS, SELinuxResource, NULL);
     XaceDeleteCallback(XACE_DEVICE_ACCESS, SELinuxDevice, NULL);
     XaceDeleteCallback(XACE_PROPERTY_ACCESS, SELinuxProperty, NULL);
     XaceDeleteCallback(XACE_SEND_ACCESS, SELinuxSend, NULL);
     XaceDeleteCallback(XACE_RECEIVE_ACCESS, SELinuxReceive, NULL);
-    XaceDeleteCallback(XACE_CLIENT_ACCESS, SELinuxClient, NULL);
     XaceDeleteCallback(XACE_SELECTION_ACCESS, SELinuxSelection, NULL);
     XaceDeleteCallback(XACE_SCREEN_ACCESS, SELinuxScreen, NULL);
     XaceDeleteCallback(XACE_SCREENSAVER_ACCESS, SELinuxScreen, truep);
@@ -929,13 +930,13 @@ SELinuxFlaskInit(void)
     ret &= AddCallback(&ExtensionAccessCallback, SELinuxExtension, NULL);
     ret &= AddCallback(&ExtensionDispatchCallback, SELinuxExtension, NULL);
     ret &= AddCallback(&ServerAccessCallback, SELinuxServer, NULL);
+    ret &= AddCallback(&ClientAccessCallback, SELinuxClient, NULL);
 
     ret &= XaceRegisterCallback(XACE_RESOURCE_ACCESS, SELinuxResource, NULL);
     ret &= XaceRegisterCallback(XACE_DEVICE_ACCESS, SELinuxDevice, NULL);
     ret &= XaceRegisterCallback(XACE_PROPERTY_ACCESS, SELinuxProperty, NULL);
     ret &= XaceRegisterCallback(XACE_SEND_ACCESS, SELinuxSend, NULL);
     ret &= XaceRegisterCallback(XACE_RECEIVE_ACCESS, SELinuxReceive, NULL);
-    ret &= XaceRegisterCallback(XACE_CLIENT_ACCESS, SELinuxClient, NULL);
     ret &= XaceRegisterCallback(XACE_SELECTION_ACCESS, SELinuxSelection, NULL);
     ret &= XaceRegisterCallback(XACE_SCREEN_ACCESS, SELinuxScreen, NULL);
     ret &= XaceRegisterCallback(XACE_SCREENSAVER_ACCESS, SELinuxScreen, truep);

--- a/dix/client_priv.h
+++ b/dix/client_priv.h
@@ -6,11 +6,31 @@
 #define _XSERVER_DIX_CLIENT_PRIV_H
 
 #include "include/callback.h"
+#include "include/dix.h"
 
 /*
  * called right before ClientRec is about to be destroyed,
  * after resources have been freed. argument is ClientPtr
  */
 extern CallbackListPtr ClientDestroyCallback;
+
+typedef struct {
+    ClientPtr client;
+    ClientPtr target;
+    Mask access_mode;
+    int status;
+} ClientAccessCallbackParam;
+
+/*
+ * called when a client tries to access another client
+ */
+extern CallbackListPtr ClientAccessCallback;
+
+static inline int dixCallClientAccessCallback(ClientPtr client, ClientPtr target, Mask access_mode)
+{
+    ClientAccessCallbackParam rec = { client, target, access_mode, Success };
+    CallCallbacks(&ClientAccessCallback, &rec);
+    return rec.status;
+}
 
 #endif /* _XSERVER_DIX_CLIENT_PRIV_H */

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -175,6 +175,7 @@ static int nClients;            /* number of authorized clients */
 
 CallbackListPtr ClientStateCallback = NULL;
 CallbackListPtr ServerAccessCallback = NULL;
+CallbackListPtr ClientAccessCallback = NULL;
 
 OsTimerPtr dispatchExceptionTimer;
 
@@ -3437,7 +3438,7 @@ ProcChangeCloseDownMode(ClientPtr client)
     REQUEST(xSetCloseDownModeReq);
     REQUEST_SIZE_MATCH(xSetCloseDownModeReq);
 
-    rc = XaceHookClientAccess(client, client, DixManageAccess);
+    rc = dixCallClientAccessCallback(client, client, DixManageAccess);
     if (rc != Success)
         return rc;
 

--- a/dix/dixutils.c
+++ b/dix/dixutils.c
@@ -86,6 +86,7 @@ Author:  Adobe Systems Incorporated
 #include <X11/Xmd.h>
 
 #include "dix/callback_priv.h"
+#include "dix/client_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/resource_priv.h"
 
@@ -231,7 +232,7 @@ dixLookupResourceOwner(ClientPtr *result, XID id, ClientPtr client, Mask access_
     if (rc != Success)
         goto bad;
 
-    rc = XaceHookClientAccess(client, clients[clientIndex], access_mode);
+    rc = dixCallClientAccessCallback(client, clients[clientIndex], access_mode);
     if (rc != Success)
         goto bad;
 


### PR DESCRIPTION
Move the callbacks directly into DIX, since it's actually core infrastructure.
Also simplifying the whole machinery, by just using a simpel CallbackListPtr.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
