### PR TITLE
os: drop OsCleanup()

### DIFF
--- a/dix/main.c
+++ b/dix/main.c
@@ -103,6 +103,7 @@ Equipment Corporation.
 #include "os/ddx_priv.h"
 #include "os/osdep.h"
 #include "os/screensaver.h"
+#include "os/serverlock.h"
 #include "Xext/panoramiXsrv.h"
 
 #include "scrnintstr.h"
@@ -350,7 +351,7 @@ dix_main(int argc, char *argv[], char *envp[])
         ClearWorkQueue();
 
         CloseWellKnownConnections();
-        OsCleanup(TRUE);
+        UnlockServer();
 
         ddxGiveUp(EXIT_NO_ERROR);
 

--- a/hw/kdrive/ephyr/ephyr.c
+++ b/hw/kdrive/ephyr/ephyr.c
@@ -32,6 +32,7 @@
 #include "mi/mipointer_priv.h"
 #include "os/client_priv.h"
 #include "os/osdep.h"
+#include "os/serverlock.h"
 
 #include "ephyr.h"
 #include "inputstr.h"
@@ -1253,7 +1254,7 @@ ephyrXcbProcessEvents(Bool queued_only)
              */
             if (xcb_connection_has_error(conn)) {
                 CloseWellKnownConnections();
-                OsCleanup(1);
+                UnlockServer();
                 exit(1);
             }
 

--- a/hw/xfree86/common/xf86Configure.c
+++ b/hw/xfree86/common/xf86Configure.c
@@ -31,6 +31,7 @@
 
 #include "os/ddx_priv.h"
 #include "os/osdep.h"
+#include "os/serverlock.h"
 
 #include "xf86_priv.h"
 #include "xf86Bus.h"
@@ -830,7 +831,7 @@ DoConfigure(void)
     ErrorF("To test the server, run 'X -config %s'\n\n", filename);
 
  bail:
-    OsCleanup(TRUE);
+    UnlockServer();
     ddxGiveUp(EXIT_ERR_CONFIGURE);
     fflush(stderr);
     exit(0);
@@ -883,7 +884,7 @@ DoShowOptions(void)
         }
     }
  bail:
-    OsCleanup(TRUE);
+    UnlockServer();
     ddxGiveUp(EXIT_ERR_DRIVERS);
     fflush(stderr);
     exit(0);

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -148,7 +148,6 @@ typedef void (*OsSigHandlerPtr) (int sig);
 OsSigHandlerPtr OsSignal(int sig, OsSigHandlerPtr handler);
 
 void OsInit(void);
-void OsCleanup(Bool);
 void OsVendorFatalError(const char *f, va_list args) _X_ATTRIBUTE_PRINTF(1, 0);
 void OsVendorInit(void);
 

--- a/os/osinit.c
+++ b/os/osinit.c
@@ -226,11 +226,3 @@ OsInit(void)
     LogInit(NULL, NULL);
     SmartScheduleInit();
 }
-
-void
-OsCleanup(Bool terminating)
-{
-    if (terminating) {
-        UnlockServer();
-    }
-}

--- a/os/utils.c
+++ b/os/utils.c
@@ -1462,7 +1462,7 @@ AbortServer(void)
     XF86BigfontCleanup();
 #endif
     CloseWellKnownConnections();
-    OsCleanup(TRUE);
+    UnlockServer();
     AbortDevices();
     ddxGiveUp(EXIT_ERR_ABORT);
     fflush(stderr);


### PR DESCRIPTION
Since we're always terminating now, everbody can call UnlockServer()
directly, so we don't need that extra function anymore.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
