### PR TITLE
dix: unexport defaultColorVisualClass

### DIFF
--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -63,6 +63,8 @@ extern Bool party_like_its_1989;
 /* needed by libglx and libglamor (server modules) */
 extern _X_EXPORT Bool enableIndirectGLX;
 
+extern int defaultColorVisualClass;
+
 /*
  * @brief callback right after one screen's root window has been initialized
  *

--- a/include/globals.h
+++ b/include/globals.h
@@ -8,6 +8,5 @@
 
 extern _X_EXPORT const char *defaultFontPath;
 extern _X_EXPORT int monitorResolution;
-extern _X_EXPORT int defaultColorVisualClass;
 
 #endif                          /* !_XSERV_GLOBAL_H_ */

--- a/mi/micmap.c
+++ b/mi/micmap.c
@@ -33,6 +33,7 @@
 #include <X11/Xproto.h>
 
 #include "dix/colormap_priv.h"
+#include "dix/dix_priv.h"
 #include "mi/mi_priv.h"
 #include "os/bug_priv.h"
 #include "os/osdep.h"


### PR DESCRIPTION
Not used by any drivers, so no need to keep it exported.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
