### PR TITLE
xfree86: fix missing includes of extinit.h

### DIFF
--- a/hw/xfree86/common/xf86Config.c
+++ b/hw/xfree86/common/xf86Config.c
@@ -52,6 +52,7 @@
 
 #include "dix/resource_priv.h"
 #include "dix/screensaver_priv.h"
+#include "include/extinit.h"
 #include "os/log_priv.h"
 #include "os/osdep.h"
 #include "xkb/xkbsrv_priv.h"

--- a/hw/xfree86/common/xf86DGA.c
+++ b/hw/xfree86/common/xf86DGA.c
@@ -52,6 +52,7 @@
 #include "dix/exevents_priv.h"
 #include "dix/request_priv.h"
 #include "dix/screen_hooks_priv.h"
+#include "include/extinit.h"
 #include "mi/mi_priv.h"
 
 #include "xf86.h"

--- a/hw/xfree86/common/xf86Helper.c
+++ b/hw/xfree86/common/xf86Helper.c
@@ -43,6 +43,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
+#include "include/extinit.h"
 #include "mi/mi_priv.h"
 #include "os/log_priv.h"
 #include "os/osdep.h"

--- a/hw/xfree86/common/xf86Mode.c
+++ b/hw/xfree86/common/xf86Mode.c
@@ -86,6 +86,7 @@
 
 #include <X11/X.h>
 
+#include "include/extinit.h"
 #include "os/log_priv.h"
 
 #include "xf86Modes.h"

--- a/hw/xfree86/common/xf86RandR.c
+++ b/hw/xfree86/common/xf86RandR.c
@@ -29,6 +29,7 @@
 
 #include "dix/input_priv.h"
 #include "dix/screen_hooks_priv.h"
+#include "include/extinit.h"
 
 #include "os.h"
 #include "globals.h"

--- a/hw/xfree86/common/xf86xv.c
+++ b/hw/xfree86/common/xf86xv.c
@@ -38,6 +38,7 @@
 #include <X11/extensions/Xvproto.h>
 
 #include "dix/screen_hooks_priv.h"
+#include "include/extinit.h"
 #include "Xext/xvdix_priv.h"
 
 #include "misc.h"

--- a/hw/xfree86/common/xf86xvmc.c
+++ b/hw/xfree86/common/xf86xvmc.c
@@ -38,6 +38,7 @@
 #include <X11/Xproto.h>
 
 #include "dix/screen_hooks_priv.h"
+#include "include/extinit.h"
 
 #include "scrnintstr.h"
 #include "resource.h"

--- a/hw/xfree86/dri/dri.c
+++ b/hw/xfree86/dri/dri.c
@@ -50,6 +50,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "dix/dix_priv.h"
 #include "dix/screen_hooks_priv.h"
 #include "dix/screenint_priv.h"
+#include "include/extinit.h"
 
 #include "xf86.h"
 #include "xf86drm.h"

--- a/hw/xfree86/dri2/dri2ext.c
+++ b/hw/xfree86/dri2/dri2ext.c
@@ -41,6 +41,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
+#include "include/extinit.h"
 
 #include "dixstruct.h"
 #include "scrnintstr.h"

--- a/hw/xfree86/modes/xf86RandR12.c
+++ b/hw/xfree86/modes/xf86RandR12.c
@@ -29,6 +29,7 @@
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
 #include "dix/screenint_priv.h"
+#include "include/extinit.h"
 
 #include "xf86.h"
 #include "os.h"


### PR DESCRIPTION
Don't rely on this file just being included indirectly by somebody else
just by accident.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
