### PR TITLE
os: unexport LogHdrMessageVerb()

### DIFF
--- a/include/os.h
+++ b/include/os.h
@@ -267,13 +267,6 @@ LogMessage(MessageType type, const char *format, ...)
 _X_ATTRIBUTE_PRINTF(2, 3);
 
 extern _X_EXPORT void
-LogHdrMessageVerb(MessageType type, int verb,
-                  const char *msg_format, va_list msg_args,
-                  const char *hdr_format, ...)
-_X_ATTRIBUTE_PRINTF(3, 0)
-_X_ATTRIBUTE_PRINTF(5, 6);
-
-extern _X_EXPORT void
 FatalError(const char *f, ...)
 _X_ATTRIBUTE_PRINTF(1, 2)
     _X_NORETURN;

--- a/os/log_priv.h
+++ b/os/log_priv.h
@@ -94,4 +94,10 @@ extern const char *xorgSyslogIdent;
  */
 void LogPrintMarkers(void);
 
+void LogHdrMessageVerb(MessageType type, int verb,
+                       const char *msg_format, va_list msg_args,
+                       const char *hdr_format, ...)
+    _X_ATTRIBUTE_PRINTF(3, 0)
+    _X_ATTRIBUTE_PRINTF(5, 6);
+
 #endif /* __XORG_OS_LOGGING_H */


### PR DESCRIPTION
Not used by any external drivers, so no need to keep it exported.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
