### PR TITLE
dix: replace XACE_SCREEN_ACCESS by direct callback

### DIFF
--- a/Xext/xace.c
+++ b/Xext/xace.c
@@ -76,13 +76,6 @@ int XaceHookReceiveAccess(ClientPtr client, WindowPtr win,
     return rec.status;
 }
 
-int XaceHookScreenAccess(ClientPtr client, ScreenPtr screen, Mask access_mode)
-{
-    XaceScreenAccessRec rec = { client, screen, access_mode, Success };
-    CallCallbacks(&XaceHooks[XACE_SCREEN_ACCESS], &rec);
-    return rec.status;
-}
-
 /* XaceHookIsSet
  *
  * Utility function to determine whether there are any callbacks listening on a

--- a/Xext/xace.h
+++ b/Xext/xace.h
@@ -43,7 +43,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define XACE_SEND_ACCESS		5
 #define XACE_RECEIVE_ACCESS		6
 #define XACE_SELECTION_ACCESS		10
-#define XACE_SCREEN_ACCESS		11
 #define XACE_NUM_HOOKS			13
 
 extern CallbackListPtr XaceHooks[XACE_NUM_HOOKS];
@@ -70,7 +69,6 @@ _X_EXPORT int XaceHookResourceAccess(ClientPtr client, XID id, RESTYPE rtype, vo
 int XaceHookSendAccess(ClientPtr client, DeviceIntPtr dev, WindowPtr win,
                        xEventPtr ev, int count);
 int XaceHookReceiveAccess(ClientPtr client, WindowPtr win, xEventPtr ev, int count);
-int XaceHookScreenAccess(ClientPtr client, ScreenPtr screen, Mask access_mode);
 
 /* Register / unregister a callback for a given hook. */
 

--- a/Xext/xacestr.h
+++ b/Xext/xacestr.h
@@ -78,12 +78,4 @@ typedef struct {
     int status;
 } XaceSelectionAccessRec;
 
-/* XACE_SCREEN_ACCESS */
-typedef struct {
-    ClientPtr client;
-    ScreenPtr screen;
-    Mask access_mode;
-    int status;
-} XaceScreenAccessRec;
-
 #endif                          /* _XACESTR_H */

