### PR TITLE
xkb: inline SProcXkbSetNamedIndicator()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -3494,13 +3494,22 @@ _XkbSetNamedIndicator(ClientPtr client, DeviceIntPtr dev,
 int
 ProcXkbSetNamedIndicator(ClientPtr client)
 {
+    REQUEST(xkbSetNamedIndicatorReq);
+    REQUEST_SIZE_MATCH(xkbSetNamedIndicatorReq);
+
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swaps(&stuff->ledClass);
+        swaps(&stuff->ledID);
+        swapl(&stuff->indicator);
+        swaps(&stuff->virtualMods);
+        swapl(&stuff->ctrls);
+    }
+
     int rc;
     DeviceIntPtr dev;
     int led = 0;
     XkbIndicatorMapPtr map;
-
-    REQUEST(xkbSetNamedIndicatorReq);
-    REQUEST_SIZE_MATCH(xkbSetNamedIndicatorReq);
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -214,20 +214,6 @@ SProcXkbSetIndicatorMap(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbSetNamedIndicator(ClientPtr client)
-{
-    REQUEST(xkbSetNamedIndicatorReq);
-    REQUEST_SIZE_MATCH(xkbSetNamedIndicatorReq);
-    swaps(&stuff->deviceSpec);
-    swaps(&stuff->ledClass);
-    swaps(&stuff->ledID);
-    swapl(&stuff->indicator);
-    swaps(&stuff->virtualMods);
-    swapl(&stuff->ctrls);
-    return ProcXkbSetNamedIndicator(client);
-}
-
-static int _X_COLD
 SProcXkbGetGeometry(ClientPtr client)
 {
     REQUEST(xkbGetGeometryReq);
@@ -322,7 +308,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbGetNamedIndicator:
         return ProcXkbGetNamedIndicator(client);
     case X_kbSetNamedIndicator:
-        return SProcXkbSetNamedIndicator(client);
+        return ProcXkbSetNamedIndicator(client);
     case X_kbGetNames:
         return ProcXkbGetNames(client);
     case X_kbSetNames:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
