### PR TITLE
dix: split ProcCreateWindow() into upper and lower half

### DIFF
--- a/Xext/panoramiXprocs.c
+++ b/Xext/panoramiXprocs.c
@@ -36,6 +36,7 @@ Equipment Corporation.
 #include "dix/rpcbuf_priv.h"
 #include "dix/screenint_priv.h"
 #include "dix/server_priv.h"
+#include "dix/window_priv.h"
 #include "os/osdep.h"
 #include "Xext/panoramiX.h"
 #include "Xext/panoramiXsrv.h"
@@ -154,7 +155,7 @@ PanoramiXCreateWindow(ClientPtr client)
             *((CARD32 *) &stuff[1] + cmap_offset) = cmap->info[walkScreenIdx].id;
         if (orig_visual != CopyFromParent)
             stuff->visual = PanoramiXTranslateVisualID(walkScreenIdx, orig_visual);
-        result = (*SavedProcVector[X_CreateWindow]) (client);
+        result = DoCreateWindowReq(client, stuff, (XID*)&stuff[1]);
         if (result != Success)
             break;
     });

--- a/dix/window_priv.h
+++ b/dix/window_priv.h
@@ -53,4 +53,10 @@ Bool MakeWindowOptional(WindowPtr pWin);
  */
 Bool dixWindowIsRoot(Window window);
 
+/*
+ * @brief lower part of X_CreateWindow request handler.
+ * Called by ProcCreateWindow() as well as PanoramiXCreateWindow()
+ */
+int DoCreateWindowReq(ClientPtr client, xCreateWindowReq *stuff, XID *xids);
+
 #endif /* _XSERVER_DIX_WINDOW_PRIV_H */


### PR DESCRIPTION
In order to reduce complexity of wrapped core request handlers with PanoramiX,
split the ProcCreateWindow() function into two pieces: the upper half is the
usual (non-PanoramiX) handler, while the lower one is what's called by both
the usual handler, as well as the PanoramiX' one.

We're already passing in the request parameters as separate pointers, so
follow-up commits can easily change PanoramiX handler to not tweaking the
request buffer directly anymore. Another one is letting PanoramiXCreateWindow()
be called by ProcCreateWindow explicitly (when enabled), so we don't need to
wrap the core request proc vector anymore. Once that's done, the swapping can
also be moved into ProcCreateWindow().

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
