### PR TITLE
xfree86: dri: drop unnecessary swapped request handler

### DIFF
--- a/hw/xfree86/dri/xf86dri.c
+++ b/hw/xfree86/dri/xf86dri.c
@@ -99,6 +99,10 @@ ProcXF86DRIQueryDirectRenderingCapable(register ClientPtr client)
 
     REQUEST(xXF86DRIQueryDirectRenderingCapableReq);
     REQUEST_SIZE_MATCH(xXF86DRIQueryDirectRenderingCapableReq);
+
+    if (client->swapped)
+        swapl(&stuff->screen);
+
     if (stuff->screen >= screenInfo.numScreens) {
         client->errorValue = stuff->screen;
         return BadValue;
@@ -479,34 +483,6 @@ ProcXF86DRIDispatch(register ClientPtr client)
     }
 }
 
-static int _X_COLD
-SProcXF86DRIQueryDirectRenderingCapable(register ClientPtr client)
-{
-    REQUEST(xXF86DRIQueryDirectRenderingCapableReq);
-    REQUEST_SIZE_MATCH(xXF86DRIQueryDirectRenderingCapableReq);
-    swapl(&stuff->screen);
-    return ProcXF86DRIQueryDirectRenderingCapable(client);
-}
-
-static int _X_COLD
-SProcXF86DRIDispatch(register ClientPtr client)
-{
-    REQUEST(xReq);
-
-    /*
-     * Only local clients are allowed DRI access, but remote clients still need
-     * these requests to find out cleanly.
-     */
-    switch (stuff->data) {
-    case X_XF86DRIQueryVersion:
-        return ProcXF86DRIQueryVersion(client);
-    case X_XF86DRIQueryDirectRenderingCapable:
-        return SProcXF86DRIQueryDirectRenderingCapable(client);
-    default:
-        return DRIErrorBase + XF86DRIClientNotLocal;
-    }
-}
-
 void
 XFree86DRIExtensionInit(void)
 {
@@ -517,7 +493,7 @@ XFree86DRIExtensionInit(void)
                                  XF86DRINumberEvents,
                                  XF86DRINumberErrors,
                                  ProcXF86DRIDispatch,
-                                 SProcXF86DRIDispatch,
+                                 ProcXF86DRIDispatch,
                                  XF86DRIResetProc, StandardMinorOpcode))) {
         DRIErrorBase = extEntry->errorBase;
     }

--- a/hw/xfree86/dri2/dri2ext.c
+++ b/hw/xfree86/dri2/dri2ext.c
@@ -594,49 +594,6 @@ ProcDRI2Dispatch(ClientPtr client)
     }
 }
 
-static int _X_COLD
-SProcDRI2Connect(ClientPtr client)
-{
-    REQUEST(xDRI2ConnectReq);
-    xDRI2ConnectReply rep = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = 0,
-        .driverNameLength = 0,
-        .deviceNameLength = 0
-    };
-
-    /* If the client is swapped, it's not local.  Talk to the hand. */
-
-    if (sizeof(*stuff) / 4 != client->req_len)
-        return BadLength;
-
-    swaps(&rep.sequenceNumber);
-
-    WriteToClient(client, sizeof(xDRI2ConnectReply), &rep);
-
-    return Success;
-}
-
-static int _X_COLD
-SProcDRI2Dispatch(ClientPtr client)
-{
-    REQUEST(xReq);
-
-    /*
-     * Only local clients are allowed DRI access, but remote clients
-     * still need these requests to find out cleanly.
-     */
-    switch (stuff->data) {
-    case X_DRI2QueryVersion:
-        return ProcDRI2QueryVersion(client);
-    case X_DRI2Connect:
-        return SProcDRI2Connect(client);
-    default:
-        return BadRequest;
-    }
-}
-
 void
 DRI2ExtensionInit(void)
 {
@@ -651,7 +608,9 @@ DRI2ExtensionInit(void)
                                  DRI2NumberEvents,
                                  DRI2NumberErrors,
                                  ProcDRI2Dispatch,
-                                 SProcDRI2Dispatch, NULL, StandardMinorOpcode);
+                                 ProcDRI2Dispatch,
+                                 NULL,
+                                 StandardMinorOpcode);
 
     DRI2EventBase = dri2Extension->eventBase;
 


### PR DESCRIPTION
The request handler already refusing non-local access, so no need
for any extra swapped handler.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
