### PR TITLE
xfree86: fix infinite boot when parsing incorrect BusID section Device

### DIFF
--- a/hw/xfree86/common/xf86Bus.c
+++ b/hw/xfree86/common/xf86Bus.c
@@ -291,8 +291,13 @@ StringToBusType(const char *busID, const char **retID)
     if (!xf86NameCmp(p, "usb"))
         ret = BUS_USB;
     if (ret != BUS_NONE)
-        if (retID)
-            *retID = busID + strlen(p) + 1;
+        if (retID) {
+            size_t len = strlen(p);
+            if (busID[len] == ':')
+                *retID = busID + len + 1;
+            else
+                *retID = busID + len; /* Points to the terminating null byte */
+        }
     free(s);
     return ret;
 }


### PR DESCRIPTION
This change checks if there is a colon after the bus name. If there is none, *retID will point to the final null character of the original string.

This related to issue: https://github.com/X11Libre/xserver/issues/1477