### PR TITLE
os: move AllowByteSwappedClients setting into DIX

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -117,6 +117,7 @@ Equipment Corporation.
 #include "dix/screensaver_priv.h"
 #include "dix/selection_priv.h"
 #include "dix/server_priv.h"
+#include "dix/settings_priv.h"
 #include "dix/window_priv.h"
 #include "include/resource.h"
 #include "miext/extinit_priv.h"
@@ -3907,7 +3908,7 @@ ProcEstablishConnection(ClientPtr client)
 
     prefix = (xConnClientPrefix *) ((char *) stuff + sz_xReq);
 
-    if (client->swapped && !AllowByteSwappedClients) {
+    if (client->swapped && !dixSettingAllowByteSwappedClients) {
         reason = "Prohibited client endianess, see the Xserver man page ";
     } else if ((client->req_len << 2) != sz_xReq + sz_xConnClientPrefix +
             pad_to_int32(prefix->nbytesAuthProto) +

--- a/dix/globals.c
+++ b/dix/globals.c
@@ -51,6 +51,7 @@ SOFTWARE.
 
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
+#include "dix/settings_priv.h"
 
 #include "misc.h"
 #include "windowstr.h"

--- a/dix/meson.build
+++ b/dix/meson.build
@@ -33,6 +33,7 @@ srcs_dix = [
     'screen_hooks.c',
     'selection.c',
     'screen.c',
+    'settings.c',
     'swaprep.c',
     'swapreq.c',
     'tables.c',

--- a/dix/settings.c
+++ b/dix/settings.c
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ *
+ * This file holds global DIX *settings*, which might be needed by other
+ * parts, e.g. OS layer or DDX'es.
+ *
+ * Some of them might be influenced by command line args, some by xf86's
+ * config files.
+ */
+#include <dix-config.h>
+
+#include <stdbool.h>
+
+#include "dix/settings_priv.h"
+
+bool dixSettingAllowByteSwappedClients = false;

--- a/dix/settings_priv.h
+++ b/dix/settings_priv.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef _XSERVER_DIX_SETTINGS_H
+#define _XSERVER_DIX_SETTINGS_H
+
+#include <stdbool.h>
+
+/* This file holds global DIX *settings*, which might be needed by other
+ * parts, e.g. OS layer or DDX'es.
+ *
+ * Some of them might be influenced by command line args, some by xf86's
+ * config files.
+ */
+
+extern bool dixSettingAllowByteSwappedClients;
+
+#endif

--- a/hw/xfree86/common/xf86Config.c
+++ b/hw/xfree86/common/xf86Config.c
@@ -51,6 +51,7 @@
 #include <grp.h>
 
 #include "dix/resource_priv.h"
+#include "dix/settings_priv.h"
 #include "dix/screensaver_priv.h"
 #include "include/extinit.h"
 #include "os/log_priv.h"
@@ -752,8 +753,11 @@ configServerFlags(XF86ConfFlagsPtr flagsconf, XF86OptionPtr layoutopts)
         LogMessageVerb(X_CONFIG, 1, "Ignoring ABI Version\n");
     }
 
-    xf86GetOptValBool(FlagOptions, FLAG_ALLOW_BYTE_SWAPPED_CLIENTS, &AllowByteSwappedClients);
-    if (AllowByteSwappedClients) {
+    Bool bv = FALSE;
+    if (xf86GetOptValBool(FlagOptions, FLAG_ALLOW_BYTE_SWAPPED_CLIENTS, &bv)) {
+        dixSettingAllowByteSwappedClients = bv;
+    }
+    if (dixSettingAllowByteSwappedClients) {
         LogMessageVerb(X_CONFIG, 1, "Allowing byte-swapped clients\n");
     }
 

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -199,7 +199,6 @@ extern Bool PartialNetwork;
 
 extern Bool CoreDump;
 extern Bool NoListenAll;
-extern Bool AllowByteSwappedClients;
 
 /*
  * This function reallocarray(3)s passed buffer, terminating the server if

--- a/os/utils.c
+++ b/os/utils.c
@@ -96,6 +96,7 @@ OR PERFORMANCE OF THIS SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
+#include "dix/settings_priv.h"
 #include "dix/screensaver_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/audit_priv.h"
@@ -126,8 +127,6 @@ OR PERFORMANCE OF THIS SOFTWARE.
 Bool CoreDump;
 
 Bool enableIndirectGLX = FALSE;
-
-Bool AllowByteSwappedClients = FALSE;
 
 #ifdef XINERAMA
 Bool PanoramiXExtensionDisabledHack = FALSE;
@@ -473,9 +472,9 @@ ProcessCommandLine(int argc, char *argv[])
                 UseMsg();
         }
         else if (strcmp(argv[i], "-byteswappedclients") == 0) {
-            AllowByteSwappedClients = FALSE;
+            dixSettingAllowByteSwappedClients = FALSE;
         } else if (strcmp(argv[i], "+byteswappedclients") == 0) {
-            AllowByteSwappedClients = TRUE;
+            dixSettingAllowByteSwappedClients = TRUE;
         }
         else if (strcmp(argv[i], "-br") == 0);  /* default */
         else if (strcmp(argv[i], "+bs") == 0)


### PR DESCRIPTION
Adding new source and header that's going to host all DIX
settings (set via cmdline or xf86 config file) in the future.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
