### PR TITLE
render: picturestr.h: unexport functions not used by drivers

### DIFF
--- a/Xext/composite/compwindow.c
+++ b/Xext/composite/compwindow.c
@@ -50,6 +50,7 @@
 #include "include/extinit.h"
 #include "os/osdep.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
+#include "Xext/render/picturestr_priv.h"
 
 #include "compint.h"
 #include "compositeext_priv.h"

--- a/Xext/randr/rrcrtc.c
+++ b/Xext/randr/rrcrtc.c
@@ -32,6 +32,7 @@
 #include "os/osdep.h"
 #include "Xext/randr/randrstr_priv.h"
 #include "Xext/randr/rrdispatch_priv.h"
+#include "Xext/render/picturestr_priv.h"
 
 #include "swaprep.h"
 #include "mipointer.h"

--- a/Xext/randr/rrinfo.c
+++ b/Xext/randr/rrinfo.c
@@ -22,6 +22,7 @@
 #include <dix-config.h>
 
 #include "Xext/randr/randrstr_priv.h"
+#include "Xext/render/picturestr_priv.h"
 
 static RRModePtr
 RROldModeAdd(RROutputPtr output, RRScreenSizePtr size, int refresh)

--- a/Xext/randr/rrscreen.c
+++ b/Xext/randr/rrscreen.c
@@ -26,6 +26,7 @@
 #include "dix/server_priv.h"
 #include "Xext/randr/randrstr_priv.h"
 #include "Xext/randr/rrdispatch_priv.h"
+#include "Xext/render/picturestr_priv.h"
 
 static CARD16
  RR10CurrentSizeID(ScreenPtr pScreen);

--- a/Xext/render/filter.c
+++ b/Xext/render/filter.c
@@ -27,6 +27,7 @@
 
 #include "dix/screenint_priv.h"
 #include "include/misc.h"
+#include "render/picturestr_priv.h"
 
 #include "scrnintstr.h"
 #include "os.h"

--- a/Xext/render/glyph.c
+++ b/Xext/render/glyph.c
@@ -29,6 +29,7 @@
 #include "include/misc.h"
 #include "os/bug_priv.h"
 #include "os/xsha1.h"
+#include "render/picturestr_priv.h"
 
 #include "scrnintstr.h"
 #include "os.h"

--- a/Xext/render/matrix.c
+++ b/Xext/render/matrix.c
@@ -23,6 +23,7 @@
 #include <dix-config.h>
 
 #include "include/misc.h"
+#include "render/picturestr_priv.h"
 
 #include "scrnintstr.h"
 #include "os.h"

--- a/Xext/render/mipict.c
+++ b/Xext/render/mipict.c
@@ -25,13 +25,13 @@
 
 #include "include/mipict.h"
 #include "os/osdep.h"
+#include "render/picturestr_priv.h"
 
 #include "scrnintstr.h"
 #include "gcstruct.h"
 #include "pixmapstr.h"
 #include "windowstr.h"
 #include "mi.h"
-#include "picturestr.h"
 
 int
 miCreatePicture(PicturePtr pPicture)

--- a/Xext/render/picturestr_priv.h
+++ b/Xext/render/picturestr_priv.h
@@ -43,4 +43,66 @@ void PanoramiXRenderInit(void);
 void PanoramiXRenderReset(void);
 #endif /* XINERAMA */
 
