### PR TITLE
xfree86: int10: use standard asprintf() instead of our own implementation

### DIFF
--- a/hw/xfree86/int10/vbeModes.c
+++ b/hw/xfree86/int10/vbeModes.c
@@ -355,10 +355,9 @@ VBESetModeNames(DisplayModePtr pMode)
                 pMode->name = strdup("BADMODE");
             }
             else {
-                char *tmp;
-                XNFasprintf(&tmp, "%dx%d",
-                            pMode->HDisplay, pMode->VDisplay);
-                pMode->name = tmp;
+                char *tmp = NULL;
+                if (asprintf(&tmp, "%dx%d", pMode->HDisplay, pMode->VDisplay) != -1)
+                    pMode->name = tmp;
             }
         }
         pMode = pMode->next;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
