### PR TITLE
dix: rename DevScreenPrivateKey to DevScreenPrivateKeyPtr

### DIFF
--- a/dix/privates.c
+++ b/dix/privates.c
@@ -388,7 +388,7 @@ dixRegisterPrivateKey(DevPrivateKey key, DevPrivateType type, unsigned size)
 }
 
 Bool
-dixRegisterScreenPrivateKey(DevScreenPrivateKey screenKey, ScreenPtr pScreen,
+dixRegisterScreenPrivateKey(DevScreenPrivateKeyPtr screenKey, ScreenPtr pScreen,
                             DevPrivateType type, unsigned size)
 {
     DevPrivateKey key;
@@ -414,7 +414,7 @@ dixRegisterScreenPrivateKey(DevScreenPrivateKey screenKey, ScreenPtr pScreen,
 }
 
 DevPrivateKey
-_dixGetScreenPrivateKey(const DevScreenPrivateKey key, ScreenPtr pScreen)
+_dixGetScreenPrivateKey(const DevScreenPrivateKeyPtr key, ScreenPtr pScreen)
 {
     return dixGetPrivate(&pScreen->devPrivates, &key->screenKey);
 }

--- a/doc/Xserver-spec.xml
+++ b/doc/Xserver-spec.xml
@@ -4716,7 +4716,7 @@ the same value for <type>size</type> or the server will abort.</para>
 <para>
 To request per-screen private space in an object, use
 <blockquote><programlisting>
-        Bool dixRegisterScreenPrivateKey(DevScreenPrivateKey key, ScreenPtr pScreen, DevPrivateType type, unsigned size);
+        Bool dixRegisterScreenPrivateKey(DevScreenPrivateKeyPtr key, ScreenPtr pScreen, DevPrivateType type, unsigned size);
 </programlisting></blockquote>
 The <parameter>type</parameter> and <parameter>size</parameter> arguments are
 the same as those to <function>dixRegisterPrivateKey</function> but this

--- a/include/privates.h
+++ b/include/privates.h
@@ -84,7 +84,7 @@ typedef struct _DevPrivateSetRec {
 
 typedef struct _DevScreenPrivateKeyRec {
     DevPrivateKeyRec screenKey;
-} DevScreenPrivateKeyRec, *DevScreenPrivateKey;
+} DevScreenPrivateKeyRec, *DevScreenPrivateKeyPtr;
 
 /*
  * Let drivers know how to initialize private keys
@@ -192,42 +192,42 @@ dixLookupPrivateAddr(PrivatePtr *privates, const DevPrivateKey key)
 
 extern _X_EXPORT Bool
 
-dixRegisterScreenPrivateKey(DevScreenPrivateKey key, ScreenPtr pScreen,
+dixRegisterScreenPrivateKey(DevScreenPrivateKeyPtr key, ScreenPtr pScreen,
                             DevPrivateType type, unsigned size);
 
 extern _X_EXPORT DevPrivateKey
- _dixGetScreenPrivateKey(const DevScreenPrivateKey key, ScreenPtr pScreen);
+ _dixGetScreenPrivateKey(const DevScreenPrivateKeyPtr key, ScreenPtr pScreen);
 
 static inline void *
-dixGetScreenPrivateAddr(PrivatePtr *privates, const DevScreenPrivateKey key,
+dixGetScreenPrivateAddr(PrivatePtr *privates, const DevScreenPrivateKeyPtr key,
                         ScreenPtr pScreen)
 {
     return dixGetPrivateAddr(privates, _dixGetScreenPrivateKey(key, pScreen));
 }
 
 static inline void *
-dixGetScreenPrivate(PrivatePtr *privates, const DevScreenPrivateKey key,
+dixGetScreenPrivate(PrivatePtr *privates, const DevScreenPrivateKeyPtr key,
                     ScreenPtr pScreen)
 {
     return dixGetPrivate(privates, _dixGetScreenPrivateKey(key, pScreen));
 }
 
 static inline void
-dixSetScreenPrivate(PrivatePtr *privates, const DevScreenPrivateKey key,
+dixSetScreenPrivate(PrivatePtr *privates, const DevScreenPrivateKeyPtr key,
                     ScreenPtr pScreen, void *val)
 {
     dixSetPrivate(privates, _dixGetScreenPrivateKey(key, pScreen), val);
 }
 
 static inline void *
-dixLookupScreenPrivate(PrivatePtr *privates, const DevScreenPrivateKey key,
+dixLookupScreenPrivate(PrivatePtr *privates, const DevScreenPrivateKeyPtr key,
                        ScreenPtr pScreen)
 {
     return dixLookupPrivate(privates, _dixGetScreenPrivateKey(key, pScreen));
 }
 
 static inline void **
-dixLookupScreenPrivateAddr(PrivatePtr *privates, const DevScreenPrivateKey key,
+dixLookupScreenPrivateAddr(PrivatePtr *privates, const DevScreenPrivateKeyPtr key,
                            ScreenPtr pScreen)
 {
     return dixLookupPrivateAddr(privates,


### PR DESCRIPTION
Be a bit more consistent in naming. We call all our pointer-to-struct
types <xyz>Ptr.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
