### PR TITLE
treewide: use helper dixGetScreenPtr() for retrieving ScreenPtr's

### DIFF
--- a/Xext/panoramiX.c
+++ b/Xext/panoramiX.c
@@ -828,7 +828,7 @@ PanoramiXConsolidate(void)
 VisualID
 PanoramiXTranslateVisualID(int screen, VisualID orig)
 {
-    ScreenPtr pOtherScreen = screenInfo.screens[screen];
+    ScreenPtr pOtherScreen = dixGetScreenPtr(screen);
     VisualPtr pVisual = NULL;
     int i;
 
@@ -971,7 +971,7 @@ ProcPanoramiXGetScreenSize(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    ScreenPtr pScreen = screenInfo.screens[stuff->screen];
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
 
     xPanoramiXGetScreenSizeReply reply = {
         /* screen dimensions */

--- a/Xext/vidmode.c
+++ b/Xext/vidmode.c
@@ -40,6 +40,7 @@ from Kaleb S. KEITHLEY
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
+#include "dix/screenint_priv.h"
 #include "os/log_priv.h"
 #include "os/osdep.h"
 
@@ -222,7 +223,6 @@ ProcVidModeGetModeLine(ClientPtr client)
     if (client->swapped)
         swaps(&stuff->screen);
 
-    ScreenPtr pScreen;
     VidModePtr pVidMode;
     DisplayModePtr mode;
     int dotClock;
@@ -232,9 +232,10 @@ ProcVidModeGetModeLine(ClientPtr client)
 
     ver = ClientMajorVersion(client);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    pScreen = screenInfo.screens[stuff->screen];
+
     pVidMode = VidModeGetPtr(pScreen);
     if (pVidMode == NULL)
         return BadImplementation;
@@ -349,7 +350,6 @@ ProcVidModeGetAllModeLines(ClientPtr client)
     if (client->swapped)
         swaps(&stuff->screen);
 
-    ScreenPtr pScreen;
     VidModePtr pVidMode;
     DisplayModePtr mode;
     int modecount, dotClock;
@@ -357,9 +357,10 @@ ProcVidModeGetAllModeLines(ClientPtr client)
 
     DEBUG_P("XF86VidModeGetAllModelines");
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    pScreen = screenInfo.screens[stuff->screen];
+
     ver = ClientMajorVersion(client);
     pVidMode = VidModeGetPtr(pScreen);
     if (pVidMode == NULL)
@@ -508,7 +509,6 @@ ProcVidModeAddModeLine(ClientPtr client)
 
 static int VidModeAddModeLine(ClientPtr client, xXF86VidModeAddModeLineReq* stuff)
 {
-    ScreenPtr pScreen;
     DisplayModePtr mode;
     VidModePtr pVidMode;
     int dotClock;
@@ -531,9 +531,9 @@ static int VidModeAddModeLine(ClientPtr client, xXF86VidModeAddModeLineReq* stuf
            stuff->after_vsyncend, stuff->after_vtotal,
            (unsigned long) stuff->after_flags);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    pScreen = screenInfo.screens[stuff->screen];
 
     if (stuff->hsyncstart < stuff->hdisplay ||
         stuff->hsyncend < stuff->hsyncstart ||
@@ -732,7 +732,6 @@ VidModeDeleteModeLine(ClientPtr client, xXF86VidModeDeleteModeLineReq* stuff)
     int dotClock;
     DisplayModePtr mode;
     VidModePtr pVidMode;
-    ScreenPtr pScreen;
 
     DebugF("DeleteModeLine - scrn: %d clock: %ld\n",
            (int) stuff->screen, (unsigned long) stuff->dotclock);
@@ -743,9 +742,9 @@ VidModeDeleteModeLine(ClientPtr client, xXF86VidModeDeleteModeLineReq* stuff)
            stuff->vdisplay, stuff->vsyncstart, stuff->vsyncend, stuff->vtotal,
            (unsigned long) stuff->flags);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    pScreen = screenInfo.screens[stuff->screen];
 
     pVidMode = VidModeGetPtr(pScreen);
     if (pVidMode == NULL)
@@ -894,7 +893,6 @@ ProcVidModeModModeLine(ClientPtr client)
 static int
 VidModeModModeLine(ClientPtr client, xXF86VidModeModModeLineReq *stuff)
 {
-    ScreenPtr pScreen;
     VidModePtr pVidMode;
     DisplayModePtr mode;
     int dotClock;
@@ -913,9 +911,9 @@ VidModeModModeLine(ClientPtr client, xXF86VidModeModModeLineReq *stuff)
         stuff->vsyncend < stuff->vsyncstart || stuff->vtotal < stuff->vsyncend)
         return BadValue;
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    pScreen = screenInfo.screens[stuff->screen];
 
     pVidMode = VidModeGetPtr(pScreen);
     if (pVidMode == NULL)
@@ -1076,7 +1074,6 @@ ProcVidModeValidateModeLine(ClientPtr client)
 static int
 VidModeValidateModeLine(ClientPtr client, xXF86VidModeValidateModeLineReq *stuff)
 {
-    ScreenPtr pScreen;
     VidModePtr pVidMode;
     DisplayModePtr mode, modetmp = NULL;
     int status, dotClock;
@@ -1090,9 +1087,9 @@ VidModeValidateModeLine(ClientPtr client, xXF86VidModeValidateModeLineReq *stuff
            stuff->vdisplay, stuff->vsyncstart, stuff->vsyncend, stuff->vtotal,
            (unsigned long) stuff->flags);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    pScreen = screenInfo.screens[stuff->screen];
 
     status = MODE_OK;
 
@@ -1166,7 +1163,6 @@ ProcVidModeSwitchMode(ClientPtr client)
         swaps(&stuff->zoom);
     }
 
-    ScreenPtr pScreen;
     VidModePtr pVidMode;
 
     DEBUG_P("XF86VidModeSwitchMode");
@@ -1175,9 +1171,9 @@ ProcVidModeSwitchMode(ClientPtr client)
     if (!VidModeAllowNonLocal && !client->local)
         return VidModeErrorBase + XF86VidModeClientNotLocal;
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    pScreen = screenInfo.screens[stuff->screen];
 
     pVidMode = VidModeGetPtr(pScreen);
     if (pVidMode == NULL)
@@ -1250,7 +1246,6 @@ ProcVidModeSwitchToMode(ClientPtr client)
 static int
 VidModeSwitchToMode(ClientPtr client, xXF86VidModeSwitchToModeReq *stuff)
 {
-    ScreenPtr pScreen;
     VidModePtr pVidMode;
     DisplayModePtr mode;
     int dotClock;
@@ -1264,9 +1259,9 @@ VidModeSwitchToMode(ClientPtr client, xXF86VidModeSwitchToModeReq *stuff)
            stuff->vdisplay, stuff->vsyncstart, stuff->vsyncend, stuff->vtotal,
            (unsigned long) stuff->flags);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    pScreen = screenInfo.screens[stuff->screen];
 
     pVidMode = VidModeGetPtr(pScreen);
     if (pVidMode == NULL)
@@ -1322,7 +1317,6 @@ ProcVidModeLockModeSwitch(ClientPtr client)
         swaps(&stuff->lock);
     }
 
-    ScreenPtr pScreen;
     VidModePtr pVidMode;
 
     DEBUG_P("XF86VidModeLockModeSwitch");
@@ -1331,9 +1325,9 @@ ProcVidModeLockModeSwitch(ClientPtr client)
     if (!VidModeAllowNonLocal && !client->local)
         return VidModeErrorBase + XF86VidModeClientNotLocal;
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    pScreen = screenInfo.screens[stuff->screen];
 
     pVidMode = VidModeGetPtr(pScreen);
     if (pVidMode == NULL)
@@ -1364,9 +1358,9 @@ ProcVidModeGetMonitor(ClientPtr client)
 
     DEBUG_P("XF86VidModeGetMonitor");
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    ScreenPtr pScreen = screenInfo.screens[stuff->screen];
 
     VidModePtr pVidMode = VidModeGetPtr(pScreen);
     if (pVidMode == NULL)
@@ -1416,15 +1410,14 @@ ProcVidModeGetViewPort(ClientPtr client)
     if (client->swapped)
         swaps(&stuff->screen);
 
-    ScreenPtr pScreen;
     VidModePtr pVidMode;
     int x, y;
 
     DEBUG_P("XF86VidModeGetViewPort");
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    pScreen = screenInfo.screens[stuff->screen];
 
     pVidMode = VidModeGetPtr(pScreen);
     if (pVidMode == NULL)
@@ -1457,7 +1450,6 @@ ProcVidModeSetViewPort(ClientPtr client)
         swapl(&stuff->y);
     }
 
-    ScreenPtr pScreen;
     VidModePtr pVidMode;
 
     DEBUG_P("XF86VidModeSetViewPort");
@@ -1466,9 +1458,9 @@ ProcVidModeSetViewPort(ClientPtr client)
     if (!VidModeAllowNonLocal && !client->local)
         return VidModeErrorBase + XF86VidModeClientNotLocal;
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    pScreen = screenInfo.screens[stuff->screen];
 
     pVidMode = VidModeGetPtr(pScreen);
     if (pVidMode == NULL)
@@ -1489,16 +1481,15 @@ ProcVidModeGetDotClocks(ClientPtr client)
     if (client->swapped)
         swaps(&stuff->screen);
 
-    ScreenPtr pScreen;
     VidModePtr pVidMode;
     int numClocks;
     Bool ClockProg;
 
     DEBUG_P("XF86VidModeGetDotClocks");
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    pScreen = screenInfo.screens[stuff->screen];
 
     pVidMode = VidModeGetPtr(pScreen);
     if (pVidMode == NULL)
@@ -1551,7 +1542,6 @@ ProcVidModeSetGamma(ClientPtr client)
         swapl(&stuff->blue);
     }
 
-    ScreenPtr pScreen;
     VidModePtr pVidMode;
 
     DEBUG_P("XF86VidModeSetGamma");
@@ -1560,9 +1550,9 @@ ProcVidModeSetGamma(ClientPtr client)
     if (!VidModeAllowNonLocal && !client->local)
         return VidModeErrorBase + XF86VidModeClientNotLocal;
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    pScreen = screenInfo.screens[stuff->screen];
 
     pVidMode = VidModeGetPtr(pScreen);
     if (pVidMode == NULL)
@@ -1585,15 +1575,14 @@ ProcVidModeGetGamma(ClientPtr client)
     if (client->swapped)
         swaps(&stuff->screen);
 
-    ScreenPtr pScreen;
     VidModePtr pVidMode;
     float red, green, blue;
 
     DEBUG_P("XF86VidModeGetGamma");
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    pScreen = screenInfo.screens[stuff->screen];
 
     pVidMode = VidModeGetPtr(pScreen);
     if (pVidMode == NULL)
@@ -1631,16 +1620,15 @@ ProcVidModeSetGammaRamp(ClientPtr client)
     }
 
     CARD16 *r, *g, *b;
