### PR TITLE
xfree86: xv: fix missed hooking of WindowDestroy

### DIFF
--- a/hw/xfree86/common/xf86xv.c
+++ b/hw/xfree86/common/xf86xv.c
@@ -251,6 +251,7 @@ xf86XVScreenInit(ScreenPtr pScreen, XF86VideoAdaptorPtr * adaptors, int num)
 
     pScrn = xf86ScreenToScrn(pScreen);
 
+    dixScreenHookWindowDestroy(pScreen, xf86XVWindowDestroy);
     dixScreenHookClose(pScreen, xf86XVCloseScreen);
 
     ScreenPriv->WindowExposures = pScreen->WindowExposures;


### PR DESCRIPTION
Forgot to register window destroy hook - that's leading to crash:

    https://github.com/X11Libre/xserver/issues/959

Fixes: b60581e393c1365c5fb90bf60cd9fac98562fd3e
Bug: https://github.com/X11Libre/xserver/issues/959
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
