### PR TITLE
xkb: inline SProcXkbSetCompatMap()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -3042,12 +3042,18 @@ _XkbSetCompatMap(ClientPtr client, DeviceIntPtr dev,
 int
 ProcXkbSetCompatMap(ClientPtr client)
 {
+    REQUEST(xkbSetCompatMapReq);
+    REQUEST_AT_LEAST_SIZE(xkbSetCompatMapReq);
+
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swaps(&stuff->firstSI);
+        swaps(&stuff->nSI);
+    }
+
     DeviceIntPtr dev;
     char *data;
     int rc;
-
-    REQUEST(xkbSetCompatMapReq);
-    REQUEST_AT_LEAST_SIZE(xkbSetCompatMapReq);
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -119,17 +119,6 @@ SProcXkbSelectEvents(ClientPtr client)
 }
 
 static int _X_COLD
-SProcXkbSetCompatMap(ClientPtr client)
-{
-    REQUEST(xkbSetCompatMapReq);
-    REQUEST_AT_LEAST_SIZE(xkbSetCompatMapReq);
-    swaps(&stuff->deviceSpec);
-    swaps(&stuff->firstSI);
-    swaps(&stuff->nSI);
-    return ProcXkbSetCompatMap(client);
-}
-
-static int _X_COLD
 SProcXkbGetKbdByName(ClientPtr client)
 {
     REQUEST(xkbGetKbdByNameReq);
@@ -166,7 +155,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbGetCompatMap:
         return ProcXkbGetCompatMap(client);
     case X_kbSetCompatMap:
-        return SProcXkbSetCompatMap(client);
+        return ProcXkbSetCompatMap(client);
     case X_kbGetIndicatorState:
         return ProcXkbGetIndicatorState(client);
     case X_kbGetIndicatorMap:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
