### PR TITLE
meson.build Use `-std=gnu99` for building the X server

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,7 @@ release_date = '2025-07-29'
 add_project_arguments('-DHAVE_DIX_CONFIG_H', language: ['c', 'objc'])
 cc = meson.get_compiler('c')
 
+add_project_arguments('-std=gnu99', language : 'c')
 add_project_arguments('-fno-strict-aliasing', language : 'c')
 add_project_arguments('-fvisibility=hidden', language : 'c')
 add_project_arguments('-Wvla', language: 'c')


### PR DESCRIPTION
We can't use `std=c99` along with feature-test macros because of our use of `typeof.`