### PR TITLE
os: move ComputeLocalClient() prototype to auth.h

### DIFF
--- a/os/auth.h
+++ b/os/auth.h
@@ -116,4 +116,6 @@ void AccessUsingXdmcp(void);
 
 extern Bool defeatAccessControl;
 
+Bool ComputeLocalClient(ClientPtr client);
+
 #endif /* _XSERVER_OS_AUTH_H */

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -109,9 +109,6 @@ listen_to_client(ClientPtr client);
 
 extern Bool NewOutputPending;
 
-/* in access.c */
-extern Bool ComputeLocalClient(ClientPtr client);
-
 /* for platforms lacking arc4random_buf() libc function */
 #ifndef HAVE_ARC4RANDOM_BUF
 static inline void arc4random_buf(void *buf, size_t nbytes)


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
