### PR TITLE
xfree86: loader: fix NULL warning on LogMessage() call

### DIFF
--- a/hw/xfree86/loader/loadmod.c
+++ b/hw/xfree86/loader/loadmod.c
@@ -227,7 +227,8 @@ LoaderSetPath(const char *driver, const char *path)
     if (item && item->name && (!path || item->paths))
         xorg_list_add(&item->entry, &modulePathLists);
     else {
-        LogMessage(X_ERROR, "Failed to store module search path \"%s\" for module %s\n", path, driver);
+        LogMessage(X_ERROR, "Failed to store module search path \"%s\" for module %s\n",
+            path ? path : "<NULL>", driver);
         if (item) {
             if (item->name) free(item->name);
             if (item->paths) FreeStringList(item->paths);


### PR DESCRIPTION
> ../hw/xfree86/loader/loadmod.c: In function ‘LoaderSetPath’:
> ../hw/xfree86/loader/loadmod.c:230:67: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
>   230 |         LogMessage(X_ERROR, "Failed to store module search path \"%s\" for module %s\n", path, driver);
>       |                                                                   ^~

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
