### PR TITLE
Xi: inline SProcXIQueryDevice()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -448,7 +448,7 @@ SProcIDispatch(ClientPtr client)
         case X_XIQueryVersion:
             return SProcXIQueryVersion(client);
         case X_XIQueryDevice:
-            return SProcXIQueryDevice(client);
+            return ProcXIQueryDevice(client);
         case X_XISetFocus:
             return SProcXISetFocus(client);
         case X_XIGetFocus:

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -81,7 +81,6 @@ int SProcXIGetFocus(ClientPtr client);
 int SProcXIGetSelectedEvents(ClientPtr client);
 int SProcXIPassiveGrabDevice(ClientPtr client);
 int SProcXIPassiveUngrabDevice(ClientPtr client);
-int SProcXIQueryDevice(ClientPtr client);
 int SProcXIQueryPointer(ClientPtr client);
 int SProcXIQueryVersion(ClientPtr client);
 int SProcXISelectEvents(ClientPtr client);

--- a/Xi/xiquerydevice.c
+++ b/Xi/xiquerydevice.c
@@ -57,28 +57,21 @@ static int
  ListDeviceInfo(ClientPtr client, DeviceIntPtr dev, xXIDeviceInfo * info);
 static int SizeDeviceInfo(DeviceIntPtr dev);
 static void SwapDeviceInfo(DeviceIntPtr dev, xXIDeviceInfo * info);
-int _X_COLD
-SProcXIQueryDevice(ClientPtr client)
-{
-    REQUEST(xXIQueryDeviceReq);
-    REQUEST_SIZE_MATCH(xXIQueryDeviceReq);
-
-    swaps(&stuff->deviceid);
-
-    return ProcXIQueryDevice(client);
-}
 
 int
 ProcXIQueryDevice(ClientPtr client)
 {
+    REQUEST(xXIQueryDeviceReq);
+    REQUEST_SIZE_MATCH(xXIQueryDeviceReq);
+
+    if (client->swapped)
+        swaps(&stuff->deviceid);
+
     DeviceIntPtr dev = NULL;
     int rc = Success;
     int i = 0, len = 0;
     char *info;
     Bool *skip = NULL;
-
-    REQUEST(xXIQueryDeviceReq);
-    REQUEST_SIZE_MATCH(xXIQueryDeviceReq);
 
     if (stuff->deviceid != XIAllDevices &&
         stuff->deviceid != XIAllMasterDevices) {

--- a/test/xi2/protocol-xiquerydevice.c
+++ b/test/xi2/protocol-xiquerydevice.c
@@ -307,7 +307,7 @@ request_XIQueryDevice(struct test_data *querydata, int deviceid, int error)
     client.swapped = TRUE;
     swaps(&request.length);
     swaps(&request.deviceid);
-    rc = SProcXIQueryDevice(&client);
+    rc = ProcXIQueryDevice(&client);
     assert(rc == error);
 
     if (rc != Success)


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
