### PR TITLE
xkb: inline SProcXkbSetIndicatorMap()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -3273,14 +3273,19 @@ _XkbSetIndicatorMap(ClientPtr client, DeviceIntPtr dev,
 int
 ProcXkbSetIndicatorMap(ClientPtr client)
 {
+    REQUEST(xkbSetIndicatorMapReq);
+    REQUEST_AT_LEAST_SIZE(xkbSetIndicatorMapReq);
+
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swapl(&stuff->which);
+    }
+
     int i, bit;
     int nIndicators;
     DeviceIntPtr dev;
     xkbIndicatorMapWireDesc *from;
     int rc;
-
-    REQUEST(xkbSetIndicatorMapReq);
-    REQUEST_AT_LEAST_SIZE(xkbSetIndicatorMapReq);
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -130,16 +130,6 @@ SProcXkbSetCompatMap(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbSetIndicatorMap(ClientPtr client)
-{
-    REQUEST(xkbSetIndicatorMapReq);
-    REQUEST_AT_LEAST_SIZE(xkbSetIndicatorMapReq);
-    swaps(&stuff->deviceSpec);
-    swapl(&stuff->which);
-    return ProcXkbSetIndicatorMap(client);
-}
-
-static int _X_COLD
 SProcXkbGetKbdByName(ClientPtr client)
 {
     REQUEST(xkbGetKbdByNameReq);
@@ -182,7 +172,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbGetIndicatorMap:
         return ProcXkbGetIndicatorMap(client);
     case X_kbSetIndicatorMap:
-        return SProcXkbSetIndicatorMap(client);
+        return ProcXkbSetIndicatorMap(client);
     case X_kbGetNamedIndicator:
         return ProcXkbGetNamedIndicator(client);
     case X_kbSetNamedIndicator:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
