### PR TITLE
dix: fix missing includes of extinit.h

### DIFF
--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -52,6 +52,7 @@ SOFTWARE.
 #include <string.h>
 #include <strings.h>
 
+#include "include/extinit.h"
 #include "dix/colormap_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/resource_priv.h"

--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -63,6 +63,7 @@ Equipment Corporation.
 #include "dix/rpcbuf_priv.h"
 #include "dix/screenint_priv.h"
 #include "dix/server_priv.h"
+#include "include/extinit.h"
 #include "include/swaprep.h"
 #include "os/auth.h"
 #include "os/log_priv.h"

--- a/dix/enterleave.c
+++ b/dix/enterleave.c
@@ -37,6 +37,7 @@
 #include "dix/input_priv.h"
 #include "dix/inpututils_priv.h"
 #include "dix/screenint_priv.h"
+#include "include/extinit.h"
 #include "os/bug_priv.h"
 
 #include "inputstr.h"

--- a/dix/events.c
+++ b/dix/events.c
@@ -131,6 +131,7 @@ Equipment Corporation.
 #include "dix/resource_priv.h"
 #include "dix/screenint_priv.h"
 #include "dix/window_priv.h"
+#include "include/extinit.h"
 #include "os/bug_priv.h"
 #include "os/client_priv.h"
 #include "os/fmt.h"

--- a/dix/getevents.c
+++ b/dix/getevents.c
@@ -43,6 +43,7 @@
 #include "dix/input_priv.h"
 #include "dix/inpututils_priv.h"
 #include "dix/screenint_priv.h"
+#include "include/extinit.h"
 #include "mi/mi_priv.h"
 #include "os/bug_priv.h"
 #include "os/probes_priv.h"

--- a/dix/main.c
+++ b/dix/main.c
@@ -95,6 +95,7 @@ Equipment Corporation.
 #include "dix/screensaver_priv.h"
 #include "dix/selection_priv.h"
 #include "dix/server_priv.h"
+#include "include/extinit.h"
 #include "os/audit_priv.h"
 #include "os/auth.h"
 #include "os/client_priv.h"

--- a/dix/property.c
+++ b/dix/property.c
@@ -54,6 +54,7 @@ SOFTWARE.
 #include "dix/property_priv.h"
 #include "dix/request_priv.h"
 #include "dix/window_priv.h"
+#include "include/extinit.h"
 #include "Xext/panoramiX.h"
 #include "Xext/panoramiXsrv.h"
 

--- a/dix/resource.c
+++ b/dix/resource.c
@@ -127,6 +127,7 @@ Equipment Corporation.
 #include "dix/gc_priv.h"
 #include "dix/registry_priv.h"
 #include "dix/resource_priv.h"
+#include "include/extinit.h"
 #include "os/osdep.h"
 #include "os/probes_priv.h"
 #include "Xext/panoramiX.h"

--- a/dix/window.c
+++ b/dix/window.c
@@ -112,6 +112,7 @@ Equipment Corporation.
 #include "dix/selection_priv.h"
 #include "dix/screenint_priv.h"
 #include "dix/window_priv.h"
+#include "include/extinit.h"
 #include "mi/mi_priv.h"         /* miPaintWindow */
 #include "os/auth.h"
 #include "os/client_priv.h"


### PR DESCRIPTION
Don't rely on this file just being included indirectly by somebody else
just by accident.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
