### PR TITLE
xkb: drop special generation magic on atom initialization

### DIFF
--- a/xkb/ddxBeep.c
+++ b/xkb/ddxBeep.c
@@ -57,7 +57,6 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #define	HIGH_PITCH	2000
 #define CLICK_PITCH	1500
 
-static x_server_generation_t atomGeneration = 0;
 static Atom featureOn;
 static Atom featureOff;
 static Atom featureChange;
@@ -127,10 +126,8 @@ _XkbDDXBeepExpire(OsTimerPtr timer, CARD32 now, void *arg)
     if ((dev == NULL) || (dev->key == NULL) || (dev->key->xkbInfo == NULL) ||
         (dev->kbdfeed == NULL))
         return 0;
-    if (atomGeneration != serverGeneration) {
-        _XkbDDXBeepInitAtoms();
-        atomGeneration = serverGeneration;
-    }
+
+    _XkbDDXBeepInitAtoms();
 
     feed = dev->kbdfeed;
     ctrl = &feed->ctrl;


### PR DESCRIPTION
dixAddAtom() is safe to call multiple times with same name,
always return the corresponding XID, no matter whether the
atom just been newly created or already existed.

Thus, there's no need for special server generation treatment here.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
