### PR TITLE
test: simple-xinit: ignore compiler warning on write()

### DIFF
--- a/test/simple-xinit.c
+++ b/test/simple-xinit.c
@@ -66,7 +66,7 @@ static const char *server_dead = "server_dead";
 static void
 handle_sigchld(int sig)
 {
-    write(server_displayfd, server_dead, strlen(server_dead));
+    (void)write(server_displayfd, server_dead, strlen(server_dead));
 }
 
 /* Starts the X server, returning its pid. */


### PR DESCRIPTION
This warning doesn't matter in this case:

> ../test/simple-xinit.c: In function ‘handle_sigchld’:
> ../test/simple-xinit.c:69:5: warning: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
>    69 |     write(server_displayfd, server_dead, strlen(server_dead));
>       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

In order to allow building w/ -Werror, it should be suppressed.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
