### PR TITLE
dix: replace XACE_CLIENT_ACCESS by direct callback

### DIFF
--- a/Xext/namespace/hook-device.c
+++ b/Xext/namespace/hook-device.c
@@ -6,17 +6,17 @@
 #include <X11/extensions/XI2proto.h>
 #include <X11/extensions/XKB.h>
 
+#include "dix/devices_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/extension_priv.h"
 #include "dix/registry_priv.h"
-#include "Xext/xacestr.h"
 
 #include "namespace.h"
 #include "hooks.h"
 
 void hookDevice(CallbackListPtr *pcbl, void *unused, void *calldata)
 {
-    XNS_HOOK_HEAD(XaceDeviceAccessRec);
+    XNS_HOOK_HEAD(DeviceAccessCallbackParam);
 
     if (subj->ns->superPower)
         goto pass;

--- a/Xext/namespace/namespace.c
+++ b/Xext/namespace/namespace.c
@@ -4,6 +4,7 @@
 #include <X11/Xmd.h>
 
 #include "dix/client_priv.h"
+#include "dix/devices_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/extension_priv.h"
 #include "dix/property_priv.h"
@@ -42,7 +43,7 @@ NamespaceExtensionInit(void)
           AddCallback(&ServerAccessCallback, hookServerAccess, NULL) &&
           AddCallback(&ClientDestroyCallback, hookClientDestroy, NULL) &&
           AddCallback(&ClientAccessCallback, hookClient, NULL) &&
-          XaceRegisterCallback(XACE_DEVICE_ACCESS, hookDevice, NULL) &&
+          AddCallback(&DeviceAccessCallback, hookDevice, NULL) &&
           XaceRegisterCallback(XACE_PROPERTY_ACCESS, hookPropertyAccess, NULL) &&
           XaceRegisterCallback(XACE_RECEIVE_ACCESS, hookReceive, NULL) &&
           XaceRegisterCallback(XACE_RESOURCE_ACCESS, hookResourceAccess, NULL) &&

--- a/Xext/security.c
+++ b/Xext/security.c
@@ -31,6 +31,7 @@ in this Software without prior written authorization from The Open Group.
 #include <X11/Xfuncproto.h>
 
 #include "dix/client_priv.h"
+#include "dix/devices_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/extension_priv.h"
 #include "dix/registry_priv.h"
@@ -651,7 +652,7 @@ SwapSecurityAuthorizationRevokedEvent(xSecurityAuthorizationRevokedEvent * from,
 static void
 SecurityDevice(CallbackListPtr *pcbl, void *unused, void *calldata)
 {
-    XaceDeviceAccessRec *rec = calldata;
+    DeviceAccessCallbackParam *rec = calldata;
     SecurityStateRec *subj, *obj;
     Mask requested = rec->access_mode;
     Mask allowed = SecurityDeviceMask;
@@ -972,9 +973,9 @@ SecurityResetProc(ExtensionEntry * extEntry)
     DeleteCallback(&ExtensionDispatchCallback, SecurityExtension, NULL);
     DeleteCallback(&ServerAccessCallback, SecurityServer, NULL);
     DeleteCallback(&ClientAccessCallback, SecurityClient, NULL);
+    DeleteCallback(&DeviceAccessCallback, SecurityDevice, NULL);
 
     XaceDeleteCallback(XACE_RESOURCE_ACCESS, SecurityResource, NULL);
-    XaceDeleteCallback(XACE_DEVICE_ACCESS, SecurityDevice, NULL);
     XaceDeleteCallback(XACE_PROPERTY_ACCESS, SecurityProperty, NULL);
     XaceDeleteCallback(XACE_SEND_ACCESS, SecuritySend, NULL);
     XaceDeleteCallback(XACE_RECEIVE_ACCESS, SecurityReceive, NULL);
@@ -1020,9 +1021,9 @@ SecurityExtensionInit(void)
     ret &= AddCallback(&ExtensionDispatchCallback, SecurityExtension, NULL);
     ret &= AddCallback(&ServerAccessCallback, SecurityServer, NULL);
     ret &= AddCallback(&ClientAccessCallback, SecurityClient, NULL);
+    ret &= AddCallback(&DeviceAccessCallback, SecurityDevice, NULL);
 
     ret &= XaceRegisterCallback(XACE_RESOURCE_ACCESS, SecurityResource, NULL);
-    ret &= XaceRegisterCallback(XACE_DEVICE_ACCESS, SecurityDevice, NULL);
     ret &= XaceRegisterCallback(XACE_PROPERTY_ACCESS, SecurityProperty, NULL);
     ret &= XaceRegisterCallback(XACE_SEND_ACCESS, SecuritySend, NULL);
     ret &= XaceRegisterCallback(XACE_RECEIVE_ACCESS, SecurityReceive, NULL);

--- a/Xext/xace.c
+++ b/Xext/xace.c
@@ -60,13 +60,6 @@ int XaceHookResourceAccess(ClientPtr client, XID id, RESTYPE rtype, void *res,
     return rec.status;
 }
 
-int XaceHookDeviceAccess(ClientPtr client, DeviceIntPtr dev, Mask access_mode)
-{
-    XaceDeviceAccessRec rec = { client, dev, access_mode, Success };
-    CallCallbacks(&XaceHooks[XACE_DEVICE_ACCESS], &rec);
-    return rec.status;
-}
-
 int XaceHookSendAccess(ClientPtr client, DeviceIntPtr dev, WindowPtr win,
                        xEventPtr ev, int count)
 {

--- a/Xext/xace.h
+++ b/Xext/xace.h
@@ -39,7 +39,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /* Constants used to identify the available security hooks
  */
 #define XACE_RESOURCE_ACCESS		2
-#define XACE_DEVICE_ACCESS		3
 #define XACE_PROPERTY_ACCESS		4
 #define XACE_SEND_ACCESS		5
 #define XACE_RECEIVE_ACCESS		6
@@ -68,8 +67,6 @@ int XaceHookSelectionAccess(ClientPtr ptr, Selection ** ppSel, Mask access_mode)
 /* needs to be exported for in-tree modesetting, but not part of public API */
 _X_EXPORT int XaceHookResourceAccess(ClientPtr client, XID id, RESTYPE rtype, void *res,
                            RESTYPE ptype, void *parent, Mask access_mode);
-
-int XaceHookDeviceAccess(ClientPtr client, DeviceIntPtr dev, Mask access_mode);
 
 int XaceHookSendAccess(ClientPtr client, DeviceIntPtr dev, WindowPtr win,
                        xEventPtr ev, int count);

--- a/Xext/xacestr.h
+++ b/Xext/xacestr.h
@@ -42,14 +42,6 @@ typedef struct {
     int status;
 } XaceResourceAccessRec;
 
-/* XACE_DEVICE_ACCESS */
-typedef struct {
-    ClientPtr client;
-    DeviceIntPtr dev;
-    Mask access_mode;
-    int status;
-} XaceDeviceAccessRec;
-
 /* XACE_PROPERTY_ACCESS */
 typedef struct {
     ClientPtr client;

--- a/Xext/xselinux_hooks.c
+++ b/Xext/xselinux_hooks.c
@@ -33,6 +33,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <X11/Xfuncproto.h>
 
 #include "dix/client_priv.h"
+#include "dix/devices_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/extension_priv.h"
 #include "dix/input_priv.h"
@@ -338,7 +339,7 @@ SELinuxLog(int type, const char *fmt, ...)
 static void
 SELinuxDevice(CallbackListPtr *pcbl, void *unused, void *calldata)
 {
-    XaceDeviceAccessRec *rec = calldata;
+    DeviceAccessCallbackParam *rec = calldata;
     SELinuxSubjectRec *subj;
     SELinuxObjectRec *obj;
     SELinuxAuditRec auditdata = {.client = rec->client,.dev = rec->dev };
@@ -835,9 +836,9 @@ SELinuxFlaskReset(void)
     DeleteCallback(&ExtensionDispatchCallback, SELinuxExtension, NULL);
     DeleteCallback(&ServerAccessCallback, SELinuxServer, NULL);
     DeleteCallback(&ClientAccessCallback, SELinuxClient, NULL);
+    DeleteCallback(&DeviceAccessCallback, SELinuxDevice, NULL);
 
     XaceDeleteCallback(XACE_RESOURCE_ACCESS, SELinuxResource, NULL);
-    XaceDeleteCallback(XACE_DEVICE_ACCESS, SELinuxDevice, NULL);
     XaceDeleteCallback(XACE_PROPERTY_ACCESS, SELinuxProperty, NULL);
     XaceDeleteCallback(XACE_SEND_ACCESS, SELinuxSend, NULL);
     XaceDeleteCallback(XACE_RECEIVE_ACCESS, SELinuxReceive, NULL);
@@ -929,9 +930,9 @@ SELinuxFlaskInit(void)
     ret &= AddCallback(&ExtensionDispatchCallback, SELinuxExtension, NULL);
     ret &= AddCallback(&ServerAccessCallback, SELinuxServer, NULL);
     ret &= AddCallback(&ClientAccessCallback, SELinuxClient, NULL);
+    ret &= AddCallback(&DeviceAccessCallback, SELinuxDevice, NULL);
 
     ret &= XaceRegisterCallback(XACE_RESOURCE_ACCESS, SELinuxResource, NULL);
-    ret &= XaceRegisterCallback(XACE_DEVICE_ACCESS, SELinuxDevice, NULL);
     ret &= XaceRegisterCallback(XACE_PROPERTY_ACCESS, SELinuxProperty, NULL);
     ret &= XaceRegisterCallback(XACE_SEND_ACCESS, SELinuxSend, NULL);
     ret &= XaceRegisterCallback(XACE_RECEIVE_ACCESS, SELinuxReceive, NULL);

--- a/Xi/exevents.c
+++ b/Xi/exevents.c
@@ -80,10 +80,6 @@ SOFTWARE.
 
 #include <dix-config.h>
 
-#include "dix/cursor_priv.h"
-#include "os/bug_priv.h"
-#include "os/osdep.h"
-
 #include <X11/X.h>
 #include <X11/Xproto.h>
 #include <X11/extensions/geproto.h>
@@ -92,6 +88,8 @@ SOFTWARE.
 #include <X11/extensions/XI2proto.h>
 #include <X11/extensions/XKBproto.h>
 
+#include "dix/cursor_priv.h"
+#include "dix/devices_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/dixgrabs_priv.h"
 #include "dix/eventconvert.h"
@@ -101,7 +99,9 @@ SOFTWARE.
 #include "dix/resource_priv.h"
 #include "dix/window_priv.h"
 #include "mi/mi_priv.h"
+#include "os/bug_priv.h"
 #include "os/log_priv.h"
+#include "os/osdep.h"
 #include "xkb/xkbsrv_priv.h"
 
 #include "inputstr.h"
@@ -2512,7 +2512,7 @@ GrabButton(ClientPtr client, DeviceIntPtr dev, DeviceIntPtr modifier_device,
     if (param->this_device_mode == GrabModeSync ||
         param->other_devices_mode == GrabModeSync)
         access_mode |= DixFreezeAccess;
-    rc = XaceHookDeviceAccess(client, dev, access_mode);
+    rc = dixCallDeviceAccessCallback(client, dev, access_mode);
     if (rc != Success)
         return rc;
     rc = dixLookupWindow(&pWin, param->grabWindow, client, DixSetAttrAccess);
@@ -2568,7 +2568,7 @@ GrabKey(ClientPtr client, DeviceIntPtr dev, DeviceIntPtr modifier_device,
     if (param->this_device_mode == GrabModeSync ||
         param->other_devices_mode == GrabModeSync)
         access_mode |= DixFreezeAccess;
-    rc = XaceHookDeviceAccess(client, dev, access_mode);
+    rc = dixCallDeviceAccessCallback(client, dev, access_mode);
     if (rc != Success)
         return rc;
 
@@ -2611,7 +2611,7 @@ GrabWindow(ClientPtr client, DeviceIntPtr dev, int type,
     if (param->this_device_mode == GrabModeSync ||
         param->other_devices_mode == GrabModeSync)
         access_mode |= DixFreezeAccess;
-    rc = XaceHookDeviceAccess(client, dev, access_mode);
+    rc = dixCallDeviceAccessCallback(client, dev, access_mode);
     if (rc != Success)
         return rc;
 
@@ -2642,7 +2642,7 @@ GrabTouchOrGesture(ClientPtr client, DeviceIntPtr dev, DeviceIntPtr mod_dev,
     rc = dixLookupWindow(&pWin, param->grabWindow, client, DixSetAttrAccess);
     if (rc != Success)
         return rc;
-    rc = XaceHookDeviceAccess(client, dev, DixGrabAccess);
+    rc = dixCallDeviceAccessCallback(client, dev, DixGrabAccess);
     if (rc != Success)
         return rc;
 

--- a/Xi/grabdevb.c
+++ b/Xi/grabdevb.c
@@ -55,13 +55,13 @@ SOFTWARE.
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XIproto.h>
 
+#include "dix/devices_priv.h"
 #include "dix/exevents_priv.h"
 #include "dix/input_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
 #include "windowstr.h"          /* window structure  */
-#include "xace.h"
 #include "grabdev.h"
 
 /***********************************************************************
@@ -113,7 +113,7 @@ ProcXGrabDeviceButton(ClientPtr client)
     }
     else {
         mdev = PickKeyboard(client);
-        ret = XaceHookDeviceAccess(client, mdev, DixUseAccess);
+        ret = dixCallDeviceAccessCallback(client, mdev, DixUseAccess);
         if (ret != Success)
             return ret;
     }

--- a/Xi/grabdevk.c
+++ b/Xi/grabdevk.c
@@ -55,13 +55,13 @@ SOFTWARE.
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XIproto.h>
 
+#include "dix/devices_priv.h"
 #include "dix/exevents_priv.h"
 #include "dix/input_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
 #include "windowstr.h"          /* window structure  */
-#include "xace.h"
 #include "grabdev.h"
 
 /***********************************************************************
@@ -108,7 +108,7 @@ ProcXGrabDeviceKey(ClientPtr client)
     }
     else {
         mdev = PickKeyboard(client);
-        ret = XaceHookDeviceAccess(client, mdev, DixUseAccess);
+        ret = dixCallDeviceAccessCallback(client, mdev, DixUseAccess);
         if (ret != Success)
             return ret;
     }

--- a/Xi/listdev.c
+++ b/Xi/listdev.c
@@ -57,6 +57,7 @@ SOFTWARE.
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XIproto.h>
 
+#include "dix/devices_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
 #include "dix/request_priv.h"
@@ -67,7 +68,6 @@ SOFTWARE.
 #include "XIstubs.h"
 #include "extnsionst.h"
 #include "exevents.h"
-#include "xace.h"
 #include "xkbsrv.h"
 #include "xkbstr.h"
 
@@ -300,7 +300,7 @@ ShouldSkipDevice(ClientPtr client, DeviceIntPtr d)
 {
     /* don't send master devices other than VCP/VCK */
     if (!InputDevIsMaster(d) || d == inputInfo.pointer ||d == inputInfo.keyboard) {
-        int rc = XaceHookDeviceAccess(client, d, DixGetAttrAccess);
+        int rc = dixCallDeviceAccessCallback(client, d, DixGetAttrAccess);
 
         if (rc == Success)
             return FALSE;

--- a/Xi/xiquerydevice.c
+++ b/Xi/xiquerydevice.c
@@ -34,6 +34,7 @@
 #include <X11/Xatom.h>
 #include <X11/extensions/XI2proto.h>
 
+#include "dix/devices_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
 #include "dix/input_priv.h"
@@ -47,7 +48,6 @@
 #include "xkbstr.h"
 #include "xkbsrv.h"
 #include "xserver-properties.h"
-#include "xace.h"
 #include "exglobals.h"
 #include "privates.h"
 #include "xiquerydevice.h"
@@ -159,8 +159,7 @@ ShouldSkipDevice(ClientPtr client, int deviceid, DeviceIntPtr dev)
 {
     /* if all devices are not being queried, only master devices are */
     if (deviceid == XIAllDevices || InputDevIsMaster(dev)) {
-        int rc = XaceHookDeviceAccess(client, dev, DixGetAttrAccess);
-
+        int rc = dixCallDeviceAccessCallback(client, dev, DixGetAttrAccess);
         if (rc == Success)
             return FALSE;
     }
@@ -556,11 +555,9 @@ ListDeviceClasses(ClientPtr client, DeviceIntPtr dev,
     int total_len = 0;
     int len;
     int i;
-    int rc;
 
     /* Check if the current device state should be suppressed */
-    rc = XaceHookDeviceAccess(client, dev, DixReadAccess);
-
+    int rc = dixCallDeviceAccessCallback(client, dev, DixReadAccess);
     if (dev->button) {
         (*nclasses)++;
         len = ListButtonInfo(dev, (xXIButtonInfo *) any, rc == Success);

--- a/dix/devices_priv.h
+++ b/dix/devices_priv.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef _XSERVER_DIX_DEVICES_PRIV_H
+#define _XSERVER_DIX_DEVICES_PRIV_H
+
+#include "include/callback.h"
+#include "include/dix.h"
+
+/*
+ * called when a client tries to access devices
+ */
+extern CallbackListPtr DeviceAccessCallback;
+
+typedef struct {
+    ClientPtr client;
+    DeviceIntPtr dev;
+    Mask access_mode;
+    int status;
+} DeviceAccessCallbackParam;
+
+static inline int dixCallDeviceAccessCallback(ClientPtr client, DeviceIntPtr dev, Mask access_mode)
+{
+    DeviceAccessCallbackParam rec = { client, dev, access_mode, Success };
+    CallCallbacks(&DeviceAccessCallback, &rec);
+    return rec.status;
+}
+
+#endif /* _XSERVER_DIX_DEVICES_PRIV_H */

--- a/dix/grabs.c
+++ b/dix/grabs.c
@@ -52,6 +52,7 @@ SOFTWARE.
 #include <X11/extensions/XI2.h>
 
 #include "dix/cursor_priv.h"
+#include "dix/devices_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/dixgrabs_priv.h"
 #include "dix/exevents_priv.h"
@@ -65,7 +66,6 @@ SOFTWARE.
 #include "windowstr.h"
 #include "inputstr.h"
 #include "cursorstr.h"
-#include "xace.h"
 #include "exglobals.h"
 
 #define MasksPerDetailMask 8    /* 256 keycodes and 256 possible
@@ -544,7 +544,7 @@ AddPassiveGrabToList(ClientPtr client, GrabPtr pGrab)
     if (pGrab->keyboardMode == GrabModeSync ||
         pGrab->pointerMode == GrabModeSync)
         access_mode |= DixFreezeAccess;
-    rc = XaceHookDeviceAccess(client, pGrab->device, access_mode);
+    rc = dixCallDeviceAccessCallback(client, pGrab->device, access_mode);
     if (rc != Success)
         return rc;
 

--- a/dix/inpututils.c
+++ b/dix/inpututils.c
@@ -25,6 +25,7 @@
 
 #include "dix-config.h"
 
+#include "dix/devices_priv.h"
 #include "dix/exevents_priv.h"
 #include "dix/input_priv.h"
 #include "dix/inpututils_priv.h"
@@ -34,7 +35,6 @@
 #include "exglobals.h"
 #include "misc.h"
 #include "inputstr.h"
-#include "xace.h"
 #include "xkbsrv.h"
 #include "xkbstr.h"
 #include "eventstr.h"
@@ -54,7 +54,7 @@ check_butmap_change(DeviceIntPtr dev, CARD8 *map, int len, CARD32 *errval_out,
         return BadDevice;
     }
 
-    ret = XaceHookDeviceAccess(client, dev, DixManageAccess);
+    ret = dixCallDeviceAccessCallback(client, dev, DixManageAccess);
     if (ret != Success) {
         client->errorValue = dev->id;
         return ret;
@@ -134,7 +134,7 @@ check_modmap_change(ClientPtr client, DeviceIntPtr dev, KeyCode *modmap)
     int ret;
     XkbDescPtr xkb;
 
-    ret = XaceHookDeviceAccess(client, dev, DixManageAccess);
+    ret = dixCallDeviceAccessCallback(client, dev, DixManageAccess);
     if (ret != Success)
         return ret;
 
@@ -288,9 +288,8 @@ generate_modkeymap(ClientPtr client, DeviceIntPtr dev,
     CARD8 keys_per_mod[8];
     int max_keys_per_mod;
     KeyCode *modkeymap = NULL;
-    int ret;
 
-    ret = XaceHookDeviceAccess(client, dev, DixGetAttrAccess);
+    int ret = dixCallDeviceAccessCallback(client, dev, DixGetAttrAccess);
     if (ret != Success)
         return ret;
 

--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -32,6 +32,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XKMformat.h>
 
+#include "dix/devices_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
@@ -44,7 +45,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "misc.h"
 #include "inputstr.h"
 #include "extnsionst.h"
-#include "xace.h"
 #include "xkb-procs.h"
 #include "protocol-versions.h"
 
@@ -577,7 +577,7 @@ ProcXkbBell(ClientPtr client)
         for (other = inputInfo.devices; other; other = other->next) {
             if ((other != dev) && other->key && !InputDevIsMaster(other) &&
                 GetMaster(other, MASTER_KEYBOARD) == dev) {
-                rc = XaceHookDeviceAccess(client, other, DixBellAccess);
+                rc = dixCallDeviceAccessCallback(client, other, DixBellAccess);
                 if (rc == Success)
                     _XkbBell(client, other, pWin, stuff->bellClass,
                              stuff->bellID, stuff->pitch, stuff->duration,
@@ -2706,7 +2706,7 @@ ProcXkbSetMap(ClientPtr client)
         for (other = inputInfo.devices; other; other = other->next) {
             if ((other != dev) && other->key && !InputDevIsMaster(other) &&
                 GetMaster(other, MASTER_KEYBOARD) == dev) {
-                rc = XaceHookDeviceAccess(client, other, DixManageAccess);
+                rc = dixCallDeviceAccessCallback(client, other, DixManageAccess);
                 if (rc == Success) {
                     rc = _XkbSetMapChecks(client, other, stuff, tmp, FALSE);
                     if (rc != Success)
@@ -2739,7 +2739,7 @@ ProcXkbSetMap(ClientPtr client)
         for (other = inputInfo.devices; other; other = other->next) {
             if ((other != dev) && other->key && !InputDevIsMaster(other) &&
                 GetMaster(other, MASTER_KEYBOARD) == dev) {
-                rc = XaceHookDeviceAccess(client, other, DixManageAccess);
+                rc = dixCallDeviceAccessCallback(client, other, DixManageAccess);
                 if (rc == Success)
                     _XkbSetMap(client, other, stuff, tmp);
                 /* ignore rc. if the SetMap failed although the check above
@@ -3057,7 +3057,7 @@ ProcXkbSetCompatMap(ClientPtr client)
         for (other = inputInfo.devices; other; other = other->next) {
             if ((other != dev) && other->key && !InputDevIsMaster(other) &&
                 GetMaster(other, MASTER_KEYBOARD) == dev) {
-                rc = XaceHookDeviceAccess(client, other, DixManageAccess);
+                rc = dixCallDeviceAccessCallback(client, other, DixManageAccess);
                 if (rc == Success) {
                     /* dry-run */
                     rc = _XkbSetCompatMap(client, other, stuff, data, TRUE);
@@ -3078,7 +3078,7 @@ ProcXkbSetCompatMap(ClientPtr client)
         for (other = inputInfo.devices; other; other = other->next) {
             if ((other != dev) && other->key && !InputDevIsMaster(other) &&
                 GetMaster(other, MASTER_KEYBOARD) == dev) {
-                rc = XaceHookDeviceAccess(client, other, DixManageAccess);
+                rc = dixCallDeviceAccessCallback(client, other, DixManageAccess);
                 if (rc == Success) {
                     rc = _XkbSetCompatMap(client, other, stuff, data, FALSE);
                     if (rc != Success)
@@ -3315,7 +3315,7 @@ ProcXkbSetIndicatorMap(ClientPtr client)
         for (other = inputInfo.devices; other; other = other->next) {
             if ((other != dev) && other->key && !InputDevIsMaster(other) &&
                 GetMaster(other, MASTER_KEYBOARD) == dev) {
-                rc = XaceHookDeviceAccess(client, other, DixSetAttrAccess);
+                rc = dixCallDeviceAccessCallback(client, other, DixSetAttrAccess);
                 if (rc == Success)
                     _XkbSetIndicatorMap(client, other, stuff->which, from);
             }
@@ -3573,7 +3573,7 @@ ProcXkbSetNamedIndicator(ClientPtr client)
             if ((other != dev) && !InputDevIsMaster(other) &&
                 GetMaster(other, MASTER_KEYBOARD) == dev && (other->kbdfeed ||
                                                              other->leds) &&
-                (XaceHookDeviceAccess(client, other, DixSetAttrAccess)
+                (dixCallDeviceAccessCallback(client, other, DixSetAttrAccess)
                  == Success)) {
                 rc = _XkbCreateIndicatorMap(other, stuff->indicator,
                                             stuff->ledClass, stuff->ledID, &map,
@@ -3597,7 +3597,7 @@ ProcXkbSetNamedIndicator(ClientPtr client)
             if ((other != dev) && !InputDevIsMaster(other) &&
                 GetMaster(other, MASTER_KEYBOARD) == dev && (other->kbdfeed ||
                                                              other->leds) &&
-                (XaceHookDeviceAccess(client, other, DixSetAttrAccess)
+                (dixCallDeviceAccessCallback(client, other, DixSetAttrAccess)
                  == Success)) {
                 _XkbSetNamedIndicator(client, other, stuff);
             }
@@ -4368,7 +4368,7 @@ ProcXkbSetNames(ClientPtr client)
             if ((other != dev) && other->key && !InputDevIsMaster(other) &&
                 GetMaster(other, MASTER_KEYBOARD) == dev) {
 
-                rc = XaceHookDeviceAccess(client, other, DixManageAccess);
+                rc = dixCallDeviceAccessCallback(client, other, DixManageAccess);
                 if (rc == Success) {
                     rc = _XkbSetNamesCheck(client, other, stuff, tmp);
                     if (rc != Success)
@@ -4391,7 +4391,7 @@ ProcXkbSetNames(ClientPtr client)
             if ((other != dev) && other->key && !InputDevIsMaster(other) &&
                 GetMaster(other, MASTER_KEYBOARD) == dev) {
 
-                rc = XaceHookDeviceAccess(client, other, DixManageAccess);
+                rc = dixCallDeviceAccessCallback(client, other, DixManageAccess);
                 if (rc == Success)
                     _XkbSetNames(client, other, stuff);
             }
@@ -5460,7 +5460,7 @@ ProcXkbSetGeometry(ClientPtr client)
         for (other = inputInfo.devices; other; other = other->next) {
             if ((other != dev) && other->key && !InputDevIsMaster(other) &&
                 GetMaster(other, MASTER_KEYBOARD) == dev) {
-                rc = XaceHookDeviceAccess(client, other, DixManageAccess);
+                rc = dixCallDeviceAccessCallback(client, other, DixManageAccess);
                 if (rc == Success)
                     _XkbSetGeometry(client, other, stuff);
             }
@@ -6765,7 +6765,7 @@ ProcXkbSetDeviceInfo(ClientPtr client)
                  GetMaster(other, MASTER_KEYBOARD) == dev) &&
                 ((stuff->deviceSpec == XkbUseCoreKbd && other->key) ||
                  (stuff->deviceSpec == XkbUseCorePtr && other->button))) {
-                rc = XaceHookDeviceAccess(client, other, DixManageAccess);
+                rc = dixCallDeviceAccessCallback(client, other, DixManageAccess);
                 if (rc == Success) {
                     rc = _XkbSetDeviceInfoCheck(client, other, stuff);
                     if (rc != Success)
@@ -6789,7 +6789,7 @@ ProcXkbSetDeviceInfo(ClientPtr client)
                  GetMaster(other, MASTER_KEYBOARD) == dev) &&
                 ((stuff->deviceSpec == XkbUseCoreKbd && other->key) ||
                  (stuff->deviceSpec == XkbUseCorePtr && other->button))) {
-                rc = XaceHookDeviceAccess(client, other, DixManageAccess);
+                rc = dixCallDeviceAccessCallback(client, other, DixManageAccess);
                 if (rc == Success) {
                     rc = _XkbSetDeviceInfo(client, other, stuff);
                     if (rc != Success)


### PR DESCRIPTION
Replace complicated xace hook by simple and cheap callback.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
