### PR TITLE
xkb: inline SProcXkbSetMap()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -2670,12 +2670,21 @@ _XkbSetMap(ClientPtr client, DeviceIntPtr dev, xkbSetMapReq * req, char *values)
 int
 ProcXkbSetMap(ClientPtr client)
 {
+    REQUEST(xkbSetMapReq);
+    REQUEST_AT_LEAST_SIZE(xkbSetMapReq);
+
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swaps(&stuff->present);
+        swaps(&stuff->flags);
+        swaps(&stuff->totalSyms);
+        swaps(&stuff->totalActs);
+        swaps(&stuff->virtualMods);
+    }
+
     DeviceIntPtr dev, master;
     char *tmp;
     int rc;
-
-    REQUEST(xkbSetMapReq);
-    REQUEST_AT_LEAST_SIZE(xkbSetMapReq);
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -119,20 +119,6 @@ SProcXkbSelectEvents(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbSetMap(ClientPtr client)
-{
-    REQUEST(xkbSetMapReq);
-    REQUEST_AT_LEAST_SIZE(xkbSetMapReq);
-    swaps(&stuff->deviceSpec);
-    swaps(&stuff->present);
-    swaps(&stuff->flags);
-    swaps(&stuff->totalSyms);
-    swaps(&stuff->totalActs);
-    swaps(&stuff->virtualMods);
-    return ProcXkbSetMap(client);
-}
-
-static int _X_COLD
 SProcXkbSetCompatMap(ClientPtr client)
 {
     REQUEST(xkbSetCompatMapReq);
@@ -207,7 +193,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbGetMap:
         return ProcXkbGetMap(client);
     case X_kbSetMap:
-        return SProcXkbSetMap(client);
+        return ProcXkbSetMap(client);
     case X_kbGetCompatMap:
         return ProcXkbGetCompatMap(client);
     case X_kbSetCompatMap:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
