### PR TITLE
dix: UngrabServer(): clear grabClient pointer

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -1203,6 +1203,7 @@ UngrabServer(ClientPtr client)
     int i;
 
     grabState = GrabNone;
+    grabClient = NULL;
     ListenToAllClients();
     mark_client_ungrab();
     for (i = mskcnt; --i >= 0 && !grabWaiters[i];);


### PR DESCRIPTION
When ungrabbing, clear the grab pointer, so no stale data left
in here.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