--- a/Xext/xselinux_hooks.c
+++ b/Xext/xselinux_hooks.c
@@ -175,7 +175,7 @@ SELinuxLabelClient(ClientPtr client)
 static void
 SELinuxLabelInitial(void)
 {
-    XaceScreenAccessRec srec;
+    ScreenAccessCallbackParam srec;
     SELinuxSubjectRec *subj;
     SELinuxObjectRec *obj;
     char *ctx;
@@ -684,7 +684,7 @@ SELinuxResource(CallbackListPtr *pcbl, void *unused, void *calldata)
 static void
 SELinuxScreen(CallbackListPtr *pcbl, void *is_saver, void *calldata)
 {
-    XaceScreenAccessRec *rec = calldata;
+    ScreenAccessCallbackParam *rec = calldata;
     SELinuxSubjectRec *subj;
     SELinuxObjectRec *obj;
     SELinuxAuditRec auditdata = {.client = rec->client };
@@ -839,13 +839,13 @@ SELinuxFlaskReset(void)
     DeleteCallback(&ClientAccessCallback, SELinuxClient, NULL);
     DeleteCallback(&DeviceAccessCallback, SELinuxDevice, NULL);
     DeleteCallback(&ScreenSaverAccessCallback, SELinuxScreen, truep);
+    DeleteCallback(&ScreenAccessCallback, SELinuxScreen, NULL);
 
     XaceDeleteCallback(XACE_RESOURCE_ACCESS, SELinuxResource, NULL);
     XaceDeleteCallback(XACE_PROPERTY_ACCESS, SELinuxProperty, NULL);
     XaceDeleteCallback(XACE_SEND_ACCESS, SELinuxSend, NULL);
     XaceDeleteCallback(XACE_RECEIVE_ACCESS, SELinuxReceive, NULL);
     XaceDeleteCallback(XACE_SELECTION_ACCESS, SELinuxSelection, NULL);
-    XaceDeleteCallback(XACE_SCREEN_ACCESS, SELinuxScreen, NULL);
 
     /* Tear down SELinux stuff */
     audit_close(audit_fd);
@@ -933,13 +933,13 @@ SELinuxFlaskInit(void)
     ret &= AddCallback(&ClientAccessCallback, SELinuxClient, NULL);
     ret &= AddCallback(&DeviceAccessCallback, SELinuxDevice, NULL);
     ret &= AddCallback(&ScreenSaverAccessCallback, SELinuxScreen, truep);
+    ret &= AddCallback(&ScreenAccessCallback, SELinuxScreen, NULL);
 
     ret &= XaceRegisterCallback(XACE_RESOURCE_ACCESS, SELinuxResource, NULL);
     ret &= XaceRegisterCallback(XACE_PROPERTY_ACCESS, SELinuxProperty, NULL);
     ret &= XaceRegisterCallback(XACE_SEND_ACCESS, SELinuxSend, NULL);
     ret &= XaceRegisterCallback(XACE_RECEIVE_ACCESS, SELinuxReceive, NULL);
     ret &= XaceRegisterCallback(XACE_SELECTION_ACCESS, SELinuxSelection, NULL);
-    ret &= XaceRegisterCallback(XACE_SCREEN_ACCESS, SELinuxScreen, NULL);
     if (!ret)
         FatalError("SELinux: Failed to register one or more callbacks\n");
 

--- a/dbe/dbe.c
+++ b/dbe/dbe.c
@@ -605,7 +605,7 @@ ProcDbeGetVisualInfo(ClientPtr client)
             pDrawables[i]->pScreen;
         pDbeScreenPriv = DBE_SCREEN_PRIV(pScreen);
 
-        rc = XaceHookScreenAccess(client, pScreen, DixGetAttrAccess);
+        rc = dixCallScreenAccessCallback(client, pScreen, DixGetAttrAccess);
         if (rc != Success)
             goto clearRpcBuf;
 

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -2584,7 +2584,7 @@ ProcInstallColormap(ClientPtr client)
     if (rc != Success)
         goto out;
 
-    rc = XaceHookScreenAccess(client, pcmp->pScreen, DixSetAttrAccess);
+    rc = dixCallScreenAccessCallback(client, pcmp->pScreen, DixSetAttrAccess);
     if (rc != Success) {
         if (rc == BadValue)
             rc = BadColor;
@@ -2616,7 +2616,7 @@ ProcUninstallColormap(ClientPtr client)
     if (rc != Success)
         goto out;
 
-    rc = XaceHookScreenAccess(client, pcmp->pScreen, DixSetAttrAccess);
+    rc = dixCallScreenAccessCallback(client, pcmp->pScreen, DixSetAttrAccess);
     if (rc != Success) {
         if (rc == BadValue)
             rc = BadColor;
@@ -2648,7 +2648,7 @@ ProcListInstalledColormaps(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    rc = XaceHookScreenAccess(client, pWin->drawable.pScreen, DixGetAttrAccess);
+    rc = dixCallScreenAccessCallback(client, pWin->drawable.pScreen, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 
@@ -3248,7 +3248,7 @@ ProcQueryBestSize(ClientPtr client)
     if (stuff->class != CursorShape && pDraw->type == UNDRAWABLE_WINDOW)
         return BadMatch;
     pScreen = pDraw->pScreen;
-    rc = XaceHookScreenAccess(client, pScreen, DixGetAttrAccess);
+    rc = dixCallScreenAccessCallback(client, pScreen, DixGetAttrAccess);
     if (rc != Success)
         return rc;
     (*pScreen->QueryBestSize) (stuff->class, &stuff->width,

--- a/dix/screen.c
+++ b/dix/screen.c
@@ -12,6 +12,7 @@
 #include "include/scrnintstr.h"
 
 CallbackListPtr ScreenSaverAccessCallback = NULL;
+CallbackListPtr ScreenAccessCallback = NULL;
 
 void dixFreeScreen(ScreenPtr pScreen)
 {

--- a/dix/screenint_priv.h
+++ b/dix/screenint_priv.h
@@ -8,6 +8,7 @@
 
 #include <X11/Xdefs.h>
 
+#include "include/callback.h"
 #include "include/screenint.h"
 #include "include/scrnintstr.h" /* for screenInfo */
 
@@ -83,5 +84,21 @@ static inline ScreenPtr dixGetMasterScreen(void) {
             __LAMBDA__; \
         } \
     } while (0);
+
+extern CallbackListPtr ScreenAccessCallback;
+
+typedef struct {
+    ClientPtr client;
+    ScreenPtr screen;
+    Mask access_mode;
+    int status;
+} ScreenAccessCallbackParam;
+
+static inline int dixCallScreenAccessCallback(ClientPtr client, ScreenPtr screen, Mask access_mode)
+{
+    ScreenAccessCallbackParam rec = { client, screen, access_mode, Success };
+    CallCallbacks(&ScreenAccessCallback, &rec);
+    return rec.status;
+}
 
 #endif /* _XSERVER_DIX_SCREENINT_PRIV_H */

--- a/xfixes/cursor.c
+++ b/xfixes/cursor.c
@@ -812,7 +812,7 @@ ProcXFixesHideCursor(ClientPtr client)
      * This is the first time this client has hid the cursor
      * for this screen.
      */
-    ret = XaceHookScreenAccess(client, pWin->drawable.pScreen, DixHideAccess);
+    ret = dixCallScreenAccessCallback(client, pWin->drawable.pScreen, DixHideAccess);
     if (ret != Success)
         return ret;
 
@@ -860,7 +860,7 @@ ProcXFixesShowCursor(ClientPtr client)
         return BadMatch;
     }
 
-    rc = XaceHookScreenAccess(client, pWin->drawable.pScreen, DixShowAccess);
+    rc = dixCallScreenAccessCallback(client, pWin->drawable.pScreen, DixShowAccess);
     if (rc != Success)
         return rc;
 


### PR DESCRIPTION
Replace complicated xace hook by simple and cheap callback.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
