### PR TITLE
xkb: inline SProcXkbSetDeviceInfo()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -6748,11 +6748,17 @@ _XkbSetDeviceInfo(ClientPtr client, DeviceIntPtr dev,
 int
 ProcXkbSetDeviceInfo(ClientPtr client)
 {
-    DeviceIntPtr dev;
-    int rc;
-
     REQUEST(xkbSetDeviceInfoReq);
     REQUEST_AT_LEAST_SIZE(xkbSetDeviceInfoReq);
+
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swaps(&stuff->change);
+        swaps(&stuff->nDeviceLedFBs);
+    }
+
+    DeviceIntPtr dev;
+    int rc;
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -160,17 +160,6 @@ SProcXkbGetKbdByName(ClientPtr client)
     return ProcXkbGetKbdByName(client);
 }
 
-static int _X_COLD
-SProcXkbSetDeviceInfo(ClientPtr client)
-{
-    REQUEST(xkbSetDeviceInfoReq);
-    REQUEST_AT_LEAST_SIZE(xkbSetDeviceInfoReq);
-    swaps(&stuff->deviceSpec);
-    swaps(&stuff->change);
-    swaps(&stuff->nDeviceLedFBs);
-    return ProcXkbSetDeviceInfo(client);
-}
-
 int _X_COLD
 SProcXkbDispatch(ClientPtr client)
 {
@@ -225,7 +214,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbGetDeviceInfo:
         return ProcXkbGetDeviceInfo(client);
     case X_kbSetDeviceInfo:
-        return SProcXkbSetDeviceInfo(client);
+        return ProcXkbSetDeviceInfo(client);
     case X_kbSetDebuggingFlags:
         return ProcXkbSetDebuggingFlags(client);
     default:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
