### PR TITLE
xfree86: vgaarbiter: drop VGAarbiterScreenKey and VGAarbiterGCKey macros

### DIFF
--- a/hw/xfree86/common/xf86VGAarbiter.c
+++ b/hw/xfree86/common/xf86VGAarbiter.c
@@ -61,11 +61,7 @@ static miPointerSpriteFuncRec VGAarbiterSpriteFuncs = {
 };
 
 static DevPrivateKeyRec VGAarbiterScreenKeyRec;
-
-#define VGAarbiterScreenKey (&VGAarbiterScreenKeyRec)
 static DevPrivateKeyRec VGAarbiterGCKeyRec;
-
-#define VGAarbiterGCKey (&VGAarbiterGCKeyRec)
 
 static int vga_no_arb = 0;
 void
@@ -180,7 +176,7 @@ xf86VGAarbiterWrapFunctions(void)
         if (!(pScreenPriv = calloc(1, sizeof(VGAarbiterScreenRec))))
             return FALSE;
 
-        dixSetPrivate(&pScreen->devPrivates, VGAarbiterScreenKey, pScreenPriv);
+        dixSetPrivate(&pScreen->devPrivates, &VGAarbiterScreenKeyRec, pScreenPriv);
 
         WRAP_SCREEN(CloseScreen, VGAarbiterCloseScreen);
         WRAP_SCREEN(SaveScreen, VGAarbiterSaveScreen);
@@ -221,7 +217,7 @@ VGAarbiterCloseScreen(ScreenPtr pScreen)
     ScrnInfoPtr pScrn = xf86ScreenToScrn(pScreen);
     VGAarbiterScreenPtr pScreenPriv =
         (VGAarbiterScreenPtr) dixLookupPrivate(&pScreen->devPrivates,
-                                               VGAarbiterScreenKey);
+                                               &VGAarbiterScreenKeyRec);
     miPointerScreenPtr PointPriv =
         (miPointerScreenPtr) dixLookupPrivate(&pScreen->devPrivates,
                                               miPointerScreenKey);
@@ -458,7 +454,7 @@ VGAarbiterAdjustFrame(ScrnInfoPtr pScrn, int x, int y)
     ScreenPtr pScreen = xf86ScrnToScreen(pScrn);
     VGAarbiterScreenPtr pScreenPriv =
         (VGAarbiterScreenPtr) dixLookupPrivate(&pScreen->devPrivates,
-                                               VGAarbiterScreenKey);
+                                               &VGAarbiterScreenKeyRec);
 
     VGAGet(pScreen);
     (*pScreenPriv->AdjustFrame) (pScrn, x, y);
@@ -472,7 +468,7 @@ VGAarbiterSwitchMode(ScrnInfoPtr pScrn, DisplayModePtr mode)
     ScreenPtr pScreen = xf86ScrnToScreen(pScrn);
     VGAarbiterScreenPtr pScreenPriv =
         (VGAarbiterScreenPtr) dixLookupPrivate(&pScreen->devPrivates,
-                                               VGAarbiterScreenKey);
+                                               &VGAarbiterScreenKeyRec);
 
     VGAGet(pScreen);
     val = (*pScreenPriv->SwitchMode) (pScrn, mode);
@@ -487,7 +483,7 @@ VGAarbiterEnterVT(ScrnInfoPtr pScrn)
     ScreenPtr pScreen = xf86ScrnToScreen(pScrn);
     VGAarbiterScreenPtr pScreenPriv =
         (VGAarbiterScreenPtr) dixLookupPrivate(&pScreen->devPrivates,
-                                               VGAarbiterScreenKey);
+                                               &VGAarbiterScreenKeyRec);
 
     VGAGet(pScreen);
     pScrn->EnterVT = pScreenPriv->EnterVT;
