### PR TITLE
Xorg backports

### DIFF
--- a/hw/xfree86/common/meson.build
+++ b/hw/xfree86/common/meson.build
@@ -71,7 +71,7 @@ endif
 if get_option('pciaccess')
     srcs_xorg_common += ['xf86pciBus.c', 'xf86VGAarbiter.c']
 
-    if host_machine.cpu() == 'sparc' or host_machine.cpu() == 'sparc64'
+    if host_machine.cpu_family() in ['sparc', 'sparc64']
         srcs_xorg_common += 'xf86sbusBus.c'
     endif
 endif

--- a/hw/xfree86/common/xf86AutoConfig.c
+++ b/hw/xfree86/common/xf86AutoConfig.c
@@ -288,7 +288,7 @@ listPossibleVideoDrivers(XF86MatchedDrivers *md)
     }
 #endif
 #ifdef __sparc__
-    char *sbusDriver = sparcDriverName();
+    const char *sbusDriver = sparcDriverName();
 
     if (sbusDriver)
         xf86AddMatchedDriver(md, sbusDriver);

--- a/hw/xfree86/common/xf86sbusBus_priv.h
+++ b/hw/xfree86/common/xf86sbusBus_priv.h
@@ -29,6 +29,6 @@ char *sparcPromGetProperty(sbusPromNodePtr pnode, const char *prop, int *lenp);
 void sparcPromAssignNodes(void);
 char *sparcPromNode2Pathname(sbusPromNodePtr pnode);
 int sparcPromPathname2Node(const char *pathName);
-char *sparcDriverName(void);
+const char *sparcDriverName(void);
 
 #endif /* _XSERVER_XF86_SBUSBUS_H */

--- a/hw/xfree86/os-support/bus/Sbus.c
+++ b/hw/xfree86/os-support/bus/Sbus.c
@@ -237,7 +237,7 @@ sparcPromGetBool(sbusPromNodePtr pnode, const char *prop)
     return promGetBool(prop);
 }
 
-static char *
+static const char *
 promWalkGetDriverName(int node, int oldnode)
 {
     int nextnode;
@@ -267,7 +267,7 @@ promWalkGetDriverName(int node, int oldnode)
 
     nextnode = promGetChild(node);
     if (nextnode) {
-        char *name;
+        const char *name;
 
         name = promWalkGetDriverName(nextnode, node);
         if (name)
@@ -280,10 +280,10 @@ promWalkGetDriverName(int node, int oldnode)
     return NULL;
 }
 
-char *
+const char *
 sparcDriverName(void)
 {
-    char *name;
+    const char *name;
 
     if (sparcPromInit() < 0)
         return NULL;
@@ -393,7 +393,7 @@ sparcPromAssignNodes(void)
         int fbNum, devId;
         static struct {
             int devId;
-            char *prefix;
+            const char *prefix;
         } procFbPrefixes[] = {
             {SBUS_DEVICE_CG14, "CGfourteen"},
             {SBUS_DEVICE_CG6, "CGsix"},

--- a/hw/xfree86/os-support/meson.build
+++ b/hw/xfree86/os-support/meson.build
@@ -16,7 +16,7 @@ os_c_args = []
 
 if get_option('pciaccess')
     srcs_xorg_os_support += 'bus/Pci.c'
-    if host_machine.cpu() == 'sparc' or host_machine.cpu() == 'sparc64'
+    if host_machine.cpu_family() in ['sparc', 'sparc64']
         srcs_xorg_os_support += 'bus/Sbus.c'
         install_data('bus/xf86Sbus.h', install_dir: xorgsdkdir)
     endif
@@ -82,7 +82,7 @@ elif host_machine.system() == 'sunos'
         srcs_xorg_os_support += 'shared/agp_noop.c'
     endif
 
-    if host_machine.cpu_family() == 'sparc'
+    if host_machine.cpu_family() in ['sparc', 'sparc64']
         srcs_xorg_os_support += 'solaris/solaris-sparcv8plus.S'
     elif host_machine.cpu_family() == 'x86_64'
         srcs_xorg_os_support += 'solaris/solaris-amd64.S'


### PR DESCRIPTION
Various SPARC fixes from Xorg.

I didn't backport this commit, because it doesn't look right to me.
I don't think it's a good idea to include headers like this based on cpu arch: https://gitlab.freedesktop.org/xorg/xserver/-/commit/c62cd2feaadaa49c385e277bb97fa7e3b48e3c4f

@metux @callmetango thoughts?