### PR TITLE
dix: inline SProcAllocColor()

### DIFF
--- a/Xext/panoramiXprocs.c
+++ b/Xext/panoramiXprocs.c
@@ -2498,8 +2498,14 @@ PanoramiXAllocColor(ClientPtr client)
     PanoramiXRes *cmap;
 
     REQUEST(xAllocColorReq);
-
     REQUEST_SIZE_MATCH(xAllocColorReq);
+
+    if (client->swapped) {
+        swapl(&stuff->cmap);
+        swaps(&stuff->red);
+        swaps(&stuff->green);
+        swaps(&stuff->blue);
+    }
 
     client->errorValue = stuff->cmap;
 

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -2709,6 +2709,13 @@ ProcAllocColor(ClientPtr client)
     REQUEST(xAllocColorReq);
     REQUEST_SIZE_MATCH(xAllocColorReq);
 
+    if (client->swapped) {
+        swapl(&stuff->cmap);
+        swaps(&stuff->red);
+        swaps(&stuff->green);
+        swaps(&stuff->blue);
+    }
+
     xAllocColorReply rep = {
         .red = stuff->red,
         .green = stuff->green,

--- a/dix/swapreq.c
+++ b/dix/swapreq.c
@@ -585,18 +585,6 @@ SProcCopyColormapAndFree(ClientPtr client)
 }
 
 int _X_COLD
-SProcAllocColor(ClientPtr client)
-{
-    REQUEST(xAllocColorReq);
-    REQUEST_SIZE_MATCH(xAllocColorReq);
-    swapl(&stuff->cmap);
-    swaps(&stuff->red);
-    swaps(&stuff->green);
-    swaps(&stuff->blue);
-    return ((*ProcVector[X_AllocColor]) (client));
-}
-
-int _X_COLD
 SProcAllocNamedColor(ClientPtr client)
 {
     REQUEST(xAllocNamedColorReq);

--- a/dix/swapreq.h
+++ b/dix/swapreq.h
@@ -30,7 +30,6 @@ extern void SwapColorItem(xColorItem * /* pItem */ );
 
 extern void SwapConnClientPrefix(xConnClientPrefix * /* pCCP */ );
 
-int SProcAllocColor(ClientPtr client);
 int SProcAllocColorCells(ClientPtr client);
 int SProcAllocColorPlanes(ClientPtr client);
 int SProcAllocNamedColor(ClientPtr client);

--- a/dix/tables.c
+++ b/dix/tables.c
@@ -416,7 +416,7 @@ int (*SwappedProcVector[256]) (ClientPtr /* client */) = {
     ProcInstallColormap,
     ProcUninstallColormap,
     ProcListInstalledColormaps,
-    SProcAllocColor,
+    ProcAllocColor,
     SProcAllocNamedColor,               /* 85 */
     SProcAllocColorCells,
     SProcAllocColorPlanes,


### PR DESCRIPTION
Now that we have untwisted Xinerama side, it's trivial to inline
the few lines for byte-swapping into the actual handlers.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
