### PR TITLE
dix: MakeRootTile(): constify `from` field

### DIFF
--- a/dix/window.c
+++ b/dix/window.c
@@ -504,7 +504,7 @@ MakeRootTile(WindowPtr pWin)
     GCPtr pGC;
     unsigned char back[128];
     int len = BitmapBytePad(sizeof(long));
-    unsigned char *from, *to;
+    unsigned char *to;
 
     pWin->background.pixmap = (*pScreen->CreatePixmap) (pScreen, 4, 4,
                                                         pScreen->rootDepth, 0);
@@ -526,7 +526,8 @@ MakeRootTile(WindowPtr pWin)
 
     ValidateGC((DrawablePtr) pWin->background.pixmap, pGC);
 
-    from = (screenInfo.bitmapBitOrder == LSBFirst) ? _back_lsb : _back_msb;
+    const unsigned char *from
+        = (screenInfo.bitmapBitOrder == LSBFirst) ? _back_lsb : _back_msb;
     to = back;
 
     for (int i = 4; i > 0; i--, from++)


### PR DESCRIPTION
It's assigned a const char* value and not writing into it,
so it should be const, too (compiler correctly warning about that)

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
