### PR TITLE
Xext: shm: fix missing ScreenClose hook registration

### DIFF
--- a/Xext/shm.c
+++ b/Xext/shm.c
@@ -203,6 +203,7 @@ ShmScreenClose(CallbackListPtr *pcbl, ScreenPtr pScreen, void *unused)
 
     dixSetPrivate(&pScreen->devPrivates, shmScrPrivateKey, NULL);
     free(screen_priv);
+    dixScreenUnhookClose(pScreen, ShmScreenClose);
 }
 
 static ShmScrPrivateRec *
@@ -1401,6 +1402,7 @@ ShmExtensionInit(void)
                 screen_priv->shmFuncs = &miFuncs;
             if (!screen_priv->shmFuncs->CreatePixmap)
                 sharedPixmaps = xFalse;
+            dixScreenHookClose(walkScreen, ShmScreenClose);
         });
         if (sharedPixmaps)
             DIX_FOR_EACH_SCREEN({


### PR DESCRIPTION
ShmScreenClose() needs to be registered as ScreenClose hook into
all screens - otherwise it won't be called and so we're missing
cleanup work.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
