### PR TITLE
Xext: shm: unexport ShmSegType variable

### DIFF
--- a/Xext/shm.c
+++ b/Xext/shm.c
@@ -55,6 +55,7 @@ in this Software without prior written authorization from The Open Group.
 #include "os/osdep.h"
 #include "Xext/panoramiX.h"
 #include "Xext/panoramiXsrv.h"
+#include "Xext/shm_priv.h"
 
 #include "misc.h"
 #include "os.h"

--- a/Xext/shm_priv.h
+++ b/Xext/shm_priv.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+
+#ifndef _XSERVER_XEXT_SHM_PRIV_H
+#define _XSERVER_XEXT_SHM_PRIV_H
+
+#include "include/resource.h"
+#include "Xext/shmint.h"
+
+extern RESTYPE ShmSegType;
+
+#endif /* _XSERVER_XEXT_SHM_PRIV_H */

--- a/Xext/shmint.h
+++ b/Xext/shmint.h
@@ -86,7 +86,6 @@ extern _X_EXPORT void
 extern _X_EXPORT void
  ShmRegisterFbFuncs(ScreenPtr pScreen);
 
-extern _X_EXPORT RESTYPE ShmSegType;
 extern _X_EXPORT int ShmCompletionCode;
 extern _X_EXPORT int BadShmSegCode;
 

--- a/Xext/xvdisp.c
+++ b/Xext/xvdisp.c
@@ -34,9 +34,10 @@ SOFTWARE.
 #include "dix/rpcbuf_priv.h"
 #include "dix/request_priv.h"
 #include "dix/screenint_priv.h"
-#include "Xext/xvdix_priv.h"
 #include "Xext/panoramiX.h"
 #include "Xext/panoramiXsrv.h"
+#include "Xext/shm_priv.h"
+#include "Xext/xvdix_priv.h"
 
 #include "misc.h"
 #include "scrnintstr.h"


### PR DESCRIPTION
Not used by any drivers, so no need to keep it exported.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
