### PR TITLE
include: globals.h: drop unnecessary includes

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -1,16 +1,8 @@
-
 #ifndef _XSERV_GLOBAL_H_
 #define _XSERV_GLOBAL_H_
 
 #include <X11/Xdefs.h>
 #include <X11/Xfuncproto.h>
-
-#include "window.h"             /* for WindowPtr */
-#include "extinit.h"
-#ifdef DPMSExtension
-/* sigh, too many drivers assume this */
-#include <X11/extensions/dpmsconst.h>
-#endif
 
 /* Global X server variables that are visible to mi, dix, os, and ddx */
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
