### PR TITLE
include: unexport CURSOR_BITS_SIZE() and CURSOR_REC_SIZE() macros

### DIFF
--- a/dix/cursor_priv.h
+++ b/dix/cursor_priv.h
@@ -16,6 +16,9 @@
 #include "include/input.h"
 #include "include/window.h"
 
+#define CURSOR_BITS_SIZE (sizeof(CursorBits) + (size_t)dixPrivatesSize(PRIVATE_CURSOR_BITS))
+#define CURSOR_REC_SIZE (sizeof(CursorRec) + (size_t)dixPrivatesSize(PRIVATE_CURSOR))
+
 extern CursorPtr rootCursor;
 
 /* reference counting */

--- a/include/cursorstr.h
+++ b/include/cursorstr.h
@@ -67,8 +67,6 @@ typedef struct _CursorBits {
     CARD32 *argb;               /* full-color alpha blended */
 } CursorBits, *CursorBitsPtr;
 
-#define CURSOR_BITS_SIZE (sizeof(CursorBits) + (size_t)dixPrivatesSize(PRIVATE_CURSOR_BITS))
-
 typedef struct _Cursor {
     CursorBitsPtr bits;
     unsigned short foreRed, foreGreen, foreBlue;        /* device-independent color */
@@ -79,8 +77,6 @@ typedef struct _Cursor {
     CARD32 serialNumber;
     Atom name;
 } CursorRec;
-
-#define CURSOR_REC_SIZE (sizeof(CursorRec) + (size_t)dixPrivatesSize(PRIVATE_CURSOR))
 
 typedef struct _CursorMetric {
     unsigned short width, height, xhot, yhot;


### PR DESCRIPTION
Not used by any drivers, so no need to keep them public.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
