### PR TITLE
Xi: inline SProcXIQueryVersion()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -446,7 +446,7 @@ SProcIDispatch(ClientPtr client)
         case X_XISelectEvents:
             return SProcXISelectEvents(client);
         case X_XIQueryVersion:
-            return SProcXIQueryVersion(client);
+            return ProcXIQueryVersion(client);
         case X_XIQueryDevice:
             return ProcXIQueryDevice(client);
         case X_XISetFocus:

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -76,7 +76,6 @@ int SProcXIGetSelectedEvents(ClientPtr client);
 int SProcXIPassiveGrabDevice(ClientPtr client);
 int SProcXIPassiveUngrabDevice(ClientPtr client);
 int SProcXIQueryPointer(ClientPtr client);
-int SProcXIQueryVersion(ClientPtr client);
 int SProcXISelectEvents(ClientPtr client);
 int SProcXISetClientPointer(ClientPtr client);
 int SProcXIWarpPointer(ClientPtr client);

--- a/Xi/xiqueryversion.c
+++ b/Xi/xiqueryversion.c
@@ -56,10 +56,15 @@ extern XExtensionVersion XIVersion;     /* defined in getvers.c */
 int
 ProcXIQueryVersion(ClientPtr client)
 {
-    int major, minor;
-
     REQUEST(xXIQueryVersionReq);
     REQUEST_SIZE_MATCH(xXIQueryVersionReq);
+
+    if (client->swapped) {
+        swaps(&stuff->major_version);
+        swaps(&stuff->minor_version);
+    }
+
+    int major, minor;
 
     /* This request only exists after XI2 */
     if (stuff->major_version < 2) {
@@ -125,16 +130,4 @@ ProcXIQueryVersion(ClientPtr client)
     }
 
     return X_SEND_REPLY_SIMPLE(client, rep);
-}
-
-/* Swapping routines */
-
-int _X_COLD
-SProcXIQueryVersion(ClientPtr client)
-{
-    REQUEST(xXIQueryVersionReq);
-    REQUEST_AT_LEAST_SIZE(xXIQueryVersionReq);
-    swaps(&stuff->major_version);
-    swaps(&stuff->minor_version);
-    return (ProcXIQueryVersion(client));
 }

--- a/test/xi2/protocol-xiqueryversion.c
+++ b/test/xi2/protocol-xiqueryversion.c
@@ -147,7 +147,7 @@ request_XIQueryVersion(int smaj, int smin, int cmaj, int cmin, int error)
     swaps(&request.major_version);
     swaps(&request.minor_version);
 
-    rc = SProcXIQueryVersion(&client);
+    rc = ProcXIQueryVersion(&client);
     assert(rc == error);
 }
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
