### PR TITLE
exa.c: small formatting fix

### DIFF
--- a/exa/exa.c
+++ b/exa/exa.c
@@ -398,7 +398,7 @@ exaFinishAccess(DrawablePtr pDrawable, int index)
 
     /* Catch unbalanced Prepare/FinishAccess calls. */
     if (i == EXA_NUM_PREPARE_INDICES)
-        EXA_FatalErrorDebugWithRet(("EXA bug: FinishAccess called without PrepareAccess for pixmap 0x%p.\n", (void *)pPixmap),);
+        EXA_FatalErrorDebugWithRet(("EXA bug: FinishAccess called without PrepareAccess for pixmap %p.\n", (void *)pPixmap),);
 
     pExaScr->access[i].pixmap = NULL;
 


### PR DESCRIPTION
formatting doesn't know how to handle struct pointers as notified by -Wpedantic, so turn it into a void pointer