### PR TITLE
dix: add dixAnyOtherGrabbed() and unexport GrabInProgress

### DIFF
--- a/Xext/saver/saver.c
+++ b/Xext/saver/saver.c
@@ -494,7 +494,7 @@ CreateSaverWindow(ScreenPtr pScreen)
 
     pPriv->installedMap = None;
 
-    if (GrabInProgress && GrabInProgress != pAttr->client->index) {
+    if (dixAnyOtherGrabbed(pAttr->client)) {
         return FALSE;
     }
 

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -4278,3 +4278,9 @@ DetachOffloadGPU(ScreenPtr secondary)
     secondary->is_offload_secondary = FALSE;
 }
 
+bool dixAnyOtherGrabbed(ClientPtr client)
+{
+    return ((grabState == GrabActive) &&
+            (grabClient != NULL) &&
+            (grabClient != client));
+}

--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -10,6 +10,7 @@
  *  drivers or extension modules. Thus the definitions here are not part of the
  *  Xserver's module API/ABI.
  */
+#include <stdbool.h>
 
 #include <X11/Xdefs.h>
 #include <X11/Xfuncproto.h>
@@ -802,5 +803,20 @@ static inline void SwapLongs(CARD32 *list, unsigned long count) {
 
 #define SwapRestL(stuff) \
     SwapLongs((CARD32 *)(stuff + 1), (client->req_len - (sizeof(*stuff) >> 2)))
+
+/*
+ * retrieve current grab client or NULL (if no grab)
+ *
+ */
+ClientPtr dixGetGrabClient(void);
+
+/*
+ * Check whether any client has grabbed the server and it's not
+ * the given client.
+ *
+ * @param client    the client to check against
+ * @return          TRUE if any client, except the given one, has grabbed
+ */
+bool dixAnyOtherGrabbed(ClientPtr client);
 
 #endif /* _XSERVER_DIX_PRIV_H */

--- a/dix/dixgrabs_priv.h
+++ b/dix/dixgrabs_priv.h
@@ -13,12 +13,6 @@
 #include "input.h"
 #include "cursor.h"
 
-/* @brief tells which client ID currently has a grab
- *
- * used by OS layer and screensaver
- */
-extern int GrabInProgress;
-
 struct _GrabParameters;
 
 /**

--- a/os/connection.c
+++ b/os/connection.c
@@ -138,7 +138,7 @@ static pid_t ParentProcess;
 static Bool RunFromSmartParent; /* send SIGUSR1 to parent process */
 #endif
 
-int GrabInProgress = 0;
+static int GrabInProgress = 0;
 
 static void
 EstablishNewConnections(int curconn, int ready, void *data);


### PR DESCRIPTION
* the `GrabInProgress` field isn't used by any known drivers, thus
  no need to export it
* the only in-tree consumer outside of it's source file is Xext/saver.c,
  which actually just wants to know whether any *other* client already
  grabbed the server - asking the OS layer isn't the right source
  (should ask dix/dispatch.c instead)

Therefore adding a simple function for that check into dispatch.c (where
grab/ungrab is actually controlled), so we can easily make this internal
field static again.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
