### PR TITLE
glamor: replace XNFasprintf() by asprintf()

### DIFF
--- a/glamor/glamor_gradient.c
+++ b/glamor/glamor_gradient.c
@@ -339,10 +339,10 @@ _glamor_create_radial_gradient_program(ScreenPtr screen, int stops_count,
                                           (stops_count > 0));
 
     if (asprintf(&gradient_fs,
-                gradient_radial_fs_template,
-                PIXMAN_REPEAT_NONE, PIXMAN_REPEAT_NORMAL,
-                PIXMAN_REPEAT_REFLECT,
-                fs_getcolor_source) == -1)
+                 gradient_radial_fs_template,
+                 PIXMAN_REPEAT_NONE, PIXMAN_REPEAT_NORMAL,
+                 PIXMAN_REPEAT_REFLECT,
+                 fs_getcolor_source) == -1)
         return FALSE;
 
     fs_prog = glamor_compile_glsl_prog(GL_FRAGMENT_SHADER, gradient_fs);
@@ -527,9 +527,9 @@ _glamor_create_linear_gradient_program(ScreenPtr screen, int stops_count,
         _glamor_create_getcolor_fs_source(screen, stops_count, stops_count > 0);
 
     if (asprintf(&gradient_fs,
-                gradient_fs_template,
-                PIXMAN_REPEAT_NORMAL, PIXMAN_REPEAT_REFLECT,
-                fs_getcolor_source) == -1)
+                 gradient_fs_template,
+                 PIXMAN_REPEAT_NORMAL, PIXMAN_REPEAT_REFLECT,
+                 fs_getcolor_source) == -1)
         return FALSE;
 
     fs_prog = glamor_compile_glsl_prog(GL_FRAGMENT_SHADER, gradient_fs);

--- a/glamor/glamor_render.c
+++ b/glamor/glamor_render.c
@@ -336,12 +336,12 @@ glamor_create_composite_fs(glamor_screen_private *glamor_priv, struct shader_key
     }
 
     if (asprintf(&source,
-                "%s"
-                GLAMOR_DEFAULT_PRECISION
-                "%s%s%s%s%s%s%s%s", header, GLAMOR_COMPAT_DEFINES_FS,
-                repeat_define, relocate_texture,
-                enable_rel_sampler ? rel_sampler : stub_rel_sampler,
-                source_fetch, mask_fetch, dest_swizzle, in) == -1)
+                 "%s"
+                 GLAMOR_DEFAULT_PRECISION
+                 "%s%s%s%s%s%s%s%s", header, GLAMOR_COMPAT_DEFINES_FS,
+                 repeat_define, relocate_texture,
+                 enable_rel_sampler ? rel_sampler : stub_rel_sampler,
+                 source_fetch, mask_fetch, dest_swizzle, in) == -1)
         FatalError("Memory allocation on asprintf() failed\n");
 
     prog = glamor_compile_glsl_prog(GL_FRAGMENT_SHADER, source);
@@ -387,11 +387,11 @@ glamor_create_composite_vs(glamor_screen_private* priv, struct shader_key *key)
         version = version_gles3;
 
     if (asprintf(&source,
-                "%s"
-                GLAMOR_DEFAULT_PRECISION
-                "%s%s%s%s%s",
-                version, defines, main_opening, source_coords_setup,
-                mask_coords_setup, main_closing) == -1)
+                 "%s"
+                 GLAMOR_DEFAULT_PRECISION
+                 "%s%s%s%s%s",
+                 version, defines, main_opening, source_coords_setup,
+                 mask_coords_setup, main_closing) == -1)
         FatalError("malloc on asprintf() failed\n");
 
     prog = glamor_compile_glsl_prog(GL_VERTEX_SHADER, source);


### PR DESCRIPTION
Just use standard libc functions instead of own (incomplete)
implementations.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
