### PR TITLE
Cleaning up Clang --warnlevel=1 warnings (reported in #23)

### DIFF
--- a/hw/xfree86/os-support/xf86_OSlib.h
+++ b/hw/xfree86/os-support/xf86_OSlib.h
@@ -234,7 +234,7 @@ struct pcvtid {
 #define MAP_FAILED ((void *)-1)
 #endif
 
-#define SYSCALL(call) while(((call) == -1) && (errno == EINTR))
+#define SYSCALL(call) while(((call) == -1) && (errno == EINTR)) {}
 
 #include "xf86_OSproc.h"
 

--- a/test/misc.c
+++ b/test/misc.c
@@ -169,7 +169,7 @@ dix_request_fixed_size_overflow(ClientRec *client)
     xReq req = { 0 };
 
     client->req_len = req.length = 1;
-    REQUEST_FIXED_SIZE(req, SIZE_MAX);
+    REQUEST_FIXED_SIZE(req, UINT_MAX);
     return Success;
 }
 

--- a/test/xi2/protocol-xiwarppointer.c
+++ b/test/xi2/protocol-xiwarppointer.c
@@ -166,7 +166,7 @@ test_XIWarpPointer(void)
     request.deviceid = devices.vcp->id;
     request_XIWarpPointer(&client_request, &request, Success);
 
-    request.dst_x = -1 << 16;
+    request.dst_x = -(1 << 16);
     expected_x = SPRITE_X - 1;
     request.deviceid = devices.vcp->id;
     request_XIWarpPointer(&client_request, &request, Success);
@@ -179,7 +179,7 @@ test_XIWarpPointer(void)
     request.deviceid = devices.vcp->id;
     request_XIWarpPointer(&client_request, &request, Success);
 
-    request.dst_y = -1 << 16;
+    request.dst_y = -(1 << 16);
     expected_y = SPRITE_Y - 1;
     request.deviceid = devices.vcp->id;
     request_XIWarpPointer(&client_request, &request, Success);


### PR DESCRIPTION
#1406
> Some of the warnings that were brought up in #23 had already been resolved, but these were the residual warnings I had encountered and fixed when compiling with Clang 19.

Rebased from `master`. First time contributor so I'm not really sure exactly how y'all want this, hopefully this is fine.