### PR TITLE
os: replace ETEST macro by ossock_wouldblock()

### DIFF
--- a/os/WaitFor.c
+++ b/os/WaitFor.c
@@ -66,6 +66,7 @@ SOFTWARE.
 #include "dix/screensaver_priv.h"
 #include "os/busfault.h"
 #include "os/client_priv.h"
+#include "os/ossock.h"
 #include "os/screensaver.h"
 
 #include "misc.h"
@@ -210,7 +211,7 @@ WaitForSomething(Bool are_ready)
             if (dispatchException)
                 return FALSE;
             if (i < 0) {
-                if (pollerr != EINTR && !ETEST(pollerr)) {
+                if (pollerr != EINTR && ossock_wouldblock(pollerr)) {
                     ErrorF("WaitForSomething(): poll: %s\n",
                            strerror(pollerr));
                 }

--- a/os/inputthread.c
+++ b/os/inputthread.c
@@ -36,6 +36,7 @@
 #include "dix/input_priv.h"
 #include "os/ddx_priv.h"
 #include "os/log_priv.h"
+#include "os/ossock.h"
 
 #include "inputstr.h"
 #include "opaque.h"
@@ -148,7 +149,7 @@ InputThreadFillPipe(int writeHead)
 
     do {
         ret = write(writeHead, &byte, 1);
-    } while (ret < 0 && ETEST(errno));
+    } while (ret < 0 && ossock_wouldblock(errno));
 }
 
 /**

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -61,20 +61,6 @@ SOFTWARE.
 # define __has_builtin(x) 0     /* Compatibility with older compilers */
 #endif
 
-/* If EAGAIN and EWOULDBLOCK are distinct errno values, then we check errno
- * for both EAGAIN and EWOULDBLOCK, because some supposedly POSIX
- * systems are broken and return EWOULDBLOCK when they should return EAGAIN
- */
-#ifndef WIN32
-# if (EAGAIN != EWOULDBLOCK)
-#  define ETEST(err) (err == EAGAIN || err == EWOULDBLOCK)
-# else
-#  define ETEST(err) (err == EAGAIN)
-# endif
-#else   /* WIN32 The socket errorcodes differ from the normal errors */
-#define ETEST(err) (err == EAGAIN || err == WSAEWOULDBLOCK)
-#endif
-
 typedef struct _connectionInput *ConnectionInputPtr;
 typedef struct _connectionOutput *ConnectionOutputPtr;
 

--- a/os/ossock.c
+++ b/os/ossock.c
@@ -46,3 +46,12 @@ int ossock_close(int fd)
     return close(fd);
 #endif
 }
+
+int ossock_wouldblock(int err)
+{
+#ifdef WIN32
+    return ((err == EAGAIN) || (err == WSAEWOULDBLOCK));
+#else
+    return ((err == EAGAIN) || (err == EWOULDBLOCK));
+#endif
+}

--- a/os/ossock.h
+++ b/os/ossock.h
@@ -22,4 +22,9 @@ int ossock_ioctl(int fd, unsigned long request, void *arg);
  */
 int ossock_close(int fd);
 
+/*
+ * os specific check for errno indicating operation would block
+ */
+int ossock_wouldblock(int err);
+
 #endif /* _XSERVER_OS_OSSOCK_H_ */


### PR DESCRIPTION
Move this to a little function (which also has a better name now)
inside the already platform specific ossock.c

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
