### PR TITLE
treewide: drop ifdef's for GLYPHPADBYTES != 4

### DIFF
--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -328,18 +328,7 @@ doOpenFont(ClientPtr client, struct open_font_closure *c)
         ((screenInfo.bitmapBitOrder == LSBFirst) ?
          BitmapFormatBitOrderLSB : BitmapFormatBitOrderMSB) |
         BitmapFormatImageRectMin |
-#if GLYPHPADBYTES == 1
-        BitmapFormatScanlinePad8 |
-#endif
-#if GLYPHPADBYTES == 2
-        BitmapFormatScanlinePad16 |
-#endif
-#if GLYPHPADBYTES == 4
         BitmapFormatScanlinePad32 |
-#endif
-#if GLYPHPADBYTES == 8
-        BitmapFormatScanlinePad64 |
-#endif
         BitmapFormatScanlineUnit8;
 
     if (client->clientGone) {

--- a/include/dixfontstr.h
+++ b/include/dixfontstr.h
@@ -65,24 +65,6 @@ SOFTWARE.
 #define N2dChars(pfont)	(N1dChars((pfont)) * \
 			 (FONTLASTROW((pfont)) - FONTFIRSTROW((pfont)) + 1))
 
-#ifndef GLYPHPADBYTES
-#define GLYPHPADBYTES -1
-#endif
-
-#if GLYPHPADBYTES == 0 || GLYPHPADBYTES == 1
-#define	GLYPHWIDTHBYTESPADDED(pci)	(GLYPHWIDTHBYTES((pci)))
-#endif
-
-#if GLYPHPADBYTES == 2
-#define	GLYPHWIDTHBYTESPADDED(pci)	((GLYPHWIDTHBYTES((pci))+1) & ~0x1)
-#endif
-
-#if GLYPHPADBYTES == 4
 #define	GLYPHWIDTHBYTESPADDED(pci)	((GLYPHWIDTHBYTES((pci))+3) & ~0x3)
-#endif
-
-#if GLYPHPADBYTES == 8          /* for a cray? */
-#define	GLYPHWIDTHBYTESPADDED(pci)	((GLYPHWIDTHBYTES((pci))+7) & ~0x7)
-#endif
 
 #endif                          /* DIXFONTSTRUCT_H */

--- a/include/fb.h
+++ b/include/fb.h
@@ -68,9 +68,6 @@
 #define FB_UNIT	    (1 << FB_SHIFT)
 #define FB_MASK	    (FB_UNIT - 1)
 #define FB_ALLONES  ((FbBits) -1)
-#if GLYPHPADBYTES != 4
-#error "GLYPHPADBYTES must be 4"
-#endif
 #define FB_STIP_SHIFT	LOG2_BITMAP_PAD
 #define FB_STIP_UNIT	(1 << FB_STIP_SHIFT)
 #define FB_STIP_MASK	(FB_STIP_UNIT - 1)

--- a/include/servermd.h
+++ b/include/servermd.h
@@ -59,9 +59,7 @@ SOFTWARE.
 #error "Too weird to live."
 #endif
 
-#ifndef GLYPHPADBYTES
 #define GLYPHPADBYTES           4
-#endif
 
 #define BITMAP_SCANLINE_PAD  32
 #define LOG2_BITMAP_PAD		5

--- a/mi/miglblt.c
+++ b/mi/miglblt.c
@@ -147,11 +147,7 @@ miPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int ngly
             nbyGlyphWidth = GLYPHWIDTHBYTESPADDED(pci);
             nbyPadGlyph = BitmapBytePad(gWidth);
 
-            if (nbyGlyphWidth == nbyPadGlyph
-#if GLYPHPADBYTES != 4
-                && (((int) pglyph) & 3) == 0
-#endif
-                ) {
+            if (nbyGlyphWidth == nbyPadGlyph) {
                 pb = pglyph;
             }
             else {


### PR DESCRIPTION
It's always defined to 4, for over a decade now, so no extra case
checks needed anymore.

See: 17c3347f14822b9f7da4253c71f6ed51be2b38d1
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
