### PR TITLE
Xtranssock.c: fix format truncation warning

### DIFF
--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -630,7 +630,7 @@ set_sun_path(const char *port, const char *upath, char *path, int abstract)
 	return -1;
 
     asprintf(&buf, "%s%s%s", at, upath, port);
-    strncpy(path, buf, sizeof(s.sun_path-1));
+    strncpy(path, buf, sizeof(s.sun_path)-1);
     s.sun_path[sizeof(s.sun_path)-1] = '\0';
     free(buf);
     return 0;

--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -612,7 +612,7 @@ set_sun_path(const char *port, const char *upath, char *path, int abstract)
     struct sockaddr_un s;
     ssize_t maxlen = sizeof(s.sun_path) - 1;
     const char *at = "";
-
+    char * buf;
     if (!port || !*port || !path)
 	return -1;
 
@@ -629,7 +629,10 @@ set_sun_path(const char *port, const char *upath, char *path, int abstract)
     if ((ssize_t)(strlen(at) + strlen(upath) + strlen(port)) > maxlen)
 	return -1;
 
-    asprintf(&path, "%s%s%s", at, upath, port);
+    asprintf(&buf, "%s%s%s", at, upath, port);
+    strncpy(path, buf, sizeof(s.sun_path-1));
+    s.sun_path[sizeof(s.sun_path)-1] = '\0';
+    free(buf);
     return 0;
 }
 #endif

--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -628,7 +628,8 @@ set_sun_path(const char *port, const char *upath, char *path, int abstract)
 
     if ((ssize_t)(strlen(at) + strlen(upath) + strlen(port)) > maxlen)
 	return -1;
-    snprintf(path, sizeof(s.sun_path), "%s%s%s", at, upath, port);
+
+    asprintf(&path, "%s%s%s", at, upath, port);
     return 0;
 }
 #endif


### PR DESCRIPTION
I was tired of staring at this every compile, since we check if the size is appropriate before we write, we can use asprintf and the compiler now trusts that we know what we are doing, and if we didn't we returned with -1 before it could allocate.