### PR TITLE
dix: inline SProcResourceReq()

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -795,9 +795,13 @@ ProcDestroyWindow(ClientPtr client)
     WindowPtr pWin;
 
     REQUEST(xResourceReq);
+    REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
+
     int rc;
 
-    REQUEST_SIZE_MATCH(xResourceReq);
     rc = dixLookupWindow(&pWin, stuff->id, client, DixDestroyAccess);
     if (rc != Success)
         return rc;
@@ -817,9 +821,13 @@ ProcDestroySubwindows(ClientPtr client)
     WindowPtr pWin;
 
     REQUEST(xResourceReq);
+    REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
+
     int rc;
 
-    REQUEST_SIZE_MATCH(xResourceReq);
     rc = dixLookupWindow(&pWin, stuff->id, client, DixRemoveAccess);
     if (rc != Success)
         return rc;
@@ -833,9 +841,13 @@ ProcChangeSaveSet(ClientPtr client)
     WindowPtr pWin;
 
     REQUEST(xChangeSaveSetReq);
+    REQUEST_SIZE_MATCH(xChangeSaveSetReq);
+
+    if (client->swapped)
+        swapl(&stuff->window);
+
     int rc;
 
-    REQUEST_SIZE_MATCH(xChangeSaveSetReq);
     rc = dixLookupWindow(&pWin, stuff->window, client, DixManageAccess);
     if (rc != Success)
         return rc;
@@ -880,9 +892,12 @@ ProcMapWindow(ClientPtr client)
     WindowPtr pWin;
 
     REQUEST(xResourceReq);
-    int rc;
-
     REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
+
+    int rc;
     rc = dixLookupWindow(&pWin, stuff->id, client, DixShowAccess);
     if (rc != Success)
         return rc;
@@ -897,9 +912,13 @@ ProcMapSubwindows(ClientPtr client)
     WindowPtr pWin;
 
     REQUEST(xResourceReq);
+    REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
+
     int rc;
 
-    REQUEST_SIZE_MATCH(xResourceReq);
     rc = dixLookupWindow(&pWin, stuff->id, client, DixListAccess);
     if (rc != Success)
         return rc;
@@ -914,9 +933,13 @@ ProcUnmapWindow(ClientPtr client)
     WindowPtr pWin;
 
     REQUEST(xResourceReq);
+    REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
+
     int rc;
 
-    REQUEST_SIZE_MATCH(xResourceReq);
     rc = dixLookupWindow(&pWin, stuff->id, client, DixHideAccess);
     if (rc != Success)
         return rc;
@@ -931,9 +954,13 @@ ProcUnmapSubwindows(ClientPtr client)
     WindowPtr pWin;
 
     REQUEST(xResourceReq);
+    REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
+
     int rc;
 
-    REQUEST_SIZE_MATCH(xResourceReq);
     rc = dixLookupWindow(&pWin, stuff->id, client, DixListAccess);
     if (rc != Success)
         return rc;
@@ -966,9 +993,13 @@ ProcCirculateWindow(ClientPtr client)
     WindowPtr pWin;
 
     REQUEST(xCirculateWindowReq);
+    REQUEST_SIZE_MATCH(xCirculateWindowReq);
+
+    if (client->swapped)
+        swapl(&stuff->window);
+
     int rc;
 
