### PR TITLE
Xext: shm: move per-screen private structure into privates area

### DIFF
--- a/Xext/shm.c
+++ b/Xext/shm.c
@@ -199,33 +199,23 @@ CheckForShmSyscall(void)
 static void
 ShmScreenClose(CallbackListPtr *pcbl, ScreenPtr pScreen, void *unused)
 {
-    ShmScrPrivateRec *screen_priv = ShmGetScreenPriv(pScreen);
-
-    dixSetPrivate(&pScreen->devPrivates, shmScrPrivateKey, NULL);
-    free(screen_priv);
     dixScreenUnhookClose(pScreen, ShmScreenClose);
 }
 
-static ShmScrPrivateRec *
-ShmInitScreenPriv(ScreenPtr pScreen)
-{
-    ShmScrPrivateRec *screen_priv = ShmGetScreenPriv(pScreen);
-
-    if (!screen_priv) {
-        screen_priv = calloc(1, sizeof(ShmScrPrivateRec));
-        dixSetPrivate(&pScreen->devPrivates, shmScrPrivateKey, screen_priv);
-        dixScreenHookClose(pScreen, ShmScreenClose);
-    }
-    return screen_priv;
-}
+static Bool privatesRegistered = FALSE;
 
 static Bool
 ShmRegisterPrivates(void)
 {
-    if (!dixRegisterPrivateKey(&shmScrPrivateKeyRec, PRIVATE_SCREEN, 0))
+    if (privatesRegistered)
+        return TRUE;
+
+    if (!dixRegisterPrivateKey(&shmScrPrivateKeyRec, PRIVATE_SCREEN, sizeof(ShmScrPrivateRec)))
         return FALSE;
     if (!dixRegisterPrivateKey(&shmPixmapPrivateKeyRec, PRIVATE_PIXMAP, 0))
         return FALSE;
+
+    privatesRegistered = TRUE;
     return TRUE;
 }
 
@@ -240,11 +230,12 @@ ShmResetProc(ExtensionEntry * extEntry)
 void
 ShmRegisterFuncs(ScreenPtr pScreen, ShmFuncsPtr funcs)
 {
+    /* we could be called before the extension initialized,
+       so make sure the privates are already registered. */
     if (!ShmRegisterPrivates())
         return;
-    ShmInitScreenPriv(pScreen)->shmFuncs = funcs;
+    ShmGetScreenPriv(pScreen)->shmFuncs = funcs;
 }
-
 
 void
 ShmRegisterFbFuncs(ScreenPtr pScreen)
@@ -1394,10 +1385,7 @@ ShmExtensionInit(void)
     {
         sharedPixmaps = xTrue;
         DIX_FOR_EACH_SCREEN({
-            ShmScrPrivateRec *screen_priv =
-                ShmInitScreenPriv(walkScreen);
-            if (!screen_priv)
-                continue;
+            ShmScrPrivateRec *screen_priv = ShmGetScreenPriv(walkScreen);
             if (!screen_priv->shmFuncs)
                 screen_priv->shmFuncs = &miFuncs;
             if (!screen_priv->shmFuncs->CreatePixmap)


### PR DESCRIPTION
Instead of having a pointer to a struct just consisting of a pointer,
just move that struct directly into the privates area, so we not just
save one extra indirection, but also not having to care about an extra
chunk of malloc'ed memory anymore (thus getting rid of a potential
OOM bug)

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
