### PR TITLE
dix: drop obsolete SProcSimpleReq()

### DIFF
--- a/dix/swapreq.c
+++ b/dix/swapreq.c
@@ -116,15 +116,6 @@ SwapShorts(short *list, unsigned long count)
 }
 
 /* The following is used for all requests that have
-   no fields to be swapped (except "length") */
-int _X_COLD
-SProcSimpleReq(ClientPtr client)
-{
-    REQUEST(xReq);
-    return (*ProcVector[stuff->reqType]) (client);
-}
-
-/* The following is used for all requests that have
    only a single 32-bit field to be swapped, coming
    right after the "length" field */
 int _X_COLD

--- a/dix/tables.c
+++ b/dix/tables.c
@@ -367,15 +367,15 @@ int (*SwappedProcVector[256]) (ClientPtr /* client */) = {
     SProcGrabKey,
     SProcUngrabKey,
     SProcResourceReq,                   /* 35 SProcAllowEvents, */
-    SProcSimpleReq,                     /* SProcGrabServer, */
-    SProcSimpleReq,                     /* SProcUngrabServer, */
+    ProcGrabServer,
+    ProcUngrabServer,
     SProcResourceReq,                   /* SProcQueryPointer, */
     SProcGetMotionEvents,
     SProcTranslateCoords,               /*40 */
     SProcWarpPointer,
     SProcSetInputFocus,
-    SProcSimpleReq,                     /* SProcGetInputFocus, */
-    SProcSimpleReq,                     /* QueryKeymap, */
+    ProcGetInputFocus,
+    ProcQueryKeymap,
     SProcOpenFont,                      /* 45 */
     SProcResourceReq,                   /* SProcCloseFont, */
     SProcResourceReq,                   /* SProcQueryFont, */
@@ -383,7 +383,7 @@ int (*SwappedProcVector[256]) (ClientPtr /* client */) = {
     SProcListFonts,
     SProcListFontsWithInfo,             /* 50 */
     SProcSetFontPath,
-    SProcSimpleReq,                     /* GetFontPath, */
+    ProcGetFontPath,
     SProcCreatePixmap,
     SProcResourceReq,                   /* SProcFreePixmap, */
     SProcCreateGC,                      /* 55 */
@@ -430,27 +430,27 @@ int (*SwappedProcVector[256]) (ClientPtr /* client */) = {
     SProcRecolorCursor,
     SProcQueryBestSize,
     SProcQueryExtension,
-    SProcSimpleReq,                     /* ListExtensions, */
+    ProcListExtensions,
     SProcChangeKeyboardMapping,         /* 100 */
-    SProcSimpleReq,                     /* GetKeyboardMapping, */
+    ProcGetKeyboardMapping,
     SProcChangeKeyboardControl,
-    SProcSimpleReq,                     /* GetKeyboardControl, */
-    SProcSimpleReq,                     /* Bell, */
+    ProcGetKeyboardControl,
+    ProcBell,
     SProcChangePointerControl,          /* 105 */
-    SProcSimpleReq,                     /* GetPointerControl, */
+    ProcGetPointerControl,
     SProcSetScreenSaver,
-    SProcSimpleReq,                     /* GetScreenSaver, */
+    ProcGetScreenSaver,
     SProcChangeHosts,
-    SProcSimpleReq,                     /* 110 ListHosts, */
-    SProcSimpleReq,                     /* SProcChangeAccessControl, */
-    SProcSimpleReq,                     /* SProcChangeCloseDownMode, */
+    ProcListHosts,                      /* 110 */
+    ProcChangeAccessControl,
+    ProcChangeCloseDownMode,
     SProcResourceReq,                   /* SProcKillClient, */
     SProcRotateProperties,
-    SProcSimpleReq,                     /* 115 ForceScreenSaver */
-    SProcSimpleReq,                     /* SetPointerMapping, */
-    SProcSimpleReq,                     /* GetPointerMapping, */
-    SProcSimpleReq,                     /* SetModifierMapping, */
-    SProcSimpleReq,                     /* GetModifierMapping, */
+    ProcForceScreenSaver,               /* 115 */
+    ProcSetPointerMapping,
+    ProcGetPointerMapping,
+    ProcSetModifierMapping,
+    ProcGetModifierMapping,
     ProcBadRequest,                     /* 120 */
     ProcBadRequest,
     ProcBadRequest,

--- a/include/swapreq.h
+++ b/include/swapreq.h
@@ -80,7 +80,6 @@ int SProcSetDashes(ClientPtr client);
 int SProcSetFontPath(ClientPtr client);
 int SProcSetScreenSaver(ClientPtr client);
 int SProcSetSelectionOwner(ClientPtr client);
-int SProcSimpleReq(ClientPtr client);
 int SProcStoreColors(ClientPtr client);
 int SProcStoreNamedColor(ClientPtr client);
 int SProcTranslateCoords(ClientPtr client);


### PR DESCRIPTION
This function is really doing nothing except of calling into the
actual request handler, so not needed at all.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
