### PR TITLE
dix: unexport screenIsSaved and HasSaverWindow()

### DIFF
--- a/Xext/xtest.c
+++ b/Xext/xtest.c
@@ -40,6 +40,7 @@
 #include "dix/exevents_priv.h"
 #include "dix/inpututils_priv.h"
 #include "dix/request_priv.h"
+#include "dix/screensaver_priv.h"
 #include "mi/mi_priv.h"
 #include "mi/mipointer_priv.h"
 #include "miext/extinit_priv.h"

--- a/composite/compwindow.c
+++ b/composite/compwindow.c
@@ -45,6 +45,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/resource_priv.h"
+#include "dix/screensaver_priv.h"
 #include "include/extinit.h"
 #include "os/osdep.h"
 #include "Xext/panoramiXsrv.h"

--- a/dix/screensaver_priv.h
+++ b/dix/screensaver_priv.h
@@ -5,12 +5,14 @@
 #ifndef _XSERVER_DIX_SCREENSAVER_PRIV_H
 #define _XSERVER_DIX_SCREENSAVER_PRIV_H
 
+#include <stdbool.h>
 #include <X11/Xdefs.h>
 #include <X11/Xmd.h>
 
 #include "include/callback.h"
 #include "include/dix.h"
 #include "include/screenint.h"
+#include "include/scrnintstr.h"
 
 extern CARD32 defaultScreenSaverTime;
 extern CARD32 defaultScreenSaverInterval;
@@ -34,6 +36,12 @@ static inline int dixCallScreensaverAccessCallback(ClientPtr client,
     ScreenSaverAccessCallbackParam rec = { client, screen, access_mode, Success };
     CallCallbacks(&ScreenSaverAccessCallback, &rec);
     return rec.status;
+}
+
+extern int screenIsSaved;
+
+static inline bool HasSaverWindow(ScreenPtr pScreen) {
+    return (pScreen->screensaver.pWindow != NullWindow);
 }
 
 #endif /* _XSERVER_DIX_SCREENSAVER_PRIV_H */

--- a/include/windowstr.h
+++ b/include/windowstr.h
@@ -208,8 +208,4 @@ typedef struct _ScreenSaverStuff *ScreenSaverStuffPtr;
 #define SCREEN_IS_TILED     2
 #define SCREEN_IS_BLACK	    3
 
-#define HasSaverWindow(pScreen)   (pScreen->screensaver.pWindow != NullWindow)
-
-extern _X_EXPORT int screenIsSaved;
-
 #endif                          /* WINDOWSTRUCT_H */

--- a/mi/mieq.c
+++ b/mi/mieq.c
@@ -45,6 +45,7 @@ in this Software without prior written authorization from The Open Group.
 #include   "dix/dix_priv.h"
 #include   "dix/input_priv.h"
 #include   "dix/inpututils_priv.h"
+#include   "dix/screensaver_priv.h"
 #include   "mi/mi_priv.h"
 #include   "mi/mipointer_priv.h"
 #include   "os/bug_priv.h"

--- a/mi/mioverlay.c
+++ b/mi/mioverlay.c
@@ -8,6 +8,7 @@
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/screen_hooks_priv.h"
+#include "dix/screensaver_priv.h"
 #include "mi/mi_priv.h"
 
 #include "scrnintstr.h"


### PR DESCRIPTION
These aren't used by any external drivers, so no need to keep them public.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
