### PR TITLE
Make IgnoreABI configurable through config files 

### DIFF
--- a/config/10-nvidia.conf.in
+++ b/config/10-nvidia.conf.in
@@ -12,5 +12,6 @@ Section "OutputClass"
 	Module "glx"
 	Module "glxserver_nvidia"
 	Option "AllowEmptyInitialConfiguration"
+	Option "IgnoreABI"
 	ModulePath "@libdir@/nvidia/xorg"
 EndSection

--- a/hw/xfree86/common/xf86Init.c
+++ b/hw/xfree86/common/xf86Init.c
@@ -331,9 +331,8 @@ InitOutput(int argc, char **argv)
         /* Tell the loader the default module search path */
         LoaderSetPath(NULL, xf86ModulePath);
 
-        if (xf86Info.ignoreABI) {
-            LoaderSetIgnoreAbi();
-        }
+        if (xf86Info.ignoreABI)
+            LoaderSetIgnoreAllABI();
 
         if (xf86DoShowOptions)
             DoShowOptions();
@@ -963,7 +962,7 @@ ddxProcessArgument(int argc, char **argv, int i)
         return 1;
     }
     if (!strcmp(argv[i], "-ignoreABI")) {
-        LoaderSetIgnoreAbi();
+        LoaderSetIgnoreAllABI();
         return 1;
     }
     if (!strcmp(argv[i], "-verbose")) {

--- a/hw/xfree86/common/xf86platformBus.c
+++ b/hw/xfree86/common/xf86platformBus.c
@@ -305,11 +305,13 @@ xf86platformProbe(void)
                 if (cl->driver) {
                     if (cl->modulepath) {
                         if (*(cl->modulepath)) {
-                            XNFasprintf(&driver_path, "%s,%s", cl->modulepath, xf86ModulePath);
+                            if (asprintf(&driver_path, "%s,%s", cl->modulepath, xf86ModulePath) == -1)
+                                goto asprintf_failed;
                             LogMessageVerb(X_CONFIG, 1, "OutputClass \"%s\" ModulePath for driver %s overridden with \"%s\"\n",
                                     cl->identifier, cl->driver, driver_path);
                         } else {
-                            XNFasprintf(&driver_path, "%s", xf86ModulePath);
+                            if (asprintf(&driver_path, "%s", xf86ModulePath) == -1)
+                                goto asprintf_failed;
                             LogMessageVerb(X_CONFIG, 1, "OutputClass \"%s\" ModulePath for driver %s reset to standard \"%s\"\n",
                                     cl->identifier, cl->driver, driver_path);
                         }
@@ -322,7 +324,8 @@ xf86platformProbe(void)
                     if (cl->modules) {
                         LogMessageVerb(X_CONFIG, 1, "    and for modules \"%s\" as well\n",
                                 cl->modules);
-                        XNFasprintf(&copy, "%s", cl->modules);
+                        if (asprintf(&copy, "%s", cl->modules) == -1)
+                            goto asprintf_failed;
                         curr = copy;
                         while ((curr = strtok_r(curr, ",", &next))) {
                             if (*curr) LoaderSetPath(curr, driver_path);
@@ -335,11 +338,13 @@ xf86platformProbe(void)
                 else if (cl->modules) {
                     if (cl->modulepath) {
                         if (*(cl->modulepath)) {
-                            XNFasprintf(&driver_path, "%s,%s", cl->modulepath, xf86ModulePath);
+                            if (asprintf(&driver_path, "%s,%s", cl->modulepath, xf86ModulePath) == -1)
+                                goto asprintf_failed;
                             LogMessageVerb(X_CONFIG, 1, "OutputClass \"%s\" ModulePath for modules %s overridden with \"%s\"\n",
                                     cl->identifier, cl->modules, driver_path);
                         } else {
-                            XNFasprintf(&driver_path, "%s", xf86ModulePath);
+                            if (asprintf(&driver_path, "%s", xf86ModulePath) == -1)
+                                goto asprintf_failed;
                             LogMessageVerb(X_CONFIG, 1, "OutputClass \"%s\" ModulePath for modules %s reset to standard \"%s\"\n",
                                     cl->identifier, cl->modules, driver_path);
                         }
@@ -348,7 +353,8 @@ xf86platformProbe(void)
                         LogMessageVerb(X_CONFIG, 1, "OutputClass \"%s\" ModulePath for modules %s reset to default\n",
                                 cl->identifier, cl->modules);
                     }
-                    XNFasprintf(&copy, "%s", cl->modules);
+                    if (asprintf(&copy, "%s", cl->modules) == -1)
+                        goto asprintf_failed;
                     curr = copy;
                     while ((curr = strtok_r(curr, ",", &next))) {
                         if (*curr) LoaderSetPath(curr, driver_path);
@@ -358,12 +364,13 @@ xf86platformProbe(void)
                 } else {
                         driver_path = path; /* Reuse for temporary storage */
                         if (*(cl->modulepath)) {
-                            XNFasprintf(&path, "%s,%s", cl->modulepath,
-                                    path ? path : xf86ModulePath);
+                            if (asprintf(&path, "%s,%s", cl->modulepath, path ? path : xf86ModulePath) == -1)
+                                goto asprintf_failed;
                             LogMessageVerb(X_CONFIG, 1, "OutputClass \"%s\" default ModulePath extended to \"%s\"\n",
                                     cl->identifier, path);
                         } else {
-                            XNFasprintf(&path, "%s", xf86ModulePath);
+                            if (asprintf(&path, "%s", xf86ModulePath) == -1)
+                                goto asprintf_failed;
                             LogMessageVerb(X_CONFIG, 1, "OutputClass \"%s\" default ModulePath reset to standard \"%s\"\n",
                                     cl->identifier, path);
                         }
@@ -379,7 +386,8 @@ xf86platformProbe(void)
                     if (cl->modules) {
                         LogMessageVerb(X_CONFIG, 1, "    and for modules \"%s\" as well\n",
                                 cl->modules);
-                        XNFasprintf(&copy, "%s", cl->modules);
+                        if (asprintf(&copy, "%s", cl->modules) == -1)
+                            goto asprintf_failed;
                         curr = copy;
                         while ((curr = strtok_r(curr, ",", &next))) {
                             if (*curr) LoaderSetIgnoreABI(curr);
@@ -390,7 +398,8 @@ xf86platformProbe(void)
                 } else if (cl->modules) {
                     LogMessageVerb(X_CONFIG, 1, "OutputClass \"%s\" sets modules \"%s\" to ignore ABI for \"%s\" managed by %s\n",
                                cl->identifier, cl->modules, dev->attribs->path, dev->attribs->driver);
-                    XNFasprintf(&copy, "%s", cl->modules);
+                    if (asprintf(&copy, "%s", cl->modules) == -1)
+                        goto asprintf_failed;
                     curr = copy;
                     while ((curr = strtok_r(curr, ",", &next))) {
                         if (*curr) LoaderSetIgnoreABI(curr);
@@ -448,6 +457,10 @@ xf86platformProbe(void)
     }
 
     return 0;
+
+  asprintf_failed:
+    FatalError("Memory allocation for asprintf() in xf86PlatformProbe() failed\n");
+    return 1;
 }
 
 void

--- a/hw/xfree86/loader/loader.c
+++ b/hw/xfree86/loader/loader.c
@@ -68,6 +68,10 @@
 extern void *xorg_symbols[];
 #endif
 
+Bool LoaderIgnoreAllABI = FALSE;
+Bool LoaderIgnoreABI = FALSE;
+Bool is_nvidia_proprietary = FALSE;
+
 void
 LoaderInit(void)
 {
@@ -154,22 +158,29 @@ LoaderUnload(const char *name, void *handle)
         dlclose(handle);
 }
 
-Bool LoaderIgnoreAbi = FALSE;
-Bool is_nvidia_proprietary = FALSE;
+void
+LoaderSetIgnoreAllABI(void)
+{
+    LoaderIgnoreAllABI = TRUE;
+}
+
+Bool
+LoaderGetAndFlagIgnoreABI(const char *name)
+{
+    if (LoaderIgnoreAllABI)
+        LoaderIgnoreABI = TRUE;
+    return LoaderIgnoreABI;
+}
 
 void
-LoaderSetIgnoreAbi(void)
+LoaderSetIgnoreABI(const char *name)
 {
-    /* Only used to keep consistency with the loader api */
-    /* This really doesn't have to be a proc */
-    LoaderIgnoreAbi = TRUE;
 }
 
 Bool
 LoaderShouldIgnoreABI(void)
 {
-    /* The nvidia proprietary DDX driver calls this deprecated function */
-    return is_nvidia_proprietary || LoaderIgnoreAbi;
+    return LoaderIgnoreABI;
 }
 
 int

--- a/hw/xfree86/loader/loader.h
+++ b/hw/xfree86/loader/loader.h
@@ -68,8 +68,8 @@ typedef struct {
 } ModuleVersions;
 extern const ModuleVersions LoaderVersionInfo;
 
-extern Bool LoaderIgnoreAbi;
-
+extern Bool LoaderIgnoreAllABI;
+extern Bool LoaderIgnoreABI;
 extern Bool is_nvidia_proprietary;
 
 /* Internal Functions */

--- a/hw/xfree86/loader/loaderProcs.h
+++ b/hw/xfree86/loader/loaderProcs.h
@@ -82,9 +82,9 @@ void LoaderClosePath(void);
 void LoaderUnload(const char *, void *);
 unsigned long LoaderGetModuleVersion(ModuleDescPtr mod);
 
-void LoaderResetOptions(void);
-
-void LoaderSetIgnoreAbi(void);
+void LoaderSetIgnoreAllABI(void);
+Bool LoaderGetAndFlagIgnoreABI(const char *);
+void LoaderSetIgnoreABI(const char *);
 
 const char **LoaderListDir(const char *, const char **);
 

--- a/hw/xfree86/loader/loadmod.c
+++ b/hw/xfree86/loader/loadmod.c
@@ -539,19 +539,27 @@ CheckVersion(const char *module, XF86ModuleVersionInfo * data,
             vermaj = GET_ABI_MAJOR(ver);
             vermin = GET_ABI_MINOR(ver);
             if (abimaj != vermaj) {
-                LogMessageVerb(LoaderIgnoreAbi ? X_WARNING : X_ERROR, 0,
-                               "%s: module ABI major version (%d) "
+                MessageType errtype;
+                if (LoaderIgnoreABI)
+                    errtype = X_WARNING;
+                else
+                    errtype = X_ERROR;
+                LogMessageVerb(errtype, 0, "%s: module ABI major version (%d) "
                                "doesn't match the server's version (%d)\n",
                                module, abimaj, vermaj);
-                if (!LoaderIgnoreAbi)
+                if (!LoaderIgnoreABI)
                     return FALSE;
             }
             else if (abimin > vermin) {
-                LogMessageVerb(LoaderIgnoreAbi ? X_WARNING : X_ERROR, 0,
-                               "%s: module ABI minor version (%d) "
+                MessageType errtype;
+                if (LoaderIgnoreABI)
+                    errtype = X_WARNING;
+                else
+                    errtype = X_ERROR;
+                LogMessageVerb(errtype, 0, "%s: module ABI minor version (%d) "
                                "is newer than the server's version (%d)\n",
                                module, abimin, vermin);
-                if (!LoaderIgnoreAbi)
+                if (!LoaderIgnoreABI)
                     return FALSE;
             }
         }
@@ -775,14 +783,9 @@ LoadModule(const char *module, void *options, const XF86ModReqInfo *modreq,
                               "between the new X server abi and the one these "
                               "old drivers are compiled against.\n");
         LogMessage(X_WARNING, "LoadModule: If you are using one of the maintained "
-                              "branches of the nvidia nvidia kernel drivers,\n");
+                              "branches of the nvidia kernel drivers,\n");
         LogMessage(X_WARNING, "LoadModule: you can try using the in-tree, open-source modesetting "
                               "DDX driver instead of the proprietary nvidia DDX driver.\n");
-        if (!LoaderIgnoreAbi) {
-            /* warn every time this is hit */
-            LogMessage(X_WARNING, "LoadModule: Implicitly ignoring abi mismatch "
-                       "for the nvidia proprierary DDX driver\n");
-        }
     }
 
     /* Backward compatibility, vbe and int10 are merged into int10 now */
@@ -875,6 +878,9 @@ LoadModule(const char *module, void *options, const XF86ModReqInfo *modreq,
         vers = initdata->vers;
         setup = initdata->setup;
         teardown = initdata->teardown;
+
+        if (LoaderGetAndFlagIgnoreABI(name))
+            LogMessageVerb(X_INFO, 3, "ABI ignored for module \"%s\"\n", name);
 
         if (vers) {
             if (!CheckVersion(module, vers, modreq)) {

--- a/hw/xfree86/man/xorg.conf.man
+++ b/hw/xfree86/man/xorg.conf.man
@@ -1342,7 +1342,7 @@ When an output device has been matched to the
 .B OutputClass
 section, any
 .B Option
-entries are applied to the device. Two
+entries are applied to the device. Three
 .B OutputClass
 specific kinds of
 .B Option
@@ -1371,6 +1371,33 @@ If multiple output devices match an
 section with the
 .B HotplugDriver
 option, the first one enumerated becomes the hotplug driver.
+.RE
+.PP
+.TP 7
+.BI "Option \*qIgnoreABI\*q \*q" boolean \*q
+If set, this option makes driver loader ignore module ABI, which may be necessary
+to use legacy proprietary NVidia drivers. If
+.PP
+.RS 7
+.nf
+.B  "Section \*qOutputClass\*q"
+.BI  "    Identifier  \*q" AnyName \*q
+.BI  "    MatchDriver  \*q" drm_driver \*q
+.BI  "    Driver  \*q" X_driver \*q
+.BI  "    Option  \*q" IgnoreABI \*q
+.B  "EndSection
+.fi
+.RE
+.PP
+.RS 7
+appears, and a DRM device with a kernel
+.I drm_driver
+is found, then
+.I X_driver
+for it will be loaded regardless of its ABI version. Please note that this has
+no effect if DRM for a GPU is not enabled. See
+.IR /usr/share/X11/xorg.conf.d/10-nvidia.conf
+for an example.
 .RE
 .PP
 .TP 7

--- a/hw/xfree86/parser/OutputClass.c
+++ b/hw/xfree86/parser/OutputClass.c
@@ -109,7 +109,8 @@ xf86parseOutputClassSection(void)
                 Error(QUOTE_MSG, "Module");
             if (ptr->modules) {
                 char *path;
-                XNFasprintf(&path, "%s,%s", ptr->modules, xf86_lex_val.str);
+                if (asprintf(&path, "%s,%s", ptr->modules, xf86_lex_val.str) == -1)
+                    FatalError("Memory allocation for Module option failed\n");
                 free(xf86_lex_val.str);
                 free(ptr->modules);
                 ptr->modules = path;
@@ -122,7 +123,8 @@ xf86parseOutputClassSection(void)
                 Error(QUOTE_MSG, "ModulePath");
             if (ptr->modulepath) {
                 char *path;
-                XNFasprintf(&path, "%s,%s", ptr->modulepath, xf86_lex_val.str);
+                if (asprintf(&path, "%s,%s", ptr->modulepath, xf86_lex_val.str) == -1)
+                    FatalError("Memory allocation for ModulePath option failed\n");
                 free(xf86_lex_val.str);
                 free(ptr->modulepath);
                 ptr->modulepath = path;


### PR DESCRIPTION
This patch series gives a user/maintainer the power to decide whether to ignore ABI version for any driver/module depending on the loaded DRM kernel drivers (with NVidia legacy drivers in mind, and a configuration file for this is included), and this policy is controlled via `/usr/share/X11/xorg.conf.d/*.conf` files.