### PR TITLE
dix: unexport ConnectionInfo field

### DIFF
--- a/Xext/panoramiX.c
+++ b/Xext/panoramiX.c
@@ -37,6 +37,7 @@ Equipment Corporation.
 #include "dix/rpcbuf_priv.h"
 #include "dix/screen_hooks_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/server_priv.h"
 #include "miext/extinit_priv.h"
 #include "Xext/panoramiX.h"
 #include "Xext/panoramiXsrv.h"

--- a/Xext/panoramiXprocs.c
+++ b/Xext/panoramiXprocs.c
@@ -35,6 +35,7 @@ Equipment Corporation.
 #include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/server_priv.h"
 #include "os/osdep.h"
 #include "Xext/panoramiX.h"
 #include "Xext/panoramiXsrv.h"

--- a/dix/main.c
+++ b/dix/main.c
@@ -93,6 +93,7 @@ Equipment Corporation.
 #include "dix/gc_priv.h"
 #include "dix/registry_priv.h"
 #include "dix/selection_priv.h"
+#include "dix/server_priv.h"
 #include "os/audit_priv.h"
 #include "os/auth.h"
 #include "os/client_priv.h"

--- a/dix/server_priv.h
+++ b/dix/server_priv.h
@@ -23,4 +23,6 @@ static inline int dixCallServerAccessCallback(ClientPtr client, Mask access_mode
     return rec.status;
 }
 
+extern char *ConnectionInfo;
+
 #endif /* _XSERVER_DIX_SERVER_PRIV_H */

--- a/include/globals.h
+++ b/include/globals.h
@@ -26,7 +26,6 @@ extern _X_EXPORT int defaultColorVisualClass;
 
 extern _X_EXPORT int GrabInProgress;
 extern _X_EXPORT char *SeatId;
-extern _X_EXPORT char *ConnectionInfo;
 
 #ifdef XINERAMA
 extern _X_EXPORT Bool PanoramiXExtensionDisabledHack;

--- a/randr/rrscreen.c
+++ b/randr/rrscreen.c
@@ -23,6 +23,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
+#include "dix/server_priv.h"
 #include "randr/randrstr_priv.h"
 #include "randr/rrdispatch_priv.h"
 

--- a/render/render.c
+++ b/render/render.c
@@ -36,6 +36,7 @@
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/server_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/osdep.h"
 #include "Xext/panoramiX.h"


### PR DESCRIPTION
Not used by any drivers, so no need to keep it in public SDK.
Since it's not used by any drivers, effectively no ABI change, so
can be safely done within ABI-25.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
