### PR TITLE
config: socket_handler(): fix -Wunused-parameter warning

### DIFF
--- a/config/udev.c
+++ b/config/udev.c
@@ -349,6 +349,9 @@ device_removed(struct udev_device *device)
 static void
 socket_handler(int fd, int ready, void *data)
 {
+    (void) fd;
+    (void) ready;
+    (void) data;
     struct udev_device *udev_device;
     const char *action;
 


### PR DESCRIPTION
This pull request is also here to help me understand if I'm doing things correctly to contribute to this project. There are many other warnings to fix!

In the case of this commit, the `socket_handler()` function needs to keep the same `func(int fd, int ready, void *data)` to match the expected function pointer signature.
