### PR TITLE
include: misc.h: drop unused xReqPtr typedef

### DIFF
--- a/include/misc.h
+++ b/include/misc.h
@@ -115,8 +115,6 @@ typedef int XRetCode;
 #define FALSE 0
 #endif
 
-typedef struct _xReq *xReqPtr;
-
 #include "os.h"                 /* for ALLOCATE_LOCAL and DEALLOCATE_LOCAL */
 #include <X11/Xfuncs.h>         /* for bcopy, bzero, and bcmp */
 


### PR DESCRIPTION
not used anywhere, so no need to keep it around any longer.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
