### PR TITLE
dix: move IMAGE_BUFSIZE define out of public header

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -2214,6 +2214,12 @@ ProcPutImage(ClientPtr client)
     return Success;
 }
 
+/* size of buffer to use with GetImage, measured in bytes. There's obviously
+ * a trade-off between the amount of heap used and the number of times the
+ * ddx routine has to be called.
+ */
+#define IMAGE_BUFSIZE                (64*1024)
+
 static int
 DoGetImage(ClientPtr client, int format, Drawable drawable,
            int x, int y, int width, int height,

--- a/include/servermd.h
+++ b/include/servermd.h
@@ -68,14 +68,6 @@ SOFTWARE.
 #define GLYPHPADBYTES           4
 #endif
 
-/* size of buffer to use with GetImage, measured in bytes. There's obviously
- * a trade-off between the amount of heap used and the number of times the
- * ddx routine has to be called.
- */
-#ifndef IMAGE_BUFSIZE
-#define IMAGE_BUFSIZE		(64*1024)
-#endif
-
 /* pad scanline to a longword */
 #ifndef BITMAP_SCANLINE_UNIT
 #define BITMAP_SCANLINE_UNIT	32


### PR DESCRIPTION
It's just a tuning parameter (that nobody touched for aeons) for
DoGetImage(), inside dix/dispatch.c

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
