### PR TITLE
Xi: inline SProcXGetSelectedExtensionEvents()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -364,7 +364,7 @@ SProcIDispatch(ClientPtr client)
         case X_SelectExtensionEvent:
             return ProcXSelectExtensionEvent(client);
         case X_GetSelectedExtensionEvents:
-            return SProcXGetSelectedExtensionEvents(client);
+            return ProcXGetSelectedExtensionEvents(client);
         case X_ChangeDeviceDontPropagateList:
             return ProcXChangeDeviceDontPropagateList(client);
         case X_GetDeviceDontPropagateList:

--- a/Xi/getselev.c
+++ b/Xi/getselev.c
@@ -68,21 +68,6 @@ SOFTWARE.
 
 /***********************************************************************
  *
- * This procedure gets the current selected extension events.
- *
- */
-
-int _X_COLD
-SProcXGetSelectedExtensionEvents(ClientPtr client)
-{
-    REQUEST(xGetSelectedExtensionEventsReq);
-    REQUEST_SIZE_MATCH(xGetSelectedExtensionEventsReq);
-    swapl(&stuff->window);
-    return (ProcXGetSelectedExtensionEvents(client));
-}
-
-/***********************************************************************
- *
  * This procedure gets the current device select mask,
  * if the client and server have a different byte ordering.
  *
@@ -91,6 +76,12 @@ SProcXGetSelectedExtensionEvents(ClientPtr client)
 int
 ProcXGetSelectedExtensionEvents(ClientPtr client)
 {
+    REQUEST(xGetSelectedExtensionEventsReq);
+    REQUEST_SIZE_MATCH(xGetSelectedExtensionEventsReq);
+
+    if (client->swapped)
+        swapl(&stuff->window);
+
     int i, rc = 0;
     WindowPtr pWin;
     XEventClass *buf = NULL;
@@ -98,9 +89,6 @@ ProcXGetSelectedExtensionEvents(ClientPtr client)
     XEventClass *aclient;
     OtherInputMasks *pOthers;
     InputClientsPtr others;
-
-    REQUEST(xGetSelectedExtensionEventsReq);
-    REQUEST_SIZE_MATCH(xGetSelectedExtensionEventsReq);
 
     xGetSelectedExtensionEventsReply rep = {
         .RepType = X_GetSelectedExtensionEvents,

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -72,7 +72,6 @@ int ProcXUngrabDeviceKey(ClientPtr client);
 int SProcXGetDeviceDontPropagateList(ClientPtr  client);
 int SProcXGetDeviceMotionEvents(ClientPtr client);
 int SProcXGetExtensionVersion(ClientPtr client);
-int SProcXGetSelectedExtensionEvents(ClientPtr client);
 int SProcXIAllowEvents(ClientPtr client);
 int SProcXIBarrierReleasePointer(ClientPtr client);
 int SProcXIGetClientPointer(ClientPtr client);


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
