### PR TITLE
dix: drop DE_RESET and associated cmdline args

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -595,7 +595,6 @@ Dispatch(void)
     }
     ddxBeforeReset();
     KillAllClients();
-    dispatchException &= ~DE_RESET;
     SmartScheduleLatencyLimited = 0;
     ResetOsBuffers();
 }
@@ -3604,7 +3603,7 @@ ProcNoOperation(ClientPtr client)
  *  then killed again, the client is really destroyed.
  *********************/
 
-char dispatchExceptionAtReset = DE_RESET;
+char dispatchExceptionAtReset = 0;
 int terminateDelay = 0;
 
 void

--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -282,7 +282,6 @@ extern Bool whiteRoot;
 extern volatile char isItTimeToYield;
 
 /* bit values for dispatchException */
-#define DE_RESET     1
 #define DE_TERMINATE 2
 #define DE_PRIORITYCHANGE 4     /* set when a client's priority changes */
 

--- a/dix/globals.c
+++ b/dix/globals.c
@@ -86,7 +86,9 @@ int currentMaxClients;          /* current size of clients array */
 long maxBigRequestSize = MAX_BIG_REQUEST_SIZE;
 
 unsigned long globalSerialNumber = 0;
-x_server_generation_t serverGeneration = 0;
+
+/* this is always 1 now, since there's no internal reset anymore */
+x_server_generation_t serverGeneration = 1;
 
 /* these next four are initialized in main.c */
 CARD32 ScreenSaverTime;

--- a/dix/main.c
+++ b/dix/main.c
@@ -147,8 +147,7 @@ dix_main(int argc, char *argv[], char *envp[])
 
     alwaysCheckForInput[0] = 0;
     alwaysCheckForInput[1] = 1;
-    while (1) {
-        serverGeneration++;
+
         ScreenSaverTime = defaultScreenSaverTime;
         ScreenSaverInterval = defaultScreenSaverInterval;
         ScreenSaverBlanking = defaultScreenSaverBlanking;
@@ -157,7 +156,7 @@ dix_main(int argc, char *argv[], char *envp[])
         InitBlockAndWakeupHandlers();
         /* Perform any operating system dependent initializations you'd like */
         OsInit();
-        if (serverGeneration == 1) {
+
             CreateWellKnownSockets();
             for (int i = 1; i < LimitClients; i++)
                 clients[i] = NULL;
@@ -165,9 +164,7 @@ dix_main(int argc, char *argv[], char *envp[])
             if (!serverClient)
                 FatalError("couldn't create server client");
             InitClient(serverClient, 0, (void *) NULL);
-        }
-        else
-            ResetWellKnownSockets();
+
         clients[0] = serverClient;
         currentMaxClients = 1;
 
@@ -352,19 +349,13 @@ dix_main(int argc, char *argv[], char *envp[])
 
         ClearWorkQueue();
 
-        if (dispatchException & DE_TERMINATE) {
-            CloseWellKnownConnections();
-        }
+        CloseWellKnownConnections();
+        OsCleanup(TRUE);
 
-        OsCleanup((dispatchException & DE_TERMINATE) != 0);
-
-        if (dispatchException & DE_TERMINATE) {
-            ddxGiveUp(EXIT_NO_ERROR);
-            break;
-        }
+        ddxGiveUp(EXIT_NO_ERROR);
 
         free(ConnectionInfo);
         ConnectionInfo = NULL;
-    }
+
     return 0;
 }

--- a/man/Xserver.man
+++ b/man/Xserver.man
@@ -241,9 +241,6 @@ with
 This option may be issued multiple times to enable listening to different
 transport types.
 .TP 8
-.B \-noreset
-prevents a server reset when the last client connection is closed.  This
-overrides a previous
 .B \-terminate
 command line option.
 .TP 8
@@ -392,10 +389,6 @@ specifies the local address to connect from (useful if the connecting host
 has multiple network interfaces).  The \fIlocal-address\fP may be expressed
 in any form acceptable to the host platform's \fIgethostbyname\fP(3)
 implementation.
-.TP 8
-.B \-once
-causes the server to terminate (rather than reset) when the XDMCP session
-ends.
 .TP 8
 .B \-class \fIdisplay-class\fP
 XDMCP has an additional display qualifier used in resource lookup for

--- a/os/connection.c
+++ b/os/connection.c
@@ -297,7 +297,6 @@ CreateWellKnownSockets(void)
 
 #if !defined(WIN32)
     OsSignal(SIGPIPE, SIG_IGN);
-    OsSignal(SIGHUP, AutoResetServer);
 #endif
     OsSignal(SIGINT, GiveUp);
     OsSignal(SIGTERM, GiveUp);

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -135,8 +135,6 @@ int Pclose(void *f);
 
 #endif /* WIN32 */
 
-void AutoResetServer(int sig);
-
 /* clone fd so it gets out of our select mask */
 int os_move_fd(int fd);
 

--- a/os/utils.c
+++ b/os/utils.c
@@ -160,18 +160,6 @@ OsSignal(int sig, OsSigHandlerPtr handler)
 #endif
 }
 
