### PR TITLE
os: drop ResetWellKnownSockets() and XdmcpReset()

### DIFF
--- a/doc/Xserver-spec.xml
+++ b/doc/Xserver-spec.xml
@@ -1013,13 +1013,7 @@ your server, main() calls the routine
 
         void CreateWellKnownSockets()
 </programlisting></blockquote>
-This routine is called only once, and not called when the server
-is reset.  To recreate any sockets during server resets, the following
-routine is called from the main loop:
-<blockquote><programlisting>
-
-        void ResetWellKnownSockets()
-</programlisting></blockquote>
+This routine is called only once.
 Sample implementations of both of these routines are found in
 Xserver/os/connection.c.
 </para>

--- a/os/client_priv.h
+++ b/os/client_priv.h
@@ -53,7 +53,6 @@ void FlushIfCriticalOutputPending(void);
 void ResetOsBuffers(void);
 void NotifyParentProcess(void);
 void CreateWellKnownSockets(void);
-void ResetWellKnownSockets(void);
 void CloseWellKnownConnections(void);
 
 // exported for nvidia driver

--- a/os/connection.c
+++ b/os/connection.c
@@ -46,7 +46,7 @@ SOFTWARE.
 /*****************************************************************
  *  Stuff to create connections --- OS dependent
  *
- *      EstablishNewConnections, CreateWellKnownSockets, ResetWellKnownSockets,
+ *      EstablishNewConnections, CreateWellKnownSockets
  *      CloseDownConnection,
  *	OnlyListToOneClient,
  *      ListenToAllClients,
@@ -306,54 +306,6 @@ CreateWellKnownSockets(void)
 
 #ifdef XDMCP
     XdmcpInit();
-#endif
-}
-
-void
-ResetWellKnownSockets(void)
-{
-    int i;
-
-    ResetOsBuffers();
-
-    for (i = 0; i < ListenTransCount; i++) {
-        int status = _XSERVTransResetListener(ListenTransConns[i]);
-
-        if (status != TRANS_RESET_NOOP) {
-            if (status == TRANS_RESET_FAILURE) {
-                /*
-                 * ListenTransConns[i] freed by xtrans.
-                 * Remove it from out list.
-                 */
-
-                RemoveNotifyFd(ListenTransFds[i]);
-                ListenTransFds[i] = ListenTransFds[ListenTransCount - 1];
-                ListenTransConns[i] = ListenTransConns[ListenTransCount - 1];
-                ListenTransCount -= 1;
-                i -= 1;
-            }
-            else if (status == TRANS_RESET_NEW_FD) {
-                /*
-                 * A new file descriptor was allocated (the old one was closed)
-                 */
-
-                int newfd = _XSERVTransGetConnectionNumber(ListenTransConns[i]);
-
-                ListenTransFds[i] = newfd;
-            }
-        }
-    }
-    for (i = 0; i < ListenTransCount; i++)
-        SetNotifyFd(ListenTransFds[i], EstablishNewConnections, X_NOTIFY_READ,
-                    NULL);
-
-    ResetAuthorization();
-    ResetHosts(display);
-    /*
-     * restart XDMCP
-     */
-#ifdef XDMCP
-    XdmcpReset();
 #endif
 }
 

--- a/os/xdmcp.c
+++ b/os/xdmcp.c
@@ -604,14 +604,6 @@ XdmcpInit(void)
     }
 }
 
-void
-XdmcpReset(void)
-{
-    state = XDM_INIT_STATE;
-    if (state != XDM_OFF)
-        xdmcp_reset();
-}
-
 /*
  * Called whenever a new connection is created; notices the
  * first connection and saves it to terminate the session

--- a/os/xdmcp.h
+++ b/os/xdmcp.h
@@ -17,7 +17,6 @@ void XdmcpRegisterConnection(int type, const char *address, int addrlen);
 void XdmcpRegisterAuthorizations(void);
 void XdmcpRegisterAuthorization(const char *name);
 void XdmcpInit(void);
-void XdmcpReset(void);
 void XdmcpOpenDisplay(int sock);
 void XdmcpCloseDisplay(int sock);
 void XdmcpRegisterAuthentication(const char *name,


### PR DESCRIPTION
Since internal server reset is gone, those aren't needed anymore.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
