### PR TITLE
xkb: inline SProcXkbGetGeometry()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -4843,13 +4843,18 @@ XkbAssembleGeometry(ClientPtr client,
 int
 ProcXkbGetGeometry(ClientPtr client)
 {
+    REQUEST(xkbGetGeometryReq);
+    REQUEST_SIZE_MATCH(xkbGetGeometryReq);
+
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swapl(&stuff->name);
+    }
+
     DeviceIntPtr dev;
     XkbGeometryPtr geom;
     Bool shouldFree;
     Status status;
-
-    REQUEST(xkbGetGeometryReq);
-    REQUEST_SIZE_MATCH(xkbGetGeometryReq);
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -140,16 +140,6 @@ SProcXkbSetIndicatorMap(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbGetGeometry(ClientPtr client)
-{
-    REQUEST(xkbGetGeometryReq);
-    REQUEST_SIZE_MATCH(xkbGetGeometryReq);
-    swaps(&stuff->deviceSpec);
-    swapl(&stuff->name);
-    return ProcXkbGetGeometry(client);
-}
-
-static int _X_COLD
 SProcXkbGetKbdByName(ClientPtr client)
 {
     REQUEST(xkbGetKbdByNameReq);
@@ -213,7 +203,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbSetNames:
         return ProcXkbSetNames(client);
     case X_kbGetGeometry:
-        return SProcXkbGetGeometry(client);
+        return ProcXkbGetGeometry(client);
     case X_kbSetGeometry:
         return ProcXkbSetGeometry(client);
     case X_kbPerClientFlags:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
