### PR TITLE
Xi: inline SProcXIWarpPointer()

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -434,7 +434,7 @@ SProcIDispatch(ClientPtr client)
         case X_XIQueryPointer:
             return SProcXIQueryPointer(client);
         case X_XIWarpPointer:
-            return SProcXIWarpPointer(client);
+            return ProcXIWarpPointer(client);
         case X_XIChangeCursor:
             return ProcXIChangeCursor(client);
         case X_XIChangeHierarchy:

--- a/Xi/handlers.h
+++ b/Xi/handlers.h
@@ -72,6 +72,5 @@ int ProcXUngrabDeviceKey(ClientPtr client);
 int SProcXIGetSelectedEvents(ClientPtr client);
 int SProcXIQueryPointer(ClientPtr client);
 int SProcXISelectEvents(ClientPtr client);
-int SProcXIWarpPointer(ClientPtr client);
 
 #endif /* _XSERVER_XI_HANDLERS_H */

--- a/Xi/xiwarppointer.c
+++ b/Xi/xiwarppointer.c
@@ -56,27 +56,24 @@
  *
  */
 
-int _X_COLD
-SProcXIWarpPointer(ClientPtr client)
+int
+ProcXIWarpPointer(ClientPtr client)
 {
     REQUEST(xXIWarpPointerReq);
     REQUEST_SIZE_MATCH(xXIWarpPointerReq);
 
-    swapl(&stuff->src_win);
-    swapl(&stuff->dst_win);
-    swapl(&stuff->src_x);
-    swapl(&stuff->src_y);
-    swaps(&stuff->src_width);
-    swaps(&stuff->src_height);
-    swapl(&stuff->dst_x);
-    swapl(&stuff->dst_y);
-    swaps(&stuff->deviceid);
-    return (ProcXIWarpPointer(client));
-}
+    if (client->swapped) {
+        swapl(&stuff->src_win);
+        swapl(&stuff->dst_win);
+        swapl(&stuff->src_x);
+        swapl(&stuff->src_y);
+        swaps(&stuff->src_width);
+        swaps(&stuff->src_height);
+        swapl(&stuff->dst_x);
+        swapl(&stuff->dst_y);
+        swaps(&stuff->deviceid);
+    }
 
-int
-ProcXIWarpPointer(ClientPtr client)
-{
     int rc;
     int x, y;
     WindowPtr dest = NULL;
@@ -85,9 +82,6 @@ ProcXIWarpPointer(ClientPtr client)
     ScreenPtr newScreen;
     int src_x, src_y;
     int dst_x, dst_y;
-
-    REQUEST(xXIWarpPointerReq);
-    REQUEST_SIZE_MATCH(xXIWarpPointerReq);
 
     /* FIXME: panoramix stuff is missing, look at ProcWarpPointer */
 

--- a/test/xi2/protocol-xiwarppointer.c
+++ b/test/xi2/protocol-xiwarppointer.c
@@ -88,7 +88,7 @@ request_XIWarpPointer(ClientPtr client, xXIWarpPointerReq * req, int error)
     swaps(&req->src_height);
     swaps(&req->deviceid);
 
-    rc = SProcXIWarpPointer(client);
+    rc = ProcXIWarpPointer(client);
     assert(rc == error);
 
     if (rc == BadDevice)


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
