### PR TITLE
dix: unexport DeleteProperty()

### DIFF
--- a/dix/property_priv.h
+++ b/dix/property_priv.h
@@ -99,4 +99,6 @@ int dixLookupProperty(PropertyPtr *result, WindowPtr pWin, Atom proprty,
 
 void DeleteAllWindowProperties(WindowPtr pWin);
 
+int DeleteProperty(ClientPtr client, WindowPtr pWin, Atom propName);
+
 #endif /* _XSERVER_PROPERTY_PRIV_H */

--- a/hw/xquartz/xpr/xprFrame.c
+++ b/hw/xquartz/xpr/xprFrame.c
@@ -30,6 +30,7 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/property_priv.h"
 #include "dix/screenint_priv.h"
 
 #include "xpr.h"

--- a/include/property.h
+++ b/include/property.h
@@ -61,8 +61,4 @@ extern _X_EXPORT int dixChangeWindowProperty(ClientPtr pClient,
                                              const void *value,
                                              Bool sendevent);
 
-extern _X_EXPORT int DeleteProperty(ClientPtr /*client */ ,
-                                    WindowPtr /*pWin */ ,
-                                    Atom /*propName */ );
-
 #endif                          /* PROPERTY_H */

--- a/miext/rootless/rootlessWindow.c
+++ b/miext/rootless/rootlessWindow.c
@@ -37,6 +37,7 @@
 #include <X11/Xatom.h>
 
 #include "dix/dix_priv.h"
+#include "dix/property_priv.h"
 #include "dix/screen_hooks_priv.h"
 #include "dix/screenint_priv.h"
 #include "fb/fb_priv.h"


### PR DESCRIPTION
Not used by any external driver, so no need to keep it public.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
