### PR TITLE
treewide: macros lambda-esque screen iteration

### DIFF
--- a/Xext/damage/damageext.c
+++ b/Xext/damage/damageext.c
@@ -28,6 +28,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
+#include "dix/screenint_priv.h"
 #include "include/pixmapstr.h"
 #include "miext/extinit_priv.h"
 #include "os/client_priv.h"
@@ -692,10 +693,9 @@ DamageExtensionInit(void)
 {
     ExtensionEntry *extEntry;
 
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         DamageSetup(walkScreen);
-    }
+    });
 
     DamageExtType = CreateNewResourceType(FreeDamageExt, "DamageExt");
     if (!DamageExtType)

--- a/Xext/dpms.c
+++ b/Xext/dpms.c
@@ -34,6 +34,7 @@ Equipment Corporation.
 
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
+#include "dix/screenint_priv.h"
 #include "dix/screensaver_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/screensaver.h"
@@ -237,17 +238,15 @@ Bool
 DPMSSupported(void)
 {
     /* For each screen, check if DPMS is supported */
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         if (walkScreen->DPMS != NULL)
             return TRUE;
-    }
+    });
 
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numGPUScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.gpuscreens[walkScreenIdx];
+    DIX_FOR_EACH_GPU_SCREEN({
         if (walkScreen->DPMS != NULL)
             return TRUE;
-    }
+    });
 
     return FALSE;
 }
@@ -287,17 +286,15 @@ DPMSSet(ClientPtr client, int level)
             return rc;
     }
 
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         if (walkScreen->DPMS != NULL)
             walkScreen->DPMS(walkScreen, level);
-    }
+    });
 
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numGPUScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.gpuscreens[walkScreenIdx];
+    DIX_FOR_EACH_GPU_SCREEN({
         if (walkScreen->DPMS != NULL)
             walkScreen->DPMS(walkScreen, level);
-    }
+    });
 
     if (DPMSPowerLevel != old_level)
         SendDPMSInfoNotify();

--- a/Xext/panoramiX.c
+++ b/Xext/panoramiX.c
@@ -590,9 +590,10 @@ PanoramiXCreateConnectionBlock(void)
     }
 
     ScreenPtr masterScreen = dixGetMasterScreen();
+    DIX_FOR_EACH_SCREEN({
+        if (!walkScreenIdx)
+            continue;  /* skip the first one */
 
-    for (unsigned int walkScreenIdx = 1; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
         if (walkScreen->rootDepth != masterScreen->rootDepth) {
             ErrorF("Xinerama error: Root window depths differ\n");
             return FALSE;
@@ -600,13 +601,12 @@ PanoramiXCreateConnectionBlock(void)
         if (walkScreen->backingStoreSupport !=
             masterScreen->backingStoreSupport)
             disable_backing_store = TRUE;
-    }
+    });
 
     if (disable_backing_store) {
-        for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+        DIX_FOR_EACH_SCREEN({
             walkScreen->backingStoreSupport = NotUseful;
-        }
+        });
     }
 
     i = screenInfo.numScreens;

