### PR TITLE
render: XineramaRenderSetPictureClipRectangle(): don't patch request buffer anymore

### DIFF
--- a/render/render.c
+++ b/render/render.c
@@ -554,12 +554,13 @@ SingleRenderChangePicture(ClientPtr client, xRenderChangePictureReq *stuff, Pict
 
 static int
 SingleRenderSetPictureClipRectangles(ClientPtr client,
-                                     xRenderSetPictureClipRectanglesReq *stuff)
+                                     xRenderSetPictureClipRectanglesReq *stuff,
+                                     Picture pictID)
 {
     PicturePtr pPicture;
     int nr;
 
-    VERIFY_PICTURE(pPicture, stuff->picture, client, DixSetAttrAccess);
+    VERIFY_PICTURE(pPicture, pictID, client, DixSetAttrAccess);
     if (!pPicture->pDrawable)
         return RenderErrBase + BadPicture;
 
@@ -2110,16 +2111,16 @@ PanoramiXRenderChangePicture(ClientPtr client, xRenderChangePictureReq *stuff, P
 
 static int
 PanoramiXRenderSetPictureClipRectangles(ClientPtr client,
-                                        xRenderSetPictureClipRectanglesReq *stuff)
+                                        xRenderSetPictureClipRectanglesReq *stuff,
+                                        Picture pictID)
 {
     int result = Success;
     PanoramiXRes *pict;
 
-    VERIFY_XIN_PICTURE(pict, stuff->picture, client, DixWriteAccess);
+    VERIFY_XIN_PICTURE(pict, pictID, client, DixWriteAccess);
 
     XINERAMA_FOR_EACH_SCREEN_BACKWARD({
-        stuff->picture = pict->info[walkScreenIdx].id;
-        result = SingleRenderSetPictureClipRectangles(client, stuff);
+        result = SingleRenderSetPictureClipRectangles(client, stuff, pict->info[walkScreenIdx].id);
         if (result != Success)
             break;
     });
@@ -2753,10 +2754,10 @@ ProcRenderSetPictureClipRectangles(ClientPtr client)
     }
 
 #ifdef XINERAMA
-    return (usePanoramiX ? PanoramiXRenderSetPictureClipRectangles(client, stuff)
-                         : SingleRenderSetPictureClipRectangles(client, stuff));
+    return (usePanoramiX ? PanoramiXRenderSetPictureClipRectangles(client, stuff, stuff->picture)
+                         : SingleRenderSetPictureClipRectangles(client, stuff, stuff->picture));
 #else
-    return SingleRenderSetPictureClipRectangles(client, stuff);
+    return SingleRenderSetPictureClipRectangles(client, stuff, stuff->picture);
 #endif
 }
 


### PR DESCRIPTION
No need for patching up the request buffer anymore - just pass in the correct
value directly.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
