### PR TITLE
loader: Print instructions about using old nvidia proprietary ddx drivers

### DIFF
--- a/hw/xfree86/loader/loadmod.c
+++ b/hw/xfree86/loader/loadmod.c
@@ -688,7 +688,11 @@ LoadModule(const char *module, void *options, const XF86ModReqInfo *modreq,
         LogMessage(X_WARNING, "LoadModule: Otherwise, you will get a "
                               "segmentation fault due to the abi mismatch "
                               "between the new X server abi and the one these "
-                              "old drivers are compiled against\n");
+                              "old drivers are compiled against.\n");
+        LogMessage(X_WARNING, "LoadModule: If you are using one of the maintained "
+                              "branches of the nvidia nvidia kernel drivers,\n");
+        LogMessage(X_WARNING, "LoadModule: you can try using the in-tree, open-source modesetting "
+                              "DDX driver instead of the proprietary nvidia DDX driver.\n");
         if (!LoaderIgnoreAbi) {
             /* warn every time this is hit */
             LogMessage(X_WARNING, "LoadModule: Implicitly ignoring abi mismatch "


### PR DESCRIPTION
Looking through issues, I noticed that some people are not aware that they need to set `-Dlegacy_nvidia_padding=true` when building the X server if they want to use old nvidia proprietary DDX drivers.

This makes it so that the X server prints instructions about this.

v2: Also tell users to give the modesetting DDX a try if they use a new enough nvidia DDX driver.