### PR TITLE
xkb: inline SProcXkbPerClientFlags()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -5427,12 +5427,21 @@ ProcXkbSetGeometry(ClientPtr client)
 int
 ProcXkbPerClientFlags(ClientPtr client)
 {
+    REQUEST(xkbPerClientFlagsReq);
+    REQUEST_SIZE_MATCH(xkbPerClientFlagsReq);
+
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swapl(&stuff->change);
+        swapl(&stuff->value);
+        swapl(&stuff->ctrlsToChange);
+        swapl(&stuff->autoCtrls);
+        swapl(&stuff->autoCtrlValues);
+    }
+
     DeviceIntPtr dev;
     XkbInterestPtr interest;
     Mask access_mode = DixGetAttrAccess | DixSetAttrAccess;
-
-    REQUEST(xkbPerClientFlagsReq);
-    REQUEST_SIZE_MATCH(xkbPerClientFlagsReq);
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -238,20 +238,6 @@ SProcXkbGetGeometry(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbPerClientFlags(ClientPtr client)
-{
-    REQUEST(xkbPerClientFlagsReq);
-    REQUEST_SIZE_MATCH(xkbPerClientFlagsReq);
-    swaps(&stuff->deviceSpec);
-    swapl(&stuff->change);
-    swapl(&stuff->value);
-    swapl(&stuff->ctrlsToChange);
-    swapl(&stuff->autoCtrls);
-    swapl(&stuff->autoCtrlValues);
-    return ProcXkbPerClientFlags(client);
-}
-
-static int _X_COLD
 SProcXkbGetKbdByName(ClientPtr client)
 {
     REQUEST(xkbGetKbdByNameReq);
@@ -332,7 +318,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbSetGeometry:
         return ProcXkbSetGeometry(client);
     case X_kbPerClientFlags:
-        return SProcXkbPerClientFlags(client);
+        return ProcXkbPerClientFlags(client);
     case X_kbListComponents:
         return ProcXkbListComponents(client);
     case X_kbGetKbdByName:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
