### PR TITLE
os: osdep: drop unused OsFlushFunc

### DIFF
--- a/os/osdep.h
+++ b/os/osdep.h
@@ -78,11 +78,6 @@ SOFTWARE.
 typedef struct _connectionInput *ConnectionInputPtr;
 typedef struct _connectionOutput *ConnectionOutputPtr;
 
-struct _osComm;
-
-typedef int (*OsFlushFunc) (ClientPtr who, struct _osComm * oc, char *extraBuf,
-                            int extraCount);
-
 typedef struct _osComm {
     int fd;
     ConnectionInputPtr input;


### PR DESCRIPTION
Not used anymore for over 20 decades now, so no need to keep it around.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
