### PR TITLE
dix: unexport SwapLongs()

### DIFF
--- a/Xi/chgfctl.c
+++ b/Xi/chgfctl.c
@@ -55,6 +55,7 @@ SOFTWARE.
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XIproto.h>     /* control constants */
 
+#include "dix/dix_priv.h"
 #include "include/inputstr.h"           /* DeviceIntPtr      */
 #include "Xi/handlers.h"
 

--- a/Xi/chgkmap.c
+++ b/Xi/chgkmap.c
@@ -55,6 +55,7 @@ SOFTWARE.
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XIproto.h>
 
+#include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
 #include "Xi/handlers.h"
 

--- a/Xi/grabdevb.c
+++ b/Xi/grabdevb.c
@@ -55,6 +55,7 @@ SOFTWARE.
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XIproto.h>
 
+#include "dix/dix_priv.h"
 #include "dix/devices_priv.h"
 #include "dix/exevents_priv.h"
 #include "dix/input_priv.h"

--- a/Xi/grabdevk.c
+++ b/Xi/grabdevk.c
@@ -55,6 +55,7 @@ SOFTWARE.
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XIproto.h>
 
+#include "dix/dix_priv.h"
 #include "dix/devices_priv.h"
 #include "dix/exevents_priv.h"
 #include "dix/input_priv.h"

--- a/Xi/sendexev.c
+++ b/Xi/sendexev.c
@@ -55,6 +55,7 @@ SOFTWARE.
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XIproto.h>
 
+#include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
 #include "Xi/handlers.h"
 

--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -765,4 +765,10 @@ int dixAllocColor(ClientPtr client, Colormap cmap, CARD16 *red,
 
 void ReplyNotSwappd(ClientPtr pClient, int size, void *pbuf)  _X_NORETURN;
 
+/* needed by some internal modules */ _X_EXPORT
+void SwapLongs(CARD32 *list, unsigned long count);
+
+#define SwapRestL(stuff) \
+    SwapLongs((CARD32 *)(stuff + 1), (client->req_len - (sizeof(*stuff) >> 2)))
+
 #endif /* _XSERVER_DIX_PRIV_H */

--- a/dix/rpcbuf.c
+++ b/dix/rpcbuf.c
@@ -6,6 +6,7 @@
 
 #include <stddef.h>
 
+#include "dix/dix_priv.h"
 #include "dix/rpcbuf_priv.h"
 
 static inline Bool __x_rpcbuf_write_bin_pad(

--- a/dix/swapreq.c
+++ b/dix/swapreq.c
@@ -50,6 +50,7 @@ SOFTWARE.
 #include <X11/Xproto.h>
 #include <X11/Xprotostr.h>
 
+#include "dix/dix_priv.h"
 #include "dix/reqhandlers_priv.h"
 
 #include "misc.h"

--- a/doc/Xserver-spec.xml
+++ b/doc/Xserver-spec.xml
@@ -600,7 +600,7 @@ are: REQUEST, REQUEST_SIZE_MATCH, REQUEST_AT_LEAST_SIZE,
 REQUEST_FIXED_SIZE, LEGAL_NEW_RESOURCE, and
 VALIDATE_DRAWABLE_AND_GC. Useful byte swapping macros can be found
 in Xserver/include/misc.h: bswap_64, bswap_32, bswap_16, LengthRestS,
-LengthRestL, SwapRestS, SwapRestL, swapl, swaps, cpswapl, and cpswaps.</para>
+SwapRestS, SwapRestL, swapl, swaps, cpswapl, and cpswaps.</para>
 </section>
 </section>
 

--- a/glx/glxcmdsswap.c
+++ b/glx/glxcmdsswap.c
@@ -31,6 +31,9 @@
 #include <dix-config.h>
 
 #include <string.h>
+
+#include "dix/dix_priv.h"
+
 #include "glxserver.h"
 #include "glxutil.h"
 #include <GL/glxtokens.h>

--- a/glx/single2swap.c
+++ b/glx/single2swap.c
@@ -30,6 +30,7 @@
 
 #include <dix-config.h>
 
+#include "dix/dix_priv.h"
 #include "dix/request_priv.h"
 
 #include "glxserver.h"

--- a/include/misc.h
+++ b/include/misc.h
@@ -214,14 +214,8 @@ padding_for_int32(const int bytes)
 #define LengthRestS(stuff) \
     ((client->req_len << 1) - (sizeof(*stuff) >> 1))
 
-#define LengthRestL(stuff) \
-    (client->req_len - (sizeof(*stuff) >> 2))
-
 #define SwapRestS(stuff) \
     SwapShorts((short *)(stuff + 1), LengthRestS(stuff))
-
-#define SwapRestL(stuff) \
-    SwapLongs((CARD32 *)(stuff + 1), LengthRestL(stuff))
 
 #if defined(__GNUC__) && ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
 void __attribute__ ((error("wrong sized variable passed to swap")))
@@ -301,8 +295,6 @@ bswap_16(uint16_t x)
 			wrong_size(); \
 		(dst) = bswap_16((src)); \
 	} while (0)
-
-extern _X_EXPORT void SwapLongs(CARD32 *list, unsigned long count);
 
 extern _X_EXPORT void SwapShorts(short *list, unsigned long count);
 


### PR DESCRIPTION
Not used by any external drivers, so no need to keep it in public SDK.
Since it's used by internal modules, still needs to be _X_EXPORT'ed.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
