### PR TITLE
dix: add some bit of documentation to privates subsystem

### DIFF
--- a/dix/privates.c
+++ b/dix/privates.c
@@ -337,6 +337,9 @@ dixRegisterPrivateKey(DevPrivateKey key, DevPrivateType type, unsigned size)
     if (type == PRIVATE_XSELINUX) {
 
         /* Resize if we can, or make sure nothing's allocated if we can't
+         *
+         * special magic for PRIVATE_XSELINUX type keys - those are registered
+         * at the same offset in several object types.
          */
         for (DevPrivateType t = PRIVATE_XSELINUX; t < PRIVATE_LAST; t++)
             if (xselinux_private[t]) {

--- a/include/privates.h
+++ b/include/privates.h
@@ -24,8 +24,18 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 typedef struct _Private PrivateRec, *PrivatePtr;
 
+/* WARNING: the values, as well as the total number are part of public ABI.
+   Adding a new one will lead to increased size as well as different field
+   offsets within ScreenRec.
+*/
 typedef enum {
-    /* XSELinux uses the same private keys for numerous objects */
+    /* XSELinux uses the same private keys for numerous objects
+
+       This black magic - keys of this type have very special handling:
+       their corresponding space is allocated at the top of the private
+       areas, in *several* object types (see xselinux_private[] array),
+       and xselinux uses the same keys for all object types
+    */
     PRIVATE_XSELINUX,
 
     /* Otherwise, you get a private in just the requested structure


### PR DESCRIPTION
Document some non-trivial aspects and add warnings what not to
touch in order to not breaking ABI.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
