### PR TITLE
dix: initialize all screens before proceeding to gc's, root windows etc

### DIFF
--- a/dix/main.c
+++ b/dix/main.c
@@ -209,11 +209,18 @@ dix_main(int argc, char *argv[], char *envp[])
                 FatalError("failed to create screen resources");
         });
 
+        /* Let all screens register the necessary privates */
+    
         DIX_FOR_EACH_SCREEN({
             if (!PixmapScreenInit(walkScreen))
                 FatalError("failed to create screen pixmap properties");
             if (!dixScreenRaiseCreateResources(walkScreen))
                 FatalError("failed to create screen resources");
+        });
+
+        /* Then use these privates to initialize root windows etc */
+
+        DIX_FOR_EACH_SCREEN({
             if (!CreateGCperDepth(walkScreen))
                 FatalError("failed to create scratch GCs");
             if (!CreateDefaultStipple(walkScreen))


### PR DESCRIPTION
Adding `asyncFlipPrivateKeyRec` to `modesetting` has revealed one more problem. Current code walks along all screens and initializes screen resources, then gc's, stipples, root windows for each of them, hence after the first screen registering new private keys is no more possible. This crashes modesetting driver if it is not initialized before others.

Namely, after screen 0 is initialized, and root window for it is created, `global_keys[PRIVATE_WINDOW].created` becomes non-zero, hence no new private keys of this type can be registered, and `modeset(1)` fails at `dixRegisterPrivatekey()`.

This patch makes screen resources for all screen initialize first, hence all necessary private keys (including of the type `PRIVATE_WINDOW`) are initialized before root windows are created. Tests show that it prevents occasional crashes on NVidia390 and constant crashes on NVidia 470, and makes no difference for NVidia 340 because it is not modesetting capable.