### PR TITLE
dix: inline SProcInternAtom()

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -1104,6 +1104,9 @@ ProcInternAtom(ClientPtr client)
     char *tchar;
 
     REQUEST(xInternAtomReq);
+    REQUEST_AT_LEAST_SIZE(xInternAtomReq);
+    if (client->swapped)
+        swaps(&stuff->nbytes);
 
     REQUEST_FIXED_SIZE(xInternAtomReq, stuff->nbytes);
     if ((stuff->onlyIfExists != xTrue) && (stuff->onlyIfExists != xFalse)) {

--- a/dix/swapreq.c
+++ b/dix/swapreq.c
@@ -170,15 +170,6 @@ SProcConfigureWindow(ClientPtr client)
 }
 
 int _X_COLD
-SProcInternAtom(ClientPtr client)
-{
-    REQUEST(xInternAtomReq);
-    REQUEST_AT_LEAST_SIZE(xInternAtomReq);
-    swaps(&stuff->nbytes);
-    return ((*ProcVector[X_InternAtom]) (client));
-}
-
-int _X_COLD
 SProcChangeProperty(ClientPtr client)
 {
     REQUEST(xChangePropertyReq);

--- a/dix/tables.c
+++ b/dix/tables.c
@@ -347,7 +347,7 @@ int (*SwappedProcVector[256]) (ClientPtr /* client */) = {
     ProcCirculateWindow,
     ProcGetGeometry,
     ProcQueryTree,                      /* 15 */
-    SProcInternAtom,
+    ProcInternAtom,
     ProcGetAtomName,
     SProcChangeProperty,
     SProcDeleteProperty,

--- a/include/swapreq.h
+++ b/include/swapreq.h
@@ -61,7 +61,6 @@ int SProcGetImage(ClientPtr client);
 int SProcGetMotionEvents(ClientPtr client);
 int SProcGetProperty(ClientPtr client);
 int SProcImageText(ClientPtr client);
-int SProcInternAtom(ClientPtr client);
 int SProcListFonts(ClientPtr client);
 int SProcListFontsWithInfo(ClientPtr client);
 int SProcLookupColor(ClientPtr client);


### PR DESCRIPTION
No need for having an extra function for just few lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