--- a/Xext/saver.c
+++ b/Xext/saver.c
@@ -1282,7 +1282,6 @@ void
 ScreenSaverExtensionInit(void)
 {
     ExtensionEntry *extEntry;
-    int i;
 
     if (!dixRegisterPrivateKey(&ScreenPrivateKeyRec, PRIVATE_SCREEN, 0))
         return;
@@ -1291,10 +1290,10 @@ ScreenSaverExtensionInit(void)
     SaverEventType = CreateNewResourceType(ScreenSaverFreeEvents, "SaverEvent");
     SuspendType = CreateNewResourceType(ScreenSaverFreeSuspend, "SaverSuspend");
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    DIX_FOR_EACH_SCREEN({
         SetScreenPrivate(walkScreen, NULL);
-    }
+    });
+
     if (AttrType && SaverEventType && SuspendType &&
         (extEntry = AddExtension(ScreenSaverName, ScreenSaverNumberEvents, 0,
                                  ProcScreenSaverDispatch,

--- a/Xext/shm.c
+++ b/Xext/shm.c
@@ -46,6 +46,7 @@ in this Software without prior written authorization from The Open Group.
 #include "dix/request_priv.h"
 #include "dix/screenint_priv.h"
 #include "dix/screen_hooks_priv.h"
+#include "dix/screenint_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/auth.h"
 #include "os/busfault.h"
@@ -230,12 +231,9 @@ ShmRegisterPrivates(void)
  /*ARGSUSED*/ static void
 ShmResetProc(ExtensionEntry * extEntry)
 {
-    int i;
-
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    DIX_FOR_EACH_SCREEN({
         ShmRegisterFuncs(walkScreen, NULL);
-    }
+    });
 }
 
 void
@@ -1380,7 +1378,6 @@ void
 ShmExtensionInit(void)
 {
     ExtensionEntry *extEntry;
-    int i;
 
 #ifdef MUST_CHECK_FOR_SHM_SYSCALL
     if (!CheckForShmSyscall()) {
@@ -1395,8 +1392,7 @@ ShmExtensionInit(void)
     sharedPixmaps = xFalse;
     {
         sharedPixmaps = xTrue;
-        for (i = 0; i < screenInfo.numScreens; i++) {
-            ScreenPtr walkScreen = screenInfo.screens[i];
+        DIX_FOR_EACH_SCREEN({
             ShmScrPrivateRec *screen_priv =
                 ShmInitScreenPriv(walkScreen);
             if (!screen_priv)
@@ -1405,12 +1401,11 @@ ShmExtensionInit(void)
                 screen_priv->shmFuncs = &miFuncs;
             if (!screen_priv->shmFuncs->CreatePixmap)
                 sharedPixmaps = xFalse;
-        }
+        });
         if (sharedPixmaps)
-            for (i = 0; i < screenInfo.numScreens; i++) {
-                ScreenPtr walkScreen = screenInfo.screens[i];
+            DIX_FOR_EACH_SCREEN({
                 dixScreenHookPixmapDestroy(walkScreen, ShmPixmapDestroy);
-            }
+            });
     }
     ShmSegType = CreateNewResourceType(ShmDetachSegment, "ShmSeg");
     if (ShmSegType &&

--- a/Xext/sync.c
+++ b/Xext/sync.c
@@ -60,6 +60,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
+#include "dix/screenint_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/bug_priv.h"
 #include "os/osdep.h"
@@ -2248,12 +2249,10 @@ void
 SyncExtensionInit(void)
 {
     ExtensionEntry *extEntry;
-    int s;
 
-    for (s = 0; s < screenInfo.numScreens; s++) {
-        ScreenPtr walkScreen = screenInfo.screens[s];
+    DIX_FOR_EACH_SCREEN({
         miSyncSetup(walkScreen);
-    }
+    });
 
     RTCounter = CreateNewResourceType(FreeCounter, "SyncCounter");
     xorg_list_init(&SysCounterList);

--- a/Xext/xselinux_hooks.c
+++ b/Xext/xselinux_hooks.c
@@ -38,6 +38,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "dix/input_priv.h"
 #include "dix/registry_priv.h"
 #include "dix/resource_priv.h"
+#include "dix/screenint_priv.h"
 #include "dix/selection_priv.h"
 #include "dix/server_priv.h"
 #include "os/client_priv.h"
@@ -172,7 +173,6 @@ SELinuxLabelClient(ClientPtr client)
 static void
 SELinuxLabelInitial(void)
 {
-    int i;
     XaceScreenAccessRec srec;
     SELinuxSubjectRec *subj;
     SELinuxObjectRec *obj;
@@ -199,9 +199,7 @@ SELinuxLabelInitial(void)
     srec.access_mode = DixCreateAccess;
     srec.status = Success;
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
-
+    DIX_FOR_EACH_SCREEN({
         /* Do the screen object */
         srec.screen = walkScreen;
         SELinuxScreen(NULL, NULL, &srec);
@@ -209,7 +207,7 @@ SELinuxLabelInitial(void)
         /* Do the default colormap */
         dixLookupResourceByType(&unused, walkScreen->defColormap,
                                 X11_RESTYPE_COLORMAP, serverClient, DixCreateAccess);
-    }
+    });
 }
 
 /*

--- a/Xi/closedev.c
+++ b/Xi/closedev.c
@@ -56,6 +56,7 @@ SOFTWARE.
 #include <X11/extensions/XIproto.h>
 
 #include "dix/resource_priv.h"
+#include "dix/screenint_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
@@ -119,7 +120,7 @@ DeleteEventsFromChildren(DeviceIntPtr dev, WindowPtr p1, ClientPtr client)
 int
 ProcXCloseDevice(ClientPtr client)
 {
-    int rc, i;
+    int rc;
     DeviceIntPtr d;
 
     REQUEST(xCloseDeviceReq);
@@ -136,11 +137,10 @@ ProcXCloseDevice(ClientPtr client)
      * and selected by this client.
      * Delete passive grabs from all windows for this device.      */
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    DIX_FOR_EACH_SCREEN({
         DeleteDeviceEvents(d, walkScreen->root, client);
         DeleteEventsFromChildren(d, walkScreen->root->firstChild, client);
-    }
+    });
 
     return Success;
 }

--- a/Xi/exevents.c
+++ b/Xi/exevents.c
@@ -3295,15 +3295,13 @@ FindInterestedChildren(DeviceIntPtr dev, WindowPtr p1, Mask mask,
 void
 SendEventToAllWindows(DeviceIntPtr dev, Mask mask, xEvent *ev, int count)
 {
-    int i;
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    DIX_FOR_EACH_SCREEN({
         WindowPtr pWin = walkScreen->root;
         if (!pWin)
             continue;
         DeliverEventsToWindow(dev, pWin, ev, count, mask, NullGrab);
         FindInterestedChildren(dev, pWin->firstChild, mask, ev, count);
-    }
+    });
 }
 
 /**

--- a/Xi/xibarriers.c
+++ b/Xi/xibarriers.c
@@ -933,21 +933,17 @@ ProcXIBarrierReleasePointer(ClientPtr client)
 Bool
 XIBarrierInit(void)
 {
-    int i;
-
     if (!dixRegisterPrivateKey(&BarrierScreenPrivateKeyRec, PRIVATE_SCREEN, 0))
         return FALSE;
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    DIX_FOR_EACH_SCREEN({
         BarrierScreenPtr cs;
-
         cs = (BarrierScreenPtr) calloc(1, sizeof(BarrierScreenRec));
         if (!cs)
             return FALSE;
         xorg_list_init(&cs->barriers);
         SetBarrierScreen(walkScreen, cs);
-    }
+    });
 
     PointerBarrierType = CreateNewResourceType(BarrierFreeBarrier,
                                                "XIPointerBarrier");
@@ -958,11 +954,9 @@ XIBarrierInit(void)
 void
 XIBarrierReset(void)
 {
-    int i;
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    DIX_FOR_EACH_SCREEN({
         BarrierScreenPtr cs = GetBarrierScreen(walkScreen);
         free(cs);
         SetBarrierScreen(walkScreen, NULL);
-    }
+    });
 }

--- a/composite/compext.c
+++ b/composite/compext.c
@@ -403,8 +403,7 @@ CompositeExtensionInit(void)
     /* Assume initialization is going to fail */
     noCompositeExtension = TRUE;
 
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
 
         /* Composite on 8bpp pseudocolor root windows appears to fail, so
          * just disable it on anything pseudocolor for safety.
@@ -419,7 +418,7 @@ CompositeExtensionInit(void)
          */
         if (GetPictureScreenIfSet(walkScreen) == NULL)
             return;
-    }
+    });
 
     CompositeClientWindowType = CreateNewResourceType
         (FreeCompositeClientWindow, "CompositeClientWindow");
@@ -443,11 +442,10 @@ CompositeExtensionInit(void)
                                sizeof(CompositeClientRec)))
         return;
 
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         if (!compScreenInit(walkScreen))
             return;
-    }
+    });
 
     ExtensionEntry *extEntry = AddExtension(COMPOSITE_NAME, 0, 0,
                             ProcCompositeDispatch,

--- a/dix/cursor.c
+++ b/dix/cursor.c
@@ -51,6 +51,7 @@ SOFTWARE.
 
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
+#include "dix/screenint_priv.h"
 #include "os/bug_priv.h"
 
 #include "servermd.h"
@@ -114,11 +115,11 @@ FreeCursor(void *value, XID cid)
 
     BUG_WARN(CursorRefCount(pCurs) < 0);
 
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         if (walkScreen->UnrealizeCursor)
             walkScreen->UnrealizeCursor(pDev, walkScreen, pCurs);
-    }
+    });
+
     FreeCursorBits(pCurs->bits);
     dixFiniPrivates(pCurs, PRIVATE_CURSOR);
     free(pCurs);
@@ -182,8 +183,7 @@ CheckForEmptyMask(CursorBitsPtr bits)
 static int
 RealizeCursorAllScreens(CursorPtr pCurs)
 {
-    for (int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         for (DeviceIntPtr pDev = inputInfo.devices; pDev; pDev = pDev->next) {
             if (DevHasCursor(pDev)) {
                 if (!(*walkScreen->RealizeCursor) (pDev, walkScreen, pCurs)) {
@@ -216,7 +216,7 @@ RealizeCursorAllScreens(CursorPtr pCurs)
                 }
             }
         }
-    }
+    });
 
     return Success;
 }

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -667,10 +667,10 @@ CreateConnectionBlock(void)
     connBlockScreenStart = sizesofar;
     memset(&depth, 0, sizeof(xDepth));
     memset(&visual, 0, sizeof(xVisualType));
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+
+    DIX_FOR_EACH_SCREEN({
         DepthPtr pDepth;
         VisualPtr pVisual;
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
 
         root.windowId = walkScreen->root->drawable.id;
         root.defaultColormap = walkScreen->defColormap;
@@ -724,7 +724,7 @@ CreateConnectionBlock(void)
                 sizesofar += sizeof(xVisualType);
             }
         }
