### PR TITLE
Xi: inline SProcXGetDeviceDontPropagateList()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -368,7 +368,7 @@ SProcIDispatch(ClientPtr client)
         case X_ChangeDeviceDontPropagateList:
             return ProcXChangeDeviceDontPropagateList(client);
         case X_GetDeviceDontPropagateList:
-            return SProcXGetDeviceDontPropagateList(client);
+            return ProcXGetDeviceDontPropagateList(client);
         case X_GetDeviceMotionEvents:
             return SProcXGetDeviceMotionEvents(client);
         case X_ChangeKeyboardDevice:

--- a/Xi/getprop.c
+++ b/Xi/getprop.c
@@ -70,21 +70,6 @@ extern int ExtEventIndex;
 
 /***********************************************************************
  *
- * Handle a request from a client with a different byte order.
- *
- */
-
-int _X_COLD
-SProcXGetDeviceDontPropagateList(ClientPtr client)
-{
-    REQUEST(xGetDeviceDontPropagateListReq);
-    REQUEST_SIZE_MATCH(xGetDeviceDontPropagateListReq);
-    swapl(&stuff->window);
-    return (ProcXGetDeviceDontPropagateList(client));
-}
-
-/***********************************************************************
- *
  * This procedure lists the input devices available to the server.
  *
  */
@@ -92,14 +77,17 @@ SProcXGetDeviceDontPropagateList(ClientPtr client)
 int
 ProcXGetDeviceDontPropagateList(ClientPtr client)
 {
+    REQUEST(xGetDeviceDontPropagateListReq);
+    REQUEST_SIZE_MATCH(xGetDeviceDontPropagateListReq);
+
+    if (client->swapped)
+        swapl(&stuff->window);
+
     CARD16 count = 0;
     int i, rc;
     XEventClass *buf = NULL, *tbuf;
     WindowPtr pWin;
     OtherInputMasks *others;
-
-    REQUEST(xGetDeviceDontPropagateListReq);
-    REQUEST_SIZE_MATCH(xGetDeviceDontPropagateListReq);
 
     xGetDeviceDontPropagateListReply rep = {
         .RepType = X_GetDeviceDontPropagateList,

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -69,7 +69,6 @@ int ProcXUngrabDeviceButton(ClientPtr client);
 int ProcXUngrabDevice(ClientPtr client);
 int ProcXUngrabDeviceKey(ClientPtr client);
 
-int SProcXGetDeviceDontPropagateList(ClientPtr  client);
 int SProcXGetDeviceMotionEvents(ClientPtr client);
 int SProcXGetExtensionVersion(ClientPtr client);
 int SProcXGetSelectedExtensionEvents(ClientPtr client);


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
