### PR TITLE
config: unexport config_init() and config_fini()

### DIFF
--- a/config/hotplug_priv.h
+++ b/config/hotplug_priv.h
@@ -31,7 +31,6 @@
 
 #include <X11/Xfuncproto.h>
 
-#include "hotplug.h"
 #include "list.h"
 
 /* Bump this each time you add something to the struct
@@ -83,5 +82,8 @@ struct xf86_platform_device *
 xf86_find_platform_device_by_devnum(unsigned int major, unsigned int minor);
 
 void config_pre_init(void);
+
+void config_init(void);
+void config_fini(void);
 
 #endif /* _XSERVER_HOTPLUG_PRIV_H */

--- a/hw/kdrive/src/kinput.c
+++ b/hw/kdrive/src/kinput.c
@@ -55,7 +55,7 @@
 #include "optionstr.h"
 
 #if defined(CONFIG_UDEV) || defined(CONFIG_HAL)
-#include "hotplug.h"
+#include "config/hotplug_priv.h"
 #endif
 
 #ifdef KDRIVE_EVDEV

--- a/hw/xfree86/os-support/xf86_os_support.h
+++ b/hw/xfree86/os-support/xf86_os_support.h
@@ -52,8 +52,6 @@ typedef struct {
 void xf86OSInitVidMem(VidMemInfoPtr);
 
 #ifdef XSERVER_PLATFORM_BUS
-#include "hotplug.h"
-
 struct OdevAttributes;
 
 void

--- a/include/hotplug.h
+++ b/include/hotplug.h
@@ -26,9 +26,4 @@
 #ifndef HOTPLUG_H
 #define HOTPLUG_H
 
-#include <X11/Xfuncproto.h>
-
-extern _X_EXPORT void config_init(void);
-extern _X_EXPORT void config_fini(void);
-
 #endif                          /* HOTPLUG_H */


### PR DESCRIPTION
Those aren't used by any drivers, so no need to keep them public.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
