### PR TITLE
Xi: inline SProcXIPassiveGrabDevice() and SProcXIPassiveUngrabDevice()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -460,9 +460,9 @@ SProcIDispatch(ClientPtr client)
         case X_XIAllowEvents:
             return ProcXIAllowEvents(client);
         case X_XIPassiveGrabDevice:
-            return SProcXIPassiveGrabDevice(client);
+            return ProcXIPassiveGrabDevice(client);
         case X_XIPassiveUngrabDevice:
-            return SProcXIPassiveUngrabDevice(client);
+            return ProcXIPassiveUngrabDevice(client);
         case X_XIListProperties:
             return ProcXIListProperties(client);
         case X_XIChangeProperty:

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -72,8 +72,6 @@ int ProcXUngrabDeviceKey(ClientPtr client);
 int SProcXIBarrierReleasePointer(ClientPtr client);
 int SProcXIGetClientPointer(ClientPtr client);
 int SProcXIGetSelectedEvents(ClientPtr client);
-int SProcXIPassiveGrabDevice(ClientPtr client);
-int SProcXIPassiveUngrabDevice(ClientPtr client);
 int SProcXIQueryPointer(ClientPtr client);
 int SProcXIQueryVersion(ClientPtr client);
 int SProcXISelectEvents(ClientPtr client);

--- a/test/xi2/protocol-xigetselectedevents.c
+++ b/test/xi2/protocol-xigetselectedevents.c
@@ -145,7 +145,7 @@ request_XIGetSelectedEvents(xXIGetSelectedEventsReq * req, int error)
        The handler proc's don't use that field anymore, thus also SProc's
        wont swap it. But this test program uses that field to initialize
        client->req_len (see above). We previously had to swap it here, so
-       that SProcXIPassiveGrabDevice() will swap it back. Since that's gone
+       that ProcXIPassiveGrabDevice() will swap it back. Since that's gone
        now, still swapping itself would break if this function is called
        again and writing back a errornously swapped value
     */

--- a/test/xi2/protocol-xipassivegrabdevice.c
+++ b/test/xi2/protocol-xipassivegrabdevice.c
@@ -151,7 +151,7 @@ request_XIPassiveGrabDevice(ClientPtr client, xXIPassiveGrabDeviceReq * req,
        The handler proc's don't use that field anymore, thus also SProc's
        wont swap it. But this test program uses that field to initialize
        client->req_len (see above). We previously had to swap it here, so
-       that SProcXIPassiveGrabDevice() will swap it back. Since that's gone
+       that ProcXIPassiveGrabDevice() will swap it back. Since that's gone
        now, still swapping itself would break if this function is called
        again and writing back a errornously swapped value
     */
@@ -172,7 +172,7 @@ request_XIPassiveGrabDevice(ClientPtr client, xXIPassiveGrabDeviceReq * req,
         swapl(mod);
     }
 
-    rc = SProcXIPassiveGrabDevice(&client_request);
+    rc = ProcXIPassiveGrabDevice(&client_request);
     assert(rc == error);
 
     if (rc != Success)

--- a/test/xi2/protocol-xiselectevents.c
+++ b/test/xi2/protocol-xiselectevents.c
@@ -114,7 +114,7 @@ request_XISelectEvent(xXISelectEventsReq * req, int error)
        The handler proc's don't use that field anymore, thus also SProc's
        wont swap it. But this test program uses that field to initialize
        client->req_len (see above). We previously had to swap it here, so
-       that SProcXIPassiveGrabDevice() will swap it back. Since that's gone
+       that ProcXIPassiveGrabDevice() will swap it back. Since that's gone
        now, still swapping itself would break if this function is called
        again and writing back a errornously swapped value
     */

--- a/test/xi2/protocol-xisetclientpointer.c
+++ b/test/xi2/protocol-xisetclientpointer.c
@@ -74,7 +74,7 @@ request_XISetClientPointer(xXISetClientPointerReq * req, int error)
        The handler proc's don't use that field anymore, thus also SProc's
        wont swap it. But this test program uses that field to initialize
        client->req_len (see above). We previously had to swap it here, so
-       that SProcXIPassiveGrabDevice() will swap it back. Since that's gone
+       that ProcXIPassiveGrabDevice() will swap it back. Since that's gone
        now, still swapping itself would break if this function is called
        again and writing back a errornously swapped value
     */


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
