### PR TITLE
[backport 25.0] dix: dixFreeScreen call hookPostCreateResources too

### DIFF
--- a/dix/screen.c
+++ b/dix/screen.c
@@ -25,5 +25,6 @@ void dixFreeScreen(ScreenPtr pScreen)
     DeleteCallbackList(&pScreen->hookClose);
     DeleteCallbackList(&pScreen->hookPostClose);
     DeleteCallbackList(&pScreen->hookPixmapDestroy);
+    DeleteCallbackList(&pScreen->hookPostCreateResources);
     free(pScreen);
 }


### PR DESCRIPTION
Call DeleteCallbackList(&pScreen->hookPostCreateResources) during dixFreeScreen, because otherwise it will be heap-use-after-free during DeleteCallbackManager call.

Backport-Of: https://github.com/X11Libre/xserver/pull/1304