-    }
+    });
     connSetupPrefix.success = xTrue;
     connSetupPrefix.length = lenofblock / 4;
     connSetupPrefix.majorVersion = X_PROTOCOL;
@@ -3224,12 +3224,11 @@ ProcSetScreenSaver(ClientPtr client)
     REQUEST(xSetScreenSaverReq);
     REQUEST_SIZE_MATCH(xSetScreenSaverReq);
 
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         int rc = XaceHookScreensaverAccess(client, walkScreen, DixSetAttrAccess);
         if (rc != Success)
             return rc;
-    }
+    });
 
     blankingOption = stuff->preferBlank;
     if ((blankingOption != DontPreferBlanking) &&
@@ -3281,12 +3280,11 @@ ProcGetScreenSaver(ClientPtr client)
 {
     REQUEST_SIZE_MATCH(xReq);
 
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         int rc = XaceHookScreensaverAccess(client, walkScreen, DixGetAttrAccess);
         if (rc != Success)
             return rc;
-    }
+    });
 
     xGetScreenSaverReply rep = {
         .timeout = ScreenSaverTime / MILLI_PER_SECOND,

--- a/dix/dixutils.c
+++ b/dix/dixutils.c
@@ -89,6 +89,7 @@ Author:  Adobe Systems Incorporated
 #include "dix/client_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/resource_priv.h"
+#include "dix/screenint_priv.h"
 
 #include "misc.h"
 #include "windowstr.h"
@@ -344,17 +345,15 @@ BlockHandler(void *pTimeout)
         if (!handlers[i].deleted)
             (*handlers[i].BlockHandler) (handlers[i].blockData, pTimeout);
 
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numGPUScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.gpuscreens[walkScreenIdx];
+    DIX_FOR_EACH_GPU_SCREEN({
         if (walkScreen->BlockHandler)
             walkScreen->BlockHandler(walkScreen, pTimeout);
-    }
+    });
 
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         if (walkScreen->BlockHandler)
             walkScreen->BlockHandler(walkScreen, pTimeout);
-    }
+    });
 
     if (handlerDeleted) {
         for (size_t i = 0; i < numHandlers;)
@@ -379,16 +378,16 @@ void
 WakeupHandler(int result)
 {
     ++inHandler;
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+
+    DIX_FOR_EACH_SCREEN({
         if (walkScreen->WakeupHandler)
             walkScreen->WakeupHandler(walkScreen, result);
-    }
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numGPUScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.gpuscreens[walkScreenIdx];
+    });
+
+    DIX_FOR_EACH_GPU_SCREEN({
         if (walkScreen->WakeupHandler)
             walkScreen->WakeupHandler(walkScreen, result);
-    }
+    });
 
     for (size_t i = numHandlers; i > 0; i--)
         if (!handlers[i-1].deleted)

--- a/dix/events.c
+++ b/dix/events.c
@@ -2487,8 +2487,7 @@ DeliverRawEvent(RawDeviceEvent *ev, DeviceIntPtr device)
 
     filter = GetEventFilter(device, xi);
 
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         InputClients *inputclients;
 
         WindowPtr root = walkScreen->root;
@@ -2512,7 +2511,7 @@ DeliverRawEvent(RawDeviceEvent *ev, DeviceIntPtr device)
                 DeliverEventToInputClients(device, &ic, root, xi, 1,
                                            filter, NULL, &c, &m);
         }
-    }
+    });
 
     free(xi);
 }
@@ -6001,8 +6000,7 @@ ProcRecolorCursor(ClientPtr client)
     pCursor->backGreen = stuff->backGreen;
     pCursor->backBlue = stuff->backBlue;
 
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
 #ifdef XINERAMA
         if (!noPanoramiXExtension)
             displayed = (walkScreen == pSprite->screen);
@@ -6011,7 +6009,7 @@ ProcRecolorCursor(ClientPtr client)
             displayed = (walkScreen == pSprite->hotPhys.pScreen);
         (*walkScreen->RecolorCursor) (PickPointer(client), walkScreen, pCursor,
                                 (pCursor == pSprite->current) && displayed);
-    }
+    });
     return Success;
 }
 

--- a/dix/inpututils.c
+++ b/dix/inpututils.c
@@ -28,6 +28,7 @@
 #include "dix/exevents_priv.h"
 #include "dix/input_priv.h"
 #include "dix/inpututils_priv.h"
+#include "dix/screenint_priv.h"
 #include "os/bug_priv.h"
 
 #include "exglobals.h"
@@ -842,14 +843,12 @@ update_desktop_dimensions(void)
     int x1 = INT_MAX, y1 = INT_MAX;     /* top-left */
     int x2 = INT_MIN, y2 = INT_MIN;     /* bottom-right */
 
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
-
+    DIX_FOR_EACH_SCREEN({
         x1 = min(x1, walkScreen->x);
         y1 = min(y1, walkScreen->y);
         x2 = max(x2, walkScreen->x + walkScreen->width);
         y2 = max(y2, walkScreen->y + walkScreen->height);
-    }
+    });
 
     screenInfo.x = x1;
     screenInfo.y = y1;

--- a/dix/main.c
+++ b/dix/main.c
@@ -202,17 +202,14 @@ dix_main(int argc, char *argv[], char *envp[])
         InitExtensions(argc, argv);
         LogMessageVerb(X_INFO, 1, "Extensions initialized\n");
 
-        for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numGPUScreens; walkScreenIdx++) {
-            ScreenPtr walkScreen = screenInfo.gpuscreens[walkScreenIdx];
+        DIX_FOR_EACH_GPU_SCREEN({
             if (!PixmapScreenInit(walkScreen))
                 FatalError("failed to create screen pixmap properties");
             if (!dixScreenRaiseCreateResources(walkScreen))
                 FatalError("failed to create screen resources");
-        }
+        });
 
