### PR TITLE
dix: ProcPolyText(): drop unused variable

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -2432,7 +2432,6 @@ ProcPolyText(ClientPtr client)
         swaps(&stuff->y);
     }
 
-    int err;
     DrawablePtr pDraw;
     GCPtr pGC;
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