-/* Force connections to close on SIGHUP from init */
-
-void
-AutoResetServer(int sig)
-{
-    int olderrno = errno;
-
-    dispatchException |= DE_RESET;
-    isItTimeToYield = TRUE;
-    errno = olderrno;
-}
-
 /* Force connections to close and then exit on SIGTERM, SIGINT */
 
 void
@@ -305,9 +293,7 @@ UseMsg(void)
     ErrorF("-maxclients n          set maximum number of clients (power of two)\n");
     ErrorF("-nolisten string       don't listen on protocol\n");
     ErrorF("-listen string         listen on protocol\n");
-    ErrorF("-noreset               don't reset after last client exists\n");
     ErrorF("-background [none]     create root window with no background\n");
-    ErrorF("-reset                 reset after last client exists\n");
     ErrorF("-p #                   screen-saver pattern duration (minutes)\n");
     ErrorF("-pn                    accept failure to listen on all ports\n");
     ErrorF("-nopn                  reject failure to listen on all ports\n");
@@ -613,12 +599,6 @@ ProcessCommandLine(int argc, char *argv[])
             }
             else
                 UseMsg();
-        }
-        else if (strcmp(argv[i], "-noreset") == 0) {
-            dispatchExceptionAtReset = 0;
-        }
-        else if (strcmp(argv[i], "-reset") == 0) {
-            dispatchExceptionAtReset = DE_RESET;
         }
         else if (strcmp(argv[i], "-p") == 0) {
             if (++i < argc)

--- a/randr/rrproperty.c
+++ b/randr/rrproperty.c
@@ -56,7 +56,7 @@ DeliverPropertyEvent(WindowPtr pWin, void *value)
 static void
 RRDeliverPropertyEvent(ScreenPtr pScreen, xEvent *event)
 {
-    if (!(dispatchException & (DE_RESET | DE_TERMINATE)))
+    if (!(dispatchException & (DE_TERMINATE)))
         WalkTree(pScreen, DeliverPropertyEvent, event);
 }
 

--- a/randr/rrproviderproperty.c
+++ b/randr/rrproviderproperty.c
@@ -54,7 +54,7 @@ DeliverPropertyEvent(WindowPtr pWin, void *value)
 static void
 RRDeliverPropertyEvent(ScreenPtr pScreen, xEvent *event)
 {
-    if (!(dispatchException & (DE_RESET | DE_TERMINATE)))
+    if (!(dispatchException & (DE_TERMINATE)))
         WalkTree(pScreen, DeliverPropertyEvent, event);
 }
 

--- a/test/scripts/xephyr-glamor-gles2-piglit.sh
+++ b/test/scripts/xephyr-glamor-gles2-piglit.sh
@@ -12,7 +12,6 @@ export PIGLIT_RESULTS_DIR=$XSERVER_BUILDDIR/test/piglit-results/xephyr-glamor-gl
 export SERVER_COMMAND="$XSERVER_BUILDDIR/hw/kdrive/ephyr/Xephyr \
         -glamor_gles2 \
         -glamor-skip-present \
-        -noreset \
         -schedMax 2000 \
         -screen 1280x1024"
 

--- a/test/scripts/xephyr-glamor-gles3-piglit.sh
+++ b/test/scripts/xephyr-glamor-gles3-piglit.sh
@@ -12,7 +12,6 @@ export PIGLIT_RESULTS_DIR=$XSERVER_BUILDDIR/test/piglit-results/xephyr-glamor-gl
 export SERVER_COMMAND="$XSERVER_BUILDDIR/hw/kdrive/ephyr/Xephyr \
         -glamor_gles2 \
         -glamor-skip-present \
-        -noreset \
         -schedMax 2000 \
         -screen 1280x1024"
 

--- a/test/scripts/xephyr-glamor-piglit.sh
+++ b/test/scripts/xephyr-glamor-piglit.sh
@@ -12,7 +12,6 @@ export PIGLIT_RESULTS_DIR=$XSERVER_BUILDDIR/test/piglit-results/xephyr-glamor
 export SERVER_COMMAND="$XSERVER_BUILDDIR/hw/kdrive/ephyr/Xephyr \
         -glamor \
         -glamor-skip-present \
-        -noreset \
         -schedMax 2000 \
         -screen 1280x1024"
 

--- a/test/scripts/xvfb-piglit.sh
+++ b/test/scripts/xvfb-piglit.sh
@@ -6,9 +6,7 @@
 #fi
 
 export SERVER_COMMAND="$XSERVER_BUILDDIR/hw/vfb/Xvfb \
-        -noreset \
         -screen scrn 1280x1024x24"
 export PIGLIT_RESULTS_DIR=$XSERVER_BUILDDIR/test/piglit-results/xvfb
 
 exec $XSERVER_DIR/test/scripts/run-piglit.sh
-


### PR DESCRIPTION
Drop the -reset flag, so Xserver now either simply continues (w/o going
through internal reset) when last client disconnected or terminates
when -terminate is given.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
