### PR TITLE
dbe.c: remove DISABLE_MI_BY_DEFAULT macro

### DIFF
--- a/dbe/dbe.c
+++ b/dbe/dbe.c
@@ -1023,8 +1023,8 @@ DbeExtensionInit(void)
         return;
 
     DIX_FOR_EACH_SCREEN({
-        /* For each screen, set up DBE screen privates and init DIX and DDX
-         * interface.
+        /* For each screen, set up DBE screen privates and init DIX
+         * interface (DDX isn't supported anymore).
          */
         if (!(pDbeScreenPriv = calloc(1, sizeof(DbeScreenPrivRec)))) {
             /* If we can not alloc a window or screen private,
@@ -1042,9 +1042,6 @@ DbeExtensionInit(void)
         dixSetPrivate(&walkScreen->devPrivates, &dbeScreenPrivKeyRec, pDbeScreenPriv);
 
         {
-            /* We don't have DDX support for DBE anymore */
-
-#ifndef DISABLE_MI_DBE_BY_DEFAULT
             /* Setup DIX. */
             pDbeScreenPriv->SetupBackgroundPainter = DbeSetupBackgroundPainter;
 
@@ -1066,10 +1063,6 @@ DbeExtensionInit(void)
                 /* DDX initialization failed.  Stub the screen. */
                 DbeStubScreen(pDbeScreenPriv, &nStubbedScreens);
             }
-#else
-            DbeStubScreen(pDbeScreenPriv, &nStubbedScreens);
-#endif
-
         }
     });
 


### PR DESCRIPTION
Unused, unwanted, and caused the compiler to complain, throw it away.