### PR TITLE
modesetting: Create the largest possible cursor image buffer.

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -4892,9 +4892,9 @@ drmmode_create_initial_bos(ScrnInfoPtr pScrn, drmmode_ptr drmmode)
          * something has gone terribly wrong. */
         assert(cursor.num_dimensions);
 
-        /* Use the minimum available size. */
-        width  = cursor.dimensions[0].width;
-        height = cursor.dimensions[0].height;
+        /* Use the maximum available size. */
+        width  = cursor.dimensions[cursor.num_dimensions - 1].width;
+        height = cursor.dimensions[cursor.num_dimensions - 1].height;
 
         /* We take the minimum of the sizes here
          * so that we don't get a cursor glyph larger


### PR DESCRIPTION
Since https://github.com/X11Libre/xserver/pull/1234 landed, the user has a way to set the hw cursor size to the size they want.

The fallback probe works around driver bugs by probing very late, so it initializes the cursor image buffer with the largest size the driver supports.

With this change, the SIZE_HINTS probe will also initialize the cursor image buffer with the largest size it finds, which is what @notbabaisyou 's code originally did.