### PR TITLE
modesetting: check for nulls in  drmmode_prop_info_update

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -359,7 +359,7 @@ drmmode_prop_info_update(drmmode_ptr drmmode,
             continue;
 
         for (j = 0; j < num_infos; j++) {
-            if (!strcmp(prop->name, info[j].name))
+            if (info[j].name != NULL && !strcmp(prop->name, info[j].name))
                 break;
         }
 


### PR DESCRIPTION


Check for null in drmmode_prop_info_ptr field during property search as it can contain null values, for example getting IN_FORMATS_ASYNC format/modifier blob in not supported kernels.

I got this when using modesettting with nvidia drivers (sorry it was quick fix for thus no backtrace):

```bash

(gdb) p info[0]

$56 = {name = 0x7ffff7fb7412 "type", prop_id = 8, value = 2, num_enum_values = 3, enum_values = 0x555555a2b400}
(gdb) p info[1]
$57 = {name = 0x7ffff7fb7417 "FB_ID", prop_id = 0, value = 0, num_enum_values = 0, enum_values = 0x0}
(gdb) p info[2]
$58 = {name = 0x7ffff7fb741d "IN_FORMATS", prop_id = 30, value = 56, num_enum_values = 0, enum_values = 0x0}
(gdb) p info[3]
$59 = {name = 0x0, prop_id = 0, value = 0, num_enum_values = 0, enum_values = 0x0}
(gdb) p info[4]
$60 = {name = 0x7ffff7fb7322 "CRTC_ID", prop_id = 0, value = 0, num_enum_values = 0, enum_values = 0x0}
(gdb) p info[5]
$61 = {name = 0x7ffff7fb7428 "SRC_X", prop_id = 0, value = 0, num_enum_values = 0, enum_values = 0x0}

```