### PR TITLE
Xi: inline SProcXGetDeviceMotionEvents()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -370,7 +370,7 @@ SProcIDispatch(ClientPtr client)
         case X_GetDeviceDontPropagateList:
             return ProcXGetDeviceDontPropagateList(client);
         case X_GetDeviceMotionEvents:
-            return SProcXGetDeviceMotionEvents(client);
+            return ProcXGetDeviceMotionEvents(client);
         case X_ChangeKeyboardDevice:
             return ProcXChangeKeyboardDevice(client);
         case X_ChangePointerDevice:

--- a/Xi/gtmotion.c
+++ b/Xi/gtmotion.c
@@ -63,22 +63,6 @@ SOFTWARE.
 
 #include "inputstr.h"           /* DeviceIntPtr      */
 
-/***********************************************************************
- *
- * Swap the request if server and client have different byte ordering.
- *
- */
-
-int _X_COLD
-SProcXGetDeviceMotionEvents(ClientPtr client)
-{
-    REQUEST(xGetDeviceMotionEventsReq);
-    REQUEST_SIZE_MATCH(xGetDeviceMotionEventsReq);
-    swapl(&stuff->start);
-    swapl(&stuff->stop);
-    return (ProcXGetDeviceMotionEvents(client));
-}
-
 /****************************************************************************
  *
  * Get the motion history for an extension pointer devices.
@@ -90,6 +74,11 @@ ProcXGetDeviceMotionEvents(ClientPtr client)
 {
     REQUEST(xGetDeviceMotionEventsReq);
     REQUEST_SIZE_MATCH(xGetDeviceMotionEventsReq);
+
+    if (client->swapped) {
+        swapl(&stuff->start);
+        swapl(&stuff->stop);
+    }
 
     DeviceIntPtr dev;
     int rc = dixLookupDevice(&dev, stuff->deviceid, client, DixReadAccess);

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -69,7 +69,6 @@ int ProcXUngrabDeviceButton(ClientPtr client);
 int ProcXUngrabDevice(ClientPtr client);
 int ProcXUngrabDeviceKey(ClientPtr client);
 
-int SProcXGetDeviceMotionEvents(ClientPtr client);
 int SProcXIAllowEvents(ClientPtr client);
 int SProcXIBarrierReleasePointer(ClientPtr client);
 int SProcXIGetClientPointer(ClientPtr client);


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
