### PR TITLE
events.c: reverse macro order

### DIFF
--- a/dix/events.c
+++ b/dix/events.c
@@ -6019,17 +6019,22 @@ ProcRecolorCursor(ClientPtr client)
     pCursor->backRed = stuff->backRed;
     pCursor->backGreen = stuff->backGreen;
     pCursor->backBlue = stuff->backBlue;
-
-    DIX_FOR_EACH_SCREEN({
 #ifdef XINERAMA
+    DIX_FOR_EACH_SCREEN({
         if (!noPanoramiXExtension)
             displayed = (walkScreen == pSprite->screen);
         else
-#endif /* XINERAMA */
             displayed = (walkScreen == pSprite->hotPhys.pScreen);
         (*walkScreen->RecolorCursor) (PickPointer(client), walkScreen, pCursor,
                                 (pCursor == pSprite->current) && displayed);
     });
+#else
+    DIX_FOR_EACH_SCREEN({
+	displayed = (walkScreen == pSprite->hotPhys.pScreen);
+	(*walkScreen->RecolorCursor) (PickPointer(client), walkScreen, pCursor,
+                                (pCursor == pSprite->current) && displayed);
+    });
+#endif
     return Success;
 }
 


### PR DESCRIPTION
This reversal ensures the macro is well defined at the expense of a few extra LOC. The preprocessor runs sequentially, so XINERAMA is evaluated and the correct version of the code is substituted, the the DIX macro is evaluated, as opposed to previously where the DIX macro was evaluated but the XINERAMA macro was inside of it, leaving how and when it is defined, undefined.