### PR TITLE
.github: move xproto build to meson

### DIFF
--- a/.github/scripts/install-prereq.sh
+++ b/.github/scripts/install-prereq.sh
@@ -12,7 +12,7 @@ if [ "$X11_OS" = "Linux" ]; then
 build_meson   drm               https://github.com/X11Libre/drm                          libdrm-2.4.121   -Domap=enabled
 fi
 build_meson   libxcvt           https://github.com/X11Libre/libxcvt                      libxcvt-0.1.0
-build_ac      xorgproto         https://github.com/X11Libre/xorgproto                    xorgproto-2024.1
+build_meson   xorgproto         https://github.com/X11Libre/xorgproto                    xorgproto-2024.1
 if [ "$X11_OS" = "Darwin" ]; then
 build_ac      xset              https://github.com/X11Libre/xset                         xset-1.2.5
 fi


### PR DESCRIPTION
This is in preparation to eliminate our ci's dependency on xutils, a collection of ancient x utilities. However xset still depends on autotools which has m4 macros that live in the xutils project. An attempt will be made to convert them to meson, however I am unsure of upstream's support.