### PR TITLE
modesetting: make DevPrivateKeyRec struct static

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -159,7 +159,7 @@ static const OptionInfoRec Options[] = {
 
 int ms_entity_index = -1;
 
-DevPrivateKeyRec asyncFlipPrivateKeyRec;
+static DevPrivateKeyRec asyncFlipPrivateKeyRec;
 
 static MODULESETUPPROTO(Setup);
 


### PR DESCRIPTION
`dixRegisterPrivateKey()` assumes that `DevPrivateKeyRec` struct passed to it is zero-filled before the first use, otherwise `assert()` fails. Therefore these structs are usually static, which assures that they are initialized to 0. A newly introduced key in the `modesetting` driver was not static, and the driver crashes like this:

```
(II) modeset(1): Damage tracking initialized

Backtrace:
0: /usr/bin/X (OsSigHandler+0x3b) [0x593c07]
unw_get_proc_name failed: no unwind info found [-10]
1: <signal handler called>
2: /lib64/libc.so.6 (pthread_kill+0xfb) [0x7fe07a29b3bb]
3: /lib64/libc.so.6 (gsignal+0x12) [0x7fe07a243032]
4: /lib64/libc.so.6 (abort+0xc5) [0x7fe07a2284a2]
5: /lib64/libc.so.6 (__assert_fail_base.cold+0x12) [0x7fe07a2283d8]
6: /lib64/libc.so.6 (__assert_fail+0x42) [0x7fe07a23a4f2]
7: /usr/bin/X (dixRegisterPrivateKey+0x26f) [0x4903cd]
8: /usr/lib64/xorg/modules/xlibre-25/drivers/modesetting_drv.so (modesetCreateScreenResources+0x3fe) [0x7fe079cad670]
9: /usr/bin/X (dixScreenRaiseCreateResources+0x3e) [0x49c3c1]
10: /usr/bin/X (dix_main+0x35f) [0x46ba84]
11: /usr/bin/X (main+0x28) [0x63a857]
12: /lib64/libc.so.6 (__libc_start_call_main+0x67) [0x7fe07a229d57]
13: /lib64/libc.so.6 (__libc_start_main+0x85) [0x7fe07a229e15]
14: /usr/bin/X (_start+0x21) [0x41ab81]
```

This should be corrected.