### PR TITLE
include: dixfont.h: drop unused NullDIXFontProp and DIXFontPropPtr

### DIFF
--- a/include/dixfont.h
+++ b/include/dixfont.h
@@ -28,10 +28,6 @@ SOFTWARE.
 #include <X11/fonts/font.h>
 #include <X11/fonts/fontstruct.h>
 
-#define NullDIXFontProp ((DIXFontPropPtr)0)
-
-typedef struct _DIXFontProp *DIXFontPropPtr;
-
 extern _X_EXPORT Bool SetDefaultFont(const char * /*defaultfontname */ );
 
 extern _X_EXPORT int OpenFont(ClientPtr /*client */ ,


### PR DESCRIPTION
Not used anywhere, so no need to keep them around any longer.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
