### PR TITLE
os: unexport inSignalContext

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -27,7 +27,6 @@ extern _X_EXPORT int defaultColorVisualClass;
 extern _X_EXPORT int GrabInProgress;
 extern _X_EXPORT char *SeatId;
 extern _X_EXPORT char *ConnectionInfo;
-extern _X_EXPORT sig_atomic_t inSignalContext;
 
 #ifdef XINERAMA
 extern _X_EXPORT Bool PanoramiXExtensionDisabledHack;

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -51,6 +51,7 @@ SOFTWARE.
 #include <X11/Xdefs.h>
 
 #include <limits.h>
+#include <signal.h>
 #include <stddef.h>
 #include <X11/Xos.h>
 #include <X11/Xmd.h>
@@ -240,5 +241,7 @@ enum ExitCode {
     EXIT_ERR_CONFIGURE = 2,
     EXIT_ERR_DRIVERS = 3,
 };
+
+extern sig_atomic_t inSignalContext;
 
 #endif                          /* _OSDEP_H_ */


### PR DESCRIPTION
Only used inside OS layer and xfree86 os-support, so no need to keep
it in public SDK.

Since never used by any drivers, it's not an actual ABI change, so
we can safely do it within ABI-25.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