-    REQUEST_SIZE_MATCH(xCirculateWindowReq);
     if ((stuff->direction != RaiseLowest) && (stuff->direction != LowerHighest)) {
         client->errorValue = stuff->direction;
         return BadValue;
@@ -988,6 +1019,9 @@ ProcGetGeometry(ClientPtr client)
 
     REQUEST(xResourceReq);
     REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
 
     rc = dixLookupDrawable(&pDraw, stuff->id, client, M_ANY, DixGetAttrAccess);
     if (rc != Success)
@@ -1027,8 +1061,11 @@ ProcQueryTree(ClientPtr client)
     WindowPtr pWin, pHead;
 
     REQUEST(xResourceReq);
-
     REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
+
     rc = dixLookupWindow(&pWin, stuff->id, client, DixListAccess);
     if (rc != Success)
         return rc;
@@ -1093,8 +1130,11 @@ ProcGetAtomName(ClientPtr client)
     const char *str;
 
     REQUEST(xResourceReq);
-
     REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
+
     if (!(str = NameForAtom(stuff->id))) {
         client->errorValue = stuff->id;
         return BadAtom;
@@ -1280,8 +1320,11 @@ ProcCloseFont(ClientPtr client)
     int rc;
 
     REQUEST(xResourceReq);
-
     REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
+
     rc = dixLookupResourceByType((void **) &pFont, stuff->id, X11_RESTYPE_FONT,
                                  client, DixDestroyAccess);
     if (rc == Success) {
@@ -1303,6 +1346,9 @@ ProcQueryFont(ClientPtr client)
 
     REQUEST(xResourceReq);
     REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
 
     rc = dixLookupFontable(&pFont, stuff->id, client, DixGetAttrAccess);
     if (rc != Success)
@@ -1354,6 +1400,9 @@ ProcQueryTextExtents(ClientPtr client)
 
     REQUEST(xQueryTextExtentsReq);
     REQUEST_AT_LEAST_SIZE(xQueryTextExtentsReq);
+
+    if (client->swapped)
+        swapl(&stuff->fid);
 
     rc = dixLookupFontable(&pFont, stuff->fid, client, DixGetAttrAccess);
     if (rc != Success)
@@ -1505,6 +1554,9 @@ ProcFreePixmap(ClientPtr client)
     REQUEST(xResourceReq);
     REQUEST_SIZE_MATCH(xResourceReq);
 
+    if (client->swapped)
+        swapl(&stuff->id);
+
     rc = dixLookupResourceByType((void **) &pMap, stuff->id, X11_RESTYPE_PIXMAP,
                                  client, DixDestroyAccess);
     if (rc == Success) {
@@ -1652,6 +1704,9 @@ ProcFreeGC(ClientPtr client)
 
     REQUEST(xResourceReq);
     REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
 
     rc = dixLookupGC(&pGC, stuff->id, client, DixDestroyAccess);
     if (rc != Success)
@@ -2441,8 +2496,11 @@ ProcFreeColormap(ClientPtr client)
     int rc;
 
     REQUEST(xResourceReq);
-
     REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
+
     rc = dixLookupResourceByType((void **) &pmap, stuff->id, X11_RESTYPE_COLORMAP,
                                  client, DixDestroyAccess);
     if (rc == Success) {
@@ -2487,6 +2545,9 @@ ProcInstallColormap(ClientPtr client)
     REQUEST(xResourceReq);
     REQUEST_SIZE_MATCH(xResourceReq);
 
+    if (client->swapped)
+        swapl(&stuff->id);
+
     rc = dixLookupResourceByType((void **) &pcmp, stuff->id, X11_RESTYPE_COLORMAP,
                                  client, DixInstallAccess);
     if (rc != Success)
@@ -2515,6 +2576,9 @@ ProcUninstallColormap(ClientPtr client)
 
     REQUEST(xResourceReq);
     REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
 
     rc = dixLookupResourceByType((void **) &pcmp, stuff->id, X11_RESTYPE_COLORMAP,
                                  client, DixUninstallAccess);
@@ -2545,6 +2609,9 @@ ProcListInstalledColormaps(ClientPtr client)
 
     REQUEST(xResourceReq);
     REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
 
     rc = dixLookupWindow(&pWin, stuff->id, client, DixGetAttrAccess);
     if (rc != Success)
@@ -3107,8 +3174,11 @@ ProcFreeCursor(ClientPtr client)
     int rc;
 
     REQUEST(xResourceReq);
-
     REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
+
     rc = dixLookupResourceByType((void **) &pCursor, stuff->id, X11_RESTYPE_CURSOR,
                                  client, DixDestroyAccess);
     if (rc == Success) {
@@ -3355,10 +3425,14 @@ int
 ProcKillClient(ClientPtr client)
 {
     REQUEST(xResourceReq);
+    REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
+
     ClientPtr killclient;
     int rc;
 
-    REQUEST_SIZE_MATCH(xResourceReq);
     if (stuff->id == AllTemporary) {
         CloseDownRetainedResources();
         return Success;

--- a/dix/events.c
+++ b/dix/events.c
@@ -1942,8 +1942,11 @@ ProcAllowEvents(ClientPtr client)
     DeviceIntPtr keybd = NULL;
 
     REQUEST(xAllowEventsReq);
-
     REQUEST_SIZE_MATCH(xAllowEventsReq);
+
+    if (client->swapped)
+        swapl(&stuff->time);
+
     UpdateCurrentTime();
     time = ClientTimeToServerTime(stuff->time);
 
@@ -5115,8 +5118,11 @@ ProcUngrabPointer(ClientPtr client)
     TimeStamp time;
 
     REQUEST(xResourceReq);
-
     REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
+
     UpdateCurrentTime();
     grab = device->deviceGrab.grab;
 
@@ -5300,8 +5306,11 @@ ProcUngrabKeyboard(ClientPtr client)
     TimeStamp time;
 
     REQUEST(xResourceReq);
-
     REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
+
     UpdateCurrentTime();
 
     grab = device->deviceGrab.grab;
@@ -5331,6 +5340,9 @@ ProcQueryPointer(ClientPtr client)
 
     REQUEST(xResourceReq);
     REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
 
     rc = dixLookupWindow(&pWin, stuff->id, client, DixGetAttrAccess);
     if (rc != Success)

--- a/dix/property.c
+++ b/dix/property.c
@@ -651,8 +651,11 @@ ProcListProperties(ClientPtr client)
     WindowPtr pWin;
 
     REQUEST(xResourceReq);
-
     REQUEST_SIZE_MATCH(xResourceReq);
+
+    if (client->swapped)
+        swapl(&stuff->id);
+
     int rc = dixLookupWindow(&pWin, stuff->id, client, DixListPropAccess);
     if (rc != Success)
         return rc;

--- a/dix/selection.c
+++ b/dix/selection.c
@@ -246,6 +246,9 @@ ProcGetSelectionOwner(ClientPtr client)
     REQUEST(xResourceReq);
     REQUEST_SIZE_MATCH(xResourceReq);
 
+    if (client->swapped)
+        swapl(&stuff->id);
+
     /* allow extensions to intercept */
     SelectionFilterParamRec param = {
         .client = client,

--- a/dix/swapreq.c
+++ b/dix/swapreq.c
@@ -124,18 +124,6 @@ SProcSimpleReq(ClientPtr client)
     return (*ProcVector[stuff->reqType]) (client);
 }
 
-/* The following is used for all requests that have
-   only a single 32-bit field to be swapped, coming
-   right after the "length" field */
-int _X_COLD
-SProcResourceReq(ClientPtr client)
-{
-    REQUEST(xResourceReq);
-    REQUEST_AT_LEAST_SIZE(xResourceReq);        /* not EXACT */
-    swapl(&stuff->id);
-    return (*ProcVector[stuff->reqType]) (client);
-}
-
 int _X_COLD
 SProcCreateWindow(ClientPtr client)
 {

--- a/dix/tables.c
+++ b/dix/tables.c
@@ -334,42 +334,42 @@ int (*SwappedProcVector[256]) (ClientPtr /* client */) = {
     ProcBadRequest,
     SProcCreateWindow,
     SProcChangeWindowAttributes,
-    SProcResourceReq,                   /* GetWindowAttributes */
-    SProcResourceReq,                   /* DestroyWindow */
-    SProcResourceReq,                   /* 5 DestroySubwindows */
-    SProcResourceReq,                   /* SProcChangeSaveSet, */
+    ProcGetWindowAttributes,
+    ProcDestroyWindow,
+    ProcDestroySubwindows,              /* 5 */
+    ProcChangeSaveSet,
     SProcReparentWindow,
-    SProcResourceReq,                   /* MapWindow */
-    SProcResourceReq,                   /* MapSubwindows */
-    SProcResourceReq,                   /* 10 UnmapWindow */
-    SProcResourceReq,                   /* UnmapSubwindows */
+    ProcMapWindow,
+    ProcMapSubwindows,
+    ProcUnmapWindow,                    /* 10 */
+    ProcUnmapSubwindows,
     SProcConfigureWindow,
-    SProcResourceReq,                   /* SProcCirculateWindow, */
-    SProcResourceReq,                   /* GetGeometry */
-    SProcResourceReq,                   /* 15 QueryTree */
+    ProcCirculateWindow,
+    ProcGetGeometry,
+    ProcQueryTree,                      /* 15 */
     SProcInternAtom,
-    SProcResourceReq,                   /* SProcGetAtomName, */
+    ProcGetAtomName,
     SProcChangeProperty,
     SProcDeleteProperty,
     SProcGetProperty,                   /* 20 */
-    SProcResourceReq,                   /* SProcListProperties, */
+    ProcListProperties,
     SProcSetSelectionOwner,
-    SProcResourceReq,                   /* SProcGetSelectionOwner, */
+    ProcGetSelectionOwner,
     SProcConvertSelection,
     SProcSendEvent,                     /* 25 */
     SProcGrabPointer,
-    SProcResourceReq,                   /* SProcUngrabPointer, */
+    ProcUngrabPointer,
     SProcGrabButton,
     SProcUngrabButton,
     SProcChangeActivePointerGrab,       /* 30 */
     SProcGrabKeyboard,
-    SProcResourceReq,                   /* SProcUngrabKeyboard, */
+    ProcUngrabKeyboard,
     SProcGrabKey,
     SProcUngrabKey,
-    SProcResourceReq,                   /* 35 SProcAllowEvents, */
+    ProcAllowEvents,                    /* 35 */
     SProcSimpleReq,                     /* SProcGrabServer, */
     SProcSimpleReq,                     /* SProcUngrabServer, */
-    SProcResourceReq,                   /* SProcQueryPointer, */
+    ProcQueryPointer,
     SProcGetMotionEvents,
     SProcTranslateCoords,               /*40 */
     SProcWarpPointer,
@@ -377,21 +377,21 @@ int (*SwappedProcVector[256]) (ClientPtr /* client */) = {
     SProcSimpleReq,                     /* SProcGetInputFocus, */
     SProcSimpleReq,                     /* QueryKeymap, */
     SProcOpenFont,                      /* 45 */
-    SProcResourceReq,                   /* SProcCloseFont, */
-    SProcResourceReq,                   /* SProcQueryFont, */
-    SProcResourceReq,                   /* SProcQueryTextExtents,  */
+    ProcCloseFont,
+    ProcQueryFont,
+    ProcQueryTextExtents,
     SProcListFonts,
     SProcListFontsWithInfo,             /* 50 */
     SProcSetFontPath,
     SProcSimpleReq,                     /* GetFontPath, */
     SProcCreatePixmap,
-    SProcResourceReq,                   /* SProcFreePixmap, */
+    ProcFreePixmap,
     SProcCreateGC,                      /* 55 */
     SProcChangeGC,
     SProcCopyGC,
     SProcSetDashes,
     SProcSetClipRectangles,
-    SProcResourceReq,                   /* 60 SProcFreeGC, */
+    ProcFreeGC,                         /* 60 */
     SProcClearToBackground,
     SProcCopyArea,
     SProcCopyPlane,
@@ -410,11 +410,11 @@ int (*SwappedProcVector[256]) (ClientPtr /* client */) = {
     SProcImageText,
     SProcImageText,
     SProcCreateColormap,
-    SProcResourceReq,                   /* SProcFreeColormap, */
+    ProcFreeColormap,
     SProcCopyColormapAndFree,           /* 80 */
-    SProcResourceReq,                   /* SProcInstallColormap, */
-    SProcResourceReq,                   /* SProcUninstallColormap, */
-    SProcResourceReq,                   /* SProcListInstalledColormaps, */
+    ProcInstallColormap,
+    ProcUninstallColormap,
+    ProcListInstalledColormaps,
     SProcAllocColor,
     SProcAllocNamedColor,               /* 85 */
     SProcAllocColorCells,
@@ -426,7 +426,7 @@ int (*SwappedProcVector[256]) (ClientPtr /* client */) = {
     SProcLookupColor,
     SProcCreateCursor,
     SProcCreateGlyphCursor,
-    SProcResourceReq,                   /* 95 SProcFreeCursor, */
+    ProcFreeCursor,                     /* 95 */
     SProcRecolorCursor,
     SProcQueryBestSize,
     SProcQueryExtension,
@@ -444,7 +444,7 @@ int (*SwappedProcVector[256]) (ClientPtr /* client */) = {
     SProcSimpleReq,                     /* 110 ListHosts, */
     SProcSimpleReq,                     /* SProcChangeAccessControl, */
     SProcSimpleReq,                     /* SProcChangeCloseDownMode, */
-    SProcResourceReq,                   /* SProcKillClient, */
+    ProcKillClient,
     SProcRotateProperties,
     SProcSimpleReq,                     /* 115 ForceScreenSaver */
     SProcSimpleReq,                     /* SetPointerMapping, */

--- a/dix/window.c
+++ b/dix/window.c
@@ -1567,6 +1567,9 @@ ProcGetWindowAttributes(ClientPtr client)
     REQUEST(xResourceReq);
     REQUEST_SIZE_MATCH(xResourceReq);
 
+    if (client->swapped)
+        swapl(&stuff->id);
+
     WindowPtr pWin;
     int rc = dixLookupWindow(&pWin, stuff->id, client, DixGetAttrAccess);
     if (rc != Success)

--- a/include/swapreq.h
+++ b/include/swapreq.h
@@ -73,7 +73,6 @@ int SProcQueryBestSize(ClientPtr client);
 int SProcQueryColors(ClientPtr client);
 int SProcQueryExtension(ClientPtr client);
 int SProcReparentWindow(ClientPtr client);
-int SProcResourceReq(ClientPtr client);
 int SProcRotateProperties(ClientPtr client);
 int SProcSetClipRectangles(ClientPtr client);
 int SProcSetDashes(ClientPtr client);


### PR DESCRIPTION
Simplifying byte-swapping code flow by inlining SProcResourceReq()
instead of having complicated call chains.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
