### PR TITLE
xkb: inline SProcXkbGetKbdByName()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -5737,6 +5737,15 @@ XkbConvertGetByNameComponents(Bool toXkm, unsigned orig)
 int
 ProcXkbGetKbdByName(ClientPtr client)
 {
+    REQUEST(xkbGetKbdByNameReq);
+    REQUEST_AT_LEAST_SIZE(xkbGetKbdByNameReq);
+
+    if (client->swapped) {
+        swaps(&stuff->deviceSpec);
+        swaps(&stuff->want);
+        swaps(&stuff->need);
+    }
+
     DeviceIntPtr dev;
     DeviceIntPtr tmpd;
     DeviceIntPtr master;
@@ -5751,9 +5760,6 @@ ProcXkbGetKbdByName(ClientPtr client)
     XkbSrvLedInfoPtr old_sli;
     XkbSrvLedInfoPtr sli;
     Mask access_mode = DixGetAttrAccess | DixManageAccess;
-
-    REQUEST(xkbGetKbdByNameReq);
-    REQUEST_AT_LEAST_SIZE(xkbGetKbdByNameReq);
 
     if (!(client->xkbClientFlags & _XkbClientInitialized))
         return BadAccess;

--- a/xkb/xkbSwap.c
+++ b/xkb/xkbSwap.c
@@ -118,17 +118,6 @@ SProcXkbSelectEvents(ClientPtr client)
     return ProcXkbSelectEvents(client);
 }
 
-static int _X_COLD
-SProcXkbGetKbdByName(ClientPtr client)
-{
-    REQUEST(xkbGetKbdByNameReq);
-    REQUEST_AT_LEAST_SIZE(xkbGetKbdByNameReq);
-    swaps(&stuff->deviceSpec);
-    swaps(&stuff->want);
-    swaps(&stuff->need);
-    return ProcXkbGetKbdByName(client);
-}
-
 int _X_COLD
 SProcXkbDispatch(ClientPtr client)
 {
@@ -179,7 +168,7 @@ SProcXkbDispatch(ClientPtr client)
     case X_kbListComponents:
         return ProcXkbListComponents(client);
     case X_kbGetKbdByName:
-        return SProcXkbGetKbdByName(client);
+        return ProcXkbGetKbdByName(client);
     case X_kbGetDeviceInfo:
         return ProcXkbGetDeviceInfo(client);
     case X_kbSetDeviceInfo:


### PR DESCRIPTION
No need to have whole extra functions for just a few LoC.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
