### PR TITLE
xfree86/loader: Apply unloadsubmodule gentoo patch

### DIFF
--- a/hw/xfree86/loader/loadmod.c
+++ b/hw/xfree86/loader/loadmod.c
@@ -883,6 +883,7 @@ RemoveChild(ModuleDescPtr child)
     parent = child->parent;
     if (parent->child == child) {
         parent->child = child->sib;
+        child->sib = NULL;
         return;
     }
 


### PR DESCRIPTION
Opened this pr to discuss if this patch makes sense or not.

Either way, after this pr gets merged, the patch should be removed from the gentoo ebuild from our overlay.

The patch gentoo uses is longer, but logically equivalent to this one, as discussed in: https://github.com/X11Libre/xserver/issues/319