### PR TITLE
modesetting: get the SIZE_HINTS cursor plane property in drmmode_crtc_create_planes

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -2512,6 +2512,9 @@ drmmode_populate_cursor_size_hints(drmmode_ptr drmmode, drmmode_crtc_private_ptr
     if (!drmmode_crtc)
         return;
 
+    if (drmmode_crtc->cursor_probed)
+        return;
+
     if (!size_hints_blob)
         return;
 


### PR DESCRIPTION
We were duplicating this code needlessly and in an error-prone way.

Fixes: https://github.com/X11Libre/xserver/issues/1373