### PR TITLE
include: windowstr.h: drop unused Guarantee* defines

### DIFF
--- a/include/windowstr.h
+++ b/include/windowstr.h
@@ -59,8 +59,6 @@ SOFTWARE.
 #include <X11/Xprotostr.h>
 #include "opaque.h"
 
-#define GuaranteeNothing	0
-#define GuaranteeVisBack	1
 
 #define SameBackground(as, a, bs, b)				\
     ((as) == (bs) && ((as) == None ||				\


### PR DESCRIPTION
They aren't used anymore since about two decades, so no need to
keep them around any longer.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
