### PR TITLE
include: move ScreenSaverStuffPtr into scrnintstr.h

### DIFF
--- a/include/scrnintstr.h
+++ b/include/scrnintstr.h
@@ -88,7 +88,7 @@ typedef struct _ScreenSaverStuff {
     Bool (*ExternalScreenSaver) (ScreenPtr /*pScreen */ ,
                                  int /*xstate */ ,
                                  Bool /*force */ );
-} ScreenSaverStuffRec;
+} ScreenSaverStuffRec, *ScreenSaverStuffPtr;
 
 typedef enum {
     WINDOW_VRR_DISABLED = 0,

--- a/include/windowstr.h
+++ b/include/windowstr.h
@@ -201,8 +201,6 @@ static inline PropertyPtr wUserProps(WindowPtr pWin) { return pWin->properties; 
 
 #define HasBorder(w)	((w)->borderWidth || wClipShape(w))
 
-typedef struct _ScreenSaverStuff *ScreenSaverStuffPtr;
-
 #define SCREEN_IS_BLANKED   0
 #define SCREEN_ISNT_SAVED   1
 #define SCREEN_IS_TILED     2


### PR DESCRIPTION
ScreenSaverStuffRec is defined in scrnintstr.h, and users of
ScreenSaverStuffPtr already including it, so let's move also this
typedef there.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
