### PR TITLE
xkb: unexport XkbGetCoreMap() and XkbSetRepeatKeys()

### DIFF
--- a/Xi/getkmap.c
+++ b/Xi/getkmap.c
@@ -59,6 +59,7 @@ SOFTWARE.
 #include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "Xi/handlers.h"
+#include "xkb/xkbsrv_priv.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
 #include "swaprep.h"

--- a/hw/xquartz/quartzKeyboard.c
+++ b/hw/xquartz/quartzKeyboard.c
@@ -44,6 +44,10 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <sys/stat.h>
+#include <assert.h>
+#include <pthread.h>
+
+#include "xkb/xkbsrv_priv.h"
 
 #include "quartz.h"
 #include "darwin.h"
@@ -52,9 +56,6 @@
 #include "quartzKeyboard.h"
 
 #include "X11Application.h"
-
-#include <assert.h>
-#include <pthread.h>
 
 #include "xkbsrv.h"
 #include "exevents.h"

--- a/include/xkbsrv.h
+++ b/include/xkbsrv.h
@@ -197,9 +197,6 @@ extern _X_EXPORT void XkbFreeKeyboard(XkbDescPtr /* xkb */ ,
                                       Bool      /* freeDesc */
     );
 
-extern _X_EXPORT KeySymsPtr XkbGetCoreMap(DeviceIntPtr  /* keybd */
-    );
-
 extern _X_EXPORT void XkbApplyMappingChange(DeviceIntPtr /* pXDev */ ,
                                             KeySymsPtr /* map */ ,
                                             KeyCode /* firstKey */ ,
@@ -211,11 +208,6 @@ extern _X_EXPORT void XkbApplyMappingChange(DeviceIntPtr /* pXDev */ ,
 extern _X_EXPORT void XkbDDXChangeControls(DeviceIntPtr /* dev */ ,
                                            XkbControlsPtr /* old */ ,
                                            XkbControlsPtr       /* new */
-    );
-
-extern _X_EXPORT void XkbSetRepeatKeys(DeviceIntPtr /* pXDev */ ,
-                                       int /* key */ ,
-                                       int      /* onoff */
     );
 
 extern _X_EXPORT void XkbGetRulesDflts(XkbRMLVOSet *    /* rmlvo */

--- a/xkb/xkbsrv_priv.h
+++ b/xkb/xkbsrv_priv.h
@@ -303,4 +303,8 @@ int XkbDDXUsesSoftRepeat(DeviceIntPtr dev);
 void XkbDDXKeybdCtrlProc(DeviceIntPtr dev, KeybdCtrl *ctrl);
 void XkbDDXUpdateDeviceIndicators(DeviceIntPtr dev, XkbSrvLedInfoPtr sli,
                                   CARD32 newState);
+
+KeySymsPtr XkbGetCoreMap(DeviceIntPtr keybd);
+void XkbSetRepeatKeys(DeviceIntPtr pXDev, int key, int onoff);
+
 #endif /* _XSERVER_XKBSRV_PRIV_H_ */


### PR DESCRIPTION
Not needed by external drivers, so no need to keep them public.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