-        for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
-
+        DIX_FOR_EACH_SCREEN({
             if (!PixmapScreenInit(walkScreen))
                 FatalError("failed to create screen pixmap properties");
             if (!dixScreenRaiseCreateResources(walkScreen))
@@ -224,7 +221,7 @@ dix_main(int argc, char *argv[], char *envp[])
             if (!CreateRootWindow(walkScreen))
                 FatalError("failed to create root window");
             CallCallbacks(&RootWindowFinalizeCallback, walkScreen);
-        }
+        });
 
         if (SetDefaultFontPath(defaultFontPath) != Success) {
             ErrorF("[dix] failed to set default font path '%s'",
@@ -248,11 +245,10 @@ dix_main(int argc, char *argv[], char *envp[])
             PanoramiXConsolidate();
 #endif /* XINERAMA */
 
-        for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+        DIX_FOR_EACH_SCREEN({
             InitRootWindow(walkScreen->root);
             CallCallbacks(&PostInitRootWindowCallback, walkScreen);
-        }
+        });
 
         LogMessageVerb(X_INFO, 1, "Screen(s) initialized\n");
 
@@ -314,10 +310,7 @@ dix_main(int argc, char *argv[], char *envp[])
 
         InputThreadFini();
 
-        for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
-            walkScreen->root = NullWindow;
-        }
+        DIX_FOR_EACH_SCREEN({ walkScreen->root = NullWindow; });
 
         CloseDownDevices();
 

--- a/dix/privates.c
+++ b/dix/privates.c
@@ -53,6 +53,7 @@ from The Open Group.
 #include <stddef.h>
 
 #include "dix/colormap_priv.h"
+#include "dix/screenint_priv.h"
 
 #include "windowstr.h"
 #include "resource.h"
@@ -211,16 +212,14 @@ fixupOneScreen(ScreenPtr pScreen, FixupFunc fixup, unsigned bytes)
 static Bool
 fixupScreens(FixupFunc fixup, unsigned bytes)
 {
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         if (!fixupOneScreen (walkScreen, fixup, bytes))
             return FALSE;
-    }
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numGPUScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.gpuscreens[walkScreenIdx];
+    });
+    DIX_FOR_EACH_GPU_SCREEN({
         if (!fixupOneScreen (walkScreen, fixup, bytes))
             return FALSE;
-    }
+    });
     return TRUE;
 }
 
@@ -249,8 +248,7 @@ fixupExtensions(FixupFunc fixup, unsigned bytes)
 static Bool
 fixupDefaultColormaps(FixupFunc fixup, unsigned bytes)
 {
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         ColormapPtr cmap;
         dixLookupResourceByType((void **) &cmap,
                                 walkScreen->defColormap, X11_RESTYPE_COLORMAP,
@@ -258,7 +256,7 @@ fixupDefaultColormaps(FixupFunc fixup, unsigned bytes)
         if (cmap &&
             !fixup(&cmap->devPrivates, walkScreen->screenSpecificPrivates[PRIVATE_COLORMAP].offset, bytes))
             return FALSE;
-    }
+    });
     return TRUE;
 }
 
@@ -300,14 +298,12 @@ static void
 grow_screen_specific_set(DevPrivateType type, unsigned bytes)
 {
     /* Update offsets for all screen-specific keys */
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         grow_private_set(&walkScreen->screenSpecificPrivates[type], bytes);
-    }
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numGPUScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.gpuscreens[walkScreenIdx];
+    });
+    DIX_FOR_EACH_GPU_SCREEN({
         grow_private_set(&walkScreen->screenSpecificPrivates[type], bytes);
-    }
+    });
 }
 
 /*

--- a/dix/screenint_priv.h
+++ b/dix/screenint_priv.h
@@ -30,4 +30,58 @@ static inline ScreenPtr dixGetMasterScreen(void) {
     return screenInfo.screens[0];
 }
 
+/*
+ * macro for looping over all screens (up to `screenInfo.numScreens`).
+ * Makes a new scopes and declares `walkScreenIdx` as the current screen's
+ * index number as well as `walkScreen` as poiner to current ScreenRec
+ *
+ * @param __LAMBDA__ the code to be executed in each iteration step.
+ */
+#define DIX_FOR_EACH_SCREEN(__LAMBDA__) \
+    do { \
+        for (unsigned walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) { \
+            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx]; \
+            (void)walkScreen; \
+            __LAMBDA__; \
+        } \
+    } while (0);
+
+/*
+ * macro for looping over all screens (up to `screenInfo.numScreens`),
+ * but if XINERAMA enabled only hit the first screen.
+ *
+ * @param __LAMBDA__ the code to be executed in each iteration step.
+ */
+#ifdef XINERAMA
+#define DIX_FOR_EACH_SCREEN_XINERAMA(__LAMBDA__) \
+    do { \
+        unsigned int __num_screens = screenInfo.numScreens; \
+        if (!noPanoramiXExtension) \
+            __num_screens = 1; \
+        for (unsigned walkScreenIdx = 0; walkScreenIdx < __num_screens; walkScreenIdx++) { \
+            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx]; \
+            (void)walkScreen; \
+            __LAMBDA__; \
+        } \
+    } while (0);
+#else
+#define DIX_FOR_EACH_SCREEN_XINERAMA DIX_FOR_EACH_SCREEN
+#endif
+
+/*
+ * macro for looping over all GPU screens (up to `screenInfo.numScreens`).
+ * Makes a new scopes and declares `walkScreenIdx` as the current screen's
+ * index number as well as `walkScreen` as poiner to current ScreenRec
+ *
+ * @param __LAMBDA__ the code to be executed in each iteration step.
+ */
+#define DIX_FOR_EACH_GPU_SCREEN(__LAMBDA__) \
+    do { \
+        for (unsigned walkScreenIdx = 0; walkScreenIdx < screenInfo.numGPUScreens; walkScreenIdx++) { \
+            ScreenPtr walkScreen = screenInfo.gpuscreens[walkScreenIdx]; \
+            (void)walkScreen; \
+            __LAMBDA__; \
+        } \
+    } while (0);
+
 #endif /* _XSERVER_DIX_SCREENINT_PRIV_H */

--- a/dix/window.c
+++ b/dix/window.c
@@ -110,6 +110,7 @@ Equipment Corporation.
 #include "dix/resource_priv.h"
 #include "dix/screenint_priv.h"
 #include "dix/selection_priv.h"
+#include "dix/screenint_priv.h"
 #include "dix/window_priv.h"
 #include "mi/mi_priv.h"         /* miPaintWindow */
 #include "os/auth.h"
@@ -395,8 +396,7 @@ PrintPassiveGrabs(void)
 void
 PrintWindowTree(void)
 {
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         ErrorF("[dix] Dumping windows for screen %d (pixmap %x):\n", walkScreenIdx,
                (unsigned) walkScreen->GetScreenPixmap(walkScreen)->drawable.id);
         WindowPtr pWin = walkScreen->root;
@@ -416,7 +416,7 @@ PrintWindowTree(void)
                 break;
             pWin = pWin->nextSib;
         }
-    }
+    });
 }
 
 int
@@ -3087,16 +3087,14 @@ dixSaveScreens(ClientPtr client, int on, int mode)
             type = SCREEN_SAVER_CYCLE;
     }
 
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         int rc = XaceHookScreensaverAccess(client, walkScreen,
                       DixShowAccess | DixHideAccess);
         if (rc != Success)
             return rc;
