### PR TITLE
xkb: inline SProcXkbGetIndicatorMap()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -3139,12 +3139,17 @@ XkbAssembleIndicatorMap(ClientPtr client,
 int
 ProcXkbGetIndicatorMap(ClientPtr client)
 {
+    REQUEST(xkbGetIndicatorMapReq);
+    REQUEST_SIZE_MATCH(xkbGetIndicatorMapReq);
+
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swapl(&stuff->which);
+    }
+
     DeviceIntPtr dev;
     XkbDescPtr xkb;
     XkbIndicatorPtr leds;
-
-    REQUEST(xkbGetIndicatorMapReq);
-    REQUEST_SIZE_MATCH(xkbGetIndicatorMapReq);
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -194,16 +194,6 @@ SProcXkbSetCompatMap(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbGetIndicatorMap(ClientPtr client)
-{
-    REQUEST(xkbGetIndicatorMapReq);
-    REQUEST_SIZE_MATCH(xkbGetIndicatorMapReq);
-    swaps(&stuff->deviceSpec);
-    swapl(&stuff->which);
-    return ProcXkbGetIndicatorMap(client);
-}
-
-static int _X_COLD
 SProcXkbSetIndicatorMap(ClientPtr client)
 {
     REQUEST(xkbSetIndicatorMapReq);
@@ -316,7 +306,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbGetIndicatorState:
         return ProcXkbGetIndicatorState(client);
     case X_kbGetIndicatorMap:
-        return SProcXkbGetIndicatorMap(client);
+        return ProcXkbGetIndicatorMap(client);
     case X_kbSetIndicatorMap:
         return SProcXkbSetIndicatorMap(client);
     case X_kbGetNamedIndicator:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
