### PR TITLE
glamor: replace XNFvasprintf() by vasprintf()

### DIFF
--- a/glamor/glamor_core.c
+++ b/glamor/glamor_core.c
@@ -93,7 +93,11 @@ glamor_link_glsl_prog(ScreenPtr screen, GLint prog, const char *format, ...)
         va_list va;
 
         va_start(va, format);
-        XNFvasprintf(&label, format, va);
+        if (vasprintf(&label, format, va) == -1) {
+            ErrorF("glamor_link_glsl_prog() memory allocation failed\n");
+            va_end(va);
+            return FALSE;
+        }
         glObjectLabel(GL_PROGRAM, prog, -1, label);
         free(label);
         va_end(va);


### PR DESCRIPTION
No need for carrying around our own (incomplete) implementation
of a standard libc function.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
