### PR TITLE
modesetting: read DRM_CAP_ATOMIC_ASYNC_PAGE_FLIP when parsing async flip capabilities

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/present.c
+++ b/hw/xfree86/drivers/video/modesetting/present.c
@@ -512,10 +512,13 @@ ms_present_screen_init(ScreenPtr screen)
     uint64_t value;
     int ret;
 
-    ret = drmGetCap(ms->fd, DRM_CAP_ASYNC_PAGE_FLIP, &value);
+    ret = drmGetCap(ms->fd, ms->atomic_modeset ?
+                            DRM_CAP_ATOMIC_ASYNC_PAGE_FLIP :
+                            DRM_CAP_ASYNC_PAGE_FLIP, &value);
     if (ret == 0 && value == 1) {
         ms_present_screen_info.capabilities |= PresentCapabilityAsync;
         ms->drmmode.can_async_flip = TRUE;
+        xf86DrvMsg(screen->myNum, X_INFO, "Async flip capable\n");
     }
 
     return present_screen_init(screen, &ms_present_screen_info);


### PR DESCRIPTION
We were only reading `DRM_CAP_ASYNC_PAGE_FLIP` and assuming the same value is valid for atomic modesetting too.