### PR TITLE
include: globals: add missing includes

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -2,6 +2,9 @@
 #ifndef _XSERV_GLOBAL_H_
 #define _XSERV_GLOBAL_H_
 
+#include <X11/Xdefs.h>
+#include <X11/Xfuncproto.h>
+
 #include "window.h"             /* for WindowPtr */
 #include "extinit.h"
 #ifdef DPMSExtension


### PR DESCRIPTION
Headers should always be self-consistent, thus including anything they need.
Not relying on those already included before by somebody else.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