-    }
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    });
 
+    DIX_FOR_EACH_SCREEN({
         if (on == SCREEN_SAVER_FORCER)
             walkScreen->SaveScreen(walkScreen, on);
         if (walkScreen->screensaver.ExternalScreenSaver) {
@@ -3160,7 +3158,8 @@ dixSaveScreens(ClientPtr client, int on, int mode)
                 walkScreen->screensaver.blanked = SCREEN_ISNT_SAVED;
             break;
         }
-    }
+    });
+
     screenIsSaved = what;
     if (mode == ScreenSaverReset) {
         if (on == SCREEN_SAVER_FORCER) {

--- a/dri3/dri3.c
+++ b/dri3/dri3.c
@@ -22,6 +22,7 @@
 #include <dix-config.h>
 
 #include "dix/screen_hooks_priv.h"
+#include "dix/screenint_priv.h"
 #include "miext/extinit_priv.h"
 
 #include "dri3_priv.h"
@@ -76,7 +77,6 @@ void
 dri3_extension_init(void)
 {
     ExtensionEntry *extension;
-    int i;
 
     /* If no screens support DRI3, there's no point offering the
      * extension at all
@@ -97,11 +97,10 @@ dri3_extension_init(void)
 
     dri3_request = extension->base;
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    DIX_FOR_EACH_SCREEN({
         if (!dri3_screen_init(walkScreen, NULL))
             goto bail;
-    }
+    });
 
     dri3_syncobj_type = CreateNewResourceType(dri3_syncobj_free, "DRI3Syncobj");
     if (!dri3_syncobj_type)

--- a/dri3/dri3_request.c
+++ b/dri3/dri3_request.c
@@ -25,6 +25,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
+#include "dix/screenint_priv.h"
 #include "os/client_priv.h"
 
 #include "dri3_priv.h"
@@ -73,8 +74,7 @@ proc_dri3_query_version(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xDRI3QueryVersionReq);
 
-    for (int i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    DIX_FOR_EACH_SCREEN({
         if (!dri3_screen_can_one_point_two(walkScreen)) {
             rep.minorVersion = 0;
             break;
@@ -83,10 +83,9 @@ proc_dri3_query_version(ClientPtr client)
             rep.minorVersion = 2;
             break;
         }
-    }
+    });
 
-    for (int i = 0; i < screenInfo.numGPUScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.gpuscreens[i];
+    DIX_FOR_EACH_GPU_SCREEN({
         if (!dri3_screen_can_one_point_two(walkScreen)) {
             rep.minorVersion = 0;
             break;
@@ -95,7 +94,7 @@ proc_dri3_query_version(ClientPtr client)
             rep.minorVersion = 2;
             break;
         }
-    }
+    });
 
     /* From DRI3 proto:
      *

--- a/glx/glxext.c
+++ b/glx/glxext.c
@@ -33,6 +33,7 @@
 #include <string.h>
 
 #include "dix/dix_priv.h"
+#include "dix/screenint_priv.h"
 #include "os/client_priv.h"
 
 #include "glxserver.h"
@@ -284,17 +285,14 @@ GlxPushProvider(__GLXprovider * provider)
 static Bool
 checkScreenVisuals(void)
 {
-    int i, j;
-
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
-        for (j = 0; j < walkScreen->numVisuals; j++) {
+    DIX_FOR_EACH_SCREEN({
+        for (int j = 0; j < walkScreen->numVisuals; j++) {
             if ((walkScreen->visuals[j].class == TrueColor ||
                  walkScreen->visuals[j].class == DirectColor) &&
                 walkScreen->visuals[j].nplanes > 12)
                 return TRUE;
         }
-    }
+    });
 
     return FALSE;
 }
@@ -535,8 +533,7 @@ xorgGlxServerInit(CallbackListPtr *pcbl, void *param, void *ext)
         return;
     }
 
-    for (int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         __GLXprovider *p;
 
         if (glxServer.getVendorForScreen(NULL, walkScreen) != NULL) {
@@ -562,7 +559,7 @@ xorgGlxServerInit(CallbackListPtr *pcbl, void *param, void *ext)
             LogMessage(X_INFO,
                        "GLX: no usable GL providers found for screen %d\n", walkScreenIdx);
         }
-    }
+    });
 }
 
 Bool

--- a/hw/kdrive/ephyr/ephyr.c
+++ b/hw/kdrive/ephyr/ephyr.c
@@ -956,10 +956,7 @@ miPointerScreenFuncRec ephyrPointerScreenFuncs = {
 static KdScreenInfo *
 screen_from_window(Window w)
 {
-    int i = 0;
-
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    DIX_FOR_EACH_SCREEN({
         KdPrivScreenPtr kdscrpriv = KdGetScreenPriv(walkScreen);
         KdScreenInfo *screen = kdscrpriv->screen;
         EphyrScrPriv *scrpriv = screen->driver;
@@ -969,7 +966,7 @@ screen_from_window(Window w)
             || scrpriv->win_pre_existing == w) {
             return screen;
         }
-    }
+    });
 
     return NULL;
 }

--- a/hw/kdrive/src/kinput.c
+++ b/hw/kdrive/src/kinput.c
@@ -40,6 +40,7 @@
 #include "config/hotplug_priv.h"
 #include "dix/input_priv.h"
 #include "dix/inpututils_priv.h"
+#include "dix/screenint_priv.h"
 #include "mi/mi_priv.h"
 #include "mi/mipointer_priv.h"
 #include "os/cmdline.h"
@@ -2134,8 +2135,8 @@ KdCursorOffScreen(ScreenPtr *ppScreen, int *x, int *y)
     best_x = 32767;
     n_best_y = -1;
     best_y = 32767;
-    for (int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+
+    DIX_FOR_EACH_SCREEN({
         if (walkScreen == pScreen)
             continue;
         int dx = KdScreenOrigin(walkScreen)->x - KdScreenOrigin(pScreen)->x;
@@ -2164,7 +2165,8 @@ KdCursorOffScreen(ScreenPtr *ppScreen, int *x, int *y)
                 n_best_y = walkScreenIdx;
             }
         }
-    }
+    });
+
     if (best_y < best_x)
         n_best_x = n_best_y;
     if (n_best_x == -1)

--- a/hw/xfree86/common/xf86DGA.c
+++ b/hw/xfree86/common/xf86DGA.c
@@ -844,20 +844,15 @@ DGACopyModeInfo(DGAModePtr mode, XDGAModePtr xmode)
 Bool
 DGAVTSwitch(void)
 {
-    int i;
-
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
-
+    DIX_FOR_EACH_SCREEN({
         /* Alternatively, this could send events to DGA clients */
 
         if (DGAScreenKeyRegistered) {
             DGAScreenPtr pScreenPriv = DGA_GET_SCREEN_PRIV(walkScreen);
-
             if (pScreenPriv && pScreenPriv->current)
                 return FALSE;
         }
-    }
+    });
 
     return TRUE;
 }
