### PR TITLE
dix: inline SProcPoly()

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -1876,13 +1876,19 @@ ProcCopyPlane(ClientPtr client)
 int
 ProcPolyPoint(ClientPtr client)
 {
+    REQUEST(xPolyPointReq);
+    REQUEST_AT_LEAST_SIZE(xPolyPointReq);
+
+    if (client->swapped) {
+        swapl(&stuff->drawable);
+        swapl(&stuff->gc);
+        SwapRestS(stuff);
+    }
+
     int npoint;
     GCPtr pGC;
     DrawablePtr pDraw;
 
-    REQUEST(xPolyPointReq);
-
-    REQUEST_AT_LEAST_SIZE(xPolyPointReq);
     if ((stuff->coordMode != CoordModeOrigin) &&
         (stuff->coordMode != CoordModePrevious)) {
         client->errorValue = stuff->coordMode;
@@ -1899,13 +1905,19 @@ ProcPolyPoint(ClientPtr client)
 int
 ProcPolyLine(ClientPtr client)
 {
+    REQUEST(xPolyPointReq);
+    REQUEST_AT_LEAST_SIZE(xPolyPointReq);
+
+    if (client->swapped) {
+        swapl(&stuff->drawable);
+        swapl(&stuff->gc);
+        SwapRestS(stuff);
+    }
+
     int npoint;
     GCPtr pGC;
     DrawablePtr pDraw;
 
-    REQUEST(xPolyLineReq);
-
-    REQUEST_AT_LEAST_SIZE(xPolyLineReq);
     if ((stuff->coordMode != CoordModeOrigin) &&
         (stuff->coordMode != CoordModePrevious)) {
         client->errorValue = stuff->coordMode;
@@ -1922,13 +1934,19 @@ ProcPolyLine(ClientPtr client)
 int
 ProcPolySegment(ClientPtr client)
 {
+    REQUEST(xPolyPointReq);
+    REQUEST_AT_LEAST_SIZE(xPolyPointReq);
+
+    if (client->swapped) {
+        swapl(&stuff->drawable);
+        swapl(&stuff->gc);
+        SwapRestS(stuff);
+    }
+
     int nsegs;
     GCPtr pGC;
     DrawablePtr pDraw;
 
-    REQUEST(xPolySegmentReq);
-
-    REQUEST_AT_LEAST_SIZE(xPolySegmentReq);
     VALIDATE_DRAWABLE_AND_GC(stuff->drawable, pDraw, DixWriteAccess);
     nsegs = (client->req_len << 2) - sizeof(xPolySegmentReq);
     if (nsegs & 4)
@@ -1942,13 +1960,19 @@ ProcPolySegment(ClientPtr client)
 int
 ProcPolyRectangle(ClientPtr client)
 {
+    REQUEST(xPolyPointReq);
+    REQUEST_AT_LEAST_SIZE(xPolyPointReq);
+
+    if (client->swapped) {
+        swapl(&stuff->drawable);
+        swapl(&stuff->gc);
+        SwapRestS(stuff);
+    }
+
     int nrects;
     GCPtr pGC;
     DrawablePtr pDraw;
 
-    REQUEST(xPolyRectangleReq);
-
-    REQUEST_AT_LEAST_SIZE(xPolyRectangleReq);
     VALIDATE_DRAWABLE_AND_GC(stuff->drawable, pDraw, DixWriteAccess);
     nrects = (client->req_len << 2) - sizeof(xPolyRectangleReq);
     if (nrects & 4)
@@ -1963,13 +1987,19 @@ ProcPolyRectangle(ClientPtr client)
 int
 ProcPolyArc(ClientPtr client)
 {
+    REQUEST(xPolyPointReq);
+    REQUEST_AT_LEAST_SIZE(xPolyPointReq);
+
+    if (client->swapped) {
+        swapl(&stuff->drawable);
+        swapl(&stuff->gc);
+        SwapRestS(stuff);
+    }
+
     int narcs;
     GCPtr pGC;
     DrawablePtr pDraw;
 
-    REQUEST(xPolyArcReq);
-
-    REQUEST_AT_LEAST_SIZE(xPolyArcReq);
     VALIDATE_DRAWABLE_AND_GC(stuff->drawable, pDraw, DixWriteAccess);
     narcs = (client->req_len << 2) - sizeof(xPolyArcReq);
     if (narcs % sizeof(xArc))
@@ -2013,13 +2043,19 @@ ProcFillPoly(ClientPtr client)
 int
 ProcPolyFillRectangle(ClientPtr client)
 {
+    REQUEST(xPolyPointReq);
+    REQUEST_AT_LEAST_SIZE(xPolyPointReq);
+
+    if (client->swapped) {
+        swapl(&stuff->drawable);
+        swapl(&stuff->gc);
+        SwapRestS(stuff);
+    }
+
     int things;
     GCPtr pGC;
     DrawablePtr pDraw;
 
-    REQUEST(xPolyFillRectangleReq);
-
-    REQUEST_AT_LEAST_SIZE(xPolyFillRectangleReq);
     VALIDATE_DRAWABLE_AND_GC(stuff->drawable, pDraw, DixWriteAccess);
     things = (client->req_len << 2) - sizeof(xPolyFillRectangleReq);
     if (things & 4)
@@ -2035,13 +2071,19 @@ ProcPolyFillRectangle(ClientPtr client)
 int
 ProcPolyFillArc(ClientPtr client)
 {
+    REQUEST(xPolyPointReq);
+    REQUEST_AT_LEAST_SIZE(xPolyPointReq);
+
+    if (client->swapped) {
+        swapl(&stuff->drawable);
+        swapl(&stuff->gc);
+        SwapRestS(stuff);
+    }
+
     int narcs;
     GCPtr pGC;
     DrawablePtr pDraw;
 
-    REQUEST(xPolyFillArcReq);
-
-    REQUEST_AT_LEAST_SIZE(xPolyFillArcReq);
     VALIDATE_DRAWABLE_AND_GC(stuff->drawable, pDraw, DixWriteAccess);
     narcs = (client->req_len << 2) - sizeof(xPolyFillArcReq);
     if (narcs % sizeof(xArc))

--- a/dix/swapreq.c
+++ b/dix/swapreq.c
@@ -557,19 +557,6 @@ SProcCopyPlane(ClientPtr client)
     return ((*ProcVector[X_CopyPlane]) (client));
 }
 
-/* The following routine is used for all Poly drawing requests
-   (except FillPoly, which uses a different request format) */
-int _X_COLD
-SProcPoly(ClientPtr client)
-{
-    REQUEST(xPolyPointReq);
-    REQUEST_AT_LEAST_SIZE(xPolyPointReq);
-    swapl(&stuff->drawable);
-    swapl(&stuff->gc);
-    SwapRestS(stuff);
-    return ((*ProcVector[stuff->reqType]) (client));
-}
-
 /* cannot use SProcPoly for this one, because xFillPolyReq
    is longer than xPolyPointReq, and we don't want to swap
    the difference as shorts! */

--- a/dix/tables.c
+++ b/dix/tables.c
@@ -395,14 +395,14 @@ int (*SwappedProcVector[256]) (ClientPtr /* client */) = {
     SProcClearToBackground,
     SProcCopyArea,
     SProcCopyPlane,
-    SProcPoly,                          /* PolyPoint, */
-    SProcPoly,                          /* 65 PolyLine */
-    SProcPoly,                          /* PolySegment, */
-    SProcPoly,                          /* PolyRectangle, */
-    SProcPoly,                          /* PolyArc, */
+    ProcPolyPoint,
+    ProcPolyLine,                       /* 65 */
+    ProcPolySegment,
+    ProcPolyRectangle,
+    ProcPolyArc,
     SProcFillPoly,
-    SProcPoly,                          /* 70 PolyFillRectangle */
-    SProcPoly,                          /* PolyFillArc, */
+    ProcPolyFillRectangle,              /* 70 */
+    ProcPolyFillArc,
     SProcPutImage,
     SProcGetImage,
     SProcPolyText,

--- a/include/swapreq.h
+++ b/include/swapreq.h
@@ -66,7 +66,6 @@ int SProcListFonts(ClientPtr client);
 int SProcListFontsWithInfo(ClientPtr client);
 int SProcLookupColor(ClientPtr client);
 int SProcOpenFont(ClientPtr client);
-int SProcPoly(ClientPtr client);
 int SProcPolyText(ClientPtr client);
 int SProcPutImage(ClientPtr client);
 int SProcQueryBestSize(ClientPtr client);


### PR DESCRIPTION
Yet another step for getting rid of the unnecessarily complicated SProc*
machinery. Later, all those swap*() calls will be replaced by macros.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
