### PR TITLE
os: move MILLI_PER_MIN and MILLI_PER_SECOND to osdep.h

### DIFF
--- a/Xext/dpms.c
+++ b/Xext/dpms.c
@@ -38,6 +38,7 @@ Equipment Corporation.
 #include "dix/screensaver_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/screensaver.h"
+#include "os/osdep.h"
 #include "Xext/geext_priv.h"
 
 #include "misc.h"

--- a/include/misc.h
+++ b/include/misc.h
@@ -121,8 +121,6 @@ typedef struct _xReq *xReqPtr;
 #include <X11/Xfuncs.h>         /* for bcopy, bzero, and bcmp */
 
 #define NullBox ((BoxPtr)0)
-#define MILLI_PER_MIN (1000 * 60)
-#define MILLI_PER_SECOND (1000)
 
 #undef min
 #undef max

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -91,6 +91,9 @@ extern void FreeOsBuffers(OsCommPtr     /*oc */
 void
 CloseDownFileDescriptor(OsCommPtr oc);
 
+#define MILLI_PER_MIN (1000 * 60)
+#define MILLI_PER_SECOND (1000)
+
 #include "dix.h"
 #include "ospoll.h"
 


### PR DESCRIPTION
Not needed in public SDK, so move them into a private header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
