### PR TITLE
os: move OS_COMM_* defines into os/connection.c

### DIFF
--- a/os/connection.c
+++ b/os/connection.c
@@ -122,6 +122,9 @@ SOFTWARE.
 
 #define MAX_CONNECTIONS (1<<16)
 
+#define OS_COMM_GRAB_IMPERVIOUS 1
+#define OS_COMM_IGNORED         2
+
 struct ospoll   *server_poll;
 
 Bool NewOutputPending;          /* not yet attempted to write some new output */

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -93,9 +93,6 @@ typedef struct _osComm {
     int flags;
 } OsCommRec, *OsCommPtr;
 
-#define OS_COMM_GRAB_IMPERVIOUS 1
-#define OS_COMM_IGNORED         2
-
 int FlushClient(ClientPtr who, OsCommPtr oc);
 
 extern void FreeOsBuffers(OsCommPtr     /*oc */


### PR DESCRIPTION
They're only used inside os/connection.c, so no need to have them
in some header and expose them to other areas.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
