### PR TITLE
dix: unexport XIUnregisterPropertyHandler() and XIDeleteAllDeviceProperties()

### DIFF
--- a/dix/exevents_priv.h
+++ b/dix/exevents_priv.h
@@ -159,4 +159,8 @@ int XIPropToInt(XIPropertyValuePtr val, int *nelem_return, int **buf_return);
 
 int XIPropToFloat(XIPropertyValuePtr val, int *nelem_return, float **buf_return);
 
+void XIUnregisterPropertyHandler(DeviceIntPtr dev, long id);
+
+void XIDeleteAllDeviceProperties(DeviceIntPtr device);
+
 #endif /* _XSERVER_EXEVENTS_PRIV_H */

--- a/include/exevents.h
+++ b/include/exevents.h
@@ -71,10 +71,6 @@ extern _X_EXPORT Bool SetScrollValuator(DeviceIntPtr /* dev */ ,
                                         double /* increment */ ,
                                         int /* flags */ );
 
-/* Input device properties */
-extern _X_EXPORT void XIDeleteAllDeviceProperties(DeviceIntPtr  /* device */
-    );
-
 extern _X_EXPORT int XIDeleteDeviceProperty(DeviceIntPtr /* device */ ,
                                             Atom /* property */ ,
                                             Bool        /* fromClient */
@@ -117,8 +113,6 @@ extern _X_EXPORT long XIRegisterPropertyHandler(DeviceIntPtr dev,
                                                 (DeviceIntPtr dev,
                                                  Atom property)
     );
-
-extern _X_EXPORT void XIUnregisterPropertyHandler(DeviceIntPtr dev, long id);
 
 extern _X_EXPORT Atom XIGetKnownProperty(const char *name);
 


### PR DESCRIPTION
Not used by any external drivers, so no need to keep the exported.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
