### PR TITLE
dix: unexport DontPropagateMask

### DIFF
--- a/dix/window_priv.h
+++ b/dix/window_priv.h
@@ -11,6 +11,8 @@
 #include "include/window.h"
 #include "include/windowstr.h"
 
+extern Mask DontPropagateMasks[];
+
 #define wTrackParent(w,field)   ((w)->optional ? \
                                     (w)->optional->field \
                                  : FindWindowWithOptional((w))->optional->field)

--- a/include/windowstr.h
+++ b/include/windowstr.h
@@ -157,8 +157,6 @@ struct _Window {
     PropertyPtr properties;     /* default: NULL */
 };
 
-extern _X_EXPORT Mask DontPropagateMasks[];
-
 #define wBorderWidth(w)		((int) (w)->borderWidth)
 
 static inline PropertyPtr wUserProps(WindowPtr pWin) { return pWin->properties; }


### PR DESCRIPTION
Those aren't used by any drivers, so no need to keep them public.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
