### PR TITLE
Xext: shm: move ShmDescRec definition into shm.c

### DIFF
--- a/Xext/shm_priv.h
+++ b/Xext/shm_priv.h
@@ -9,6 +9,20 @@
 #include "include/resource.h"
 #include "Xext/shmint.h"
 
+typedef struct _ShmDesc {
+    struct _ShmDesc *next;
+    int shmid;
+    int refcnt;
+    char *addr;
+    Bool writable;
+    unsigned long size;
+#ifdef SHM_FD_PASSING
+    Bool is_fd;
+    struct busfault *busfault;
+    XID resource;
+#endif
+} ShmDescRec, *ShmDescPtr;
+
 extern RESTYPE ShmSegType;
 
 #endif /* _XSERVER_XEXT_SHM_PRIV_H */

--- a/Xext/shmint.h
+++ b/Xext/shmint.h
@@ -60,20 +60,6 @@ typedef struct _ShmFuncs {
 #define SHM_FD_PASSING  1
 #endif
 
-typedef struct _ShmDesc {
-    struct _ShmDesc *next;
-    int shmid;
-    int refcnt;
-    char *addr;
-    Bool writable;
-    unsigned long size;
-#ifdef SHM_FD_PASSING
-    Bool is_fd;
-    struct busfault *busfault;
-    XID resource;
-#endif
-} ShmDescRec, *ShmDescPtr;
-
 #ifdef SHM_FD_PASSING
 #define SHMDESC_IS_FD(shmdesc)  ((shmdesc)->is_fd)
 #else


### PR DESCRIPTION
Only used inside shm.c, not anywhere else, so no need to keep it
in a public header file.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
