### PR TITLE
kdrive: drop obsolete support for internal server reset

### DIFF
--- a/hw/kdrive/fbdev/fbinit.c
+++ b/hw/kdrive/fbdev/fbinit.c
@@ -56,9 +56,7 @@ ddxInputThreadInit(void)
 void
 InitOutput(int argc, char **argv)
 {
-    if (serverGeneration == 1)
-        ephyrExtensionInit();
-
+    ephyrExtensionInit();
     KdInitOutput(argc, argv);
 }
 

--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -77,7 +77,6 @@ KdDepths kdDepths[] = {
 #define KD_DEFAULT_BUTTONS 5
 
 DevPrivateKeyRec kdScreenPrivateKeyRec;
-x_server_generation_t kdGeneration;
 
 Bool kdVideoTest;
 unsigned long kdVideoTestTime;
@@ -623,20 +622,15 @@ KdOsInit(const KdOsFuncs * pOsFuncs)
 {
     kdOsFuncs = pOsFuncs;
     if (pOsFuncs) {
-        if (serverGeneration == 1) {
-            KdDoSwitchCmd("start");
-            if (pOsFuncs->Init)
-                (*pOsFuncs->Init) ();
-        }
+        KdDoSwitchCmd("start");
+        if (pOsFuncs->Init)
+            (*pOsFuncs->Init) ();
     }
 }
 
 Bool KdAllocatePrivates(ScreenPtr pScreen)
 {
     KdPrivScreenPtr pScreenPriv;
-
-    if (kdGeneration != serverGeneration)
-        kdGeneration = serverGeneration;
 
     if (!dixRegisterPrivateKey(&kdScreenPrivateKeyRec, PRIVATE_SCREEN, 0))
         return FALSE;

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -295,7 +295,7 @@ int KdAddKeyboard(KdKeyboardInfo * ki);
 void KdRemoveKeyboard(KdKeyboardInfo * ki);
 
 typedef struct _KdOsFuncs {
-    int (*Init) (void); /* Only called when the X server is started, when serverGeneration == 1 */
+    int (*Init) (void);           /* only called when the X server is started */
     void (*Enable) (void);        /* called when screen is enabled */
     void (*Disable) (void);       /* called when screen is disabled */
     Bool (*SpecialKey) (KeySym);
@@ -338,7 +338,6 @@ extern DevPrivateKeyRec kdScreenPrivateKeyRec;
 
 #define kdScreenPrivateKey (&kdScreenPrivateKeyRec)
 
-extern x_server_generation_t kdGeneration;
 extern Bool kdEnabled;
 extern Bool kdSwitchPending;
 extern Bool kdEmulateMiddleButton;

--- a/hw/kdrive/src/kxv.c
+++ b/hw/kdrive/src/kxv.c
@@ -100,7 +100,6 @@ static DevPrivateKeyRec KdXVWindowKeyRec;
 #define KdXVWindowKey (&KdXVWindowKeyRec)
 static DevPrivateKey KdXvScreenKey;
 static DevPrivateKeyRec KdXVScreenPrivateKey;
-static x_server_generation_t KdXVGeneration = 0;
 static unsigned long PortResource = 0;
 
 #define GET_XV_SCREEN(pScreen) ((XvScreenPtr) \
@@ -118,9 +117,6 @@ KdXVScreenInit(ScreenPtr pScreen, KdVideoAdaptorPtr adaptors, int num)
     KdXVScreenPtr ScreenPriv;
 
 /*   fprintf(stderr,"KdXVScreenInit initializing %d adaptors\n",num); */
-
-    if (KdXVGeneration != serverGeneration)
-        KdXVGeneration = serverGeneration;
 
     if (noXvExtension)
         return FALSE;


### PR DESCRIPTION
Not used anymore.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
