### PR TITLE
xkb: inline SProcXkbSetControls()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -773,6 +773,35 @@ ProcXkbGetControls(ClientPtr client)
 int
 ProcXkbSetControls(ClientPtr client)
 {
+    REQUEST(xkbSetControlsReq);
+    REQUEST_SIZE_MATCH(xkbSetControlsReq);
+
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swaps(&stuff->affectInternalVMods);
+        swaps(&stuff->internalVMods);
+        swaps(&stuff->affectIgnoreLockVMods);
+        swaps(&stuff->ignoreLockVMods);
+        swaps(&stuff->axOptions);
+        swapl(&stuff->affectEnabledCtrls);
+        swapl(&stuff->enabledCtrls);
+        swapl(&stuff->changeCtrls);
+        swaps(&stuff->repeatDelay);
+        swaps(&stuff->repeatInterval);
+        swaps(&stuff->slowKeysDelay);
+        swaps(&stuff->debounceDelay);
+        swaps(&stuff->mkDelay);
+        swaps(&stuff->mkInterval);
+        swaps(&stuff->mkTimeToMax);
+        swaps(&stuff->mkMaxSpeed);
+        swaps(&stuff->mkCurve);
+        swaps(&stuff->axTimeout);
+        swapl(&stuff->axtCtrlsMask);
+        swapl(&stuff->axtCtrlsValues);
+        swaps(&stuff->axtOptsMask);
+        swaps(&stuff->axtOptsValues);
+    }
+
     DeviceIntPtr dev, tmpd;
     XkbSrvInfoPtr xkbi;
     XkbControlsPtr ctrl;
@@ -780,9 +809,6 @@ ProcXkbSetControls(ClientPtr client)
     xkbControlsNotify cn;
     XkbEventCauseRec cause;
     XkbSrvLedInfoPtr sli;
-
-    REQUEST(xkbSetControlsReq);
-    REQUEST_SIZE_MATCH(xkbSetControlsReq);
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -138,37 +138,6 @@ SProcXkbLatchLockState(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbSetControls(ClientPtr client)
-{
-    REQUEST(xkbSetControlsReq);
-    REQUEST_SIZE_MATCH(xkbSetControlsReq);
-    swaps(&stuff->deviceSpec);
-    swaps(&stuff->affectInternalVMods);
-    swaps(&stuff->internalVMods);
-    swaps(&stuff->affectIgnoreLockVMods);
-    swaps(&stuff->ignoreLockVMods);
-    swaps(&stuff->axOptions);
-    swapl(&stuff->affectEnabledCtrls);
-    swapl(&stuff->enabledCtrls);
-    swapl(&stuff->changeCtrls);
-    swaps(&stuff->repeatDelay);
-    swaps(&stuff->repeatInterval);
-    swaps(&stuff->slowKeysDelay);
-    swaps(&stuff->debounceDelay);
-    swaps(&stuff->mkDelay);
-    swaps(&stuff->mkInterval);
-    swaps(&stuff->mkTimeToMax);
-    swaps(&stuff->mkMaxSpeed);
-    swaps(&stuff->mkCurve);
-    swaps(&stuff->axTimeout);
-    swapl(&stuff->axtCtrlsMask);
-    swapl(&stuff->axtCtrlsValues);
-    swaps(&stuff->axtOptsMask);
-    swaps(&stuff->axtOptsValues);
-    return ProcXkbSetControls(client);
-}
-
-static int _X_COLD
 SProcXkbSetMap(ClientPtr client)
 {
     REQUEST(xkbSetMapReq);
@@ -304,7 +273,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbGetControls:
         return ProcXkbGetControls(client);
     case X_kbSetControls:
-        return SProcXkbSetControls(client);
+        return ProcXkbSetControls(client);
     case X_kbGetMap:
         return ProcXkbGetMap(client);
     case X_kbSetMap:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
