### PR TITLE
rootless: drop obsolete support for internal server reset

### DIFF
--- a/miext/rootless/rootlessWindow.c
+++ b/miext/rootless/rootlessWindow.c
@@ -61,13 +61,7 @@ extern Bool no_configure_window;
 
 #define DEFINE_ATOM_HELPER(func,atom_name)                      \
   static Atom func (void) {                                     \
-    static x_server_generation_t generation = 0;                \
-    static Atom atom;                                           \
-    if (generation != serverGeneration) {                       \
-      generation = serverGeneration;                            \
-      atom = dixAddAtom(atom_name);                             \
-    }                                                           \
-    return atom;                                                \
+    return dixAddAtom(atom_name);                               \
   }
 
 DEFINE_ATOM_HELPER(xa_native_window_id, "_NATIVE_WINDOW_ID")


### PR DESCRIPTION
Not used anymore.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
