### PR TITLE
include: dixfontstr.h: drop unused PADGLYPHWIDTHBYTES defines

### DIFF
--- a/include/dixfontstr.h
+++ b/include/dixfontstr.h
@@ -71,22 +71,18 @@ SOFTWARE.
 
 #if GLYPHPADBYTES == 0 || GLYPHPADBYTES == 1
 #define	GLYPHWIDTHBYTESPADDED(pci)	(GLYPHWIDTHBYTES(pci))
-#define	PADGLYPHWIDTHBYTES(w)		(((w)+7)>>3)
 #endif
 
 #if GLYPHPADBYTES == 2
 #define	GLYPHWIDTHBYTESPADDED(pci)	((GLYPHWIDTHBYTES(pci)+1) & ~0x1)
-#define	PADGLYPHWIDTHBYTES(w)		(((((w)+7)>>3)+1) & ~0x1)
 #endif
 
 #if GLYPHPADBYTES == 4
 #define	GLYPHWIDTHBYTESPADDED(pci)	((GLYPHWIDTHBYTES(pci)+3) & ~0x3)
-#define	PADGLYPHWIDTHBYTES(w)		(((((w)+7)>>3)+3) & ~0x3)
 #endif
 
 #if GLYPHPADBYTES == 8          /* for a cray? */
 #define	GLYPHWIDTHBYTESPADDED(pci)	((GLYPHWIDTHBYTES(pci)+7) & ~0x7)
-#define	PADGLYPHWIDTHBYTES(w)		(((((w)+7)>>3)+7) & ~0x7)
 #endif
 
 #endif                          /* DIXFONTSTRUCT_H */


### PR DESCRIPTION
Not used anywhere anymore, so no need to keep them around.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
