### PR TITLE
xfree86: device parser fix crash with duplicate "Clocks" property

### DIFF
--- a/hw/xfree86/parser/Device.c
+++ b/hw/xfree86/parser/Device.c
@@ -203,9 +203,9 @@ xf86parseDeviceSection(void)
             break;
 
         case CLOCKS:
+            ptr->dev_clocks = 0;
             token = xf86getSubToken(&(ptr->dev_comment));
-            for (i = ptr->dev_clocks;
-                 token == NUMBER && i < CONF_MAXCLOCKS; i++) {
+            for (i = 0; token == NUMBER && i < CONF_MAXCLOCKS; i++) {
                 ptr->dev_clock[i] = (int) (xf86_lex_val.realnum * 1000.0 + 0.5);
                 token = xf86getSubToken(&(ptr->dev_comment));
             }


### PR DESCRIPTION
Related to issue: https://github.com/X11Libre/xserver/issues/1407

This commit fixes when processing the first line, the clock frequency value ptr->dev_clocks is 0. If the first line of the clock frequency contains 100 values, the clock frequency value ptr->dev_clocks will be 100. When processing the second row "Clocks", which contains, for example, 100 more values, the loop will start with i = 100. This will cause 72 values to be written outside the 128-element dev_block array, which will lead to buffer overflow and an emergency crash xserver.