@@ -504,7 +500,7 @@ VGAarbiterLeaveVT(ScrnInfoPtr pScrn)
     ScreenPtr pScreen = xf86ScrnToScreen(pScrn);
     VGAarbiterScreenPtr pScreenPriv =
         (VGAarbiterScreenPtr) dixLookupPrivate(&pScreen->devPrivates,
-                                               VGAarbiterScreenKey);
+                                               &VGAarbiterScreenKeyRec);
 
     VGAGet(pScreen);
     pScrn->LeaveVT = pScreenPriv->LeaveVT;
@@ -520,7 +516,7 @@ VGAarbiterFreeScreen(ScrnInfoPtr pScrn)
     ScreenPtr pScreen = xf86ScrnToScreen(pScrn);
     VGAarbiterScreenPtr pScreenPriv =
         (VGAarbiterScreenPtr) dixLookupPrivate(&pScreen->devPrivates,
-                                               VGAarbiterScreenKey);
+                                               &VGAarbiterScreenKeyRec);
 
     VGAGet(pScreen);
     (*pScreenPriv->FreeScreen) (pScrn);
@@ -532,7 +528,7 @@ VGAarbiterCreateGC(GCPtr pGC)
 {
     ScreenPtr pScreen = pGC->pScreen;
     VGAarbiterGCPtr pGCPriv =
-        (VGAarbiterGCPtr) dixLookupPrivate(&pGC->devPrivates, VGAarbiterGCKey);
+        (VGAarbiterGCPtr) dixLookupPrivate(&pGC->devPrivates, &VGAarbiterGCKeyRec);
     Bool ret;
 
     SCREEN_PROLOG(CreateGC);

--- a/hw/xfree86/common/xf86VGAarbiterPriv.h
+++ b/hw/xfree86/common/xf86VGAarbiterPriv.h
@@ -51,7 +51,7 @@
 
 #define UNWRAP_SCREEN(x) pScreen->x = pScreenPriv->x
 
-#define SCREEN_PRIV()   ((VGAarbiterScreenPtr) dixLookupPrivate(&(pScreen)->devPrivates, VGAarbiterScreenKey))
+#define SCREEN_PRIV()   ((VGAarbiterScreenPtr) dixLookupPrivate(&(pScreen)->devPrivates, &VGAarbiterScreenKeyRec))
 
 #define SCREEN_PROLOG(x) (pScreen->x = SCREEN_PRIV()->x)
 
@@ -67,7 +67,7 @@
 
 #define PICTURE_PROLOGUE(field) ps->field = \
     ((VGAarbiterScreenPtr)dixLookupPrivate(&(pScreen)->devPrivates, \
-    VGAarbiterScreenKey))->field
+    &VGAarbiterScreenKeyRec))->field
 
 #define PICTURE_EPILOGUE(field, wrap) ps->field = wrap
 
@@ -82,7 +82,7 @@
     PointPriv = dixLookupPrivate(&pScreen->devPrivates,         \
                                  miPointerScreenKey);           \
     pScreenPriv = dixLookupPrivate(&(pScreen)->devPrivates,     \
-                                   VGAarbiterScreenKey);        \
+                                   &VGAarbiterScreenKeyRec);    \
     PointPriv->spriteFuncs = pScreenPriv->miSprite;             \
 
 #define SPRITE_EPILOG                                   \
@@ -101,7 +101,7 @@
     (x)->funcs = &VGAarbiterGCFuncs;
 
 #define GC_UNWRAP(x) VGAarbiterGCPtr  pGCPriv = \
-    (VGAarbiterGCPtr)dixLookupPrivate(&(x)->devPrivates, VGAarbiterGCKey);\
+    (VGAarbiterGCPtr)dixLookupPrivate(&(x)->devPrivates, &VGAarbiterGCKeyRec);\
     (x)->ops = pGCPriv->wrapOps; (x)->funcs = pGCPriv->wrapFuncs;
 
 static inline void


### PR DESCRIPTION
Use the actual fields directly instead.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
