### PR TITLE
maint-25.0 modesetting: call xf86_cursors_fini during CloseScreen

### DIFF
--- a/hw/xfree86/drivers/modesetting/driver.c
+++ b/hw/xfree86/drivers/modesetting/driver.c
@@ -2183,6 +2183,10 @@ CloseScreen(ScreenPtr pScreen)
         ms->drmmode.shadow_fb2 = NULL;
     }
 
+    if (!ms->drmmode.sw_cursor) {
+        xf86_cursors_fini(pScreen);
+    }
+
     drmmode_uevent_fini(pScrn, &ms->drmmode);
 
     drmmode_free_bos(pScrn, &ms->drmmode);


### PR DESCRIPTION
To keep same commits in maint-25.0 (or is not strong requirement?)

This is same as https://github.com/X11Libre/xserver/pull/1324 
After that, the @stefan11111 pr ( https://github.com/X11Libre/xserver/pull/1370 ) goes.





