### PR TITLE
os: utils.c ignore '-reset' and '-noreset' command line arguments

### DIFF
--- a/os/utils.c
+++ b/os/utils.c
@@ -600,6 +600,12 @@ ProcessCommandLine(int argc, char *argv[])
             else
                 UseMsg();
         }
+        else if (strcmp(argv[i],"-noreset") == 0){
+            ErrorF("Argument -noreset is removed in XLibre (for more context: https://github.com/orgs/X11Libre/discussions/424 )\n");
+        }
+        else if(strcmp(argv[i],"-reset") == 0){
+            ErrorF("Argument -reset is removed in XLibre (for more context: https://github.com/orgs/X11Libre/discussions/424 )\n");
+        }
         else if (strcmp(argv[i], "-p") == 0) {
             if (++i < argc)
                 defaultScreenSaverInterval = ((CARD32) atoi(argv[i])) *


### PR DESCRIPTION
We should respect user expectations for a while™. This PR ignores `-reset` and `-noreset` flags.

Our 1st complain is from SDDM display manager (it has hardcoded `-noreset` flag: https://github.com/sddm/sddm/blob/dfa5315fd600760f8f3abddf7fb704202ffb07b3/src/daemon/XorgDisplayServer.cpp#L126 )
 

closes: #1462 