### PR TITLE
dix: unexport functions from pixmap.h

### DIFF
--- a/Xext/dri2/dri2.c
+++ b/Xext/dri2/dri2.c
@@ -35,6 +35,7 @@
 #include <errno.h>
 
 #include "dix/dix_priv.h"
+#include "dix/pixmap_priv.h"
 #include "dix/request_priv.h"
 #include "os/client_priv.h"
 

--- a/Xext/randr/rrcrtc.c
+++ b/Xext/randr/rrcrtc.c
@@ -25,6 +25,7 @@
 #include <X11/Xatom.h>
 
 #include "dix/dix_priv.h"
+#include "dix/pixmap_priv.h"
 #include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "os/bug_priv.h"

--- a/dix/main.c
+++ b/dix/main.c
@@ -91,6 +91,7 @@ Equipment Corporation.
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
 #include "dix/gc_priv.h"
+#include "dix/pixmap_priv.h"
 #include "dix/registry_priv.h"
 #include "dix/screensaver_priv.h"
 #include "dix/selection_priv.h"

--- a/dix/pixmap.c
+++ b/dix/pixmap.c
@@ -32,6 +32,7 @@ from The Open Group.
 #include <X11/X.h>
 #include <X11/extensions/render.h>
 
+#include "dix/pixmap_priv.h"
 #include "include/misc.h"
 #include "include/randrstr.h"
 #include "mi/mi_priv.h"

--- a/dix/pixmap_priv.h
+++ b/dix/pixmap_priv.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef _XSERVER_DIX_PIXMAP_PRIV_H
+#define _XSERVER_DIX_PIXMAP_PRIV_H
+
+#include "include/pixmap.h"
+#include "include/regionstr.h"
+#include "include/screenint.h"
+
+Bool PixmapScreenInit(ScreenPtr pScreen);
+
+/* for DRI2 module */ _X_EXPORT
+PixmapPtr PixmapShareToSecondary(PixmapPtr pixmap, ScreenPtr secondary);
+
+/* for DRI2 module */ _X_EXPORT
+void PixmapUnshareSecondaryPixmap(PixmapPtr secondary_pixmap);
+
+/* for modesetting module */ _X_EXPORT
+void PixmapDirtyCopyArea(PixmapPtr dst, DrawablePtr src,
+                         int x, int y, int dst_x, int dst_y,
+                         RegionPtr dirty_region);
+
+#endif /* _XSERVER_DIX_PIXMAP_PRIV_H */

--- a/hw/xfree86/common/xf86platformBus.c
+++ b/hw/xfree86/common/xf86platformBus.c
@@ -36,6 +36,7 @@
 #include <unistd.h>
 
 #include "config/hotplug_priv.h"
+#include "dix/pixmap_priv.h"
 #include "dix/screenint_priv.h"
 #include "os/osdep.h"
 #include "Xext/randr/randrstr_priv.h"

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -36,6 +36,7 @@
 #include <unistd.h>
 
 #include "dix/dix_priv.h"
+#include "dix/pixmap_priv.h"
 #include "os/fmt.h"
 #include "os/mathx_priv.h"
 #include "Xext/present/present_priv.h"

--- a/include/pixmap.h
+++ b/include/pixmap.h
@@ -103,18 +103,10 @@ extern _X_EXPORT PixmapPtr GetScratchPixmapHeader(ScreenPtr pScreen,
 
 extern _X_EXPORT void FreeScratchPixmapHeader(PixmapPtr /*pPixmap */ );
 
-extern _X_EXPORT Bool PixmapScreenInit(ScreenPtr /*pScreen */ );
-
 extern _X_EXPORT PixmapPtr AllocatePixmap(ScreenPtr /*pScreen */ ,
                                           int /*pixDataSize */ );
 
 extern _X_EXPORT void FreePixmap(PixmapPtr /*pPixmap */ );
-
-extern _X_EXPORT PixmapPtr
-PixmapShareToSecondary(PixmapPtr pixmap, ScreenPtr secondary);
-
-extern _X_EXPORT void
-PixmapUnshareSecondaryPixmap(PixmapPtr secondary_pixmap);
 
 #define HAS_DIRTYTRACKING_ROTATION 1
 #define HAS_DIRTYTRACKING_DRAWABLE_SRC 1
@@ -131,10 +123,5 @@ PixmapStopDirtyTracking(DrawablePtr src, PixmapPtr slave_dst);
    efficiently */
 extern _X_EXPORT Bool
 PixmapSyncDirtyHelper(PixmapDirtyUpdatePtr dirty);
-
-extern _X_EXPORT void
-PixmapDirtyCopyArea(PixmapPtr dst, DrawablePtr src,
-                    int x, int y, int dst_x, int dst_y,
-                    RegionPtr dirty_region);
 
 #endif                          /* PIXMAP_H */


### PR DESCRIPTION
Several functions from pixmap.h aren't needed by any external drivers,
so no need to keep them in public SDK. Some still need to be _X_EXPORT'ed
for internal modules (but don't belong to SDK anymore).

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
