### PR TITLE
os: utils: unexport PanoramiXExtensionDisabledHack

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -18,8 +18,4 @@ extern _X_EXPORT int defaultColorVisualClass;
 extern _X_EXPORT int GrabInProgress;
 extern _X_EXPORT char *SeatId;
 
-#ifdef XINERAMA
-extern _X_EXPORT Bool PanoramiXExtensionDisabledHack;
-#endif /* XINERAMA */
-
 #endif                          /* !_XSERV_GLOBAL_H_ */

--- a/miext/extinit_priv.h
+++ b/miext/extinit_priv.h
@@ -27,6 +27,8 @@ extern Bool noXFixesExtension;
 extern Bool noXFree86BigfontExtension;
 extern Bool noNamespaceExtension;
 
+extern Bool PanoramiXExtensionDisabledHack;
+
 extern char *namespaceConfigFile;
 
 void CompositeExtensionInit(void);


### PR DESCRIPTION
This variable is only used in os layer and PanoramiX, nowhere else,
and shouldn't be visible to drivers at all.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
