### PR TITLE
Xi: inline SProcXIGetClientPointer() and SProcXISetClientPointer()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -440,9 +440,9 @@ SProcIDispatch(ClientPtr client)
         case X_XIChangeHierarchy:
             return ProcXIChangeHierarchy(client);
         case X_XISetClientPointer:
-            return SProcXISetClientPointer(client);
+            return ProcXISetClientPointer(client);
         case X_XIGetClientPointer:
-            return SProcXIGetClientPointer(client);
+            return ProcXIGetClientPointer(client);
         case X_XISelectEvents:
             return SProcXISelectEvents(client);
         case X_XIQueryVersion:

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -69,14 +69,12 @@ int ProcXUngrabDeviceButton(ClientPtr client);
 int ProcXUngrabDevice(ClientPtr client);
 int ProcXUngrabDeviceKey(ClientPtr client);
 
-int SProcXIGetClientPointer(ClientPtr client);
 int SProcXIGetSelectedEvents(ClientPtr client);
 int SProcXIPassiveGrabDevice(ClientPtr client);
 int SProcXIPassiveUngrabDevice(ClientPtr client);
 int SProcXIQueryPointer(ClientPtr client);
 int SProcXIQueryVersion(ClientPtr client);
 int SProcXISelectEvents(ClientPtr client);
-int SProcXISetClientPointer(ClientPtr client);
 int SProcXIWarpPointer(ClientPtr client);
 
 #endif /* _XSERVER_XI_HANDLERS_H */

--- a/Xi/xigetclientpointer.c
+++ b/Xi/xigetclientpointer.c
@@ -46,16 +46,6 @@
  * setting.
  */
 
-int _X_COLD
-SProcXIGetClientPointer(ClientPtr client)
-{
-    REQUEST(xXIGetClientPointerReq);
-    REQUEST_SIZE_MATCH(xXIGetClientPointerReq);
-
-    swapl(&stuff->win);
-    return ProcXIGetClientPointer(client);
-}
-
 int
 ProcXIGetClientPointer(ClientPtr client)
 {
@@ -64,6 +54,9 @@ ProcXIGetClientPointer(ClientPtr client)
 
     REQUEST(xXIGetClientPointerReq);
     REQUEST_SIZE_MATCH(xXIGetClientPointerReq);
+
+    if (client->swapped)
+        swapl(&stuff->win);
 
     if (stuff->win != None) {
         rc = dixLookupResourceOwner(&winclient, stuff->win, client, DixGetAttrAccess);

--- a/Xi/xisetclientpointer.c
+++ b/Xi/xisetclientpointer.c
@@ -47,17 +47,6 @@
 #include "exevents.h"
 #include "exglobals.h"
 
-int _X_COLD
-SProcXISetClientPointer(ClientPtr client)
-{
-    REQUEST(xXISetClientPointerReq);
-    REQUEST_SIZE_MATCH(xXISetClientPointerReq);
-
-    swapl(&stuff->win);
-    swaps(&stuff->deviceid);
-    return (ProcXISetClientPointer(client));
-}
-
 int
 ProcXISetClientPointer(ClientPtr client)
 {
@@ -67,6 +56,11 @@ ProcXISetClientPointer(ClientPtr client)
 
     REQUEST(xXISetClientPointerReq);
     REQUEST_SIZE_MATCH(xXISetClientPointerReq);
+
+    if (client->swapped) {
+        swapl(&stuff->win);
+        swaps(&stuff->deviceid);
+    }
 
     rc = dixLookupDevice(&pDev, stuff->deviceid, client, DixManageAccess);
     if (rc != Success) {

--- a/test/xi2/protocol-xigetclientpointer.c
+++ b/test/xi2/protocol-xigetclientpointer.c
@@ -93,7 +93,7 @@ request_XIGetClientPointer(ClientPtr client, xXIGetClientPointerReq * req,
     client_request.swapped = TRUE;
     swapl(&req->win);
     swaps(&req->length);
-    rc = SProcXIGetClientPointer(&client_request);
+    rc = ProcXIGetClientPointer(&client_request);
     assert(rc == error);
 
     if (rc == BadWindow)

--- a/test/xi2/protocol-xisetclientpointer.c
+++ b/test/xi2/protocol-xisetclientpointer.c
@@ -81,7 +81,7 @@ request_XISetClientPointer(xXISetClientPointerReq * req, int error)
 
     swapl(&req->win);
     swaps(&req->deviceid);
-    rc = SProcXISetClientPointer(&client_request);
+    rc = ProcXISetClientPointer(&client_request);
     assert(rc == error);
 
     if (rc == BadDevice)


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
