### PR TITLE
os: move OsVendorFatalError() and OsVendorInit() to ddx_priv.h

### DIFF
--- a/os/ddx_priv.h
+++ b/os/ddx_priv.h
@@ -25,4 +25,7 @@ void ddxGiveUp(enum ExitCode error);
 
 void ddxInputThreadInit(void);
 
+void OsVendorFatalError(const char *f, va_list args) _X_ATTRIBUTE_PRINTF(1, 0);
+void OsVendorInit(void);
+
 #endif /* _XSERVER_OS_DDX_PRIV_H */

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -148,8 +148,6 @@ typedef void (*OsSigHandlerPtr) (int sig);
 OsSigHandlerPtr OsSignal(int sig, OsSigHandlerPtr handler);
 
 void OsInit(void);
-void OsVendorFatalError(const char *f, va_list args) _X_ATTRIBUTE_PRINTF(1, 0);
-void OsVendorInit(void);
 
 _X_EXPORT /* needed by the int10 module, but should not be used by OOT drivers */
 void OsBlockSignals(void);

--- a/os/osinit.c
+++ b/os/osinit.c
@@ -60,6 +60,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "os/busfault.h"
+#include "os/ddx_priv.h"
 #include "os/log_priv.h"
 #include "os/osdep.h"
 #include "os/serverlock.h"


### PR DESCRIPTION
These are implemented by DDX, thus should be declared in ddx_priv.h

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
