### PR TITLE
Xnest: drop support for "full regeneration"

### DIFF
--- a/hw/xnest/Args.c
+++ b/hw/xnest/Args.c
@@ -33,7 +33,6 @@ is" without express or implied warranty.
 #include "Args.h"
 
 char *xnestDisplayName = NULL;
-Bool xnestFullGeneration = FALSE;
 int xnestDefaultClass;
 Bool xnestUserDefaultClass = FALSE;
 int xnestDefaultDepth;
@@ -68,10 +67,6 @@ ddxProcessArgument(int argc, char *argv[], int i)
             return 2;
         }
         return 0;
-    }
-    if (!strcmp(argv[i], "-full")) {
-        xnestFullGeneration = TRUE;
-        return 1;
     }
     if (!strcmp(argv[i], "-class")) {
         if (++i < argc) {
@@ -182,7 +177,6 @@ void
 ddxUseMsg(void)
 {
     ErrorF("-display string        display name of the real server\n");
-    ErrorF("-full                  utilize full regeneration\n");
     ErrorF("-class string          default visual class\n");
     ErrorF("-depth int             default depth\n");
     ErrorF("-sss                   use software screen saver\n");

--- a/hw/xnest/Args.h
+++ b/hw/xnest/Args.h
@@ -21,7 +21,6 @@ is" without express or implied warranty.
 #include <xcb/xcb.h>
 
 extern char *xnestDisplayName;
-extern Bool xnestFullGeneration;
 extern int xnestDefaultClass;
 extern Bool xnestUserDefaultClass;
 extern int xnestDefaultDepth;

--- a/hw/xnest/Init.c
+++ b/hw/xnest/Init.c
@@ -109,7 +109,7 @@ InitOutput(int argc, char *argv[])
 
     xnestNumScreens = screenInfo.numScreens;
 
-    xnestDoFullGeneration = xnestFullGeneration;
+    xnestDoFullGeneration = FALSE;
 }
 
 static void

--- a/hw/xnest/man/Xnest.man
+++ b/hw/xnest/man/Xnest.man
@@ -74,20 +74,6 @@ This is a useful option for debugging, but it will slow down
 performance considerably.
 It should not be used unless absolutely necessary.
 .TP
-.B \-full
-This option tells
-.B Xnest
-to utilize full regeneration of real server objects and reopen a new connection
-to the real server each time the nested server regenerates.
-The sample server implementation regenerates all objects in the server when the
-last client of this server terminates.
-When this happens,
-.B Xnest
-by default maintains the same top-level window and the same real server
-connection in each new generation.
-If the user selects full regeneration, even the top-level window and the
-connection to the real server will be regenerated for each server generation.
-.TP
 .BI "\-class " string
 This option specifies the default visual class of the nested server.
 It is similar to the


### PR DESCRIPTION
This is (rarely used) special mode where, at server regeneration
(when last client exited), Xnest is additionally terminating and
restarting it's upstream connection, thus also recreating it's
main window, etc.

That mode is only meant for special debug scenarios, not suited for
practical use. And the same can be achieved by just terminating the
whole Xnest process (-terminate cmdline arg) and restrting it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
