### PR TITLE
win32: move definition of sigset_t to os/osdep.h

### DIFF
--- a/include/os.h
+++ b/include/os.h
@@ -294,12 +294,6 @@ _X_ATTRIBUTE_PRINTF(1, 2);
 extern _X_EXPORT void
 xorg_backtrace(void);
 
-#include <signal.h>
-
-#if defined(WIN32)
-typedef _sigset_t sigset_t;
-#endif
-
 /* should not be used anymore, just for backwards compat with drivers */
 #define LogVMessageVerbSigSafe(...) LogVMessageVerb(__VA_ARGS__)
 #define LogMessageVerbSigSafe(...) LogMessageVerb(__VA_ARGS__)

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -137,6 +137,9 @@ _X_EXPORT Bool TimerForce(OsTimerPtr);
 
 #ifdef WIN32
 #include <X11/Xwinsock.h>
+#include <signal.h>
+
+typedef _sigset_t sigset_t;
 
 #undef CreateWindow
 


### PR DESCRIPTION
Not needed by drivers (there aren't any on win32), so no need to
have it in public SDK header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
