### PR TITLE
include: move PropertyPtr from property.h to window.h

### DIFF
--- a/include/property.h
+++ b/include/property.h
@@ -49,8 +49,6 @@ SOFTWARE.
 
 #include "window.h"
 
-typedef struct _Property *PropertyPtr;
-
 extern _X_EXPORT int dixChangeWindowProperty(ClientPtr pClient,
                                              WindowPtr pWin,
                                              Atom property,

--- a/include/window.h
+++ b/include/window.h
@@ -71,6 +71,7 @@ struct _Cursor;
 
 typedef struct _BackingStore *BackingStorePtr;
 typedef struct _Window *WindowPtr;
+typedef struct _Property *PropertyPtr;
 
 enum RootClipMode {
     ROOT_CLIP_NONE = 0, /**< resize the root window to 0x0 */


### PR DESCRIPTION
The property.h file is deprecated and going to be removed, so move
over the typedef to window.h -- also drivers needing it already including
window.h one way or another.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
