### PR TITLE
fb: wfbrename: drop unused symbol fbGeneration

### DIFF
--- a/fb/wfbrename.h
+++ b/fb/wfbrename.h
@@ -54,7 +54,6 @@
 #define fbFixCoordModePrevious wfbFixCoordModePrevious
 #define fbGCFuncs wfbGCFuncs
 #define fbGCOps wfbGCOps
-#define fbGeneration wfbGeneration
 #define fbGetImage wfbGetImage
 #define fbGetScreenPrivateKey wfbGetScreenPrivateKey
 #define fbGetSpans wfbGetSpans


### PR DESCRIPTION
Just fallout from mfb removal back 17 years ago.

See: f31bd087e8a7f65cd588bd1d022bb18e72b2a60c
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
