### PR TITLE
xf86pciBus: replace on thread-safe strtok_r in xf86ParsePciBusString()

### DIFF
--- a/hw/xfree86/common/xf86pciBus.c
+++ b/hw/xfree86/common/xf86pciBus.c
@@ -264,15 +264,15 @@ xf86ParsePciBusString(const char *busID, int *bus, int *device, int *func)
      * omitted and assumed to be zero, although doing this isn't encouraged.
      */
 
-    char *p, *s, *d;
+    char *p, *s, *d, *last;
     const char *id;
     int i;
 
     if (StringToBusType(busID, &id) != BUS_PCI)
         return FALSE;
 
-    s = Xstrdup(id);
-    p = strtok(s, ":");
+    s = last = Xstrdup(id);
+    p = strtok_r(last, ":", &last);
     if (p == NULL || *p == 0) {
         free(s);
         return FALSE;
@@ -296,7 +296,7 @@ xf86ParsePciBusString(const char *busID, int *bus, int *device, int *func)
     *bus = atoi(p);
     if (d != NULL && *d != 0)
         *bus += atoi(d) << 8;
-    p = strtok(NULL, ":");
+    p = strtok_r(NULL, ":", &last);
     if (p == NULL || *p == 0) {
         free(s);
         return FALSE;
@@ -309,7 +309,7 @@ xf86ParsePciBusString(const char *busID, int *bus, int *device, int *func)
     }
     *device = atoi(p);
     *func = 0;
-    p = strtok(NULL, ":");
+    p = strtok_r(NULL, ":", &last);
     if (p == NULL || *p == 0) {
         free(s);
         return TRUE;


### PR DESCRIPTION
Related to issue: https://github.com/X11Libre/xserver/issues/1398

- Thread A calls xf86ParsePciBusString("PCI:1@0:2:3 "). Execution of strtok_r (in the patched version) or strtok (in the vulnerable version) is suspended after the first call, when the internal pointer is set to the rest of the string ":2:3".
- Thread B (the attacker's thread) calls another function in the X server that also uses strtok (for example, to parse another configuration string). This call overwrites the internal static state of strtok.
- Thread A resumes and calls strtok(NULL, ":") again. Instead of getting the token "2" from the source string, it will receive data from the string processed by Thread B, or NULL, which will lead to incorrect BusID parsing, potential failure, or other unpredictable behavior.

Applying patch with strtok_r completely eliminates this category of vulnerabilities in multithreaded scenarios.