### PR TITLE
dix: make BITMAP_SCANLINE_UNIT private

### DIFF
--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -29,6 +29,9 @@
 #include "include/resource.h"
 #include "include/window.h"
 
+/* pad scanline to a longword */
+#define BITMAP_SCANLINE_UNIT    32
+
 #define LEGAL_NEW_RESOURCE(id,client)           \
     do {                                        \
         if (!LegalNewID((id), (client))) {      \

--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -23,6 +23,7 @@
 #include <kdrive-config.h>
 
 #include "config/hotplug_priv.h"
+#include "dix/dix_priv.h"
 #include "dix/screenint_priv.h"
 #include "os/cmdline.h"
 #include "os/ddx_priv.h"

--- a/hw/xquartz/darwin.c
+++ b/hw/xquartz/darwin.c
@@ -34,6 +34,7 @@
 #include <X11/X.h>
 #include <X11/Xproto.h>
 
+#include "dix/dix_priv.h"
 #include "dix/screenint_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/ddx_priv.h"

--- a/include/servermd.h
+++ b/include/servermd.h
@@ -68,16 +68,9 @@ SOFTWARE.
 #define GLYPHPADBYTES           4
 #endif
 
-/* pad scanline to a longword */
-#ifndef BITMAP_SCANLINE_UNIT
-#define BITMAP_SCANLINE_UNIT	32
-#endif
-
-#ifndef BITMAP_SCANLINE_PAD
 #define BITMAP_SCANLINE_PAD  32
 #define LOG2_BITMAP_PAD		5
 #define LOG2_BYTES_PER_SCANLINE_PAD	2
-#endif
 
 #include <X11/Xfuncproto.h>
 /*


### PR DESCRIPTION
Not used by any external drivers, so no need to keep it public.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
