### PR TITLE
xkb: inline SProcXkbSetDebuggingFlags()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -6750,11 +6750,19 @@ ProcXkbSetDeviceInfo(ClientPtr client)
 int
 ProcXkbSetDebuggingFlags(ClientPtr client)
 {
-    CARD32 newFlags, newCtrls, extraLength;
-    int rc;
-
     REQUEST(xkbSetDebuggingFlagsReq);
     REQUEST_AT_LEAST_SIZE(xkbSetDebuggingFlagsReq);
+
+    if (client->swapped) {
+        swapl(&stuff->affectFlags);
+        swapl(&stuff->flags);
+        swapl(&stuff->affectCtrls);
+        swapl(&stuff->ctrls);
+        swaps(&stuff->msgLength);
+    }
+
+    CARD32 newFlags, newCtrls, extraLength;
+    int rc;
 
     rc = dixCallServerAccessCallback(client, DixDebugAccess);
     if (rc != Success)

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -273,19 +273,6 @@ SProcXkbSetDeviceInfo(ClientPtr client)
     return ProcXkbSetDeviceInfo(client);
 }
 
-static int _X_COLD
-SProcXkbSetDebuggingFlags(ClientPtr client)
-{
-    REQUEST(xkbSetDebuggingFlagsReq);
-    REQUEST_AT_LEAST_SIZE(xkbSetDebuggingFlagsReq);
-    swapl(&stuff->affectFlags);
-    swapl(&stuff->flags);
-    swapl(&stuff->affectCtrls);
-    swapl(&stuff->ctrls);
-    swaps(&stuff->msgLength);
-    return ProcXkbSetDebuggingFlags(client);
-}
-
 int _X_COLD
 SProcXkbDispatch(ClientPtr client)
 {
@@ -342,7 +329,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbSetDeviceInfo:
         return SProcXkbSetDeviceInfo(client);
     case X_kbSetDebuggingFlags:
-        return SProcXkbSetDebuggingFlags(client);
+        return ProcXkbSetDebuggingFlags(client);
     default:
         return BadRequest;
     }


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