+int PictureGetSubpixelOrder(ScreenPtr pScreen);
+Bool PictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats);
+int PictureGetFilterId(const char *filter, int len, Bool makeit);
+int PictureAddFilter(ScreenPtr pScreen, const char *filter,
+                     PictFilterValidateParamsProcPtr ValidateParams,
+                     int width, int height);
+Bool PictureSetFilterAlias(ScreenPtr pScreen, const char *filter,
+                           const char *alias);
+Bool PictureSetDefaultFilters(ScreenPtr pScreen);
+void PictureResetFilters(ScreenPtr pScreen);
+Bool PictureFinishInit(void);
+int SetPictureClipRects(PicturePtr pPicture, int xOrigin, int yOrigin,
+                        int nRect, xRectangle *rects);
+int SetPictureClipRegion(PicturePtr pPicture, int xOrigin, int yOrigin,
+                         RegionPtr pRegion);
+void CompositeGlyphs(CARD8 op, PicturePtr pSrc, PicturePtr pDst,
+                     PictFormatPtr maskFormat, INT16 xSrc, INT16 ySrc,
+                     int nlist, GlyphListPtr lists, GlyphPtr *glyphs);
+void CompositeRects(CARD8 op, PicturePtr pDst, xRenderColor *color,
+                    int nRect, xRectangle *rects);
+void CompositeTrapezoids(CARD8 op, PicturePtr pSrc, PicturePtr pDst,
+                         PictFormatPtr maskFormat, INT16 xSrc, INT16 ySrc,
+                         int ntrap, xTrapezoid *traps);
+void CompositeTriangles(CARD8 op, PicturePtr pSrc, PicturePtr pDst,
+                        PictFormatPtr maskFormat, INT16 xSrc, INT16 ySrc,
+                        int ntriangles, xTriangle * triangles);
+void CompositeTriStrip(CARD8 op, PicturePtr pSrc, PicturePtr pDst,
+                       PictFormatPtr maskFormat, INT16 xSrc, INT16 ySrc,
+                       int npoints, xPointFixed * points);
+void CompositeTriFan(CARD8 op, PicturePtr pSrc, PicturePtr pDst,
+                     PictFormatPtr maskFormat, INT16 xSrc, INT16 ySrc,
+                     int npoints, xPointFixed * points);
+void AddTraps(PicturePtr pPicture, INT16 xOff, INT16 yOff, int ntraps,
+              xTrap *traps);
+PicturePtr CreateLinearGradientPicture(Picture pid, xPointFixed *p1,
+                                       xPointFixed *p2, int nStops,
+                                       xFixed *stops, xRenderColor *colors,
+                                       int *error);
+PicturePtr CreateRadialGradientPicture(Picture pid, xPointFixed *inner,
+                                       xPointFixed *outer, xFixed innerRadius,
+                                       xFixed outerRadius, int nStops,
+                                       xFixed *stops, xRenderColor *colors,
+                                       int *error);
+PicturePtr CreateConicalGradientPicture(Picture pid, xPointFixed *center,
+                                        xFixed angle, int nStops, xFixed *stops,
+                                        xRenderColor *colors, int *error);
+void PictTransform_from_xRenderTransform(PictTransformPtr pict,
+                                         xRenderTransform *render);
+void xRenderTransform_from_PictTransform(xRenderTransform *render,
+                                         PictTransformPtr pict);
+Bool PictureTransformPoint3d(PictTransformPtr transform,
+                             PictVectorPtr vector);
+
+/* these need to be _X_EXPORT'ed for Nvidia proprietary, but should not
+   be used by external drivers anymore */
+_X_EXPORT PictFormatPtr PictureMatchVisual(ScreenPtr pScreen, int depth,
+                                           VisualPtr pVisual);
+_X_EXPORT PictFilterPtr PictureFindFilter(ScreenPtr pScreen, char *name,
+                                          int len);
+_X_EXPORT int SetPictureFilter(PicturePtr pPicture, char *name, int len,
+                               xFixed *params, int nparams);
+
 #endif /* _XSERVER_PICTURESTR_PRIV_H_ */

--- a/hw/xfree86/common/xf86Init.c
+++ b/hw/xfree86/common/xf86Init.c
@@ -63,6 +63,7 @@
 #include "Xext/dpms/dpms_priv.h"
 #endif
 #include "Xext/randr/randrstr_priv.h"
+#include "Xext/render/picturestr_priv.h"
 
 #include "servermd.h"
 #include "windowstr.h"
@@ -85,7 +86,6 @@
 #include "xf86Xinput.h"
 #include "xf86InPriv.h"
 #include "xf86Crtc.h"
-#include "picturestr.h"
 #include "xf86Bus.h"
 #include "globals.h"
 #include "xserver-properties.h"

--- a/hw/xwin/winrandr.c
+++ b/hw/xwin/winrandr.c
@@ -34,6 +34,7 @@
 #include "win.h"
 
 #include "Xext/randr/randrstr_priv.h"
