### PR TITLE
dix: consolidate struct _CallbackList and struct _CallbackRec into dixutil.c

### DIFF
--- a/dix/dixutils.c
+++ b/dix/dixutils.c
@@ -652,6 +652,20 @@ ClientIsAsleep(ClientPtr client)
 
 /* ===== Private Procedures ===== */
 
+typedef struct _CallbackRec {
+    CallbackProcPtr proc;
+    void *data;
+    Bool deleted;
+    struct _CallbackRec *next;
+} CallbackRec, *CallbackPtr;
+
+typedef struct _CallbackList {
+    int inCallback;
+    Bool deleted;
+    int numDeleted;
+    CallbackPtr list;
+} CallbackListRec;
+
 static size_t numCallbackListsToCleanup = 0;
 static CallbackListPtr **listsToCleanup = NULL;
 

--- a/include/dixstruct.h
+++ b/include/dixstruct.h
@@ -127,20 +127,6 @@ CompareTimeStamps(TimeStamp /*a */ ,
 extern _X_EXPORT TimeStamp
 ClientTimeToServerTime(CARD32 /*c */ );
 
-typedef struct _CallbackRec {
-    CallbackProcPtr proc;
-    void *data;
-    Bool deleted;
-    struct _CallbackRec *next;
-} CallbackRec, *CallbackPtr;
-
-typedef struct _CallbackList {
-    int inCallback;
-    Bool deleted;
-    int numDeleted;
-    CallbackPtr list;
-} CallbackListRec;
-
 /* proc vectors */
 
 extern _X_EXPORT int (*ProcVector[256]) (ClientPtr /*client */ );


### PR DESCRIPTION
These structs are only used inside dixutils, the actual callback handling
functions. Therefore no need to keep them in public header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
