### PR TITLE
dix: unexport GrabInProgress

### DIFF
--- a/Xext/saver.c
+++ b/Xext/saver.c
@@ -36,6 +36,7 @@ in this Software without prior written authorization from the X Consortium.
 #include "dix/colormap_priv.h"
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
+#include "dix/dixgrabs_priv.h"
 #include "dix/request_priv.h"
 #include "dix/screensaver_priv.h"
 #include "dix/window_priv.h"

--- a/dix/dixgrabs_priv.h
+++ b/dix/dixgrabs_priv.h
@@ -12,6 +12,12 @@
 #include "input.h"
 #include "cursor.h"
 
+/* @brief tells which client ID currently has a grab
+ *
+ * used by OS layer and screensaver
+ */
+extern int GrabInProgress;
+
 struct _GrabParameters;
 
 /**

--- a/include/globals.h
+++ b/include/globals.h
@@ -18,7 +18,6 @@ extern _X_EXPORT const char *defaultFontPath;
 extern _X_EXPORT int monitorResolution;
 extern _X_EXPORT int defaultColorVisualClass;
 
-extern _X_EXPORT int GrabInProgress;
 extern _X_EXPORT char *SeatId;
 
 #endif                          /* !_XSERV_GLOBAL_H_ */

--- a/os/connection.c
+++ b/os/connection.c
@@ -92,6 +92,7 @@ SOFTWARE.
 #endif                          /* WIN32 */
 
 #include "dix/dix_priv.h"
+#include "dix/dixgrabs_priv.h"
 #include "dix/server_priv.h"
 #include "os/audit_priv.h"
 #include "os/auth.h"


### PR DESCRIPTION
Only internally within OS layer and screen saver logic,
so no need to keep it exported.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
