### PR TITLE
modesetting: Fix leak when disabling hw cursor

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -2268,7 +2268,7 @@ CloseScreen(ScreenPtr pScreen)
         ms->drmmode.shadow_fb2 = NULL;
     }
 
-    if (!ms->drmmode.sw_cursor) {
+    if (!ms->drmmode.sw_cursor || ms->drmmode.set_cursor_failed) {
         xf86_cursors_fini(pScreen);
     }
 

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -1843,6 +1843,7 @@ drmmode_set_cursor(xf86CrtcPtr crtc, int width, int height)
 
         cursor_info->MaxWidth = cursor_info->MaxHeight = 0;
         drmmode_crtc->drmmode->sw_cursor = TRUE;
+        drmmode_crtc->drmmode->set_cursor_failed = TRUE;
     }
 
     if (ret) {

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.h
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.h
@@ -104,6 +104,7 @@ typedef struct {
     drmEventContext event_context;
     drmmode_bo front_bo;
     Bool sw_cursor;
+    Bool set_cursor_failed;
 
     /* Broken-out options. */
     OptionInfoPtr Options;


### PR DESCRIPTION
As discussed in https://github.com/X11Libre/xserver/pull/1324#issuecomment-3483116400