### PR TITLE
Xext: shm: drop obsolete ShmScreenClose()

### DIFF
--- a/Xext/shm.c
+++ b/Xext/shm.c
@@ -197,12 +197,6 @@ CheckForShmSyscall(void)
 
 #endif
 
-static void
-ShmScreenClose(CallbackListPtr *pcbl, ScreenPtr pScreen, void *unused)
-{
-    dixScreenUnhookClose(pScreen, ShmScreenClose);
-}
-
 static Bool privatesRegistered = FALSE;
 
 static Bool
@@ -1391,7 +1385,6 @@ ShmExtensionInit(void)
                 screen_priv->shmFuncs = &miFuncs;
             if (!screen_priv->shmFuncs->CreatePixmap)
                 sharedPixmaps = xFalse;
-            dixScreenHookClose(walkScreen, ShmScreenClose);
         });
         if (sharedPixmaps)
             DIX_FOR_EACH_SCREEN({


### PR DESCRIPTION
Since it's now doing nothing more than unhooking itself, we really
don't need it anymore.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
