### PR TITLE
dix: unexport lastResourceType and TypeMask

### DIFF
--- a/Xext/xselinux/xselinux_label.c
+++ b/Xext/xselinux/xselinux_label.c
@@ -23,6 +23,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "dix/registry_priv.h"
 #include "dix/request_priv.h"
+#include "dix/resource_priv.h"
 
 #include "xselinuxint.h"
 

--- a/dix/privates.c
+++ b/dix/privates.c
@@ -54,10 +54,10 @@ from The Open Group.
 #include <stddef.h>
 
 #include "dix/colormap_priv.h"
+#include "dix/resource_priv.h"
 #include "dix/screenint_priv.h"
 
 #include "windowstr.h"
-#include "resource.h"
 #include "privates.h"
 #include "gcstruct.h"
 #include "cursorstr.h"

--- a/dix/registry.c
+++ b/dix/registry.c
@@ -25,8 +25,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <X11/Xproto.h>
 
 #include "dix/registry_priv.h"
-
-#include "resource.h"
+#include "dix/resource_priv.h"
 
 #define BASE_SIZE 16
 

--- a/dix/resource_priv.h
+++ b/dix/resource_priv.h
@@ -11,6 +11,9 @@
 #include "include/dix.h"
 #include "include/resource.h"
 
+extern RESTYPE lastResourceType;
+extern RESTYPE TypeMask;
+
 #define SameClient(obj,client) \
         (CLIENT_BITS((obj)->resource) == (client)->clientAsMask)
 

--- a/include/resource.h
+++ b/include/resource.h
@@ -230,9 +230,6 @@ extern _X_EXPORT int dixLookupResourceByClass(void **result,
                                               ClientPtr client,
                                               Mask access_mode);
 
-extern _X_EXPORT RESTYPE lastResourceType;
-extern _X_EXPORT RESTYPE TypeMask;
-
 /*
  * @brief allocate a XID (resource ID) for the server itself
  *


### PR DESCRIPTION
Not used by any drivers, so no need to keep them exported

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
