### PR TITLE
Xorg backports: Fix mach64 driver crash

### DIFF
--- a/hw/xfree86/os-support/linux/lnx_video.c
+++ b/hw/xfree86/os-support/linux/lnx_video.c
@@ -120,8 +120,8 @@ hwEnableIO(void)
     char *buf=NULL, target[5];
     FILE *fp;
 
-    if (ioperm(0, 1024, 1)) {
-        ErrorF("xf86EnableIO: failed to enable I/O ports 0000-03ff (%s)\n",
+    if (ioperm(0, 1024, 1) || iopl(3)) {
+        ErrorF("xf86EnableIO: failed to enable I/O ports access (%s)\n",
                strerror(errno));
         return FALSE;
     }


### PR DESCRIPTION
Draft because I'm not sure that we should do `ioperm(0, 1024, 1)` if we also do `iopl(3)`.
See https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2052.