### PR TITLE
include: misc.h: unexport lowbit() macro

### DIFF
--- a/dix/window.c
+++ b/dix/window.c
@@ -117,6 +117,7 @@ Equipment Corporation.
 #include "mi/mi_priv.h"         /* miPaintWindow */
 #include "os/auth.h"
 #include "os/client_priv.h"
+#include "os/osdep.h"
 #include "os/screensaver.h"
 #include "Xext/panoramiX.h"
 #include "Xext/panoramiXsrv.h"

--- a/hw/kdrive/fbdev/fbdev.c
+++ b/hw/kdrive/fbdev/fbdev.c
@@ -21,11 +21,14 @@
  */
 
 #include <kdrive-config.h>
-#include "fbdev.h"
-#include "fb/fb_priv.h"
-#include <sys/ioctl.h>
 
+#include <sys/ioctl.h>
 #include <errno.h>
+
+#include "fb/fb_priv.h"
+#include "os/osdep.h"
+
+#include "fbdev.h"
 
 #ifndef xallocarray
 #define xallocarray(num, size) reallocarray(NULL, (num), (size))

--- a/hw/xnest/Color.c
+++ b/hw/xnest/Color.c
@@ -20,6 +20,7 @@ is" without express or implied warranty.
 #include <xcb/xcb.h>
 
 #include "dix/colormap_priv.h"
+#include "os/osdep.h"
 
 #include "scrnintstr.h"
 #include "window.h"

--- a/include/misc.h
+++ b/include/misc.h
@@ -136,14 +136,6 @@ typedef struct _xReq *xReqPtr;
 #define sign(x) ((x) < 0 ? -1 : ((x) > 0 ? 1 : 0))
 /* this assumes b > 0 */
 #define modulus(a, b, d)    if (((d) = (a) % (b)) < 0) (d) += (b)
-/*
- * return the least significant bit in x which is set
- *
- * This works on 1's complement and 2's complement machines.
- * If you care about the extra instruction on 2's complement
- * machines, change to ((x) & (-(x)))
- */
-#define lowbit(x) ((x) & (~(x) + 1))
 
 /* XXX Not for modules */
 #include <limits.h>

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -57,6 +57,15 @@ SOFTWARE.
 #include <X11/Xmd.h>
 #include <X11/Xdefs.h>
 
+/*
+ * return the least significant bit in x which is set
+ *
+ * This works on 1's complement and 2's complement machines.
+ * If you care about the extra instruction on 2's complement
+ * machines, change to ((x) & (-(x)))
+ */
+#define lowbit(x) ((x) & (~(x) + 1))
+
 #ifndef __has_builtin
 # define __has_builtin(x) 0     /* Compatibility with older compilers */
 #endif


### PR DESCRIPTION
Not used by any drivers.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
