### PR TITLE
modesetting: call xf86_cursors_fini during CloseScreen

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -2225,6 +2225,10 @@ CloseScreen(ScreenPtr pScreen)
         ms->drmmode.shadow_fb2 = NULL;
     }
 
+    if (!ms->drmmode.sw_cursor) {
+        xf86_cursors_fini(pScreen);
+    }
+
     drmmode_uevent_fini(pScrn, &ms->drmmode);
 
     drmmode_free_bos(pScrn, &ms->drmmode);


### PR DESCRIPTION
Add matching call for xf86_cursors_init to clean memory, as during initialization it allocates memory (depends, but is something like ~256Kb) and it leaks when XServer resets.

Is will feel  if you reset Xserver something like 500 times -> for 256x256 cursor it will be ~125MB + additional allocations 