### PR TITLE
Alternative fix for glx reset.

### DIFF
--- a/dix/callback_priv.h
+++ b/dix/callback_priv.h
@@ -22,4 +22,7 @@ void DeleteCallbackManager(void);
 _X_EXPORT /* only for GLX module */
 void DeleteCallbackList(CallbackListPtr *pcbl);
 
+_X_EXPORT /* only for GLX module */
+Bool CreateCallbackList(CallbackListPtr *pcbl);
+
 #endif /* _XSERVER_CALLBACK_PRIV_H */

--- a/dix/dixutils.c
+++ b/dix/dixutils.c
@@ -787,7 +787,7 @@ void DeleteCallbackList(CallbackListPtr *pcbl)
     *pcbl = NULL;
 }
 
-static Bool
+Bool
 CreateCallbackList(CallbackListPtr *pcbl)
 {
     if (!pcbl)

--- a/glx/vndext.c
+++ b/glx/vndext.c
@@ -200,6 +200,8 @@ GLXReset(ExtensionEntry *extEntry)
 
     if ((dispatchException & DE_TERMINATE) == DE_TERMINATE) {
         DeleteCallbackList(&vndInitCallbackListPtr);
+        // glxServer needs a non-null .extensionInitCallback
+        CreateCallbackList(&vndInitCallbackListPtr);
     }
 }
 


### PR DESCRIPTION
glxServer seems to require a non-null extensionInitCallback

Not sure that it will work, requires testing.