@@ -1307,7 +1302,7 @@ DGAClientStateChange(CallbackListPtr *pcbl, void *nulldata, void *calldata)
 {
     NewClientInfoRec *pci = (NewClientInfoRec *) calldata;
 
-    for (int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+    DIX_FOR_EACH_SCREEN({
         if (pci->client && (DGA_GETCLIENT(walkScreenIdx) == pci->client)) {
             if ((pci->client->clientState == ClientStateGone) ||
                 (pci->client->clientState == ClientStateRetained))
@@ -1324,7 +1319,7 @@ DGAClientStateChange(CallbackListPtr *pcbl, void *nulldata, void *calldata)
             }
             break;
         }
-    }
+    });
 }
 
 static int

--- a/hw/xfree86/common/xf86VidMode.c
+++ b/hw/xfree86/common/xf86VidMode.c
@@ -40,6 +40,7 @@
 
 #include <X11/X.h>
 
+#include "dix/screenint_priv.h"
 #include "os/log_priv.h"
 
 #include "os.h"
@@ -442,7 +443,6 @@ xf86VidModeInit(ScreenPtr pScreen)
 void
 XFree86VidModeExtensionInit(void)
 {
-    int i;
     Bool enabled = FALSE;
 
     DebugF("XFree86VidModeExtensionInit");
@@ -451,11 +451,11 @@ XFree86VidModeExtensionInit(void)
     if (!xf86Info.vidModeEnabled)
         return;
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    DIX_FOR_EACH_SCREEN({
         if (xf86VidModeInit(walkScreen))
             enabled = TRUE;
-    }
+    });
+
     /* This means that the DDX doesn't want the vidmode extension enabled */
     if (!enabled)
         return;

--- a/hw/xfree86/dri/dri.c
+++ b/hw/xfree86/dri/dri.c
@@ -49,6 +49,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/screen_hooks_priv.h"
+#include "dix/screenint_priv.h"
 
 #include "xf86.h"
 #include "xf86drm.h"
@@ -1713,29 +1714,21 @@ DRIDestroyInfoRec(DRIInfoPtr DRIInfo)
 void
 DRIWakeupHandler(void *wakeupData, int result)
 {
-    int i;
-
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    DIX_FOR_EACH_SCREEN({
         DRIScreenPrivPtr pDRIPriv = DRI_SCREEN_PRIV(walkScreen);
-
         if (pDRIPriv && pDRIPriv->pDriverInfo->wrap.WakeupHandler)
             (*pDRIPriv->pDriverInfo->wrap.WakeupHandler) (walkScreen, result);
-    }
+    });
 }
 
 void
 DRIBlockHandler(void *blockData, void *pTimeout)
 {
-    int i;
-
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    DIX_FOR_EACH_SCREEN({
         DRIScreenPrivPtr pDRIPriv = DRI_SCREEN_PRIV(walkScreen);
-
         if (pDRIPriv && pDRIPriv->pDriverInfo->wrap.BlockHandler)
             (*pDRIPriv->pDriverInfo->wrap.BlockHandler) (walkScreen, pTimeout);
-    }
+    });
 }
 
 void

