### PR TITLE
Fix compalloc

### DIFF
--- a/composite/compalloc.c
+++ b/composite/compalloc.c
@@ -540,6 +540,10 @@ compNewPixmap(WindowPtr pWin, int x, int y, int w, int h)
     pPixmap->screen_x = x;
     pPixmap->screen_y = y;
 
+    if (pWin->backgroundState != None) {
+        return pPixmap;
+    }
+
     if (pParent->drawable.depth == pWin->drawable.depth) {
         GCPtr pGC = GetScratchGC(pWin->drawable.depth, pScreen);
 

--- a/composite/compalloc.c
+++ b/composite/compalloc.c
@@ -544,6 +544,13 @@ compNewPixmap(WindowPtr pWin, int x, int y, int w, int h)
         return pPixmap;
     }
 
+    /*
+     * Copy bits from the parent into the new pixmap so that it will
+     * have "reasonable" contents in case for background None areas.
+     *
+     * This can be very expensive, so we only do it when we absolutely have to.
+     */
+
     if (pParent->drawable.depth == pWin->drawable.depth) {
         GCPtr pGC = GetScratchGC(pWin->drawable.depth, pScreen);
 


### PR DESCRIPTION
composite: Only copy bits from the parent pixmap when absolutely necessary

Since https://gitlab.freedesktop.org/xorg/xserver/-/commit/1e728c3e88f6a74b93dc11827c9fcfe7b39ca5a5 ,
Whenever we allocate a composite pixmap, we perform an expensive CopyArea call from the parent pixmap.

This leads to very bad performance when not using a framebuffer driver without shadowfb.

My guess is that this call ends up reading memory from the framebuffer memory directly, which is very slow.

Fixes: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1814

Signed-off-by: stefan11111 <stefan11111@shitposting.expert>