### PR TITLE
render: consolidate byte-swapping in ProcRenderFreePicture()

### DIFF
--- a/render/render.c
+++ b/render/render.c
@@ -97,7 +97,6 @@ static int ProcRenderCreateConicalGradient(ClientPtr pClient);
 
 static int ProcRenderDispatch(ClientPtr pClient);
 
-static int SProcRenderFreePicture(ClientPtr pClient);
 static int SProcRenderTrapezoids(ClientPtr pClient);
 static int SProcRenderTriangles(ClientPtr pClient);
 static int SProcRenderTriStrip(ClientPtr pClient);
@@ -161,7 +160,7 @@ int (*SProcRenderVector[RenderNumberRequests]) (ClientPtr) = {
         ProcRenderCreatePicture,
         ProcRenderChangePicture,
         ProcRenderSetPictureClipRectangles,
-        SProcRenderFreePicture,
+        ProcRenderFreePicture,
         ProcRenderComposite,
         _not_implemented, /* SProcRenderScale */
         SProcRenderTrapezoids,
@@ -589,8 +588,6 @@ SingleRenderFreePicture(ClientPtr client)
     PicturePtr pPicture;
 
     REQUEST(xRenderFreePictureReq);
-
-    REQUEST_SIZE_MATCH(xRenderFreePictureReq);
 
     VERIFY_PICTURE(pPicture, stuff->picture, client, DixDestroyAccess);
     FreeResource(stuff->picture, X11_RESTYPE_NONE);
@@ -1964,15 +1961,6 @@ ProcRenderDispatch(ClientPtr client)
 }
 
 static int _X_COLD
-SProcRenderFreePicture(ClientPtr client)
-{
-    REQUEST(xRenderFreePictureReq);
-    REQUEST_SIZE_MATCH(xRenderFreePictureReq);
-    swapl(&stuff->picture);
-    return ProcRenderFreePicture(client);
-}
-
-static int _X_COLD
 SProcRenderTrapezoids(ClientPtr client)
 {
     REQUEST(xRenderTrapezoidsReq);
@@ -2445,8 +2433,6 @@ PanoramiXRenderFreePicture(ClientPtr client)
     int result = Success;
 
     REQUEST(xRenderFreePictureReq);
-
-    REQUEST_SIZE_MATCH(xRenderFreePictureReq);
 
     client->errorValue = stuff->picture;
 
@@ -3064,6 +3050,12 @@ ProcRenderSetPictureClipRectangles(ClientPtr client)
 static int
 ProcRenderFreePicture(ClientPtr client)
 {
+    REQUEST(xRenderFreePictureReq);
+    REQUEST_SIZE_MATCH(xRenderFreePictureReq);
+
+    if (client->swapped)
+        swapl(&stuff->picture);
+
 #ifdef XINERAMA
     return (usePanoramiX ? PanoramiXRenderFreePicture(client)
                          : SingleRenderFreePicture(client));


### PR DESCRIPTION
No need for extra functions and call tables for the few trivial lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
