### PR TITLE
xkb: inline SProcXkbGetState()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -597,10 +597,13 @@ int
 ProcXkbGetState(ClientPtr client)
 {
     REQUEST(xkbGetStateReq);
+    REQUEST_SIZE_MATCH(xkbGetStateReq);
+
+    if (client->swapped)
+        swaps(&stuff->deviceSpec);
+
     DeviceIntPtr dev;
     XkbStateRec *xkb;
-
-    REQUEST_SIZE_MATCH(xkbGetStateReq);
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -119,15 +119,6 @@ SProcXkbSelectEvents(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbGetState(ClientPtr client)
-{
-    REQUEST(xkbGetStateReq);
-    REQUEST_SIZE_MATCH(xkbGetStateReq);
-    swaps(&stuff->deviceSpec);
-    return ProcXkbGetState(client);
-}
-
-static int _X_COLD
 SProcXkbLatchLockState(ClientPtr client)
 {
     REQUEST(xkbLatchLockStateReq);
@@ -298,7 +289,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbBell:
         return ProcXkbBell(client);
     case X_kbGetState:
-        return SProcXkbGetState(client);
+        return ProcXkbGetState(client);
     case X_kbLatchLockState:
         return SProcXkbLatchLockState(client);
     case X_kbGetControls:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
