### PR TITLE
Xext: shm: shmint.h: drop superflous `extern` on function prototypes

### DIFF
--- a/Xext/shmint.h
+++ b/Xext/shmint.h
@@ -80,11 +80,8 @@ typedef struct _ShmDesc {
 #define SHMDESC_IS_FD(shmdesc)  (0)
 #endif
 
-extern _X_EXPORT void
- ShmRegisterFuncs(ScreenPtr pScreen, ShmFuncsPtr funcs);
-
-extern _X_EXPORT void
- ShmRegisterFbFuncs(ScreenPtr pScreen);
+_X_EXPORT void ShmRegisterFuncs(ScreenPtr pScreen, ShmFuncsPtr funcs);
+_X_EXPORT void ShmRegisterFbFuncs(ScreenPtr pScreen);
 
 extern _X_EXPORT RESTYPE ShmSegType;
 extern _X_EXPORT int ShmCompletionCode;


### PR DESCRIPTION
Functions are already `extern` by default.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
