### PR TITLE
dix: unexport PrintPassiveGrabs() and PrintWindowTree()

### DIFF
--- a/dix/window_priv.h
+++ b/dix/window_priv.h
@@ -59,4 +59,7 @@ Bool dixWindowIsRoot(Window window);
  */
 int DoCreateWindowReq(ClientPtr client, xCreateWindowReq *stuff, XID *xids);
 
+void PrintPassiveGrabs(void);
+void PrintWindowTree(void);
+
 #endif /* _XSERVER_DIX_WINDOW_PRIV_H */

--- a/include/window.h
+++ b/include/window.h
@@ -211,8 +211,6 @@ extern _X_EXPORT RegionPtr CreateBoundingShape(WindowPtr /* pWin */ );
 extern _X_EXPORT RegionPtr CreateClipShape(WindowPtr /* pWin */ );
 
 extern _X_EXPORT void SetRootClip(ScreenPtr pScreen, int enable);
-extern _X_EXPORT void PrintWindowTree(void);
-extern _X_EXPORT void PrintPassiveGrabs(void);
 
 extern _X_EXPORT VisualPtr WindowGetVisual(WindowPtr /*pWin*/);
 #endif                          /* WINDOW_H */

--- a/xkb/xkbActions.c
+++ b/xkb/xkbActions.c
@@ -39,6 +39,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "dix/dixgrabs_priv.h"
 #include "dix/input_priv.h"
 #include "dix/inpututils_priv.h"
+#include "dix/window_priv.h"
 #include "mi/mi_priv.h"
 #include "mi/mipointer_priv.h"
 #include "xkb/xkbsrv_priv.h"


### PR DESCRIPTION
These are only for internal debug output, not needed for drivers.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
