### PR TITLE
treewide: __FUNCTION__ -> __func__

### DIFF
--- a/exa/exa_priv.h
+++ b/exa/exa_priv.h
@@ -59,7 +59,7 @@
 #if DEBUG_TRACE_FALL
 #define EXA_FALLBACK(x)     					\
 do {								\
-	ErrorF("EXA fallback at %s: ", __FUNCTION__);		\
+	ErrorF("EXA fallback at %s: ", __func__);		\
 	ErrorF x;						\
 } while (0)
 

--- a/glamor/glamor_compositerects.c
+++ b/glamor/glamor_compositerects.c
@@ -92,7 +92,7 @@ _pixman_region_init_clipped_rectangles(pixman_region16_t * region,
         free(boxes);
 
     DEBUGF("%s: nrects=%d, region=(%d, %d), (%d, %d) x %d\n",
-           __FUNCTION__, num_rects,
+           __func__, num_rects,
            region->extents.x1, region->extents.y1,
            region->extents.x2, region->extents.y2, j);
     return ret;
@@ -113,7 +113,7 @@ glamor_composite_rectangles(CARD8 op,
     Bool need_free_region = FALSE;
 
     DEBUGF("%s(op=%d, %08x x %d [(%d, %d)x(%d, %d) ...])\n",
-           __FUNCTION__, op,
+           __func__, op,
            (color->alpha >> 8 << 24) |
            (color->red >> 8 << 16) |
            (color->green >> 8 << 8) |
@@ -124,7 +124,7 @@ glamor_composite_rectangles(CARD8 op,
         return;
 
     if (RegionNil(dst->pCompositeClip)) {
-        DEBUGF("%s: empty clip, skipping\n", __FUNCTION__);
+        DEBUGF("%s: empty clip, skipping\n", __func__);
         return;
     }
 
@@ -180,7 +180,7 @@ glamor_composite_rectangles(CARD8 op,
             break;
         }
     }
-    DEBUGF("%s: converted to op %d\n", __FUNCTION__, op);
+    DEBUGF("%s: converted to op %d\n", __func__, op);
 
     if (!_pixman_region_init_clipped_rectangles(&region,
                                                 num_rects, rects,
@@ -188,7 +188,7 @@ glamor_composite_rectangles(CARD8 op,
                                                 dst->pDrawable->y,
                                                 &dst->pCompositeClip->extents))
     {
-        DEBUGF("%s: allocation failed for region\n", __FUNCTION__);
+        DEBUGF("%s: allocation failed for region\n", __func__);
         return;
     }
 
@@ -198,14 +198,14 @@ glamor_composite_rectangles(CARD8 op,
     if (!GLAMOR_PIXMAP_PRIV_HAS_FBO(priv))
         goto fallback;
     if (dst->alphaMap) {
-        DEBUGF("%s: fallback, dst has an alpha-map\n", __FUNCTION__);
+        DEBUGF("%s: fallback, dst has an alpha-map\n", __func__);
         goto fallback;
     }
 
     need_free_region = TRUE;
 
     DEBUGF("%s: drawable extents (%d, %d),(%d, %d) x %d\n",
-           __FUNCTION__,
+           __func__,
            RegionExtents(&region)->x1, RegionExtents(&region)->y1,
            RegionExtents(&region)->x2, RegionExtents(&region)->y2,
            RegionNumRects(&region));
@@ -214,13 +214,13 @@ glamor_composite_rectangles(CARD8 op,
         (!pixman_region_intersect(&region, &region, dst->pCompositeClip) ||
          RegionNil(&region))) {
         DEBUGF("%s: zero-intersection between rectangles and clip\n",
-               __FUNCTION__);
+               __func__);
         pixman_region_fini(&region);
         return;
     }
 
     DEBUGF("%s: clipped extents (%d, %d),(%d, %d) x %d\n",
-           __FUNCTION__,
+           __func__,
            RegionExtents(&region)->x1, RegionExtents(&region)->y1,
            RegionExtents(&region)->x2, RegionExtents(&region)->y2,
            RegionNumRects(&region));
@@ -232,7 +232,7 @@ glamor_composite_rectangles(CARD8 op,
         pixman_region_translate(&region, -dst->pDrawable->x, -dst->pDrawable->y);
 
         DEBUGF("%s: drawable extents (%d, %d),(%d, %d)\n",
-               __FUNCTION__, dst_x, dst_y,
+               __func__, dst_x, dst_y,
                RegionExtents(&region)->x1, RegionExtents(&region)->y1,
                RegionExtents(&region)->x2, RegionExtents(&region)->y2);
 

--- a/glamor/glamor_debug.h
+++ b/glamor/glamor_debug.h
@@ -39,7 +39,7 @@
   do {							\
     LogMessageVerb(X_NONE, 0, "Glamor Fatal Error"	\
 		   " at %32s line %d: " _format_ "\n",	\
-		   __FUNCTION__, __LINE__,		\
+		   __func__, __LINE__,			\
 		   ##__VA_ARGS__ );			\
     exit(1);                                            \
   } while(0)
@@ -48,7 +48,7 @@
   LogMessageVerb(X_NONE, 0,				\
 		 "%32s:\t" _format_ ,		\
 		 /*_prefix_,*/				\
-		 __FUNCTION__,				\
+		 __func__,				\
 		 ##__VA_ARGS__)
 
 #define glamor_debug_output(_level_, _format_,...)	\

--- a/hw/kdrive/ephyr/ephyr_draw.c
+++ b/hw/kdrive/ephyr/ephyr_draw.c
@@ -34,7 +34,7 @@
 #define EPHYR_TRACE_DRAW 0
 
 #if EPHYR_TRACE_DRAW
-#define TRACE_DRAW() ErrorF("%s\n", __FUNCTION__);
+#define TRACE_DRAW() ErrorF("%s\n", __func__);
 #else
 #define TRACE_DRAW() do { } while (0)
 #endif

--- a/hw/xfree86/common/compiler.h
+++ b/hw/xfree86/common/compiler.h
@@ -72,10 +72,6 @@
 #define __inline /**/
 #endif
 #endif                          /* __inline */
-/* Support gcc's __FUNCTION__ for people using other compilers */
-#if !defined(__GNUC__) && !defined(__FUNCTION__)
-#define __FUNCTION__ __func__   /* C99 */
-#endif
 
 #ifdef __GNUC__
 #ifdef __i386__

--- a/hw/xfree86/common/xf86Xinput.c
+++ b/hw/xfree86/common/xf86Xinput.c
@@ -114,7 +114,7 @@
 #define XI_VERIFY_VALUATORS(num_valuators) \
     if (num_valuators > MAX_VALUATORS) { \
         LogMessageVerb(X_ERROR, 1, "%s: num_valuator %d is greater than MAX_VALUATORS\n", \
-                       __FUNCTION__, num_valuators); \
+                       __func__, num_valuators); \
         return; \
     }
 

--- a/hw/xfree86/drivers/video/modesetting/dri2.c
+++ b/hw/xfree86/drivers/video/modesetting/dri2.c
@@ -753,7 +753,7 @@ ms_dri2_schedule_wait_msc(ClientPtr client, DrawablePtr draw, CARD64 target_msc,
             if (limit) {
                 xf86DrvMsg(scrn->scrnIndex, X_WARNING,
                            "%s:%d get vblank counter failed: %s\n",
-                           __FUNCTION__, __LINE__,
+                           __func__, __LINE__,
                            strerror(errno));
                 limit--;
             }
@@ -791,7 +791,7 @@ ms_dri2_schedule_wait_msc(ClientPtr client, DrawablePtr draw, CARD64 target_msc,
         if (limit) {
             xf86DrvMsg(scrn->scrnIndex, X_WARNING,
                        "%s:%d get vblank counter failed: %s\n",
-                       __FUNCTION__, __LINE__,
+                       __func__, __LINE__,
                        strerror(errno));
             limit--;
         }

--- a/hw/xquartz/darwin.h
+++ b/hw/xquartz/darwin.h
@@ -89,7 +89,7 @@ xq_asl_log(int level, const char *subsystem, const char *file,
 
 #define ASL_LOG(level, subsystem, msg, args ...) xq_asl_log(level, subsystem, \
                                                             __FILE__, \
-                                                            __FUNCTION__, \
+                                                            __func__, \
                                                             __LINE__, msg, \
                                                             ## args)
 #define DEBUG_LOG(msg, args ...)                 ASL_LOG(ASL_LEVEL_DEBUG, \

--- a/hw/xquartz/darwinEvents.c
+++ b/hw/xquartz/darwinEvents.c
@@ -454,7 +454,7 @@ DarwinSendTabletEvents(DeviceIntPtr pDev, int ev_type, int ev_button,
     screen = miPointerGetScreen(pDev);
     if (!screen) {
         DEBUG_LOG("%s called before screen was initialized\n",
-                  __FUNCTION__);
+                  __func__);
         return;
     }
 
@@ -497,7 +497,7 @@ DarwinSendPointerEvents(DeviceIntPtr pDev, int ev_type, int ev_button,
     screen = miPointerGetScreen(pDev);
     if (!screen) {
         DEBUG_LOG("%s called before screen was initialized\n",
-                  __FUNCTION__);
+                  __func__);
         return;
     }
 

--- a/hw/xquartz/pbproxy/pbproxy.h
+++ b/hw/xquartz/pbproxy/pbproxy.h
@@ -89,7 +89,7 @@ xq_asl_log(int level, const char *subsystem, const char *file,
 
 #define ASL_LOG(level, subsystem, msg, args ...) xq_asl_log(level, subsystem, \
                                                             __FILE__, \
-                                                            __FUNCTION__, \
+                                                            __func__, \
                                                             __LINE__, msg, \
                                                             ## args)
 #define DebugF(msg, args ...)                    ASL_LOG(ASL_LEVEL_DEBUG, \

--- a/hw/xwin/glx/glwindows.h
+++ b/hw/xwin/glx/glwindows.h
@@ -50,8 +50,8 @@ void glAddSwapHintRectWINWrapper(GLint x, GLint y, GLsizei width, GLsizei height
 int glWinSelectImplementation(int native);
 
 #if 1
-#define GLWIN_TRACE_MSG(msg, args...) if (glxWinDebugSettings.enableTrace) ErrorF(msg " [%s:%d]\n" , ##args , __FUNCTION__, __LINE__ )
-#define GLWIN_DEBUG_MSG(msg, args...) if (glxWinDebugSettings.enableDebug) ErrorF(msg " [%s:%d]\n" , ##args , __FUNCTION__, __LINE__ )
+#define GLWIN_TRACE_MSG(msg, args...) if (glxWinDebugSettings.enableTrace) ErrorF(msg " [%s:%d]\n" , ##args , __func__, __LINE__ )
+#define GLWIN_DEBUG_MSG(msg, args...) if (glxWinDebugSettings.enableDebug) ErrorF(msg " [%s:%d]\n" , ##args , __func__, __LINE__ )
 #else
 #define GLWIN_TRACE_MSG(a, ...)
 #define GLWIN_DEBUG_MSG(a, ...)

--- a/hw/xwin/glx/winpriv.c
+++ b/hw/xwin/glx/winpriv.c
@@ -21,7 +21,7 @@ void
 HWND
 winGetWindowInfo(WindowPtr pWin)
 {
-    winTrace("%s: pWin %p XID 0x%x\n", __FUNCTION__, pWin, (unsigned int)pWin->drawable.id);
+    winTrace("%s: pWin %p XID 0x%x\n", __func__, pWin, (unsigned int)pWin->drawable.id);
 
     /* a real window was requested */
     if (pWin != NULL) {

--- a/hw/xwin/winscrinit.c
+++ b/hw/xwin/winscrinit.c
@@ -176,7 +176,7 @@ winScreenInit(ScreenPtr pScreen, int argc, char **argv)
     miClearVisualTypes();
 
     if (!winFinishScreenInitFB(pScreen->myNum, pScreen, argc, argv)) {
-        ErrorF("%s(): winFinishScreenInitFB () failed\n", __FUNCTION__);
+        ErrorF("%s(): winFinishScreenInitFB () failed\n", __func__);
 
         /* call the engine dependent screen close procedure to clean up from a failure */
         pScreenPriv->pwinCloseScreen(pScreen);

--- a/hw/xwin/winshadgdi.c
+++ b/hw/xwin/winshadgdi.c
@@ -198,12 +198,12 @@ winQueryRGBBitsAndMasks(ScreenPtr pScreen)
         pdw = (DWORD *) ((CARD8 *) pbmih + sizeof(BITMAPINFOHEADER));
 
 #if ENABLE_DEBUG
-        winDebug("%s - Masks: %08x %08x %08x\n", __FUNCTION__,
+        winDebug("%s - Masks: %08x %08x %08x\n", __func__,
                  (unsigned int)pdw[0], (unsigned int)pdw[1], (unsigned int)pdw[2]);
-        winDebug("%s - Bitmap: %dx%d %d bpp %d planes\n", __FUNCTION__,
+        winDebug("%s - Bitmap: %dx%d %d bpp %d planes\n", __func__,
                  (int)pbmih->biWidth, (int)pbmih->biHeight, pbmih->biBitCount,
                  pbmih->biPlanes);
-        winDebug("%s - Compression: %u %s\n", __FUNCTION__,
+        winDebug("%s - Compression: %u %s\n", __func__,
                  (unsigned int)pbmih->biCompression,
                  (pbmih->biCompression ==
                   BI_RGB ? "(BI_RGB)" : (pbmih->biCompression ==

--- a/miext/damage/damage.c
+++ b/miext/damage/damage.c
@@ -127,7 +127,7 @@ getDrawableDamageRef(DrawablePtr pDrawable)
 static void
 _damageRegionAppend(DrawablePtr pDrawable, RegionPtr pRegion, Bool clip,
                     int subWindowMode, const char *where)
-#define damageRegionAppend(d,r,c,m) _damageRegionAppend(d,r,c,m,__FUNCTION__)
+#define damageRegionAppend(d,r,c,m) _damageRegionAppend(d,r,c,m,__func__)
 #else
 static void
 damageRegionAppend(DrawablePtr pDrawable, RegionPtr pRegion, Bool clip,
@@ -298,7 +298,7 @@ damageRegionProcessPending(DrawablePtr pDrawable)
 }
 
 #if DAMAGE_DEBUG_ENABLE
-#define damageDamageBox(d,b,m) _damageDamageBox(d,b,m,__FUNCTION__)
+#define damageDamageBox(d,b,m) _damageDamageBox(d,b,m,__func__)
 static void
 _damageDamageBox(DrawablePtr pDrawable, BoxPtr pBox, int subWindowMode,
                  const char *where)

--- a/pseudoramiX/pseudoramiX.c
+++ b/pseudoramiX/pseudoramiX.c
@@ -49,7 +49,7 @@
 #include <X11/extensions/panoramiXproto.h>
 #include "globals.h"
 
-#define TRACE LogMessageVerb(X_NONE, 10, "TRACE " __FILE__ ":%s", __FUNCTION__)
+#define TRACE LogMessageVerb(X_NONE, 10, "TRACE " __FILE__ ":%s", __func__)
 #define DEBUG_LOG(...) LogMessageVerb(X_NONE, 3, __VA_ARGS__);
 
 Bool noPseudoramiXExtension = FALSE;


### PR DESCRIPTION
This removes about 400 lines of -Wpedantic complaining, this is a useless gnuism, as the c99 standard __func__ does the exact same thing as __FUNCTION__