### PR TITLE
dix: unexport internal region helper functions

### DIFF
--- a/dix/main.c
+++ b/dix/main.c
@@ -91,6 +91,7 @@ Equipment Corporation.
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
 #include "dix/gc_priv.h"
+#include "dix/region_priv.h"
 #include "dix/registry_priv.h"
 #include "dix/screensaver_priv.h"
 #include "dix/selection_priv.h"

--- a/dix/region.c
+++ b/dix/region.c
@@ -83,7 +83,7 @@ Equipment Corporation.
 
 #include "os/mathx_priv.h"
 
-#include "regionstr.h"
+#include "dix/region_priv.h"
 #include "gc.h"
 
 #undef assert

--- a/dix/region_priv.h
+++ b/dix/region_priv.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef _XSERVER_DIX_REGION_PRIV_H
+#define _XSERVER_DIX_REGION_PRIV_H
+
+#include "include/regionstr.h"
+
+void InitRegions(void);
+Bool RegionRectAlloc(RegionPtr pRgn, int n);
+Bool RegionIsValid(RegionPtr prgn);
+void RegionPrint(RegionPtr pReg);
+
+#endif /* _XSERVER_DIX_REGION_PRIV_H */

--- a/fb/fbpixmap.c
+++ b/fb/fbpixmap.c
@@ -24,6 +24,7 @@
 
 #include <stdlib.h>
 
+#include "dix/region_priv.h"
 #include "fb/fb_priv.h"
 
 #ifdef FB_DEBUG

--- a/include/regionstr.h
+++ b/include/regionstr.h
@@ -211,8 +211,6 @@ RegionNull(RegionPtr _pReg)
     (_pReg)->data = &RegionEmptyData;
 }
 
-extern _X_EXPORT void InitRegions(void);
-
 extern _X_EXPORT RegionPtr RegionCreate(BoxPtr /*rect */ ,
                                         int /*size */ );
 
@@ -327,17 +325,6 @@ RegionEqual(RegionPtr reg1, RegionPtr reg2)
 {
     return pixman_region_equal(reg1, reg2);
 }
-
-extern _X_EXPORT Bool RegionRectAlloc(RegionPtr /*pRgn */ ,
-                                      int       /*n */
-    );
-
-#ifdef DEBUG
-extern _X_EXPORT Bool RegionIsValid(RegionPtr   /*prgn */
-    );
-#endif
-
-extern _X_EXPORT void RegionPrint(RegionPtr /*pReg */ );
 
 #define INCLUDE_LEGACY_REGION_DEFINES
 #ifdef INCLUDE_LEGACY_REGION_DEFINES


### PR DESCRIPTION
Not used by any drivers.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
