### PR TITLE
Xi: inline SProcXUngrabDeviceButton()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -386,7 +386,7 @@ SProcIDispatch(ClientPtr client)
         case X_GrabDeviceButton:
             return ProcXGrabDeviceButton(client);
         case X_UngrabDeviceButton:
-            return SProcXUngrabDeviceButton(client);
+            return ProcXUngrabDeviceButton(client);
         case X_AllowDeviceEvents:
             return ProcXAllowDeviceEvents(client);
         case X_GetDeviceFocus:

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -80,7 +80,6 @@ int SProcXIQueryVersion(ClientPtr client);
 int SProcXISelectEvents(ClientPtr client);
 int SProcXISetClientPointer(ClientPtr client);
 int SProcXIWarpPointer(ClientPtr client);
-int SProcXUngrabDeviceButton(ClientPtr client);
 int SProcXUngrabDeviceKey(ClientPtr client);
 
 #endif /* _XSERVER_XI_HANDLERS_H */

--- a/Xi/ungrdevb.c
+++ b/Xi/ungrdevb.c
@@ -69,22 +69,6 @@ SOFTWARE.
 
 /***********************************************************************
  *
- * Handle requests from a client with a different byte order.
- *
- */
-
-int _X_COLD
-SProcXUngrabDeviceButton(ClientPtr client)
-{
-    REQUEST(xUngrabDeviceButtonReq);
-    REQUEST_SIZE_MATCH(xUngrabDeviceButtonReq);
-    swapl(&stuff->grabWindow);
-    swaps(&stuff->modifiers);
-    return (ProcXUngrabDeviceButton(client));
-}
-
-/***********************************************************************
- *
  * Release a grab of a button on an extension device.
  *
  */
@@ -92,14 +76,19 @@ SProcXUngrabDeviceButton(ClientPtr client)
 int
 ProcXUngrabDeviceButton(ClientPtr client)
 {
+    REQUEST(xUngrabDeviceButtonReq);
+    REQUEST_SIZE_MATCH(xUngrabDeviceButtonReq);
+
+    if (client->swapped) {
+        swapl(&stuff->grabWindow);
+        swaps(&stuff->modifiers);
+    }
+
     DeviceIntPtr dev;
     DeviceIntPtr mdev;
     WindowPtr pWin;
     GrabPtr temporaryGrab;
     int rc;
-
-    REQUEST(xUngrabDeviceButtonReq);
-    REQUEST_SIZE_MATCH(xUngrabDeviceButtonReq);
 
     rc = dixLookupDevice(&dev, stuff->grabbed_device, client, DixGrabAccess);
     if (rc != Success)


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
