### PR TITLE
xfree86: modes: replace XNFasprintf() by standard libc asprintf()

### DIFF
--- a/hw/xfree86/modes/xf86Crtc.c
+++ b/hw/xfree86/modes/xf86Crtc.c
@@ -515,9 +515,6 @@ static OptionInfoRec xf86DeviceOptions[] = {
 static void
 xf86OutputSetMonitor(xf86OutputPtr output)
 {
-    char *option_name;
-    const char *monitor;
-
     if (!output->name)
         return;
 
@@ -526,8 +523,11 @@ xf86OutputSetMonitor(xf86OutputPtr output)
     output->options = XNFalloc(sizeof(xf86OutputOptions));
     memcpy(output->options, xf86OutputOptions, sizeof(xf86OutputOptions));
 
-    XNFasprintf(&option_name, "monitor-%s", output->name);
-    monitor = xf86findOptionValue(output->scrn->options, option_name);
+    const char *monitor = NULL;
+    char *option_name = NULL;
+    if (asprintf(&option_name, "monitor-%s", output->name) != -1)
+        monitor = xf86findOptionValue(output->scrn->options, option_name);
+
     if (!monitor)
         monitor = output->name;
     else

--- a/hw/xfree86/modes/xf86Modes.c
+++ b/hw/xfree86/modes/xf86Modes.c
@@ -124,11 +124,11 @@ void
 xf86SetModeDefaultName(DisplayModePtr mode)
 {
     Bool interlaced = ! !(mode->Flags & V_INTERLACE);
-    char *tmp;
+    char *tmp = NULL;
 
     free((void *) mode->name);
 
-    XNFasprintf(&tmp, "%dx%d%s", mode->HDisplay, mode->VDisplay,
+    asprintf(&tmp, "%dx%d%s", mode->HDisplay, mode->VDisplay,
                 interlaced ? "i" : "");
     mode->name = tmp;
 }
@@ -801,14 +801,14 @@ xf86CVTMode(int HDisplay, int VDisplay, float VRefresh, Bool Reduced,
 {
     struct libxcvt_mode_info *libxcvt_mode_info;
     DisplayModeRec *Mode = XNFcallocarray(1, sizeof(DisplayModeRec));
-    char *tmp;
+    char *tmp = NULL;
 
     libxcvt_mode_info =
         libxcvt_gen_mode_info(HDisplay, VDisplay, VRefresh, Reduced, Interlaced);
 
-    XNFasprintf(&tmp, "%dx%d", HDisplay, VDisplay);
+    asprintf(&tmp, "%dx%d", HDisplay, VDisplay);
     Mode->name = tmp;
-    
+
     Mode->VDisplay   = libxcvt_mode_info->vdisplay;
     Mode->HDisplay   = libxcvt_mode_info->hdisplay;
     Mode->Clock      = libxcvt_mode_info->dot_clock;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
