### PR TITLE
dix: move ReplyNotSwappd() out of public header

### DIFF
--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -761,4 +761,6 @@ static inline int xmitClientEvent(ClientPtr pClient, xEvent ev)
 int dixAllocColor(ClientPtr client, Colormap cmap, CARD16 *red,
                   CARD16 *green, CARD16 *blue, CARD32 *pixel);
 
+void ReplyNotSwappd(ClientPtr pClient, int size, void *pbuf)  _X_NORETURN;
+
 #endif /* _XSERVER_DIX_PRIV_H */

--- a/dix/swaprep.c
+++ b/dix/swaprep.c
@@ -48,9 +48,12 @@ SOFTWARE.
 
 #include <X11/X.h>
 #include <X11/Xproto.h>
+#include <X11/fonts/fontstruct.h>
+
+#include "dix/dix_priv.h"
+
 #include "misc.h"
 #include "dixstruct.h"
-#include <X11/fonts/fontstruct.h>
 #include "scrnintstr.h"
 #include "swaprep.h"
 #include "globals.h"

--- a/dix/tables.c
+++ b/dix/tables.c
@@ -49,6 +49,7 @@ SOFTWARE.
 #include <X11/X.h>
 #include <X11/Xproto.h>
 
+#include "dix/dix_priv.h"
 #include "dix/reqhandlers_priv.h"
 
 #include "windowstr.h"

--- a/include/dixstruct.h
+++ b/include/dixstruct.h
@@ -53,11 +53,6 @@ typedef void (*ReplySwapPtr) (ClientPtr /* pClient */ ,
                               int /* size */ ,
                               void * /* pbuf */ );
 
-extern _X_EXPORT void
-ReplyNotSwappd(ClientPtr /* pClient */ ,
-               int /* size */ ,
-               void * /* pbuf */ ) _X_NORETURN;
-
 typedef enum { ClientStateInitial,
     ClientStateRunning,
     ClientStateRetained,


### PR DESCRIPTION
Internal, non-publich function - should not be in public header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
