### PR TITLE
{dix,include}: reexport ConnectionInfo

### DIFF
--- a/dix/globals.c
+++ b/dix/globals.c
@@ -51,6 +51,7 @@ SOFTWARE.
 
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
+#include "dix/server_priv.h"
 #include "dix/settings_priv.h"
 
 #include "misc.h"

--- a/dix/server_priv.h
+++ b/dix/server_priv.h
@@ -23,6 +23,7 @@ static inline int dixCallServerAccessCallback(ClientPtr client, Mask access_mode
     return rec.status;
 }
 
-extern char *ConnectionInfo;
+/* NVidia v.390 proprietary driver needs this */
+extern _X_EXPORT char *ConnectionInfo;
 
 #endif /* _XSERVER_DIX_SERVER_PRIV_H */


### PR DESCRIPTION
NVidia v.390 legacy driver complains about an undefined symbol. With this PR it works OK.