### PR TITLE
xquartz: drop support for internal server reset

### DIFF
--- a/hw/xquartz/applewm.c
+++ b/hw/xquartz/applewm.c
@@ -60,13 +60,7 @@
 
 #define DEFINE_ATOM_HELPER(func, atom_name)                      \
     static Atom func(void) {                                       \
-        static x_server_generation_t generation;                    \
-        static Atom atom;                                           \
-        if (generation != serverGeneration) {                       \
-            generation = serverGeneration;                          \
-            atom = dixAddAtom(atom_name);                           \
-        }                                                           \
-        return atom;                                                \
+        return dixAddAtom(atom_name);                           \
     }
 
 DEFINE_ATOM_HELPER(xa_native_screen_origin, "_NATIVE_SCREEN_ORIGIN")

--- a/hw/xquartz/darwin.c
+++ b/hw/xquartz/darwin.c
@@ -674,7 +674,6 @@ OsVendorFatalError(const char *f, va_list args)
 void
 OsVendorInit(void)
 {
-    if (serverGeneration == 1) {
         char *lf;
         char *home = getenv("HOME");
         assert(home);
@@ -693,7 +692,6 @@ OsVendorInit(void)
         free(lf);
 
         DarwinPrintBanner();
-    }
 }
 
 /*

--- a/hw/xquartz/xpr/xprFrame.c
+++ b/hw/xquartz/xpr/xprFrame.c
@@ -49,13 +49,7 @@
 
 #define DEFINE_ATOM_HELPER(func, atom_name)                      \
     static Atom func(void) {                                       \
-        static x_server_generation_t generation;                    \
-        static Atom atom;                                           \
-        if (generation != serverGeneration) {                       \
-            generation = serverGeneration;                          \
-            atom = dixAddAtom(atom_name);                           \
-        }                                                           \
-        return atom;                                                \
+        return dixAddAtom(atom_name);                           \
     }
 
 DEFINE_ATOM_HELPER(xa_native_window_id, "_NATIVE_WINDOW_ID")


### PR DESCRIPTION
Not needed anymore.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