--- a/hw/xquartz/darwin.c
+++ b/hw/xquartz/darwin.c
@@ -584,9 +584,8 @@ CloseInput(void)
 void DarwinAdjustScreenOrigins(void)
 {
     /* Find leftmost screen. If there's a tie, take the topmost of the two. */
-    for (unsigned walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
-        if (walkScreenIdx == 0) {
+    DIX_FOR_EACH_SCREEN({
+        if (walkScreenIdx  == 0) {
             darwinMainScreenX  = walkScreen->x;
             darwinMainScreenY = walkScreen->y;
             continue;
@@ -597,7 +596,7 @@ void DarwinAdjustScreenOrigins(void)
             darwinMainScreenX  = walkScreen->x;
             darwinMainScreenY = walkScreen->y;
         }
-    }
+    });
 
     /* Shift all screens so that there is a screen whose top left
      * is at X11 (0,0) and at global screen coordinate
@@ -605,13 +604,13 @@ void DarwinAdjustScreenOrigins(void)
      */
 
     if (darwinMainScreenX != 0 || darwinMainScreenY != 0) {
-        for (unsigned walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
+        DIX_FOR_EACH_SCREEN({
             ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
             walkScreen->x -= darwinMainScreenX;
             walkScreen->y -= darwinMainScreenY;
             DEBUG_LOG("Screen %d placed at X11 coordinate (%d,%d).\n",
                       walkScreenIdx, walkScreen->x, walkScreen->y);
-        }
+        });
     }
 
     /* Update screenInfo.x/y */

--- a/hw/xquartz/quartz.c
+++ b/hw/xquartz/quartz.c
@@ -387,12 +387,11 @@ QuartzShowFullscreen(int state)
 
     if (XQuartzFullscreenVisible) {
         RootlessShowAllWindows();
-        for (i = 0; i < screenInfo.numScreens; i++) {
-            ScreenPtr walkScreen = screenInfo.screens[i];
+        DIX_FOR_EACH_SCREEN({
             RootlessRepositionWindows(walkScreen);
             // JH: I don't think this is necessary, but keeping it here as a reminder
             //RootlessUpdateScreenPixmap(walkScreen);
-        }
+        });
     }
 
     /* Somehow the menubar manages to interfere with our event stream
@@ -447,17 +446,12 @@ QuartzSetRootless(Bool state)
 void
 QuartzShow(void)
 {
-    int i;
-
     if (XQuartzServerVisible)
         return;
 
     XQuartzServerVisible = TRUE;
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
-        if (walkScreen)
-            quartzProcs->ResumeScreen(walkScreen);
-    }
+
+    DIX_FOR_EACH_SCREEN({ quartzProcs->ResumeScreen(walkScreen); });
 
     if (!XQuartzIsRootless)
         QuartzShowFullscreen(TRUE);
@@ -475,11 +469,7 @@ QuartzHide(void)
     int i;
 
     if (XQuartzServerVisible) {
-        for (i = 0; i < screenInfo.numScreens; i++) {
-            ScreenPtr walkScreen = screenInfo.screens[i];
-            if (walkScreen)
-                quartzProcs->SuspendScreen(walkScreen);
-        }
+        DIX_FOR_EACH_SCREEN({ quartzProcs->SuspendScreen(walkScreen); });
     }
 
     if (!XQuartzIsRootless)
@@ -494,16 +484,10 @@ QuartzHide(void)
 void
 QuartzSetRootClip(int mode)
 {
-    int i;
-
     if (!XQuartzServerVisible)
         return;
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
-        if (walkScreen)
-            SetRootClip(walkScreen, mode);
-    }
+    DIX_FOR_EACH_SCREEN({ SetRootClip(walkScreen, mode); });
 }
 
 /*

--- a/hw/xquartz/quartzRandR.c
+++ b/hw/xquartz/quartzRandR.c
@@ -461,29 +461,23 @@ QuartzRandRInit(ScreenPtr pScreen)
 void
 QuartzRandRSetFakeRootless(void)
 {
-    int i;
-
     DEBUG_LOG("QuartzRandRSetFakeRootless called.\n");
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    DIX_FOR_EACH_SCREEN({
         QuartzScreenPtr pQuartzScreen = QUARTZ_PRIV(walkScreen);
         QuartzRandRSetMode(walkScreen, &pQuartzScreen->rootlessMode, TRUE);
-    }
+    });
 }
 
 void
 QuartzRandRSetFakeFullscreen(BOOL state)
 {
-    int i;
-
     DEBUG_LOG("QuartzRandRSetFakeFullscreen called.\n");
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    DIX_FOR_EACH_SCREEN({
         QuartzScreenPtr pQuartzScreen = QUARTZ_PRIV(walkScreen);
         QuartzRandRSetMode(walkScreen, &pQuartzScreen->fullscreenMode, TRUE);
-    }
+    });
 
     QuartzShowFullscreen(state);
 }

--- a/hw/xquartz/xpr/xprFrame.c
+++ b/hw/xquartz/xpr/xprFrame.c
@@ -30,6 +30,7 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/screenint_priv.h"
 
 #include "xpr.h"
 #include "rootlessCommon.h"
@@ -528,11 +529,9 @@ xprIsX11Window(int windowNumber)
 void
 xprHideWindows(Bool hide)
 {
-    int screen;
     WindowPtr pWin;
 
-    for (screen = 0; screen < screenInfo.numScreens; screen++) {
-        ScreenPtr walkScreen = screenInfo.screens[screen];
+    DIX_FOR_EACH_SCREEN({
         RootlessFrameID prevWid = NULL;
         WindowPtr pRoot = walkScreen->root;
 
@@ -559,7 +558,7 @@ xprHideWindows(Bool hide)
                 }
             }
         }
-    }
+    });
 }
 
 // XXX: identical to x_cvt_vptr_to_uint ?

--- a/hw/xquartz/xpr/xprScreen.c
+++ b/hw/xquartz/xpr/xprScreen.c
@@ -31,6 +31,8 @@
 
 #include <dix-config.h>
 
+#include "dix/screenint_priv.h"
+
 #include "inputstr.h"
 #include "quartz.h"
 #include "quartzRandR.h"
@@ -473,15 +475,12 @@ xprUpdateScreen(ScreenPtr pScreen)
 static void
 xprInitInput(int argc, char **argv)
 {
-    int i;
-
     rootlessGlobalOffsetX = darwinMainScreenX;
     rootlessGlobalOffsetY = darwinMainScreenY;
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
-        AppleWMSetScreenOrigin(screenInfo.screens[i]->root);
-    }
+    DIX_FOR_EACH_SCREEN({
+        AppleWMSetScreenOrigin(walkScreen->root);
+    });
 }
 
 /*

--- a/hw/xwin/winmultiwindowwindow.c
+++ b/hw/xwin/winmultiwindowwindow.c
@@ -1070,11 +1070,9 @@ winModifyPixmapHeaderMultiwindow(PixmapPtr pPixmap,
     */
 
     /* Look for which screen this pixmap corresponds to */
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+    DIX_FOR_EACH_SCREEN({
         winScreenPriv(walkScreen);
         winScreenInfo *pScreenInfo = pScreenPriv->pScreenInfo;
-
         if (pScreenInfo->pfb == pPixData)
             {
                 /* and initialize pixmap privates from screen privates */
@@ -1087,7 +1085,7 @@ winModifyPixmapHeaderMultiwindow(PixmapPtr pPixmap,
 
                 return TRUE;
             }
-    }
+    });
 
     /* Otherwise, since creating a DIBSection from arbitrary memory is not
      * possible, fallback to normal.  If needed, we can create a DIBSection with

--- a/miext/rootless/rootlessScreen.c
+++ b/miext/rootless/rootlessScreen.c
@@ -38,6 +38,7 @@
 
 #include "dix/colormap_priv.h"
 #include "dix/screen_hooks_priv.h"
+#include "dix/screenint_priv.h"
 #include "mi/mi_priv.h"
 
 #include "scrnintstr.h"
@@ -707,18 +708,10 @@ RootlessInit(ScreenPtr pScreen, RootlessFrameProcsPtr procs)
 void
 RootlessUpdateRooted(Bool state)
 {
-    int i;
-
     if (!state) {
-        for (i = 0; i < screenInfo.numScreens; i++) {
-            ScreenPtr walkScreen = screenInfo.screens[i];
-            RootlessDisableRoot(walkScreen);
-        }
+        DIX_FOR_EACH_SCREEN({ RootlessDisableRoot(walkScreen); });
     }
     else {
-        for (i = 0; i < screenInfo.numScreens; i++) {
-            ScreenPtr walkScreen = screenInfo.screens[i];
-            RootlessEnableRoot(walkScreen);
-        }
+        DIX_FOR_EACH_SCREEN({ RootlessEnableRoot(walkScreen); });
     }
 }

--- a/miext/rootless/rootlessWindow.c
+++ b/miext/rootless/rootlessWindow.c
@@ -38,6 +38,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/screen_hooks_priv.h"
+#include "dix/screenint_priv.h"
 #include "fb/fb_priv.h"
 #include "mi/mi_priv.h"
 
@@ -1169,16 +1170,12 @@ RootlessChangeBorderWidth(WindowPtr pWin, unsigned int width)
 void
 RootlessOrderAllWindows(Bool include_unhitable)
 {
-    int i;
-
     if (windows_hidden)
         return;
 
     RL_DEBUG_MSG("RootlessOrderAllWindows() ");
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
-        if (walkScreen == NULL)
-            continue;
+
+    DIX_FOR_EACH_SCREEN({
         WindowPtr pWin = walkScreen->root;
         if (pWin == NULL)
             continue;
@@ -1192,7 +1189,8 @@ RootlessOrderAllWindows(Bool include_unhitable)
                 continue;
             RootlessReorderWindow(pWin);
         }
-    }
+    });
+
     RL_DEBUG_MSG("RootlessOrderAllWindows() done");
 }
 
@@ -1227,7 +1225,6 @@ RootlessDisableRoot(ScreenPtr pScreen)
 void
 RootlessHideAllWindows(void)
 {
-    int i;
     RootlessWindowRec *winRec;
 
     if (windows_hidden)
@@ -1235,10 +1232,7 @@ RootlessHideAllWindows(void)
 
     windows_hidden = TRUE;
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
-        if (walkScreen == NULL)
-            continue;
+    DIX_FOR_EACH_SCREEN({
         WindowPtr pWin = walkScreen->root;
         if (pWin == NULL)
             continue;
@@ -1255,13 +1249,12 @@ RootlessHideAllWindows(void)
                     SCREENREC(walkScreen)->imp->HideWindow(winRec->wid);
             }
         }
-    }
+    });
 }
 
 void
 RootlessShowAllWindows(void)
 {
-    int i;
     RootlessWindowRec *winRec;
 
     if (!windows_hidden)
@@ -1269,10 +1262,7 @@ RootlessShowAllWindows(void)
 
     windows_hidden = FALSE;
 
-    for (i = 0; i < screenInfo.numScreens; i++) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
-        if (walkScreen == NULL)
-            continue;
+    DIX_FOR_EACH_SCREEN({
         WindowPtr pWin = walkScreen->root;
         if (pWin == NULL)
             continue;
@@ -1289,7 +1279,7 @@ RootlessShowAllWindows(void)
         }
 
         RootlessScreenExpose(walkScreen);
-    }
+    });
 }
 
 /*

--- a/present/present_scmd.c
+++ b/present/present_scmd.c
@@ -21,6 +21,7 @@
  */
 #include <dix-config.h>
 
+#include "dix/screenint_priv.h"
 #include "present/present_priv.h"
 #include "randr/randrstr_priv.h"
 
@@ -408,8 +409,7 @@ present_event_notify(uint64_t event_id, uint64_t ust, uint64_t msc)
         }
     }
 
