### PR TITLE
dix: unexport enableIndirectGLX

### DIFF
--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -60,6 +60,9 @@ extern HWEventQueuePtr checkForInput[2];
  /* -retro mode */
 extern Bool party_like_its_1989;
 
+/* needed by libglx and libglamor (server modules) */
+extern _X_EXPORT Bool enableIndirectGLX;
+
 /*
  * @brief callback right after one screen's root window has been initialized
  *

--- a/glamor/glamor_glx_provider.c
+++ b/glamor/glamor_glx_provider.c
@@ -32,6 +32,8 @@
 
 #include <dix-config.h>
 
+#include "dix/dix_priv.h"
+
 #define MESA_EGL_NO_X11_HEADERS
 #define EGL_NO_X11
 #include <epoxy/egl.h>

--- a/glx/createcontext.c
+++ b/glx/createcontext.c
@@ -23,6 +23,9 @@
 #include <dix-config.h>
 
 #include <GL/glxtokens.h>
+
+#include "dix/dix_priv.h"
+
 #include "glxserver.h"
 #include "glxext.h"
 #include "indirect_dispatch.h"

--- a/glx/extension_string.c
+++ b/glx/extension_string.c
@@ -33,6 +33,7 @@
 
 #include <dix-config.h>
 
+#include "dix/dix_priv.h"
 #include "include/extinit.h"
 
 #include "extension_string.h"

--- a/hw/xfree86/common/xf86Config.c
+++ b/hw/xfree86/common/xf86Config.c
@@ -50,6 +50,7 @@
 #include <sys/types.h>
 #include <grp.h>
 
+#include "dix/dix_priv.h"
 #include "dix/resource_priv.h"
 #include "dix/screensaver_priv.h"
 #include "include/extinit.h"

--- a/include/opaque.h
+++ b/include/opaque.h
@@ -33,8 +33,6 @@ from The Open Group.
 
 #include "globals.h"
 
-// needed by libglx and libglamor (server modules)
-extern _X_EXPORT Bool enableIndirectGLX;
 extern _X_EXPORT Bool bgNoneRoot;
 
 #endif                          /* OPAQUE_H */


### PR DESCRIPTION
These still need to be _X_EXPORT'ed for internal modules, but
not supposed to be visible to external drivers.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
