### PR TITLE
Xi: inline SProcXGrabDeviceButton()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -384,7 +384,7 @@ SProcIDispatch(ClientPtr client)
         case X_UngrabDeviceKey:
             return SProcXUngrabDeviceKey(client);
         case X_GrabDeviceButton:
-            return SProcXGrabDeviceButton(client);
+            return ProcXGrabDeviceButton(client);
         case X_UngrabDeviceButton:
             return SProcXUngrabDeviceButton(client);
         case X_AllowDeviceEvents:

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -73,7 +73,6 @@ int SProcXGetDeviceDontPropagateList(ClientPtr  client);
 int SProcXGetDeviceMotionEvents(ClientPtr client);
 int SProcXGetExtensionVersion(ClientPtr client);
 int SProcXGetSelectedExtensionEvents(ClientPtr client);
-int SProcXGrabDeviceButton(ClientPtr client);
 int SProcXIAllowEvents(ClientPtr client);
 int SProcXIBarrierReleasePointer(ClientPtr client);
 int SProcXIGetClientPointer(ClientPtr client);


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