-    ScreenPtr pScreen;
     VidModePtr pVidMode;
 
     /* limited to local-only connections */
     if (!VidModeAllowNonLocal && !client->local)
         return VidModeErrorBase + XF86VidModeClientNotLocal;
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    pScreen = screenInfo.screens[stuff->screen];
 
     pVidMode = VidModeGetPtr(pScreen);
     if (pVidMode == NULL)
@@ -1674,9 +1662,9 @@ ProcVidModeGetGammaRamp(ClientPtr client)
         swaps(&stuff->screen);
     }
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    ScreenPtr pScreen = screenInfo.screens[stuff->screen];
 
     VidModePtr pVidMode = VidModeGetPtr(pScreen);
     if (pVidMode == NULL)
@@ -1724,12 +1712,11 @@ ProcVidModeGetGammaRampSize(ClientPtr client)
     if (client->swapped)
         swaps(&stuff->screen);
 
-    ScreenPtr pScreen;
     VidModePtr pVidMode;
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
-    pScreen = screenInfo.screens[stuff->screen];
 
     pVidMode = VidModeGetPtr(pScreen);
     if (pVidMode == NULL)
@@ -1754,7 +1741,7 @@ ProcVidModeGetPermissions(ClientPtr client)
     if (client->swapped)
         swaps(&stuff->screen);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    if (!dixScreenExists(stuff->screen))
         return BadValue;
 
     xXF86VidModeGetPermissionsReply reply =  {

--- a/dbe/dbe.c
+++ b/dbe/dbe.c
@@ -601,8 +601,7 @@ ProcDbeGetVisualInfo(ClientPtr client)
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
     for (int i = 0; i < count; i++) {
-        ScreenPtr pScreen = (stuff->n == 0) ? screenInfo.screens[i] :
-            pDrawables[i]->pScreen;
+        ScreenPtr pScreen = (stuff->n == 0) ? dixGetScreenPtr(i) : pDrawables[i]->pScreen;
         pDbeScreenPriv = DBE_SCREEN_PRIV(pScreen);
 
         rc = dixCallScreenAccessCallback(client, pScreen, DixGetAttrAccess);
@@ -1033,7 +1032,7 @@ DbeExtensionInit(void)
              */
 
             for (int j = 0; j < walkScreenIdx; j++) {
-                ScreenPtr pScreen = screenInfo.screens[j];
+                ScreenPtr pScreen = dixGetScreenPtr(j);
                 free(dixLookupPrivate(&pScreen->devPrivates, &dbeScreenPrivKeyRec));
                 dixSetPrivate(&pScreen->devPrivates, &dbeScreenPrivKeyRec, NULL);
             }

--- a/dix/cursor.c
+++ b/dix/cursor.c
@@ -201,7 +201,7 @@ RealizeCursorAllScreens(CursorPtr pCurs)
                         pDevIt = pDevIt->next;
                     }
                     while (--walkScreenIdx>= 0) {
-                        walkScreen = screenInfo.screens[walkScreenIdx];
+                        walkScreen = dixGetScreenPtr(walkScreenIdx);
                         /* now unrealize all devices on previous screens */
                         pDevIt = inputInfo.devices;
                         while (pDevIt) {

--- a/dix/events.c
+++ b/dix/events.c
@@ -633,12 +633,14 @@ XineramaConfineCursorToWindow(DeviceIntPtr pDev,
     unsigned int walkScreenIdx = PanoramiXNumScreens - 1;
 
     RegionCopy(&pSprite->Reg1, &pSprite->windows[walkScreenIdx]->borderSize);
-    ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+
+    ScreenPtr walkScreen = dixGetScreenPtr(walkScreenIdx);
     off_x = walkScreen->x;
     off_y = walkScreen->y;
 
     while (walkScreenIdx--) {
-        walkScreen = screenInfo.screens[walkScreenIdx];
+        walkScreen = dixGetScreenPtr(walkScreenIdx);
+
         x = off_x - walkScreen->x;
         y = off_y - walkScreen->y;
 
@@ -839,12 +841,12 @@ CheckVirtualMotion(DeviceIntPtr pDev, QdEventPtr qe, WindowPtr pWin)
             unsigned int walkScreenIdx = PanoramiXNumScreens - 1;
 
             RegionCopy(&pSprite->Reg2, &pSprite->windows[walkScreenIdx]->borderSize);
-            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+            ScreenPtr walkScreen = dixGetScreenPtr(walkScreenIdx);
             off_x = walkScreen->x;
             off_y = walkScreen->y;
 
             while (walkScreenIdx--) {
-                walkScreen = screenInfo.screens[walkScreenIdx];
+                walkScreen = dixGetScreenPtr(walkScreenIdx);
                 x = off_x - walkScreen->x;
                 y = off_y - walkScreen->y;
 

--- a/dix/screenint_priv.h
+++ b/dix/screenint_priv.h
@@ -6,6 +6,7 @@
 #ifndef _XSERVER_DIX_SCREENINT_PRIV_H
 #define _XSERVER_DIX_SCREENINT_PRIV_H
 
+#include <stdbool.h>
 #include <X11/Xdefs.h>
 
 #include "include/callback.h"
@@ -29,6 +30,30 @@ void InitOutput(int argc, char **argv);
 
 static inline ScreenPtr dixGetMasterScreen(void) {
     return screenInfo.screens[0];
+}
+
+/*
+ * retrieve pointer to screen by it's index. If index is above the total
+ * number of screens, returns NULL
+ *
+ * @param idx screen index
+ * @return pointer to idx'th screen or NULL
+ */
+static inline ScreenPtr dixGetScreenPtr(unsigned int idx) {
+    if (idx < screenInfo.numScreens)
+        return screenInfo.screens[idx];
+    return NULL;
+}
+
+/*
+ * check whether screen with given index exists
+ *
+ * @param idx screen index
+ * @return TRUE if the screen at this index exists
+ */
+static inline bool dixScreenExists(unsigned int idx) {
+    return ((idx < screenInfo.numScreens) &&
+            (screenInfo.screens[idx] != NULL));
 }
 
 /*

--- a/glx/glxcmds.c
+++ b/glx/glxcmds.c
@@ -39,6 +39,7 @@
 #include "dix/resource_priv.h"
 #include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
+#include "dix/screenint_priv.h"
 #include "os/bug_priv.h"
 #include "present/present_priv.h"
 
@@ -64,12 +65,13 @@ validGlxScreen(ClientPtr client, int screen, __GLXscreen ** pGlxScreen,
     /*
      ** Check if screen exists.
      */
-    if (screen < 0 || screen >= screenInfo.numScreens) {
+    ScreenPtr pScreen = dixGetScreenPtr(screen);
+    if (!pScreen) {
         client->errorValue = screen;
         *err = BadValue;
         return FALSE;
     }
-    *pGlxScreen = glxGetScreen(screenInfo.screens[screen]);
+    *pGlxScreen = glxGetScreen(pScreen);
 
     return TRUE;
 }

--- a/glx/glxext.c
+++ b/glx/glxext.c
@@ -330,15 +330,6 @@ xorgGlxHandleRequest(ClientPtr client)
     return __glXDispatch(client);
 }
 
-static ScreenPtr
-screenNumToScreen(int screen)
-{
-    if (screen < 0 || screen >= screenInfo.numScreens)
-        return NULL;
-
-    return screenInfo.screens[screen];
-}
-
 static int
 maybe_swap32(ClientPtr client, int x)
 {
@@ -350,7 +341,7 @@ vendorForScreen(ClientPtr client, int screen)
 {
     screen = maybe_swap32(client, screen);
 
-    return glxServer.getVendorForScreen(client, screenNumToScreen(screen));
+    return glxServer.getVendorForScreen(client, dixGetScreenPtr(screen));
 }
 
 /* this ought to be generated */

--- a/glx/vnd_dispatch_stubs.c
+++ b/glx/vnd_dispatch_stubs.c
@@ -2,6 +2,7 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/screenint_priv.h"
 
 #include <dix.h>
 #include "vndserver.h"
@@ -13,9 +14,11 @@
 
 static inline GlxServerVendor *vendorForScreen(ClientPtr pClient, CARD32 screen)
 {
-    if (screen < screenInfo.numScreens)
-        return glxServer.getVendorForScreen(pClient, screenInfo.screens[screen]);
-    return NULL;
+    ScreenPtr pScreen = dixGetScreenPtr(screen);
+    if (!pScreen)
+        return NULL;
+
+    return glxServer.getVendorForScreen(pClient, pScreen);
 }
 
 static int dispatch_Render(ClientPtr client)

--- a/hw/kdrive/src/kinput.c
+++ b/hw/kdrive/src/kinput.c
@@ -2121,7 +2121,7 @@ KdCursorOffScreen(ScreenPtr *ppScreen, int *x, int *y)
     int n_best_x, n_best_y;
     CARD32 ms;
 
-    if (kdDisableZaphod || screenInfo.numScreens <= 1)
+    if (kdDisableZaphod || (!dixScreenExists(1)))
         return FALSE;
 
     if (0 <= *x && *x < pScreen->width && 0 <= *y && *y < pScreen->height)
@@ -2173,7 +2173,7 @@ KdCursorOffScreen(ScreenPtr *ppScreen, int *x, int *y)
     if (n_best_x == -1)
         return FALSE;
 
-    ScreenPtr pNewScreen = screenInfo.screens[n_best_x];
+    ScreenPtr pNewScreen = dixGetScreenPtr(n_best_x);
 
     if (*x < 0)
         *x += pNewScreen->width;

--- a/hw/xfree86/common/xf86Cursor.c
+++ b/hw/xfree86/common/xf86Cursor.c
@@ -352,7 +352,7 @@ xf86CursorOffScreen(ScreenPtr *pScreen, int *x, int *y)
     xf86EdgePtr edge;
     int tmp;
 
-    if (screenInfo.numScreens == 1)
+    if (!dixGetScreenPtr(1))
         return FALSE;
 
     if (*x < 0) {

--- a/hw/xfree86/common/xf86DGA.c
+++ b/hw/xfree86/common/xf86DGA.c
@@ -1185,7 +1185,8 @@ ProcXDGAOpenFramebuffer(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xXDGAOpenFramebufferReq);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
 
     if (!DGAAvailable(stuff->screen))
@@ -1215,7 +1216,8 @@ ProcXDGACloseFramebuffer(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xXDGACloseFramebufferReq);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
 
     if (!DGAAvailable(stuff->screen))
@@ -1237,7 +1239,8 @@ ProcXDGAQueryModes(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xXDGAQueryModesReq);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
 
     if ((!DGAAvailable(stuff->screen)) ||
@@ -1334,7 +1337,8 @@ ProcXDGASetMode(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xXDGASetModeReq);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
     owner = DGA_GETCLIENT(stuff->screen);
 
@@ -1416,7 +1420,8 @@ ProcXDGASetViewport(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xXDGASetViewportReq);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
 
     if (DGA_GETCLIENT(stuff->screen) != client)
@@ -1437,7 +1442,8 @@ ProcXDGAInstallColormap(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xXDGAInstallColormapReq);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
 
     if (DGA_GETCLIENT(stuff->screen) != client)
@@ -1458,7 +1464,8 @@ ProcXDGASelectInput(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xXDGASelectInputReq);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
 
     if (DGA_GETCLIENT(stuff->screen) != client)
@@ -1477,7 +1484,8 @@ ProcXDGAFillRectangle(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xXDGAFillRectangleReq);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
 
     if (DGA_GETCLIENT(stuff->screen) != client)
@@ -1497,7 +1505,8 @@ ProcXDGACopyArea(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xXDGACopyAreaReq);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (pScreen)
         return BadValue;
 
     if (DGA_GETCLIENT(stuff->screen) != client)
@@ -1518,7 +1527,8 @@ ProcXDGACopyTransparentArea(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xXDGACopyTransparentAreaReq);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
 
     if (DGA_GETCLIENT(stuff->screen) != client)
@@ -1539,7 +1549,8 @@ ProcXDGAGetViewportStatus(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xXDGAGetViewportStatusReq);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
 
     if (DGA_GETCLIENT(stuff->screen) != client)
@@ -1559,7 +1570,8 @@ ProcXDGASync(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xXDGASyncReq);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (pScreen)
         return BadValue;
 
     if (DGA_GETCLIENT(stuff->screen) != client)
@@ -1600,7 +1612,8 @@ ProcXDGAChangePixmapMode(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xXDGAChangePixmapModeReq);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
 
     if (DGA_GETCLIENT(stuff->screen) != client)
@@ -1628,7 +1641,8 @@ ProcXDGACreateColormap(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xXDGACreateColormapReq);
 
-    if (stuff->screen >= screenInfo.numScreens)
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen)
         return BadValue;
 
     if (DGA_GETCLIENT(stuff->screen) != client)

--- a/hw/xquartz/xpr/appledri.c
+++ b/hw/xquartz/xpr/appledri.c
@@ -43,6 +43,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
+#include "dix/screenint_priv.h"
 
 #include "misc.h"
 #include "dixstruct.h"
@@ -118,7 +119,8 @@ ProcAppleDRIQueryDirectRenderingCapable(register ClientPtr client)
 
     Bool isCapable;
 
-    if (stuff->screen >= screenInfo.numScreens) {
+    ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
+    if (!pScreen) {
         return BadValue;
     }
 

--- a/randr/rrxinerama.c
+++ b/randr/rrxinerama.c
@@ -74,6 +74,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
+#include "dix/screenint_priv.h"
 #include "include/extinit.h"
 #include "randr/randrstr_priv.h"
 
@@ -313,7 +314,7 @@ RRXineramaExtensionInit(void)
      * with their own output geometry.  So if there's more than one protocol
      * screen, just don't even try.
      */
-    if (screenInfo.numScreens > 1)
+    if (dixGetScreenPtr(1))
         return;
 
     (void) AddExtension(PANORAMIX_PROTOCOL_NAME, 0, 0,

--- a/render/glyph.c
+++ b/render/glyph.c
@@ -369,7 +369,7 @@ AllocateGlyph(xGlyphInfo * gi, int fdepth)
 
  bail:
     while (i--) {
-        ScreenPtr walkScreen = screenInfo.screens[i];
+        ScreenPtr walkScreen = dixGetScreenPtr(i);
         PictureScreenPtr ps = GetPictureScreenIfSet(walkScreen);
         if (ps)
             ps->UnrealizeGlyph(walkScreen, glyph);

--- a/test/misc.c
+++ b/test/misc.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 #include "dix/input_priv.h"
+#include "dix/screenint_priv.h"
 #include "os/fmt.h"
 
 #include "misc.h"
@@ -66,7 +67,7 @@ dix_version_compare(void)
 
 static inline void set_screen(unsigned int idx, short x, short y, short w, short h)
 {
-    ScreenPtr pScreen = screenInfo.screens[idx];
+    ScreenPtr pScreen = dixGetScreenPtr(idx);
     pScreen->x = x;
     pScreen->y = y;
     pScreen->width = w;


### PR DESCRIPTION
Instead of directly accessing the global screenInfo.screens[] array,
let everybody go through a little inline helper. This one also checks
for array bounds - if the screen doesn't exist, return NULL.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
