### PR TITLE
xfree86: parser: use standard asprintf() instead of our own implementation

### DIFF
--- a/hw/xfree86/parser/OutputClass.c
+++ b/hw/xfree86/parser/OutputClass.c
@@ -118,8 +118,9 @@ xf86parseOutputClassSection(void)
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "ModulePath");
             if (ptr->modulepath) {
-                char *path;
-                XNFasprintf(&path, "%s,%s", ptr->modulepath, xf86_lex_val.str);
+                char *path = NULL;
+                if (asprintf(&path, "%s,%s", ptr->modulepath, xf86_lex_val.str) == -1)
+                    FatalError("xf86parseOutputClassSection() malloc failed\n");
                 free(xf86_lex_val.str);
                 free(ptr->modulepath);
                 ptr->modulepath = path;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
