### PR TITLE
dix: unexport defaultFontPath

### DIFF
--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -63,6 +63,8 @@ extern Bool party_like_its_1989;
 /* needed by libglx and libglamor (server modules) */
 extern _X_EXPORT Bool enableIndirectGLX;
 
+extern const char *defaultFontPath;
+
 /*
  * @brief callback right after one screen's root window has been initialized
  *

--- a/hw/xfree86/common/xf86Configure.c
+++ b/hw/xfree86/common/xf86Configure.c
@@ -27,6 +27,7 @@
 #include <assert.h>
 #include <errno.h>
 
+#include "dix/dix_priv.h"
 #include "include/misc.h"
 #include "os/ddx_priv.h"
 #include "os/mathx_priv.h"

--- a/hw/xwin/winconfig.c
+++ b/hw/xwin/winconfig.c
@@ -29,6 +29,8 @@
  */
 #include <xwin-config.h>
 
+#include "dix/dix_priv.h"
+
 #include "win.h"
 #include "winconfig.h"
 #include "winmsg.h"

--- a/include/globals.h
+++ b/include/globals.h
@@ -6,7 +6,6 @@
 
 /* Global X server variables that are visible to mi, dix, os, and ddx */
 
-extern _X_EXPORT const char *defaultFontPath;
 extern _X_EXPORT int monitorResolution;
 extern _X_EXPORT int defaultColorVisualClass;
 


### PR DESCRIPTION
Not needed by any external module, so no need to keep it exported.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