+#include "Xext/render/picturestr_priv.h"
 
 /*
  * Answer queries about the RandR features supported.

--- a/include/picturestr.h
+++ b/include/picturestr.h
@@ -356,51 +356,14 @@ extern _X_EXPORT PictFormatPtr
 extern _X_EXPORT Bool
  PictureSetSubpixelOrder(ScreenPtr pScreen, int subpixel);
 
-extern _X_EXPORT int
- PictureGetSubpixelOrder(ScreenPtr pScreen);
-
-extern _X_EXPORT PictFormatPtr
-PictureMatchVisual(ScreenPtr pScreen, int depth, VisualPtr pVisual);
-
 extern _X_EXPORT PictFormatPtr
 PictureMatchFormat(ScreenPtr pScreen, int depth, CARD32 format);
-
-extern _X_EXPORT Bool
- PictureInit(ScreenPtr pScreen, PictFormatPtr formats, int nformats);
-
-extern _X_EXPORT int
- PictureGetFilterId(const char *filter, int len, Bool makeit);
 
 extern _X_EXPORT char *PictureGetFilterName(int id);
 
 extern _X_EXPORT int
-PictureAddFilter(ScreenPtr pScreen,
-                 const char *filter,
-                 PictFilterValidateParamsProcPtr ValidateParams,
-                 int width, int height);
-
-extern _X_EXPORT Bool
-PictureSetFilterAlias(ScreenPtr pScreen, const char *filter, const char *alias);
-
-extern _X_EXPORT Bool
- PictureSetDefaultFilters(ScreenPtr pScreen);
-
-extern _X_EXPORT void
- PictureResetFilters(ScreenPtr pScreen);
-
-extern _X_EXPORT PictFilterPtr
-PictureFindFilter(ScreenPtr pScreen, char *name, int len);
-
-extern _X_EXPORT int
 SetPicturePictFilter(PicturePtr pPicture, PictFilterPtr pFilter,
                      xFixed * params, int nparams);
-
-extern _X_EXPORT int
-SetPictureFilter(PicturePtr pPicture, char *name, int len,
-                 xFixed * params, int nparams);
-
-extern _X_EXPORT Bool
- PictureFinishInit(void);
 
 extern _X_EXPORT PicturePtr
 CreatePicture(Picture pid,
@@ -411,15 +374,6 @@ CreatePicture(Picture pid,
 extern _X_EXPORT int
 ChangePicture(PicturePtr pPicture,
               Mask vmask, XID *vlist, DevUnion *ulist, ClientPtr client);
-
-extern _X_EXPORT int
-
-SetPictureClipRects(PicturePtr pPicture,
-                    int xOrigin, int yOrigin, int nRect, xRectangle *rects);
-
-extern _X_EXPORT int
-SetPictureClipRegion(PicturePtr pPicture,
-                     int xOrigin, int yOrigin, RegionPtr pRegion);
 
 extern _X_EXPORT int
  SetPictureTransform(PicturePtr pPicture, PictTransform * transform);
@@ -441,94 +395,14 @@ CompositePicture(CARD8 op,
                  INT16 yMask,
                  INT16 xDst, INT16 yDst, CARD16 width, CARD16 height);
 
-extern _X_EXPORT void
-CompositeGlyphs(CARD8 op,
-                PicturePtr pSrc,
-                PicturePtr pDst,
-                PictFormatPtr maskFormat,
-                INT16 xSrc,
-                INT16 ySrc, int nlist, GlyphListPtr lists, GlyphPtr * glyphs);
-
-extern _X_EXPORT void
-CompositeRects(CARD8 op,
-               PicturePtr pDst,
-               xRenderColor * color, int nRect, xRectangle *rects);
-
-extern _X_EXPORT void
-CompositeTrapezoids(CARD8 op,
-                    PicturePtr pSrc,
-                    PicturePtr pDst,
-                    PictFormatPtr maskFormat,
-                    INT16 xSrc, INT16 ySrc, int ntrap, xTrapezoid * traps);
-
-extern _X_EXPORT void
-CompositeTriangles(CARD8 op,
-                   PicturePtr pSrc,
-                   PicturePtr pDst,
-                   PictFormatPtr maskFormat,
-                   INT16 xSrc,
-                   INT16 ySrc, int ntriangles, xTriangle * triangles);
-
-extern _X_EXPORT void
-CompositeTriStrip(CARD8 op,
-                  PicturePtr pSrc,
-                  PicturePtr pDst,
-                  PictFormatPtr maskFormat,
-                  INT16 xSrc, INT16 ySrc, int npoints, xPointFixed * points);
-
-extern _X_EXPORT void
-CompositeTriFan(CARD8 op,
-                PicturePtr pSrc,
-                PicturePtr pDst,
-                PictFormatPtr maskFormat,
-                INT16 xSrc, INT16 ySrc, int npoints, xPointFixed * points);
-
-extern _X_EXPORT void
-AddTraps(PicturePtr pPicture,
-         INT16 xOff, INT16 yOff, int ntraps, xTrap * traps);
-
 extern _X_EXPORT PicturePtr
 CreateSolidPicture(Picture pid, xRenderColor * color, int *error);
-
-extern _X_EXPORT PicturePtr
-CreateLinearGradientPicture(Picture pid,
-                            xPointFixed * p1,
-                            xPointFixed * p2,
-                            int nStops,
-                            xFixed * stops, xRenderColor * colors, int *error);
-
-extern _X_EXPORT PicturePtr
-CreateRadialGradientPicture(Picture pid,
-                            xPointFixed * inner,
-                            xPointFixed * outer,
-                            xFixed innerRadius,
-                            xFixed outerRadius,
-                            int nStops,
-                            xFixed * stops, xRenderColor * colors, int *error);
-
-extern _X_EXPORT PicturePtr
-CreateConicalGradientPicture(Picture pid,
-                             xPointFixed * center,
-                             xFixed angle,
-                             int nStops,
-                             xFixed * stops, xRenderColor * colors, int *error);
 
 /*
  * matrix.c
  */
 
-extern _X_EXPORT void
-PictTransform_from_xRenderTransform(PictTransformPtr pict,
-                                    xRenderTransform * render);
-
-extern _X_EXPORT void
-xRenderTransform_from_PictTransform(xRenderTransform * render,
-                                    PictTransformPtr pict);
-
 extern _X_EXPORT Bool
  PictureTransformPoint(PictTransformPtr transform, PictVectorPtr vector);
-
-extern _X_EXPORT Bool
- PictureTransformPoint3d(PictTransformPtr transform, PictVectorPtr vector);
 
 #endif                          /* _PICTURESTR_H_ */


### PR DESCRIPTION
Unexporting several functions not used by external drivers.
A few ones need to be _X_EXPORT'ed for proprietary Nvidia driver,
but are not supposed to be used by any new drivers.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
