### PR TITLE
dix: dixFreeScreen call hookPostCreateResources too

### DIFF
--- a/dix/screen.c
+++ b/dix/screen.c
@@ -29,5 +29,6 @@ void dixFreeScreen(ScreenPtr pScreen)
     DeleteCallbackList(&pScreen->hookClose);
     DeleteCallbackList(&pScreen->hookPostClose);
     DeleteCallbackList(&pScreen->hookPixmapDestroy);
+    DeleteCallbackList(&pScreen->hookPostCreateResources);
     free(pScreen);
 }


### PR DESCRIPTION
AddressSanitizer complains it is heap-use-after-free as `DeleteCallbackManager`  will clean `pScreen->hookPostCreateResources` after ScreenPtr  was freed few lines earlier during `dixFreeScreen` call.

To reproduce it (the crash), you need enable `address` sanitizer, for example :
`meson setup --reconfigure -Db_sanitize=leak,address`

and then reset Xserver (start `xterm` and exit), the start command can be:
```
bin/X vt2 :2 -retro
```


```
Errors from xkbcomp are not fatal to the X server
[New Thread 0x7bffdde416c0 (LWP 7680)]
[Thread 0x7bffdde416c0 (LWP 7680) exited]
=================================================================
==7669==ERROR: AddressSanitizer: heap-use-after-free on address 0x7d9ff640a5d0 at pc 0x5555556f030c bp 0x7fffffffe0e0 sp 0x7fffffffe0d0
READ of size 8 at 0x7d9ff640a5d0 thread T0
    #0 0x5555556f030b in DeleteCallbackList ../dix/dixutils.c:765
    #1 0x5555556f0fa6 in DeleteCallbackManager ../dix/dixutils.c:847
    #2 0x5555556ed9d6 in dix_main ../dix/main.c:351
    #3 0x7ffff74783fa  (/usr/lib64/libc.so.6+0x273fa)
    #4 0x7ffff74784aa in __libc_start_main (/usr/lib64/libc.so.6+0x274aa)
    #5 0x555555627c74 in _start (/tmp/x11libre/bin/Xorg+0xd3c74)

0x7d9ff640a5d0 is located 1360 bytes inside of 1384-byte region [0x7d9ff640a080,0x7d9ff640a5e8)
freed by thread T0 here:
    #0 0x7ffff7921f6b in free /usr/src/debug/sys-devel/gcc-15.2.0/gcc-15.2.0/libsanitizer/asan/asan_malloc_linux.cpp:51
    #1 0x5555556edb07 in dix_main ../dix/main.c:333
    #2 0x7ffff74783fa  (/usr/lib64/libc.so.6+0x273fa)
    #3 0x7fffffffe5cb  ([stack]+0x285cb)
    #4 0x69622f657262696b  (<unknown module>)

previously allocated by thread T0 here:
    #0 0x7ffff7922d7b in calloc /usr/src/debug/sys-devel/gcc-15.2.0/gcc-15.2.0/libsanitizer/asan/asan_malloc_linux.cpp:74
    #1 0x5555556df419 in AddScreen ../dix/dispatch.c:4092
    #2 0x555555a2d6dc in InitOutput ../hw/xfree86/common/xf86Init.c:636
    #3 0x5555556ed264 in dix_main ../dix/main.c:198
    #4 0x7ffff74783fa  (/usr/lib64/libc.so.6+0x273fa)
    #5 0x7fffffffe5cb  ([stack]+0x285cb)
    #6 0x69622f657262696b  (<unknown module>)

SUMMARY: AddressSanitizer: heap-use-after-free ../dix/dixutils.c:765 in DeleteCallbackList
Shadow bytes around the buggy address:
  0x7d9ff640a300: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7d9ff640a380: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7d9ff640a400: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7d9ff640a480: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7d9ff640a500: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x7d9ff640a580: fd fd fd fd fd fd fd fd fd fd[fd]fd fd fa fa fa
  0x7d9ff640a600: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7d9ff640a680: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7d9ff640a700: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7d9ff640a780: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7d9ff640a800: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==7669==ABORTING
```