### PR TITLE
Xi: inline SProcXGetExtensionVersion()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -352,7 +352,7 @@ SProcIDispatch(ClientPtr client)
 
     switch (stuff->data) {
         case X_GetExtensionVersion:
-            return SProcXGetExtensionVersion(client);
+            return ProcXGetExtensionVersion(client);
         case X_ListInputDevices:
             return ProcXListInputDevices(client);
         case X_OpenDevice:

--- a/Xi/getvers.c
+++ b/Xi/getvers.c
@@ -66,21 +66,6 @@ XExtensionVersion XIVersion;
 
 /***********************************************************************
  *
- * Handle a request from a client with a different byte order than us.
- *
- */
-
-int _X_COLD
-SProcXGetExtensionVersion(ClientPtr client)
-{
-    REQUEST(xGetExtensionVersionReq);
-    REQUEST_AT_LEAST_SIZE(xGetExtensionVersionReq);
-    swaps(&stuff->nbytes);
-    return (ProcXGetExtensionVersion(client));
-}
-
-/***********************************************************************
- *
  * This procedure returns the major/minor version of the X Input extension.
  *
  */
@@ -90,6 +75,9 @@ ProcXGetExtensionVersion(ClientPtr client)
 {
     REQUEST(xGetExtensionVersionReq);
     REQUEST_AT_LEAST_SIZE(xGetExtensionVersionReq);
+
+    if (client->swapped)
+        swaps(&stuff->nbytes);
 
     if (client->req_len != bytes_to_int32(sizeof(xGetExtensionVersionReq) +
                                         stuff->nbytes))

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -70,7 +70,6 @@ int ProcXUngrabDevice(ClientPtr client);
 int ProcXUngrabDeviceKey(ClientPtr client);
 
 int SProcXGetDeviceMotionEvents(ClientPtr client);
-int SProcXGetExtensionVersion(ClientPtr client);
 int SProcXIAllowEvents(ClientPtr client);
 int SProcXIBarrierReleasePointer(ClientPtr client);
 int SProcXIGetClientPointer(ClientPtr client);


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
