### PR TITLE
Xi: inline SProcXIAllowEvents()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -458,7 +458,7 @@ SProcIDispatch(ClientPtr client)
         case X_XIUngrabDevice:
             return ProcXIUngrabDevice(client);
         case X_XIAllowEvents:
-            return SProcXIAllowEvents(client);
+            return ProcXIAllowEvents(client);
         case X_XIPassiveGrabDevice:
             return SProcXIPassiveGrabDevice(client);
         case X_XIPassiveUngrabDevice:

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -69,7 +69,6 @@ int ProcXUngrabDeviceButton(ClientPtr client);
 int ProcXUngrabDevice(ClientPtr client);
 int ProcXUngrabDeviceKey(ClientPtr client);
 
-int SProcXIAllowEvents(ClientPtr client);
 int SProcXIBarrierReleasePointer(ClientPtr client);
 int SProcXIGetClientPointer(ClientPtr client);
 int SProcXIGetSelectedEvents(ClientPtr client);

--- a/Xi/xiallowev.c
+++ b/Xi/xiallowev.c
@@ -46,28 +46,23 @@
 #include "eventstr.h"
 #include "exglobals.h"          /* BadDevice */
 
-int _X_COLD
-SProcXIAllowEvents(ClientPtr client)
-{
-    REQUEST(xXIAllowEventsReq);
-    REQUEST_AT_LEAST_SIZE(xXIAllowEventsReq);
-
-    swaps(&stuff->deviceid);
-    swapl(&stuff->time);
-    if (client->req_len > 3) {
-        xXI2_2AllowEventsReq *req_xi22 = (xXI2_2AllowEventsReq *) stuff;
-
-        REQUEST_AT_LEAST_SIZE(xXI2_2AllowEventsReq);
-        swapl(&req_xi22->touchid);
-        swapl(&req_xi22->grab_window);
-    }
-
-    return ProcXIAllowEvents(client);
-}
-
 int
 ProcXIAllowEvents(ClientPtr client)
 {
+    if (client->swapped) {
+        REQUEST(xXIAllowEventsReq);
+        REQUEST_AT_LEAST_SIZE(xXIAllowEventsReq);
+        swaps(&stuff->deviceid);
+        swapl(&stuff->time);
+        if (client->req_len > 3) {
+            xXI2_2AllowEventsReq *req_xi22 = (xXI2_2AllowEventsReq *) stuff;
+
+            REQUEST_AT_LEAST_SIZE(xXI2_2AllowEventsReq);
+            swapl(&req_xi22->touchid);
+            swapl(&req_xi22->grab_window);
+        }
+    }
+
     Bool have_xi22 = FALSE;
     CARD32 clientTime;
     int deviceId;


### PR DESCRIPTION
No need to have a hole bunch of extra functions, if we can just easily
inline the few relevant lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