-    for (unsigned walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         present_screen_priv_ptr screen_priv = present_screen_priv(walkScreen);
 
         if (event_id == screen_priv->unflip_event_id) {
@@ -419,7 +419,7 @@ present_event_notify(uint64_t event_id, uint64_t ust, uint64_t msc)
             present_flip_try_ready(walkScreen);
             return;
         }
-    }
+    });
 }
 
 /*

--- a/present/present_screen.c
+++ b/present/present_screen.c
@@ -22,6 +22,7 @@
 #include <dix-config.h>
 
 #include "dix/screen_hooks_priv.h"
+#include "dix/screenint_priv.h"
 #include "miext/extinit_priv.h"
 #include "present/present_priv.h"
 
@@ -258,11 +259,11 @@ present_extension_init(void)
     if (!present_event_init())
         goto bail;
 
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         if (!present_screen_init(walkScreen, NULL))
             goto bail;
-    }
+    });
+
     return;
 
 bail:

--- a/randr/randr.c
+++ b/randr/randr.c
@@ -29,6 +29,7 @@
 #include <dix-config.h>
 
 #include "dix/screen_hooks_priv.h"
+#include "dix/screenint_priv.h"
 #include "miext/extinit_priv.h"
 #include "randr/randrstr_priv.h"
 #include "randr/rrdispatch_priv.h"
@@ -71,17 +72,13 @@ RRClientCallback(CallbackListPtr *list, void *closure, void *data)
     pRRClient->major_version = 0;
     pRRClient->minor_version = 0;
 
-    unsigned int walkScreenIdx;
-    for (walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
-
+    DIX_FOR_EACH_SCREEN({
         rrScrPriv(walkScreen);
-
         if (pScrPriv) {
             pTimes[walkScreenIdx].setTime = pScrPriv->lastSetTime;
             pTimes[walkScreenIdx].configTime = pScrPriv->lastConfigTime;
         }
-    }
+    });
 }
 
 static void RRCloseScreen(CallbackListPtr *pcbl, ScreenPtr pScreen, void *unused)

--- a/render/animcur.c
+++ b/render/animcur.c
@@ -305,11 +305,10 @@ AnimCursorCreate(CursorPtr *cursors, CARD32 *deltas, int ncursor,
     int rc = BadAlloc, i;
     AnimCurPtr ac;
 
-    for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         if (!GetAnimCurScreen(walkScreen))
             return BadImplementation;
-    }
+    });
 
     for (i = 0; i < ncursor; i++)
         if (IsAnimCur(cursors[i]))

--- a/render/filter.c
+++ b/render/filter.c
@@ -342,12 +342,14 @@ SetPictureFilter(PicturePtr pPicture, char *name, int len, xFixed * params,
         /* For source pictures, the picture isn't tied to a screen.  So, ensure
          * that all screens can handle a filter we set for the picture.
          */
-        for (unsigned int walkScreenIdx = 1; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+        DIX_FOR_EACH_SCREEN({
+            if (!walkScreenIdx)
+                continue; // skip the first screen
+
             PictFilterPtr pScreenFilter = PictureFindFilter(walkScreen, name, len);
             if (!pScreenFilter || pScreenFilter->id != pFilter->id)
                 return BadMatch;
-        }
+        });
     }
     return SetPicturePictFilter(pPicture, pFilter, params, nparams);
 }

--- a/render/render.c
+++ b/render/render.c
@@ -1034,8 +1034,7 @@ ProcRenderAddGlyphs(ClientPtr client)
                 goto bail;
             }
 
-            for (unsigned int walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-                ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+            DIX_FOR_EACH_SCREEN({
                 int width = gi[i].width;
                 int height = gi[i].height;
                 int depth = glyphSet->format->depth;
@@ -1097,7 +1096,7 @@ ProcRenderAddGlyphs(ClientPtr client)
 
                 FreePicture((void *) pSrc, 0);
                 FreeScratchPixmapHeader(pSrcPix);
-            }
+            });
 
             memcpy(glyph_new->glyph->sha1, glyph_new->sha1, 20);
         }

--- a/xfixes/cursor.c
+++ b/xfixes/cursor.c
@@ -976,13 +976,13 @@ XFixesCursorInit(void)
     if (!dixRegisterPrivateKey(&CursorScreenPrivateKeyRec, PRIVATE_SCREEN, sizeof(CursorScreenRec)))
         return FALSE;
 
-    for (unsigned walkScreenIdx = 0; walkScreenIdx < screenInfo.numScreens; walkScreenIdx++) {
-        ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+    DIX_FOR_EACH_SCREEN({
         CursorScreenPtr cs = GetCursorScreen(walkScreen);
         dixScreenHookClose(walkScreen, CursorScreenClose);
         Wrap(cs, walkScreen, DisplayCursor, CursorDisplayCursor);
         cs->pCursorHideCounts = NULL;
-    }
+    });
+
     CursorClientType = CreateNewResourceType(CursorFreeClient,
                                              "XFixesCursorClient");
     CursorHideCountType = CreateNewResourceType(CursorFreeHideCount,


### PR DESCRIPTION
iterating over screen list via lambda-esque macros calls like this

    DIX_FOR_EACH_SCREEN({
        do_something
    });

withing the body, the iterator variables `walkScreenIdx` and `walkScreen`
are defined and can be directly used (read-only). the code inside the body
is running in a separate scope.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
