### PR TITLE
dix: unexport several extension related functions

### DIFF
--- a/Xext/geext/geext.c
+++ b/Xext/geext/geext.c
@@ -28,6 +28,7 @@
 #include <X11/extensions/ge.h>
 #include <X11/extensions/geproto.h>
 
+#include "dix/extension_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
 #include "miext/extinit_priv.h"

--- a/Xext/xinput/sendexev.c
+++ b/Xext/xinput/sendexev.c
@@ -58,6 +58,7 @@ SOFTWARE.
 #include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
 #include "dix/request_priv.h"
+#include "dix/extension_priv.h"
 #include "handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */

--- a/Xext/xtest/xtest.c
+++ b/Xext/xtest/xtest.c
@@ -35,9 +35,9 @@
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XIproto.h>
 
-#include "dix/input_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
+#include "dix/extension_priv.h"
 #include "dix/inpututils_priv.h"
 #include "dix/request_priv.h"
 #include "dix/screensaver_priv.h"

--- a/dix/extension_priv.h
+++ b/dix/extension_priv.h
@@ -58,4 +58,12 @@ typedef struct {
 extern CallbackListPtr ExtensionAccessCallback;
 extern CallbackListPtr ExtensionDispatchCallback;
 
+void EnableDisableExtensionError(const char *name, Bool enable);
+void InitExtensions(int argc, char **argv);
+void CloseDownExtensions(void);
+
+ExtensionEntry *GetExtensionEntry(int major);
+
+void NotImplemented(xEvent *, xEvent *) _X_NORETURN;
+
 #endif /* _XSERVER_EXTENSION_PRIV_H */

--- a/dix/main.c
+++ b/dix/main.c
@@ -89,6 +89,7 @@ Equipment Corporation.
 #include "dix/callback_priv.h"
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
+#include "dix/extension_priv.h"
 #include "dix/input_priv.h"
 #include "dix/gc_priv.h"
 #include "dix/registry_priv.h"

--- a/dix/privates.c
+++ b/dix/privates.c
@@ -54,6 +54,7 @@ from The Open Group.
 #include <stddef.h>
 
 #include "dix/colormap_priv.h"
+#include "dix/extension_priv.h"
 #include "dix/screenint_priv.h"
 
 #include "windowstr.h"

--- a/dix/registry.c
+++ b/dix/registry.c
@@ -24,6 +24,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <X11/X.h>
 #include <X11/Xproto.h>
 
+#include "dix/extension_priv.h"
 #include "dix/registry_priv.h"
 
 #include "resource.h"

--- a/dix/swaprep.c
+++ b/dix/swaprep.c
@@ -51,6 +51,7 @@ SOFTWARE.
 #include <X11/fonts/fontstruct.h>
 
 #include "dix/dix_priv.h"
+#include "dix/extension_priv.h"
 #include "include/misc.h"
 
 #include "dixstruct.h"

--- a/dix/swapreq.c
+++ b/dix/swapreq.c
@@ -51,6 +51,7 @@ SOFTWARE.
 #include <X11/Xprotostr.h>
 
 #include "dix/dix_priv.h"
+#include "dix/extension_priv.h"
 #include "dix/reqhandlers_priv.h"
 #include "include/misc.h"
 

--- a/dix/tables.c
+++ b/dix/tables.c
@@ -50,6 +50,7 @@ SOFTWARE.
 #include <X11/Xproto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/extension_priv.h"
 #include "dix/reqhandlers_priv.h"
 
 #include "windowstr.h"

--- a/include/extension.h
+++ b/include/extension.h
@@ -91,13 +91,6 @@ extern _X_EXPORT unsigned short StandardMinorOpcode(ClientPtr /*client */ );
 
 extern _X_EXPORT Bool EnableDisableExtension(const char *name, Bool enable);
 
-extern _X_EXPORT void EnableDisableExtensionError(const char *name,
-                                                  Bool enable);
-
-extern _X_EXPORT void InitExtensions(int argc, char **argv);
-
-extern _X_EXPORT void CloseDownExtensions(void);
-
 extern _X_EXPORT void LoadExtensionList(const ExtensionModule ext[],
                                         int listSize, Bool external);
 

--- a/include/extnsionst.h
+++ b/include/extnsionst.h
@@ -76,10 +76,6 @@ typedef void (*EventSwapPtr) (xEvent *, xEvent *);
 
 extern _X_EXPORT EventSwapPtr EventSwapVector[128];
 
-extern _X_EXPORT void
-NotImplemented(                 /* FIXME: this may move to another file... */
-                  xEvent *, xEvent *) _X_NORETURN;
-
 extern _X_EXPORT ExtensionEntry *
 AddExtension(const char * /*name */ ,
              int /*NumEvents */ ,
@@ -92,7 +88,5 @@ AddExtension(const char * /*name */ ,
 
 extern _X_EXPORT ExtensionEntry *
 CheckExtension(const char *extname);
-extern _X_EXPORT ExtensionEntry *
-GetExtensionEntry(int major);
 
 #endif                          /* EXTENSIONSTRUCT_H */

--- a/mi/miinitext.c
+++ b/mi/miinitext.c
@@ -84,6 +84,7 @@ SOFTWARE.
 #undef CONFIG_MITSHM
 #endif
 
+#include "dix/extension_priv.h"
 #include "include/misc.h"
 #include "miext/extinit_priv.h"
 

--- a/os/utils.c
+++ b/os/utils.c
@@ -104,6 +104,7 @@ __stdcall unsigned long GetTickCount(void);
 #endif
 
 #include "dix/dix_priv.h"
+#include "dix/extension_priv.h"
 #include "dix/input_priv.h"
 #include "dix/settings_priv.h"
 #include "dix/screensaver_priv.h"


### PR DESCRIPTION
These aren't used (neither supposed to be used) by any drivers,
so no need to keep them public.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
