### PR TITLE
xfree86: pci_ids: drop unused ifndef IRIS

### DIFF
--- a/hw/xfree86/dri2/pci_ids/i965_pci_ids.h
+++ b/hw/xfree86/dri2/pci_ids/i965_pci_ids.h
@@ -1,4 +1,3 @@
-#ifndef IRIS
 CHIPSET(0x29A2, i965,    "Intel(R) 965G")
 CHIPSET(0x2992, i965,    "Intel(R) 965Q")
 CHIPSET(0x2982, i965,    "Intel(R) 965G")
@@ -96,7 +95,6 @@ CHIPSET(0x22B0, chv,     "Intel(R) HD Graphics (Cherrytrail)")
 CHIPSET(0x22B1, chv,     "Intel(R) HD Graphics XXX (Braswell)") /* Overridden in brw_get_renderer_string */
 CHIPSET(0x22B2, chv,     "Intel(R) HD Graphics (Cherryview)")
 CHIPSET(0x22B3, chv,     "Intel(R) HD Graphics (Cherryview)")
-#endif
 CHIPSET(0x1602, bdw_gt1, "Intel(R) Broadwell GT1")
 CHIPSET(0x1606, bdw_gt1, "Intel(R) Broadwell GT1")
 CHIPSET(0x160A, bdw_gt1, "Intel(R) Broadwell GT1")


### PR DESCRIPTION
This symbol was never defined. Just a fallout from copying over
this file from MESA.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
