### PR TITLE
dix: replace XACE_SCREENSAVER_ACCESS by direct callback

### DIFF
--- a/Xext/saver.c
+++ b/Xext/saver.c
@@ -624,7 +624,7 @@ ProcScreenSaverQueryInfo(ClientPtr client)
                            DixGetAttrAccess);
     if (rc != Success)
         return rc;
-    rc = XaceHookScreensaverAccess(client, pDraw->pScreen, DixGetAttrAccess);
+    rc = dixCallScreensaverAccessCallback(client, pDraw->pScreen, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 
@@ -689,7 +689,7 @@ ProcScreenSaverSelectInput(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    rc = XaceHookScreensaverAccess(client, pDraw->pScreen, DixSetAttrAccess);
+    rc = dixCallScreensaverAccessCallback(client, pDraw->pScreen, DixSetAttrAccess);
     if (rc != Success)
         return rc;
 
@@ -730,7 +730,7 @@ ScreenSaverSetAttributes(ClientPtr client, xScreenSaverSetAttributesReq *stuff)
     pScreen = pDraw->pScreen;
     pParent = pScreen->root;
 
-    ret = XaceHookScreensaverAccess(client, pScreen, DixSetAttrAccess);
+    ret = dixCallScreensaverAccessCallback(client, pScreen, DixSetAttrAccess);
     if (ret != Success)
         return ret;
 

--- a/Xext/xace.c
+++ b/Xext/xace.c
@@ -83,13 +83,6 @@ int XaceHookScreenAccess(ClientPtr client, ScreenPtr screen, Mask access_mode)
     return rec.status;
 }
 
-int XaceHookScreensaverAccess(ClientPtr client, ScreenPtr screen, Mask access_mode)
-{
-    XaceScreenAccessRec rec = { client, screen, access_mode, Success };
-    CallCallbacks(&XaceHooks[XACE_SCREENSAVER_ACCESS], &rec);
-    return rec.status;
-}
-
 /* XaceHookIsSet
  *
  * Utility function to determine whether there are any callbacks listening on a

--- a/Xext/xace.h
+++ b/Xext/xace.h
@@ -44,7 +44,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define XACE_RECEIVE_ACCESS		6
 #define XACE_SELECTION_ACCESS		10
 #define XACE_SCREEN_ACCESS		11
-#define XACE_SCREENSAVER_ACCESS		12
 #define XACE_NUM_HOOKS			13
 
 extern CallbackListPtr XaceHooks[XACE_NUM_HOOKS];
@@ -72,7 +71,6 @@ int XaceHookSendAccess(ClientPtr client, DeviceIntPtr dev, WindowPtr win,
                        xEventPtr ev, int count);
 int XaceHookReceiveAccess(ClientPtr client, WindowPtr win, xEventPtr ev, int count);
 int XaceHookScreenAccess(ClientPtr client, ScreenPtr screen, Mask access_mode);
-int XaceHookScreensaverAccess(ClientPtr client, ScreenPtr screen, Mask access_mode);
 
 /* Register / unregister a callback for a given hook. */
 

--- a/Xext/xacestr.h
+++ b/Xext/xacestr.h
@@ -79,7 +79,6 @@ typedef struct {
 } XaceSelectionAccessRec;
 
 /* XACE_SCREEN_ACCESS */
-/* XACE_SCREENSAVER_ACCESS */
 typedef struct {
     ClientPtr client;
     ScreenPtr screen;

--- a/Xext/xselinux_hooks.c
+++ b/Xext/xselinux_hooks.c
@@ -40,6 +40,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "dix/registry_priv.h"
 #include "dix/resource_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/screensaver_priv.h"
 #include "dix/selection_priv.h"
 #include "dix/server_priv.h"
 #include "os/client_priv.h"
@@ -837,6 +838,7 @@ SELinuxFlaskReset(void)
     DeleteCallback(&ServerAccessCallback, SELinuxServer, NULL);
     DeleteCallback(&ClientAccessCallback, SELinuxClient, NULL);
     DeleteCallback(&DeviceAccessCallback, SELinuxDevice, NULL);
+    DeleteCallback(&ScreenSaverAccessCallback, SELinuxScreen, truep);
 
     XaceDeleteCallback(XACE_RESOURCE_ACCESS, SELinuxResource, NULL);
     XaceDeleteCallback(XACE_PROPERTY_ACCESS, SELinuxProperty, NULL);
@@ -844,7 +846,6 @@ SELinuxFlaskReset(void)
     XaceDeleteCallback(XACE_RECEIVE_ACCESS, SELinuxReceive, NULL);
     XaceDeleteCallback(XACE_SELECTION_ACCESS, SELinuxSelection, NULL);
     XaceDeleteCallback(XACE_SCREEN_ACCESS, SELinuxScreen, NULL);
-    XaceDeleteCallback(XACE_SCREENSAVER_ACCESS, SELinuxScreen, truep);
 
     /* Tear down SELinux stuff */
     audit_close(audit_fd);
@@ -931,6 +932,7 @@ SELinuxFlaskInit(void)
     ret &= AddCallback(&ServerAccessCallback, SELinuxServer, NULL);
     ret &= AddCallback(&ClientAccessCallback, SELinuxClient, NULL);
     ret &= AddCallback(&DeviceAccessCallback, SELinuxDevice, NULL);
+    ret &= AddCallback(&ScreenSaverAccessCallback, SELinuxScreen, truep);
 
     ret &= XaceRegisterCallback(XACE_RESOURCE_ACCESS, SELinuxResource, NULL);
     ret &= XaceRegisterCallback(XACE_PROPERTY_ACCESS, SELinuxProperty, NULL);
@@ -938,7 +940,6 @@ SELinuxFlaskInit(void)
     ret &= XaceRegisterCallback(XACE_RECEIVE_ACCESS, SELinuxReceive, NULL);
     ret &= XaceRegisterCallback(XACE_SELECTION_ACCESS, SELinuxSelection, NULL);
     ret &= XaceRegisterCallback(XACE_SCREEN_ACCESS, SELinuxScreen, NULL);
-    ret &= XaceRegisterCallback(XACE_SCREENSAVER_ACCESS, SELinuxScreen, truep);
     if (!ret)
         FatalError("SELinux: Failed to register one or more callbacks\n");
 

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -3267,7 +3267,7 @@ ProcSetScreenSaver(ClientPtr client)
     REQUEST_SIZE_MATCH(xSetScreenSaverReq);
 
     DIX_FOR_EACH_SCREEN({
-        int rc = XaceHookScreensaverAccess(client, walkScreen, DixSetAttrAccess);
+        int rc = dixCallScreensaverAccessCallback(client, walkScreen, DixSetAttrAccess);
         if (rc != Success)
             return rc;
     });
@@ -3323,7 +3323,7 @@ ProcGetScreenSaver(ClientPtr client)
     REQUEST_SIZE_MATCH(xReq);
 
     DIX_FOR_EACH_SCREEN({
-        int rc = XaceHookScreensaverAccess(client, walkScreen, DixGetAttrAccess);
+        int rc = dixCallScreensaverAccessCallback(client, walkScreen, DixGetAttrAccess);
         if (rc != Success)
             return rc;
     });

--- a/dix/screen.c
+++ b/dix/screen.c
@@ -7,8 +7,11 @@
 #include "dix/callback_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/gc_priv.h"
+#include "dix/screensaver_priv.h"
 #include "include/screenint.h"
 #include "include/scrnintstr.h"
+
+CallbackListPtr ScreenSaverAccessCallback = NULL;
 
 void dixFreeScreen(ScreenPtr pScreen)
 {

--- a/dix/screensaver_priv.h
+++ b/dix/screensaver_priv.h
@@ -8,10 +8,32 @@
 #include <X11/Xdefs.h>
 #include <X11/Xmd.h>
 
+#include "include/callback.h"
+#include "include/dix.h"
+#include "include/screenint.h"
+
 extern CARD32 defaultScreenSaverTime;
 extern CARD32 defaultScreenSaverInterval;
 extern CARD32 ScreenSaverTime;
 extern CARD32 ScreenSaverInterval;
 extern Bool screenSaverSuspended;
+
+extern CallbackListPtr ScreenSaverAccessCallback;
+
+typedef struct {
+    ClientPtr client;
+    ScreenPtr screen;
+    Mask access_mode;
+    int status;
+} ScreenSaverAccessCallbackParam;
+
+static inline int dixCallScreensaverAccessCallback(ClientPtr client,
+                                                   ScreenPtr screen,
+                                                   Mask access_mode)
+{
+    ScreenSaverAccessCallbackParam rec = { client, screen, access_mode, Success };
+    CallCallbacks(&ScreenSaverAccessCallback, &rec);
+    return rec.status;
+}
 
 #endif /* _XSERVER_DIX_SCREENSAVER_PRIV_H */

--- a/dix/window.c
+++ b/dix/window.c
@@ -109,6 +109,7 @@ Equipment Corporation.
 #include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/screensaver_priv.h"
 #include "dix/selection_priv.h"
 #include "dix/screenint_priv.h"
 #include "dix/window_priv.h"
@@ -3089,7 +3090,7 @@ dixSaveScreens(ClientPtr client, int on, int mode)
     }
 
     DIX_FOR_EACH_SCREEN({
-        int rc = XaceHookScreensaverAccess(client, walkScreen,
+        int rc = dixCallScreensaverAccessCallback(client, walkScreen,
                       DixShowAccess | DixHideAccess);
         if (rc != Success)
             return rc;


### PR DESCRIPTION
Replace complicated xace hook by simple and cheap callback.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
