### PR TITLE
Xvmc: inline SProcXvMCDispatch()

### DIFF
--- a/Xext/xvmc.c
+++ b/Xext/xvmc.c
@@ -680,6 +680,9 @@ ProcXvMCGetDRInfo(ClientPtr client)
 static int
 ProcXvMCDispatch(ClientPtr client)
 {
+    if (!(client->local))
+        return BadImplementation;
+
     REQUEST(xReq);
     switch (stuff->data)
     {
@@ -708,13 +711,6 @@ ProcXvMCDispatch(ClientPtr client)
     }
 }
 
-static int _X_COLD
-SProcXvMCDispatch(ClientPtr client)
-{
-    /* We only support local */
-    return BadImplementation;
-}
-
 void
 XvMCExtensionInit(void)
 {
@@ -736,7 +732,7 @@ XvMCExtensionInit(void)
         return;
 
     extEntry = AddExtension(XvMCName, XvMCNumEvents, XvMCNumErrors,
-                            ProcXvMCDispatch, SProcXvMCDispatch,
+                            ProcXvMCDispatch, ProcXvMCDispatch,
                             NULL, StandardMinorOpcode);
 
     if (!extEntry)


### PR DESCRIPTION
No need for an extra function for a one-liner.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
