### PR TITLE
treewide: replace min/max macros by non-exported MIN/MAX and deprecate them

### DIFF
--- a/Xext/composite/compinit.c
+++ b/Xext/composite/compinit.c
@@ -47,6 +47,7 @@
 #include "dix/dix_priv.h"
 #include "dix/screen_hooks_priv.h"
 #include "include/extinit.h"
+#include "os/mathx_priv.h"
 #include "os/osdep.h"
 
 #include "compint.h"
@@ -283,8 +284,8 @@ compAddAlternateVisual(ScreenPtr pScreen, CompScreenPtr cs,
                                visual->greenMask |
                                visual->blueMask | alphaMask);
         /* find widest component */
-        visual->ColormapEntries = (1 << max(Ones(visual->redMask),
-                                            max(Ones(visual->greenMask),
+        visual->ColormapEntries = (1 << MAX(Ones(visual->redMask),
+                                            MAX(Ones(visual->greenMask),
                                                 Ones(visual->blueMask))));
     }
 

--- a/Xext/glx/glxscreens.c
+++ b/Xext/glx/glxscreens.c
@@ -37,6 +37,7 @@
 
 #include "dix/colormap_priv.h"
 #include "include/extinit.h"
+#include "os/mathx_priv.h"
 
 #include <windowstr.h>
 #include <os.h>
@@ -227,7 +228,7 @@ initGlxVisual(VisualPtr visual, __GLXconfig * config)
 {
     int maxBits;
 
-    maxBits = max(config->redBits, max(config->greenBits, config->blueBits));
+    maxBits = MAX(config->redBits, MAX(config->greenBits, config->blueBits));
 
     config->visualID = visual->vid;
     visual->class = glxConvertToXVisualType(config->visualType);

--- a/Xext/panoramiX/panoramiXprocs.c
+++ b/Xext/panoramiX/panoramiXprocs.c
@@ -39,6 +39,8 @@ Equipment Corporation.
 #include "dix/window_priv.h"
 #include "include/misc.h"
 #include "os/osdep.h"
+#include "os/mathx_priv.h"
+
 #include "panoramiX.h"
 #include "panoramiXsrv.h"
 
@@ -1166,10 +1168,10 @@ PanoramiXCopyArea(ClientPtr client)
                 dy += masterScreen->y;
             }
 
-            sourceBox.x1 = min(srcx + dx, 0);
-            sourceBox.y1 = min(srcy + dy, 0);
-            sourceBox.x2 = max(sourceBox.x1 + width, 32767);
-            sourceBox.y2 = max(sourceBox.y1 + height, 32767);
+            sourceBox.x1 = MIN(srcx + dx, 0);
+            sourceBox.y1 = MIN(srcy + dy, 0);
+            sourceBox.x2 = MAX(sourceBox.x1 + width, 32767);
+            sourceBox.y2 = MAX(sourceBox.y1 + height, 32767);
 
             RegionInit(&rgn, &sourceBox, 1);
 
@@ -2078,7 +2080,7 @@ PanoramiXGetImage(ClientPtr client)
     else if (format == ZPixmap) {
         linesDone = 0;
         while (h - linesDone > 0) {
-            nlines = min(linesPerBuf, h - linesDone);
+            nlines = MIN(linesPerBuf, h - linesDone);
 
             char *pBuf = x_rpcbuf_reserve(&rpcbuf, nlines * widthBytesLine);
             if (!pBuf)
@@ -2095,7 +2097,7 @@ PanoramiXGetImage(ClientPtr client)
             if (planemask & plane) {
                 linesDone = 0;
                 while (h - linesDone > 0) {
-                    nlines = min(linesPerBuf, h - linesDone);
+                    nlines = MIN(linesPerBuf, h - linesDone);
 
                     char *pBuf = x_rpcbuf_reserve(&rpcbuf, nlines * widthBytesLine);
                     if (!pBuf)

--- a/Xext/randr/rrcrtc.c
+++ b/Xext/randr/rrcrtc.c
@@ -28,6 +28,7 @@
 #include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "os/bug_priv.h"
+#include "os/mathx_priv.h"
 #include "os/osdep.h"
 #include "Xext/randr/randrstr_priv.h"
 #include "Xext/randr/rrdispatch_priv.h"
@@ -322,10 +323,10 @@ crtcs_adjacent(const RRCrtcPtr a, const RRCrtcPtr b)
     if (!cursor_bounds(b, &bl, &br, &bt, &bb))
 	    return FALSE;
 
-    cl = max(al, bl);
-    cr = min(ar, br);
-    ct = max(at, bt);
-    cb = min(ab, bb);
+    cl = MAX(al, bl);
+    cr = MIN(ar, br);
+    ct = MAX(at, bt);
+    cb = MIN(ab, bb);
 
     return (cl <= cr) && (ct <= cb);
 }

--- a/Xext/randr/rrmonitor.c
+++ b/Xext/randr/rrmonitor.c
@@ -23,6 +23,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
+#include "os/mathx_priv.h"
 #include "Xext/randr/randrstr_priv.h"
 #include "Xext/randr/rrdispatch_priv.h"
 
@@ -151,10 +152,10 @@ RRMonitorGetGeometry(RRMonitorPtr monitor, RRMonitorGeometryPtr geometry)
                 first = this;
                 *geometry = this;
             } else {
-                geometry->box.x1 = min(this.box.x1, geometry->box.x1);
-                geometry->box.x2 = max(this.box.x2, geometry->box.x2);
-                geometry->box.y1 = min(this.box.y1, geometry->box.y1);
-                geometry->box.y2 = max(this.box.y2, geometry->box.y2);
+                geometry->box.x1 = MIN(this.box.x1, geometry->box.x1);
+                geometry->box.x2 = MAX(this.box.x2, geometry->box.x2);
+                geometry->box.y1 = MIN(this.box.y1, geometry->box.y1);
+                geometry->box.y2 = MAX(this.box.y2, geometry->box.y2);
             }
             active_crtcs++;
         }

--- a/Xext/randr/rrproperty.c
+++ b/Xext/randr/rrproperty.c
@@ -25,6 +25,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
+#include "os/mathx_priv.h"
 #include "Xext/randr/rrdispatch_priv.h"
 #include "Xext/randr/randrstr_priv.h"
 
@@ -697,7 +698,7 @@ ProcRRGetOutputProperty(ClientPtr client)
         return BadValue;
     }
 
-    size_t len = min(n - ind, 4 * stuff->longLength);
+    size_t len = MIN(n - ind, 4 * stuff->longLength);
 
     reply.bytesAfter = n - (ind + len);
     reply.format = prop_value->format;

--- a/Xext/randr/rrproviderproperty.c
+++ b/Xext/randr/rrproviderproperty.c
@@ -23,6 +23,7 @@
 
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
+#include "os/mathx_priv.h"
 #include "Xext/randr/randrstr_priv.h"
 #include "Xext/randr/rrdispatch_priv.h"
 
@@ -621,7 +622,7 @@ ProcRRGetProviderProperty(ClientPtr client)
         return BadValue;
     }
 
-    len = min(n - ind, 4 * stuff->longLength);
+    len = MIN(n - ind, 4 * stuff->longLength);
 
     reply.bytesAfter = n - (ind + len);
     reply.format = prop_value->format;

--- a/Xext/record/record.c
+++ b/Xext/record/record.c
@@ -47,6 +47,7 @@ and Jim Haggerty of Metheus.
 #include "dix/screenint_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/client_priv.h"
+#include "os/mathx_priv.h"
 #include "os/osdep.h"
 #include "Xext/panoramiX/panoramiX.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
@@ -1998,7 +1999,7 @@ RecordAllocRanges(GetContextRangeInfoPtr pri, int nRanges)
 
 #define SZINCR 8
 
-    newsize = max(pri->size + SZINCR, nRanges);
+    newsize = MAX(pri->size + SZINCR, nRanges);
     pNewRange = reallocarray(pri->pRanges, newsize, sizeof(xRecordRange));
     if (!pNewRange)
         return BadAlloc;
@@ -2062,7 +2063,7 @@ RecordConvertSetToRanges(RecordSetPtr pSet,
                 return err;
         }
         else
-            pri->nRanges = max(pri->nRanges, nRanges);
+            pri->nRanges = MAX(pri->nRanges, nRanges);
         if (card8) {
             pCARD8 = ((CARD8 *) &pri->pRanges[nRanges - 1]) + byteoffset;
             *pCARD8++ = interval.first;

--- a/Xext/record/set.c
+++ b/Xext/record/set.c
@@ -48,6 +48,9 @@ from The Open Group.
 #include <dix-config.h>
 
 #include <string.h>
+#include <stdlib.h>
+
+#include "os/mathx_priv.h"
 
 #include "include/misc.h"
 
@@ -59,9 +62,9 @@ from The Open Group.
  * should be a valid assumption on all supported architectures.
  */
 #if defined(__STDC__) && (__STDC_VERSION__ - 0 >= 201112L)
-#define MinSetAlignment(type) max(_Alignof((type)), _Alignof(unsigned long))
+#define MinSetAlignment(type) MAX(_Alignof(type), _Alignof(unsigned long))
 #else
-#define MinSetAlignment(type) max(sizeof(void*), sizeof(unsigned long))
+#define MinSetAlignment(type) MAX(sizeof(void*), sizeof(unsigned long))
 #endif
 
 static int
@@ -339,7 +342,7 @@ IntervalListCreateSet(RecordSetInterval * pIntervals, int nIntervals,
                 i++;            /* disjoint intervals */
             }
             else {
-                stackIntervals[i].last = max(stackIntervals[i].last,
+                stackIntervals[i].last = MAX(stackIntervals[i].last,
                                              stackIntervals[i + 1].last);
                 nIntervals--;
                 for (j = i + 1; j < nIntervals; j++)

--- a/Xext/render/mitrap.c
+++ b/Xext/render/mitrap.c
@@ -24,6 +24,7 @@
 #include <dix-config.h>
 
 #include "include/mipict.h"
+#include "os/mathx_priv.h"
 
 #include "scrnintstr.h"
 #include "gcstruct.h"
@@ -65,7 +66,7 @@ miTrapezoidBounds(int ntrap, xTrapezoid * traps, BoxPtr box)
         if (y2 > box->y2)
             box->y2 = y2;
 
-        x1 = xFixedToInt(min(miLineFixedX(&traps->left, traps->top, FALSE),
+        x1 = xFixedToInt(MIN(miLineFixedX(&traps->left, traps->top, FALSE),
                              miLineFixedX(&traps->left, traps->bottom, FALSE)));
         if (x1 < box->x1)
             box->x1 = x1;

--- a/Xext/xfixes/xfixes.c
+++ b/Xext/xfixes/xfixes.c
@@ -48,6 +48,7 @@
 #include "dix/request_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/fmt.h"
+#include "os/mathx_priv.h"
 #include "Xext/xinput/xibarriers.h"
 
 #include "xfixesint.h"
@@ -75,7 +76,7 @@ ProcXFixesQueryVersion(ClientPtr client)
     if (version_compare(stuff->majorVersion, stuff->minorVersion,
                         SERVER_XFIXES_MAJOR_VERSION,
                         SERVER_XFIXES_MINOR_VERSION) < 0) {
-        major = max(pXFixesClient->major_version, stuff->majorVersion);
+        major = MAX(pXFixesClient->major_version, stuff->majorVersion);
         minor = stuff->minorVersion;
     }
     else {
@@ -86,7 +87,7 @@ ProcXFixesQueryVersion(ClientPtr client)
     pXFixesClient->major_version = major;
 
     xXFixesQueryVersionReply reply = {
-        .majorVersion = min(stuff->majorVersion, major),
+        .majorVersion = MIN(stuff->majorVersion, major),
         .minorVersion = minor
     };
 

--- a/Xext/xinput/exevents.c
+++ b/Xext/xinput/exevents.c
@@ -101,6 +101,7 @@ SOFTWARE.
 #include "mi/mi_priv.h"
 #include "os/bug_priv.h"
 #include "os/log_priv.h"
+#include "os/mathx_priv.h"
 #include "os/osdep.h"
 #include "Xext/xkeyboard/xkbsrv_priv.h"
 
@@ -618,7 +619,7 @@ DeepCopyPointerClasses(DeviceIntPtr from, DeviceIntPtr to)
         }
 
         if (from->button->xkb_acts) {
-            size_t maxbuttons = max(to->button->numButtons, from->button->numButtons);
+            size_t maxbuttons = MAX(to->button->numButtons, from->button->numButtons);
             to->button->xkb_acts = XNFreallocarray(to->button->xkb_acts,
                                                    maxbuttons,
                                                    sizeof(XkbAction));
@@ -3337,7 +3338,7 @@ XISetEventMask(DeviceIntPtr dev, WindowPtr win, ClientPtr client,
 
     if (others) {
         xi2mask_zero(others->xi2mask, dev->id);
-        len = min(len, xi2mask_mask_size(others->xi2mask));
+        len = MIN(len, xi2mask_mask_size(others->xi2mask));
     }
 
     if (len) {

--- a/Xext/xinput/xibarriers.c
+++ b/Xext/xinput/xibarriers.c
@@ -50,8 +50,9 @@
 #include "dix/resource_priv.h"
 #include "mi/mi_priv.h"
 #include "os/bug_priv.h"
-#include "handlers.h"
+#include "os/mathx_priv.h"
 
+#include "handlers.h"
 #include "xibarriers.h"
 #include "scrnintstr.h"
 #include "cursorstr.h"
@@ -546,8 +547,8 @@ sort_min_max(INT16 *a, INT16 *b)
         return;
     A = *a;
     B = *b;
-    *a = min(A, B);
-    *b = max(A, B);
+    *a = MIN(A, B);
+    *b = MAX(A, B);
 }
 
 static int

--- a/Xext/xinput/xigrabdev.c
+++ b/Xext/xinput/xigrabdev.c
@@ -39,6 +39,7 @@
 #include "dix/inpututils_priv.h"
 #include "dix/request_priv.h"
 #include "dix/resource_priv.h"
+#include "os/mathx_priv.h"
 #include "handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
@@ -94,7 +95,7 @@ ProcXIGrabDevice(ClientPtr client)
     if (!mask.xi2mask)
         return BadAlloc;
 
-    mask_len = min(xi2mask_mask_size(mask.xi2mask), stuff->mask_len * 4);
+    mask_len = MIN(xi2mask_mask_size(mask.xi2mask), stuff->mask_len * 4);
     /* FIXME: I think the old code was broken here */
     xi2mask_set_one_mask(mask.xi2mask, dev->id, (unsigned char *) &stuff[1],
                          mask_len);

--- a/Xext/xinput/xipassivegrab.c
+++ b/Xext/xinput/xipassivegrab.c
@@ -41,6 +41,7 @@
 #include "dix/rpcbuf_priv.h"
 #include "dix/request_priv.h"
 #include "include/misc.h"
+#include "os/mathx_priv.h"
 
 #include "handlers.h"
 #include "inputstr.h"           /* DeviceIntPtr      */
@@ -125,7 +126,7 @@ ProcXIPassiveGrabDevice(ClientPtr client)
     if (!mask.xi2mask)
         return BadAlloc;
 
-    mask_len = min(xi2mask_mask_size(mask.xi2mask), stuff->mask_len * 4);
+    mask_len = MIN(xi2mask_mask_size(mask.xi2mask), stuff->mask_len * 4);
     xi2mask_set_one_mask(mask.xi2mask, stuff->deviceid,
                          (unsigned char *) &stuff[1], mask_len);
 

--- a/Xext/xinput/xiproperty.c
+++ b/Xext/xinput/xiproperty.c
@@ -38,8 +38,9 @@
 #include "dix/input_priv.h"
 #include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
-#include "handlers.h"
+#include "os/mathx_priv.h"
 
+#include "handlers.h"
 #include "dix.h"
 #include "inputstr.h"
 #include "exglobals.h"
@@ -282,7 +283,7 @@ get_property(ClientPtr client, DeviceIntPtr dev, Atom property, Atom type,
         return BadValue;
     }
 
-    len = min(n - ind, 4 * length);
+    len = MIN(n - ind, 4 * length);
 
     *bytes_after = n - (ind + len);
     *format = prop_value->format;

--- a/dix/color.c
+++ b/dix/color.c
@@ -50,6 +50,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "include/dix.h"
+#include "os/mathx_priv.h"
 
 typedef struct _builtinColor {
     unsigned char red;
@@ -858,7 +859,7 @@ dixLookupBuiltinColor(char *name,
         int mid = (low + high) / 2;
         const BuiltinColor *c = &BuiltinColors[mid];
         const size_t currentLen = strlen(c->name);
-        const int r = strncasecmp(c->name, name, min(len, currentLen));
+        const int r = strncasecmp(c->name, name, MIN(len, currentLen));
 
         if (r == 0) {
             if (len == currentLen) {

--- a/dix/devices.c
+++ b/dix/devices.c
@@ -69,6 +69,7 @@ SOFTWARE.
 #include "mi/mi_priv.h"
 #include "os/bug_priv.h"
 #include "os/log_priv.h"
+#include "os/mathx_priv.h"
 #include "os/osdep.h"
 #include "Xext/xkeyboard/xkbsrv_priv.h"
 
@@ -2444,7 +2445,7 @@ RecalculateMasterButtons(DeviceIntPtr slave)
             GetMaster(dev, MASTER_ATTACHED) != master || !dev->button)
             continue;
 
-        maxbuttons = max(maxbuttons, dev->button->numButtons);
+        maxbuttons = MAX(maxbuttons, dev->button->numButtons);
     }
 
     if (master->button && master->button->numButtons != maxbuttons) {

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -125,6 +125,7 @@ Equipment Corporation.
 #include "os/auth.h"
 #include "os/client_priv.h"
 #include "os/ddx_priv.h"
+#include "os/mathx_priv.h"
 #include "os/osdep.h"
 #include "os/probes_priv.h"
 #include "os/screensaver.h"
@@ -2338,7 +2339,7 @@ DoGetImage(ClientPtr client, int format, Drawable drawable,
     else if (format == ZPixmap) {
         linesDone = 0;
         while (height - linesDone > 0) {
-            size_t nlines = min(linesPerBuf, height - linesDone);
+            size_t nlines = MIN(linesPerBuf, height - linesDone);
 
             char *pBuf = x_rpcbuf_reserve(&rpcbuf, (nlines * widthBytesLine));
             if (!pBuf) {
@@ -2370,7 +2371,7 @@ DoGetImage(ClientPtr client, int format, Drawable drawable,
             if (planemask & plane) {
                 linesDone = 0;
                 while (height - linesDone > 0) {
-                    size_t nlines = min(linesPerBuf, height - linesDone);
+                    size_t nlines = MIN(linesPerBuf, height - linesDone);
 
                     char *pBuf = x_rpcbuf_reserve(&rpcbuf, (nlines * widthBytesLine));
                     if (!pBuf) {

--- a/dix/extension.c
+++ b/dix/extension.c
@@ -54,6 +54,7 @@ SOFTWARE.
 #include "dix/registry_priv.h"
 #include "dix/request_priv.h"
 #include "include/misc.h"
+#include "os/mathx_priv.h"
 
 #include "dixstruct.h"
 #include "extnsionst.h"
@@ -299,7 +300,7 @@ ProcQueryExtension(ClientPtr client)
 
     if (NumExtensions && extensions) {
         char extname[PATH_MAX] = { 0 };
-        strncpy(extname, (char *) &stuff[1], min(stuff->nbytes, sizeof(extname)-1));
+        strncpy(extname, (char *) &stuff[1], MIN(stuff->nbytes, sizeof(extname)-1));
         ExtensionEntry *extEntry = CheckExtension(extname);
 
         if (extEntry && ExtensionAvailable(client, extEntry)) {

--- a/dix/getevents.c
+++ b/dix/getevents.c
@@ -48,6 +48,7 @@
 #include "mi/mi_priv.h"
 #include "os/bug_priv.h"
 #include "os/probes_priv.h"
+#include "os/mathx_priv.h"
 #include "Xext/panoramiX/panoramiX.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
 
@@ -2000,7 +2001,7 @@ GetTouchEvents(InternalEvent *events, DeviceIntPtr dev, uint32_t ddx_touchid,
      * these come from the touchpoint in Absolute mode, or the sprite in
      * Relative. */
     if (t->mode == XIDirectTouch) {
-        for (int i = 0; i < max(valuator_mask_size(&mask), 2); i++) {
+        for (int i = 0; i < MAX(valuator_mask_size(&mask), 2); i++) {
             double val;
 
             if (valuator_mask_fetch_double(&mask, i, &val))

--- a/dix/inpututils.c
+++ b/dix/inpututils.c
@@ -32,6 +32,7 @@
 #include "dix/screenint_priv.h"
 #include "include/misc.h"
 #include "os/bug_priv.h"
+#include "os/mathx_priv.h"
 #include "Xext/xinput/exglobals.h"
 
 #include "inputstr.h"
@@ -452,7 +453,7 @@ valuator_mask_set_range(ValuatorMask *mask, int first_valuator,
     valuator_mask_zero(mask);
 
     for (int i = first_valuator;
-         i < min(first_valuator + num_valuators, MAX_VALUATORS); i++)
+         i < MIN(first_valuator + num_valuators, MAX_VALUATORS); i++)
         valuator_mask_set(mask, i, valuators[i - first_valuator]);
 }
 
@@ -482,7 +483,7 @@ valuator_mask_size(const ValuatorMask *mask)
 int
 valuator_mask_num_valuators(const ValuatorMask *mask)
 {
-    return CountBits(mask->mask, min(mask->last_bit + 1, MAX_VALUATORS));
+    return CountBits(mask->mask, MIN(mask->last_bit + 1, MAX_VALUATORS));
 }
 
 /**
@@ -497,7 +498,7 @@ valuator_mask_isset(const ValuatorMask *mask, int valuator)
 static inline void
 _valuator_mask_set_double(ValuatorMask *mask, int valuator, double data)
 {
-    mask->last_bit = max(valuator, mask->last_bit);
+    mask->last_bit = MAX(valuator, mask->last_bit);
     SetBit(mask->mask, valuator);
     mask->valuators[valuator] = data;
 }
@@ -595,7 +596,7 @@ valuator_mask_unset(ValuatorMask *mask, int valuator)
 
         for (int i = 0; i <= mask->last_bit; i++)
             if (valuator_mask_isset(mask, i))
-                lastbit = max(lastbit, i);
+                lastbit = MAX(lastbit, i);
         mask->last_bit = lastbit;
 
         if (mask->last_bit == -1)
@@ -843,10 +844,10 @@ update_desktop_dimensions(void)
     int x2 = INT_MIN, y2 = INT_MIN;     /* bottom-right */
 
     DIX_FOR_EACH_SCREEN({
-        x1 = min(x1, walkScreen->x);
-        y1 = min(y1, walkScreen->y);
-        x2 = max(x2, walkScreen->x + walkScreen->width);
-        y2 = max(y2, walkScreen->y + walkScreen->height);
+        x1 = MIN(x1, walkScreen->x);
+        y1 = MIN(y1, walkScreen->y);
+        x2 = MAX(x2, walkScreen->x + walkScreen->width);
+        y2 = MAX(y2, walkScreen->y + walkScreen->height);
     });
 
     screenInfo.x = x1;
@@ -1174,8 +1175,8 @@ xi2mask_zero(XI2Mask *mask, int deviceid)
 void
 xi2mask_merge(XI2Mask *dest, const XI2Mask *source)
 {
-    for (int i = 0; i < min(dest->nmasks, source->nmasks); i++)
-        for (int j = 0; j < min(dest->mask_size, source->mask_size); j++)
+    for (int i = 0; i < MIN(dest->nmasks, source->nmasks); i++)
+        for (int j = 0; j < MIN(dest->mask_size, source->mask_size); j++)
             dest->masks[i][j] |= source->masks[i][j];
 }
 
@@ -1209,7 +1210,7 @@ xi2mask_set_one_mask(XI2Mask *xi2mask, int deviceid, const unsigned char *mask,
     BUG_WARN(deviceid < 0);
     BUG_WARN(deviceid >= xi2mask->nmasks);
 
-    memcpy(xi2mask->masks[deviceid], mask, min(xi2mask->mask_size, mask_size));
+    memcpy(xi2mask->masks[deviceid], mask, MIN(xi2mask->mask_size, mask_size));
 }
 
 /**

--- a/dix/property.c
+++ b/dix/property.c
@@ -55,6 +55,7 @@ SOFTWARE.
 #include "dix/request_priv.h"
 #include "dix/window_priv.h"
 #include "include/extinit.h"
+#include "os/mathx_priv.h"
 #include "Xext/panoramiX/panoramiX.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
 
@@ -614,7 +615,7 @@ ProcGetProperty(ClientPtr client)
         return BadValue;
     }
 
-    len = min(n - ind, 4 * p.longLength);
+    len = MIN(n - ind, 4 * p.longLength);
 
     xGetPropertyReply reply = {
         .bytesAfter = n - (ind + len),

--- a/dix/region.c
+++ b/dix/region.c
@@ -77,11 +77,14 @@ Equipment Corporation.
 
 #include <dix-config.h>
 
-#include "regionstr.h"
 #include <X11/Xprotostr.h>
 #include <X11/Xfuncproto.h>
-#include "gc.h"
 #include <pixman.h>
+
+#include "os/mathx_priv.h"
+
+#include "regionstr.h"
+#include "gc.h"
 
 #undef assert
 #ifdef REGION_DEBUG
@@ -657,7 +660,7 @@ RegionOp(RegionPtr newReg,      /* Place to store result         */
      * the top of the rectangles of both regions and ybot clips the bottoms.
      */
 
-    ybot = min(r1->y1, r2->y1);
+    ybot = MIN(r1->y1, r2->y1);
 
     /*
      * prevBand serves to mark the start of the previous band so rectangles
@@ -694,8 +697,8 @@ RegionOp(RegionPtr newReg,      /* Place to store result         */
          */
         if (r1y1 < r2y1) {
             if (appendNon1) {
-                top = max(r1y1, ybot);
-                bot = min(r1->y2, r2y1);
+                top = MAX(r1y1, ybot);
+                bot = MIN(r1->y2, r2y1);
                 if (top != bot) {
                     curBand = newReg->data->numRects;
                     RegionAppendNonO(newReg, r1, r1BandEnd, top, bot);
@@ -706,8 +709,8 @@ RegionOp(RegionPtr newReg,      /* Place to store result         */
         }
         else if (r2y1 < r1y1) {
             if (appendNon2) {
-                top = max(r2y1, ybot);
-                bot = min(r2->y2, r1y1);
+                top = MAX(r2y1, ybot);
+                bot = MIN(r2->y2, r1y1);
                 if (top != bot) {
                     curBand = newReg->data->numRects;
                     RegionAppendNonO(newReg, r2, r2BandEnd, top, bot);
@@ -724,7 +727,7 @@ RegionOp(RegionPtr newReg,      /* Place to store result         */
          * Now see if we've hit an intersecting band. The two bands only
          * intersect if ybot > ytop
          */
-        ybot = min(r1->y2, r2->y2);
+        ybot = MIN(r1->y2, r2->y2);
         if (ybot > ytop) {
             curBand = newReg->data->numRects;
             (*overlapFunc) (newReg, r1, r1BandEnd, r2, r2BandEnd, ytop, ybot,
@@ -755,7 +758,7 @@ RegionOp(RegionPtr newReg,      /* Place to store result         */
         /* Do first nonOverlap1Func call, which may be able to coalesce */
         FindBand(r1, r1BandEnd, r1End, r1y1);
         curBand = newReg->data->numRects;
-        RegionAppendNonO(newReg, r1, r1BandEnd, max(r1y1, ybot), r1->y2);
+        RegionAppendNonO(newReg, r1, r1BandEnd, MAX(r1y1, ybot), r1->y2);
         Coalesce(newReg, prevBand, curBand);
         /* Just append the rest of the boxes  */
         AppendRegions(newReg, r1BandEnd, r1End);
@@ -765,7 +768,7 @@ RegionOp(RegionPtr newReg,      /* Place to store result         */
         /* Do first nonOverlap2Func call, which may be able to coalesce */
         FindBand(r2, r2BandEnd, r2End, r2y1);
         curBand = newReg->data->numRects;
-        RegionAppendNonO(newReg, r2, r2BandEnd, max(r2y1, ybot), r2->y2);
+        RegionAppendNonO(newReg, r2, r2BandEnd, MAX(r2y1, ybot), r2->y2);
         Coalesce(newReg, prevBand, curBand);
         /* Append rest of boxes */
         AppendRegions(newReg, r2BandEnd, r2End);

--- a/dix/window.c
+++ b/dix/window.c
@@ -118,6 +118,7 @@ Equipment Corporation.
 #include "mi/mi_priv.h"         /* miPaintWindow */
 #include "os/auth.h"
 #include "os/client_priv.h"
+#include "os/mathx_priv.h"
 #include "os/osdep.h"
 #include "os/screensaver.h"
 #include "Xext/composite/compint.h"
@@ -206,7 +207,7 @@ get_window_name(WindowPtr pWin)
     for (PropertyPtr prop = pWin->properties; prop; prop = prop->next) {
         if (prop->propertyName == XA_WM_NAME && prop->type == XA_STRING &&
             prop->data) {
-            len = min(prop->size, WINDOW_NAME_BUF_LEN - 1);
+            len = MIN(prop->size, WINDOW_NAME_BUF_LEN - 1);
             memcpy(buf, prop->data, len);
             buf[len] = '\0';
             return buf;

--- a/exa/exa.c
+++ b/exa/exa.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 
 #include "dix/screen_hooks_priv.h"
+#include "os/mathx_priv.h"
 
 #include "exa_priv.h"
 #include "exa.h"
@@ -128,13 +129,14 @@ exaGetDrawableDeltas(DrawablePtr pDrawable, PixmapPtr pPixmap, int *xp, int *yp)
 void
 exaPixmapDirty(PixmapPtr pPix, int x1, int y1, int x2, int y2)
 {
-    BoxRec box;
     RegionRec region;
 
-    box.x1 = max(x1, 0);
-    box.y1 = max(y1, 0);
-    box.x2 = min(x2, pPix->drawable.width);
-    box.y2 = min(y2, pPix->drawable.height);
+    BoxRec box = {
+        .x1 = MAX(x1, 0),
+        .y1 = MAX(y1, 0),
+        .x2 = MIN(x2, pPix->drawable.width),
+        .y2 = MIN(y2, pPix->drawable.height),
+    };
 
     if (box.x1 >= box.x2 || box.y1 >= box.y2)
         return;
@@ -678,7 +680,7 @@ ExaBlockHandler(ScreenPtr pScreen, void *pTimeout)
         CARD32 now = GetTimeInMillis();
 
         pExaScr->nextDefragment = now +
-            max(100, (INT32) (pExaScr->lastDefragment + 1000 - now));
+            MAX(100, (INT32) (pExaScr->lastDefragment + 1000 - now));
         AdjustWaitForDelay(pTimeout, pExaScr->nextDefragment - now);
     }
 }

--- a/exa/exa_accel.c
+++ b/exa/exa_accel.c
@@ -28,8 +28,12 @@
  */
 
 #include <dix-config.h>
-#include "exa_priv.h"
+
 #include <X11/fonts/fontstruct.h>
+
+#include "os/mathx_priv.h"
+
+#include "exa_priv.h"
 #include "dixfontstr.h"
 #include "exa.h"
 
@@ -1134,7 +1138,7 @@ exaFillRegionTiled(DrawablePtr pDrawable, RegionPtr pRegion, PixmapPtr pTile,
             int tileY;
 
             if (alu == GXcopy)
-                height = min(height, tileHeight);
+                height = MIN(height, tileHeight);
 
             modulus(dstY - yoff - pDrawable->y - pPatOrg->y, tileHeight, tileY);
 
@@ -1145,7 +1149,7 @@ exaFillRegionTiled(DrawablePtr pDrawable, RegionPtr pRegion, PixmapPtr pTile,
                 int h = tileHeight - tileY;
 
                 if (alu == GXcopy)
-                    width = min(width, tileWidth);
+                    width = MIN(width, tileWidth);
 
                 if (h > height)
                     h = height;
@@ -1204,26 +1208,26 @@ exaFillRegionTiled(DrawablePtr pDrawable, RegionPtr pRegion, PixmapPtr pTile,
                 for (i = 0; i < nbox; i++) {
                     int dstX = pBox[i].x1 + tileWidth;
                     int dstY = pBox[i].y1 + tileHeight;
-                    int width = min(pBox[i].x2 - dstX, tileWidth);
-                    int height = min(pBox[i].y2 - pBox[i].y1, tileHeight);
+                    int width = MIN(pBox[i].x2 - dstX, tileWidth);
+                    int height = MIN(pBox[i].y2 - pBox[i].y1, tileHeight);
 
                     while (dstX < pBox[i].x2) {
                         (*pExaScr->info->Copy) (pPixmap, pBox[i].x1, pBox[i].y1,
                                                 dstX, pBox[i].y1, width,
                                                 height);
                         dstX += width;
-                        width = min(pBox[i].x2 - dstX, width * 2);
+                        width = MIN(pBox[i].x2 - dstX, width * 2);
                     }
 
                     width = pBox[i].x2 - pBox[i].x1;
-                    height = min(pBox[i].y2 - dstY, tileHeight);
+                    height = MIN(pBox[i].y2 - dstY, tileHeight);
 
                     while (dstY < pBox[i].y2) {
                         (*pExaScr->info->Copy) (pPixmap, pBox[i].x1, pBox[i].y1,
                                                 pBox[i].x1, dstY, width,
                                                 height);
                         dstY += height;
-                        height = min(pBox[i].y2 - dstY, height * 2);
+                        height = MIN(pBox[i].y2 - dstY, height * 2);
                     }
                 }
 

--- a/exa/exa_migration_classic.c
+++ b/exa/exa_migration_classic.c
@@ -30,6 +30,8 @@
 
 #include <string.h>
 
+#include "os/mathx_priv.h"
+
 #include "exa_priv.h"
 #include "exa.h"
 
@@ -164,17 +166,18 @@ exaCopyDirty(ExaMigrationPtr migrate, RegionPtr pValidDst, RegionPtr pValidSrc,
              * destination valid region and the pending damage region.
              */
             if (RegionNumRects(pValidDst) > 10) {
-                BoxRec box;
                 BoxPtr pValidExt, pDamageExt;
                 RegionRec closure;
 
                 pValidExt = RegionExtents(pValidDst);
                 pDamageExt = RegionExtents(pending_damage);
 
-                box.x1 = min(pValidExt->x1, pDamageExt->x1);
-                box.y1 = min(pValidExt->y1, pDamageExt->y1);
-                box.x2 = max(pValidExt->x2, pDamageExt->x2);
-                box.y2 = max(pValidExt->y2, pDamageExt->y2);
+                BoxRec box = {
+                    .x1 = MIN(pValidExt->x1, pDamageExt->x1),
+                    .y1 = MIN(pValidExt->y1, pDamageExt->y1),
+                    .x2 = MAX(pValidExt->x2, pDamageExt->x2),
+                    .y2 = MAX(pValidExt->y2, pDamageExt->y2),
+                };
 
                 RegionInit(&closure, &box, 0);
                 RegionIntersect(&CopyReg, &CopyReg, &closure);
@@ -207,10 +210,10 @@ exaCopyDirty(ExaMigrationPtr migrate, RegionPtr pValidDst, RegionPtr pValidSrc,
     pPixmap->devKind = pExaPixmap->fb_pitch;
 
     while (nbox--) {
-        pBox->x1 = max(pBox->x1, 0);
-        pBox->y1 = max(pBox->y1, 0);
-        pBox->x2 = min(pBox->x2, pPixmap->drawable.width);
-        pBox->y2 = min(pBox->y2, pPixmap->drawable.height);
+        pBox->x1 = MAX(pBox->x1, 0);
+        pBox->y1 = MAX(pBox->y1, 0);
+        pBox->x2 = MIN(pBox->x2, pPixmap->drawable.width);
+        pBox->y2 = MIN(pBox->y2, pPixmap->drawable.height);
 
         if (pBox->x1 >= pBox->x2 || pBox->y1 >= pBox->y2)
             continue;
@@ -566,10 +569,10 @@ exaAssertNotDirty(PixmapPtr pPixmap)
     while (nbox--) {
         int rowbytes;
 
-        pBox->x1 = max(pBox->x1, 0);
-        pBox->y1 = max(pBox->y1, 0);
-        pBox->x2 = min(pBox->x2, pPixmap->drawable.width);
-        pBox->y2 = min(pBox->y2, pPixmap->drawable.height);
+        pBox->x1 = MAX(pBox->x1, 0);
+        pBox->y1 = MAX(pBox->y1, 0);
+        pBox->x2 = MIN(pBox->x2, pPixmap->drawable.width);
+        pBox->y2 = MIN(pBox->y2, pPixmap->drawable.height);
 
         if (pBox->x1 >= pBox->x2 || pBox->y1 >= pBox->y2)
             continue;

--- a/glamor/glamor_copy.c
+++ b/glamor/glamor_copy.c
@@ -22,6 +22,7 @@
 #include <dix-config.h>
 
 #include "os/bug_priv.h"
+#include "os/mathx_priv.h"
 
 #include "glamor_priv.h"
 #include "glamor_transfer.h"
@@ -465,10 +466,10 @@ glamor_copy_fbo_fbo_draw(DrawablePtr src,
 
         glamor_pixmap_loop(dst_priv, dst_box_index) {
             BoxRec scissor = {
-                .x1 = max(-args.dx, bounds.x1),
-                .y1 = max(-args.dy, bounds.y1),
-                .x2 = min(-args.dx + src_box->x2 - src_box->x1, bounds.x2),
-                .y2 = min(-args.dy + src_box->y2 - src_box->y1, bounds.y2),
+                .x1 = MAX(-args.dx, bounds.x1),
+                .y1 = MAX(-args.dy, bounds.y1),
+                .x2 = MIN(-args.dx + src_box->x2 - src_box->x1, bounds.x2),
+                .y2 = MIN(-args.dy + src_box->y2 - src_box->y1, bounds.y2),
             };
             if (scissor.x1 >= scissor.x2 || scissor.y1 >= scissor.y2)
                 continue;
@@ -543,10 +544,10 @@ glamor_copy_fbo_fbo_temp(DrawablePtr src,
      */
     bounds = box[0];
     for (n = 1; n < nbox; n++) {
-        bounds.x1 = min(bounds.x1, box[n].x1);
-        bounds.x2 = max(bounds.x2, box[n].x2);
-        bounds.y1 = min(bounds.y1, box[n].y1);
-        bounds.y2 = max(bounds.y2, box[n].y2);
+        bounds.x1 = MIN(bounds.x1, box[n].x1);
+        bounds.x2 = MAX(bounds.x2, box[n].x2);
+        bounds.y1 = MIN(bounds.y1, box[n].y1);
+        bounds.y2 = MAX(bounds.y2, box[n].y2);
     }
 
     /* Allocate a suitable temporary pixmap
@@ -659,11 +660,11 @@ glamor_copy_needs_temp(DrawablePtr src,
 
         bounds = box[0];
         for (n = 1; n < nbox; n++) {
-            bounds.x1 = min(bounds.x1, box[n].x1);
-            bounds.y1 = min(bounds.y1, box[n].y1);
+            bounds.x1 = MIN(bounds.x1, box[n].x1);
+            bounds.y1 = MIN(bounds.y1, box[n].y1);
 
-            bounds.x2 = max(bounds.x2, box[n].x2);
-            bounds.y2 = max(bounds.y2, box[n].y2);
+            bounds.x2 = MAX(bounds.x2, box[n].x2);
+            bounds.y2 = MAX(bounds.y2, box[n].y2);
         }
 
         /* Check to see if the pixmap-relative boxes overlap in both X and Y,

--- a/glamor/glamor_dash.c
+++ b/glamor/glamor_dash.c
@@ -22,6 +22,7 @@
 #include <dix-config.h>
 
 #include "os/bug_priv.h"
+#include "os/mathx_priv.h"
 
 #include "glamor_priv.h"
 #include "glamor_program.h"
@@ -238,7 +239,7 @@ glamor_dash_loop(DrawablePtr drawable, GCPtr gc, glamor_program *prog,
 static int
 glamor_line_length(short x1, short y1, short x2, short y2)
 {
-    return max(abs(x2 - x1), abs(y2 - y1));
+    return MAX(abs(x2 - x1), abs(y2 - y1));
 }
 
 Bool

--- a/glamor/glamor_largepixmap.c
+++ b/glamor/glamor_largepixmap.c
@@ -5,6 +5,7 @@
 #include <stdint.h> /* For INT16_MAX */
 
 #include "os/bug_priv.h"
+#include "os/mathx_priv.h"
 
 #include "glamor_priv.h"
 
@@ -1143,9 +1144,9 @@ glamor_composite_largepixmap_region(CARD8 op,
             return FALSE;
         }
         fixed_block_width =
-            min(fixed_block_width, source_transformed_block_width);
+            MIN(fixed_block_width, source_transformed_block_width);
         fixed_block_height =
-            min(fixed_block_height, source_transformed_block_height);
+            MIN(fixed_block_height, source_transformed_block_height);
         DEBUGF("new source block size %d x %d \n", fixed_block_width,
                fixed_block_height);
     }
@@ -1164,9 +1165,9 @@ glamor_composite_largepixmap_region(CARD8 op,
             return FALSE;
         }
         fixed_block_width =
-            min(fixed_block_width, mask_transformed_block_width);
+            MIN(fixed_block_width, mask_transformed_block_width);
         fixed_block_height =
-            min(fixed_block_height, mask_transformed_block_height);
+            MIN(fixed_block_height, mask_transformed_block_height);
         DEBUGF("new mask block size %d x %d \n", fixed_block_width,
                fixed_block_height);
     }

--- a/glamor/glamor_rects.c
+++ b/glamor/glamor_rects.c
@@ -22,6 +22,7 @@
 #include <dix-config.h>
 
 #include "os/bug_priv.h"
+#include "os/mathx_priv.h"
 
 #include "glamor_priv.h"
 #include "glamor_program.h"
@@ -141,10 +142,10 @@ glamor_poly_fill_rect_gl(DrawablePtr drawable,
 
         while (nbox--) {
             BoxRec scissor = {
-                .x1 = max(box->x1, bounds.x1 + drawable->x),
-                .y1 = max(box->y1, bounds.y1 + drawable->y),
-                .x2 = min(box->x2, bounds.x2 + drawable->x),
-                .y2 = min(box->y2, bounds.y2 + drawable->y),
+                .x1 = MAX(box->x1, bounds.x1 + drawable->x),
+                .y1 = MAX(box->y1, bounds.y1 + drawable->y),
+                .x2 = MIN(box->x2, bounds.x2 + drawable->x),
+                .y2 = MIN(box->y2, bounds.y2 + drawable->y),
             };
 
             box++;

--- a/glamor/glamor_utils.h
+++ b/glamor/glamor_utils.h
@@ -34,6 +34,7 @@
 
 #include "include/mipict.h"
 #include "os/bug_priv.h"
+#include "os/mathx_priv.h"
 
 #include "glamor_prepare.h"
 
@@ -567,8 +568,6 @@
 #ifndef ALIGN /* FreeBSD already has it */
 #define ALIGN(i,m)	(((i) + (m) - 1) & ~((m) - 1))
 #endif
-#define MIN(a,b)	((a) < (b) ? (a) : (b))
-#define MAX(a,b)	((a) > (b) ? (a) : (b))
 
 #define glamor_check_fbo_size(_glamor_,_w_, _h_)    ((_w_) > 0 && (_h_) > 0 \
                                                     && (_w_) <= (_glamor_)->max_fbo_size  \
@@ -720,19 +719,19 @@ glamor_start_rendering_bounds(void)
 static inline void
 glamor_bounds_union_rect(BoxPtr bounds, xRectangle *rect)
 {
-    bounds->x1 = min(bounds->x1, rect->x);
-    bounds->y1 = min(bounds->y1, rect->y);
-    bounds->x2 = min(SHRT_MAX, max(bounds->x2, rect->x + rect->width));
-    bounds->y2 = min(SHRT_MAX, max(bounds->y2, rect->y + rect->height));
+    bounds->x1 = MIN(bounds->x1, rect->x);
+    bounds->y1 = MIN(bounds->y1, rect->y);
+    bounds->x2 = MIN(SHRT_MAX, MAX(bounds->x2, rect->x + rect->width));
+    bounds->y2 = MIN(SHRT_MAX, MAX(bounds->y2, rect->y + rect->height));
 }
 
 static inline void
 glamor_bounds_union_box(BoxPtr bounds, BoxPtr box)
 {
-    bounds->x1 = min(bounds->x1, box->x1);
-    bounds->y1 = min(bounds->y1, box->y1);
-    bounds->x2 = max(bounds->x2, box->x2);
-    bounds->y2 = max(bounds->y2, box->y2);
+    bounds->x1 = MIN(bounds->x1, box->x1);
+    bounds->y1 = MIN(bounds->y1, box->y1);
+    bounds->x2 = MAX(bounds->x2, box->x2);
+    bounds->y2 = MAX(bounds->y2, box->y2);
 }
 
 /**

--- a/hw/vfb/InitOutput.c
+++ b/hw/vfb/InitOutput.c
@@ -44,6 +44,7 @@ from The Open Group.
 #include "mi/mipointer_priv.h"
 #include "os/cmdline.h"
 #include "os/ddx_priv.h"
+#include "os/mathx_priv.h"
 #include "os/osdep.h"
 #include "os/xhostname.h"
 
@@ -610,7 +611,7 @@ vfbAllocateMmappedFramebuffer(vfbScreenInfoPtr pvfb)
     for (currentFileSize = 0;
          currentFileSize < pvfb->sizeInBytes;
          currentFileSize += writeThisTime) {
-        writeThisTime = min(DUMMY_BUFFER_SIZE,
+        writeThisTime = MIN(DUMMY_BUFFER_SIZE,
                             pvfb->sizeInBytes - currentFileSize);
         if (-1 == write(pvfb->mmap_fd, dummyBuffer, writeThisTime)) {
             perror("write");

--- a/hw/xfree86/common/xf86Configure.c
+++ b/hw/xfree86/common/xf86Configure.c
@@ -29,6 +29,7 @@
 
 #include "include/misc.h"
 #include "os/ddx_priv.h"
+#include "os/mathx_priv.h"
 #include "os/osdep.h"
 #include "os/serverlock.h"
 
@@ -312,7 +313,7 @@ configureDeviceSection(int screennum)
                 if (asprintf(&optname, "\"%s\"", p->name) == -1)
                     break;
 
-                len += max(20, strlen(optname));
+                len += MAX(20, strlen(optname));
                 len += strlen(opttype);
 
                 ptr->dev_comment = realloc(ptr->dev_comment, len);

--- a/hw/xfree86/common/xf86Helper.c
+++ b/hw/xfree86/common/xf86Helper.c
@@ -45,6 +45,7 @@
 #include "include/xf86DDC.h"
 #include "mi/mi_priv.h"
 #include "os/log_priv.h"
+#include "os/mathx_priv.h"
 #include "os/osdep.h"
 
 #include "os.h"
@@ -1362,7 +1363,7 @@ xf86GetVisualName(int visual)
 int
 xf86GetVerbosity(void)
 {
-    return max(xf86Verbose, xf86LogVerbose);
+    return MAX(xf86Verbose, xf86LogVerbose);
 }
 
 Gamma

--- a/hw/xfree86/common/xf86Mode.c
+++ b/hw/xfree86/common/xf86Mode.c
@@ -86,6 +86,7 @@
 #include "include/edid.h"
 #include "include/extinit.h"
 #include "os/log_priv.h"
+#include "os/mathx_priv.h"
 
 #include "xf86Modes.h"
 #include "xf86Crtc.h"
@@ -256,8 +257,8 @@ xf86ShowClockRanges(ScrnInfoPtr scrp, ClockRangePtr clockRanges)
     int scaledClock;
 
     for (cp = clockRanges; cp != NULL; cp = cp->next) {
-        DivFactor = max(1, cp->ClockDivFactor);
-        MulFactor = max(1, cp->ClockMulFactor);
+        DivFactor = MAX(1, cp->ClockDivFactor);
+        MulFactor = MAX(1, cp->ClockMulFactor);
         if (scrp->progClock) {
             if (cp->minClock) {
                 if (cp->maxClock) {
@@ -497,8 +498,8 @@ xf86LookupMode(ScrnInfoPtr scrp, DisplayModePtr modep,
     }
     for (cp = clockRanges; cp != NULL; cp = cp->next) {
         /* DivFactor and MulFactor must be > 0 */
-        cp->ClockDivFactor = max(1, cp->ClockDivFactor);
-        cp->ClockMulFactor = max(1, cp->ClockMulFactor);
+        cp->ClockDivFactor = MAX(1, cp->ClockDivFactor);
+        cp->ClockMulFactor = MAX(1, cp->ClockMulFactor);
     }
 
     /* Scan the mode pool for matching names */
@@ -1019,8 +1020,8 @@ xf86CheckModeForDriver(ScrnInfoPtr scrp, DisplayModePtr mode, int flags)
 
     for (cp = scrp->clockRanges; cp != NULL; cp = cp->next) {
         /* DivFactor and MulFactor must be > 0 */
-        cp->ClockDivFactor = max(1, cp->ClockDivFactor);
-        cp->ClockMulFactor = max(1, cp->ClockMulFactor);
+        cp->ClockDivFactor = MAX(1, cp->ClockDivFactor);
+        cp->ClockMulFactor = MAX(1, cp->ClockMulFactor);
     }
 
     if (scrp->progClock) {

--- a/hw/xfree86/common/xf86VidMode.c
+++ b/hw/xfree86/common/xf86VidMode.c
@@ -39,6 +39,7 @@
 
 #include "dix/screenint_priv.h"
 #include "os/log_priv.h"
+#include "os/mathx_priv.h"
 
 #include "os.h"
 #include "xf86_priv.h"
@@ -219,10 +220,10 @@ xf86VidModeSetViewPort(ScreenPtr pScreen, int x, int y)
     ScrnInfoPtr pScrn;
 
     pScrn = xf86ScreenToScrn(pScreen);
-    pScrn->frameX0 = min(max(x, 0),
+    pScrn->frameX0 = MIN(MAX(x, 0),
                          pScrn->virtualX - pScrn->currentMode->HDisplay);
     pScrn->frameX1 = pScrn->frameX0 + pScrn->currentMode->HDisplay - 1;
-    pScrn->frameY0 = min(max(y, 0),
+    pScrn->frameY0 = MIN(MAX(y, 0),
                          pScrn->virtualY - pScrn->currentMode->VDisplay);
     pScrn->frameY1 = pScrn->frameY0 + pScrn->currentMode->VDisplay - 1;
     if (pScrn->AdjustFrame != NULL)

--- a/hw/xfree86/ddc/interpret_edid.c
+++ b/hw/xfree86/ddc/interpret_edid.c
@@ -30,9 +30,9 @@
 #include <string.h>
 
 #include "include/misc.h"
+#include "os/mathx_priv.h"
 
 #include "edid_priv.h"
-
 #include "xf86.h"
 #include "xf86_OSproc.h"
 #include "xf86DDC_priv.h"
@@ -92,7 +92,7 @@ static void
 find_max_detailed_clock(struct detailed_monitor_section *det, void *ret)
 {
     if (det->type == DT) {
-        *(int *) ret = max(*((int *) ret), det->section.d_timings.clock);
+        *(int *) ret = MAX(*((int *) ret), det->section.d_timings.clock);
     }
 }
 
@@ -144,8 +144,8 @@ handle_detailed_hvsize(struct detailed_monitor_section *det_mon, void *data)
 
         timing_aspect = (float) timing->h_size / timing->v_size;
         if (fabs(1 - (timing_aspect / p->target_aspect)) < 0.05) {
-            p->real_hsize = max(p->real_hsize, timing->h_size);
-            p->real_vsize = max(p->real_vsize, timing->v_size);
+            p->real_hsize = MAX(p->real_hsize, timing->h_size);
+            p->real_vsize = MAX(p->real_vsize, timing->v_size);
         }
     }
 }

--- a/hw/xfree86/dri/xf86dri.c
+++ b/hw/xfree86/dri/xf86dri.c
@@ -45,6 +45,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "dix/screenint_priv.h"
 #include "include/dristruct.h"
 #include "include/sarea.h"
+#include "os/mathx_priv.h"
 
 #include "xf86.h"
 #include "dixstruct.h"
@@ -376,10 +377,10 @@ ProcXF86DRIGetDrawableInfo(register ClientPtr client)
 
         for (int i = 0; i < reply.numClipRects; i++) {
             /* Clip cliprects to screen dimensions (redirected windows) */
-            CARD16 x1 = max(pClipRects[i].x1, 0);
-            CARD16 y1 = max(pClipRects[i].y1, 0);
-            CARD16 x2 = min(pClipRects[i].x2, pScreen->width);
-            CARD16 y2 = min(pClipRects[i].y2, pScreen->height);
+            CARD16 x1 = MAX(pClipRects[i].x1, 0);
+            CARD16 y1 = MAX(pClipRects[i].y1, 0);
+            CARD16 x2 = MIN(pClipRects[i].x2, pScreen->width);
+            CARD16 y2 = MIN(pClipRects[i].y2, pScreen->height);
 
             /* only write visible ones */
             if (x1 < x2 && y1 < y2) {

--- a/hw/xfree86/drivers/input/inputtest/xf86-input-inputtest.c
+++ b/hw/xfree86/drivers/input/inputtest/xf86-input-inputtest.c
@@ -34,6 +34,7 @@
 #include <X11/Xatom.h>
 
 #include "include/xorgVersion.h"
+#include "os/mathx_priv.h"
 
 #include <exevents.h>
 #include <input.h>
@@ -546,7 +547,7 @@ static void
 convert_to_valuator_mask(xf86ITValuatorData *event, ValuatorMask *mask)
 {
     valuator_mask_zero(mask);
-    for (int i = 0; i < min(XF86IT_MAX_VALUATORS, MAX_VALUATORS); ++i) {
+    for (int i = 0; i < MIN(XF86IT_MAX_VALUATORS, MAX_VALUATORS); ++i) {
         if (BitIsOn(event->mask, i)) {
             if (event->has_unaccelerated) {
                 valuator_mask_set_unaccelerated(mask, i, event->valuators[i],

--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -46,6 +46,7 @@
 #include "include/edid.h"
 #include "include/xorgVersion.h"
 #include "mi/mi_priv.h"
+#include "os/mathx_priv.h"
 
 #include "xf86.h"
 #include "xf86Priv.h"
@@ -597,10 +598,10 @@ rotate_clip(PixmapPtr pixmap, xf86CrtcPtr crtc, BoxPtr rect, drmModeClip *clip,
         rect->y2 > crtc->y && rect->y1 < crtc->y + h) {
         /* new coordinate of the partial rect on the crtc area
          * + x/y offsets in the framebuffer */
-        x1 = max(rect->x1 - crtc->x, 0) + x;
-        y1 = max(rect->y1 - crtc->y, 0) + y;
-        x2 = min(rect->x2 - crtc->x, w) + x;
-        y2 = min(rect->y2 - crtc->y, h) + y;
+        x1 = MAX(rect->x1 - crtc->x, 0) + x;
+        y1 = MAX(rect->y1 - crtc->y, 0) + y;
+        x2 = MIN(rect->x2 - crtc->x, w) + x;
+        y2 = MIN(rect->y2 - crtc->y, h) + y;
 
         /* coordinate transposing/inversion and offset adjustment */
         if (rotation == RR_Rotate_90) {
@@ -1557,12 +1558,12 @@ msUpdatePacked(ScreenPtr pScreen, shadowBufPtr pBuf)
         nrects = 0;
         for (j = ty2 - 1; j >= ty1; j--) {
             for (i = tx2 - 1; i >= tx1; i--) {
-                BoxRec box;
-
-                box.x1 = max(i * TILE, extents->x1);
-                box.y1 = max(j * TILE, extents->y1);
-                box.x2 = min((i+1) * TILE, extents->x2);
-                box.y2 = min((j+1) * TILE, extents->y2);
+                BoxRec box = {
+                    .x1 = MAX(i * TILE, extents->x1),
+                    .y1 = MAX(j * TILE, extents->y1),
+                    .x2 = MIN((i+1) * TILE, extents->x2),
+                    .y2 = MIN((j+1) * TILE, extents->y2),
+                };
 
                 if (RegionContainsRect(damage, &box) != rgnOUT) {
                     if (msUpdateIntersect(ms, pBuf, &box, prect + nrects)) {

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -37,6 +37,7 @@
 
 #include "dix/dix_priv.h"
 #include "os/fmt.h"
+#include "os/mathx_priv.h"
 #include "Xext/present/present_priv.h"
 
 #include "inputstr.h"
@@ -58,9 +59,6 @@
 #include <X11/extensions/dpmsconst.h>
 
 #include "driver.h"
-
-#define MIN(a,b) ((a) < (b) ? (a) : (b))
-#define MAX(a,b) ((a) > (b) ? (a) : (b))
 
 #ifndef GBM_BO_USE_FRONT_RENDERING
 #define GBM_BO_USE_FRONT_RENDERING 0
@@ -3125,12 +3123,12 @@ drmmode_output_add_gtf_modes(xf86OutputPtr output, DisplayModePtr Modes)
     for (m = Modes; m; m = m->next) {
         if (m->type & M_T_PREFERRED)
             preferred = m;
-        max_x = max(max_x, m->HDisplay);
-        max_y = max(max_y, m->VDisplay);
-        max_vrefresh = max(max_vrefresh, xf86ModeVRefresh(m));
+        max_x = MAX(max_x, m->HDisplay);
+        max_y = MAX(max_y, m->VDisplay);
+        max_vrefresh = MAX(max_vrefresh, xf86ModeVRefresh(m));
     }
 
-    max_vrefresh = max(max_vrefresh, 60.0);
+    max_vrefresh = MAX(max_vrefresh, 60.0);
     max_vrefresh *= (1 + SYNC_TOLERANCE);
 
     m = xf86GetDefaultModes();

--- a/hw/xfree86/modes/xf86EdidModes.c
+++ b/hw/xfree86/modes/xf86EdidModes.c
@@ -29,9 +29,11 @@
  */
 #include <xorg-config.h>
 
+#include "os/mathx_priv.h"
+
+#define _PARSE_EDID_
 #include "xf86.h"
 #include "xf86DDC_priv.h"
-#include <X11/Xatom.h>
 #include "property.h"
 #include "propertyst.h"
 #include "xf86Crtc.h"
@@ -1154,7 +1156,7 @@ handle_detailed_monset(struct detailed_monitor_section *det_mon, void *data)
 
         clock = det_mon->section.ranges.max_clock * 1000;
         if (p->quirks & DDC_QUIRK_DVI_SINGLE_LINK)
-            clock = min(clock, 165000);
+            clock = MIN(clock, 165000);
         if (!p->have_maxpixclock && clock > p->Monitor->maxPixClock)
             p->Monitor->maxPixClock = clock;
 

--- a/hw/xfree86/modes/xf86Modes.c
+++ b/hw/xfree86/modes/xf86Modes.c
@@ -28,6 +28,8 @@
 
 #include <libxcvt/libxcvt.h>
 
+#include "os/mathx_priv.h"
+
 #include "xf86_priv.h"
 #include "xf86Config.h"
 #include "xf86Modes.h"
@@ -180,10 +182,10 @@ xf86SetModeCrtc(DisplayModePtr p, int adjustFlags)
         p->CrtcVSyncEnd *= p->VScan;
         p->CrtcVTotal *= p->VScan;
     }
-    p->CrtcVBlankStart = min(p->CrtcVSyncStart, p->CrtcVDisplay);
-    p->CrtcVBlankEnd = max(p->CrtcVSyncEnd, p->CrtcVTotal);
-    p->CrtcHBlankStart = min(p->CrtcHSyncStart, p->CrtcHDisplay);
-    p->CrtcHBlankEnd = max(p->CrtcHSyncEnd, p->CrtcHTotal);
+    p->CrtcVBlankStart = MIN(p->CrtcVSyncStart, p->CrtcVDisplay);
+    p->CrtcVBlankEnd = MAX(p->CrtcVSyncEnd, p->CrtcVTotal);
+    p->CrtcHBlankStart = MIN(p->CrtcHSyncStart, p->CrtcHDisplay);
+    p->CrtcHBlankEnd = MAX(p->CrtcHSyncEnd, p->CrtcHTotal);
 
     p->CrtcHAdjusted = FALSE;
     p->CrtcVAdjusted = FALSE;

--- a/hw/xfree86/modes/xf86RandR12.c
+++ b/hw/xfree86/modes/xf86RandR12.c
@@ -28,6 +28,7 @@
 #include "dix/screenint_priv.h"
 #include "include/extinit.h"
 #include "include/xf86DDC.h"
+#include "os/mathx_priv.h"
 #include "Xext/randr/randrstr_priv.h"
 
 #include "xf86.h"
@@ -1975,7 +1976,7 @@ xf86RandR12LoadPalette(ScrnInfoPtr pScrn, int numColors, int *indices,
         reds = greens = blues = pVisual->ColormapEntries;
     }
 
-    palette_size = max(reds, max(greens, blues));
+    palette_size = MAX(reds, MAX(greens, blues));
 
     if (dixPrivateKeyRegistered(rrPrivKey)) {
         XF86RandRInfoPtr randrp = XF86RANDRINFO(pScreen);
@@ -2040,7 +2041,7 @@ xf86RandR12ChangeGamma(ScrnInfoPtr pScrn, Gamma gamma)
     if (!randr_crtc || pScrn->LoadPalette == xf86RandR12LoadPalette)
         return Success;
 
-    size = max(0, randr_crtc->gammaSize);
+    size = MAX(0, randr_crtc->gammaSize);
     if (!size)
         return Success;
 

--- a/hw/xfree86/os-support/solaris/sun_bell.c
+++ b/hw/xfree86/os-support/solaris/sun_bell.c
@@ -27,6 +27,7 @@
 #include <limits.h>
 #include <math.h>
 
+#include "os/mathx_priv.h"
 #include "os/xserver_poll.h"
 
 #include "xf86.h"
@@ -74,8 +75,8 @@ xf86OSRingBell(int loudness, int pitch, int duration)
     }
 
     freq = pitch;
-    freq = min(freq, (BELL_RATE / 2) - 1);
-    freq = max(freq, 2 * BELL_HZ);
+    freq = MIN(freq, (BELL_RATE / 2) - 1);
+    freq = MAX(freq, 2 * BELL_HZ);
 
     /*
      * Ensure full waves per buffer
@@ -98,10 +99,10 @@ xf86OSRingBell(int loudness, int pitch, int duration)
     }
 
     repeats = (duration + (BELL_MS / 2)) / BELL_MS;
-    repeats = max(repeats, BELL_MIN);
+    repeats = MAX(repeats, BELL_MIN);
 
-    loudness = max(0, loudness);
-    loudness = min(loudness, 100);
+    loudness = MAX(0, loudness);
+    loudness = MIN(loudness, 100);
 
 #ifdef DEBUG
     ErrorF("BELL : freq %d volume %d duration %d repeats %d\n",
@@ -113,7 +114,7 @@ xf86OSRingBell(int loudness, int pitch, int duration)
     audioInfo.play.sample_rate = BELL_RATE;
     audioInfo.play.channels = 2;
     audioInfo.play.precision = 16;
-    audioInfo.play.gain = min(AUDIO_MAX_GAIN, AUDIO_MAX_GAIN * loudness / 100);
+    audioInfo.play.gain = MIN(AUDIO_MAX_GAIN, AUDIO_MAX_GAIN * loudness / 100);
 
     if (ioctl(audioFD, AUDIO_SETINFO, &audioInfo) < 0) {
         LogMessageVerb(X_ERROR, 1,

--- a/hw/xwin/wincursor.c
+++ b/hw/xwin/wincursor.c
@@ -37,6 +37,7 @@
 
 #include "include/misc.h"
 #include "mi/mipointer_priv.h"
+#include "os/mathx_priv.h"
 
 #include <cursorstr.h>
 #include <mipointrst.h>
@@ -189,8 +190,8 @@ winLoadCursor(ScreenPtr pScreen, CursorPtr pCursor, int screen)
         bits_to_bytes(pScreenPriv->cursor.sm_cx) * pScreenPriv->cursor.sm_cy;
 
     /* Get the effective width and height */
-    nCX = min(pScreenPriv->cursor.sm_cx, pCursor->bits->width);
-    nCY = min(pScreenPriv->cursor.sm_cy, pCursor->bits->height);
+    nCX = MIN(pScreenPriv->cursor.sm_cx, pCursor->bits->width);
+    nCY = MIN(pScreenPriv->cursor.sm_cy, pCursor->bits->height);
 
     /* Allocate memory for the bitmaps */
     unsigned char *pAnd = calloc(1, nBytes);

--- a/mi/miarc.c
+++ b/mi/miarc.c
@@ -55,6 +55,7 @@ SOFTWARE.
 
 #include "include/misc.h"
 #include "mi/mi_priv.h"
+#include "os/mathx_priv.h"
 
 #include "gcstruct.h"
 #include "scrnintstr.h"
@@ -941,10 +942,10 @@ miWideArc(DrawablePtr pDraw, GCPtr pGC, int narcs, xArc * parcs)
         xMax = yMax = MINSHORT;
 
         for (i = narcs, parc = parcs; --i >= 0; parc++) {
-            xMin = min(xMin, parc->x);
-            yMin = min(yMin, parc->y);
-            xMax = max(xMax, (parc->x + (int) parc->width));
-            yMax = max(yMax, (parc->y + (int) parc->height));
+            xMin = MIN(xMin, parc->x);
+            yMin = MIN(yMin, parc->y);
+            xMax = MAX(xMax, (parc->x + (int) parc->width));
+            yMax = MAX(yMax, (parc->y + (int) parc->height));
         }
 
         /* expand box to deal with line widths */
@@ -955,10 +956,10 @@ miWideArc(DrawablePtr pDraw, GCPtr pGC, int narcs, xArc * parcs)
         yMax += halfWidth;
 
         /* compute pixmap size; limit it to size of drawable */
-        xOrg = max(xMin, 0);
-        yOrg = max(yMin, 0);
-        pixmapWidth = min(xMax, pDraw->width) - xOrg;
-        pixmapHeight = min(yMax, pDraw->height) - yOrg;
+        xOrg = MAX(xMin, 0);
+        yOrg = MAX(yMin, 0);
+        pixmapWidth = MIN(xMax, pDraw->width) - xOrg;
+        pixmapHeight = MIN(yMax, pDraw->height) - yOrg;
 
         /* if nothing left, return */
         if ((pixmapWidth <= 0) || (pixmapHeight <= 0))
@@ -1228,7 +1229,7 @@ miFillSppPoly(DrawablePtr dst, GCPtr pgc, int count,    /* number of points */
             if (dy != 0.0) {
                 ml = (ptsIn[nextleft].x - ptsIn[left].x) / dy;
                 dy = y - (ptsIn[left].y + yFtrans);
-                xl = (ptsIn[left].x + xFtrans) + ml * max(dy, 0);
+                xl = (ptsIn[left].x + xFtrans) + ml * MAX(dy, 0);
             }
         }
 
@@ -1248,7 +1249,7 @@ miFillSppPoly(DrawablePtr dst, GCPtr pgc, int count,    /* number of points */
             if (dy != 0.0) {
                 mr = (ptsIn[nextright].x - ptsIn[right].x) / dy;
                 dy = y - (ptsIn[right].y + yFtrans);
-                xr = (ptsIn[right].x + xFtrans) + mr * max(dy, 0);
+                xr = (ptsIn[right].x + xFtrans) + mr * MAX(dy, 0);
             }
         }
 
@@ -1256,7 +1257,7 @@ miFillSppPoly(DrawablePtr dst, GCPtr pgc, int count,    /* number of points */
          *  generate scans to fill while we still have
          *  a right edge as well as a left edge.
          */
-        i = (min(ptsIn[nextleft].y, ptsIn[nextright].y) + yFtrans) - y;
+        i = (MIN(ptsIn[nextleft].y, ptsIn[nextright].y) + yFtrans) - y;
 
         if (i < EPSILON) {
             if (Marked[nextleft] && Marked[nextright]) {
@@ -3188,8 +3189,8 @@ newFinalSpan(int y, int xmin, int xmax)
             }
             if (x->min <= xmax && xmin <= x->max) {
                 if (oldx) {
-                    oldx->min = min(x->min, xmin);
-                    oldx->max = max(x->max, xmax);
+                    oldx->min = MIN(x->min, xmin);
+                    oldx->max = MAX(x->max, xmax);
                     if (prev)
                         prev->next = x->next;
                     else
@@ -3197,8 +3198,8 @@ newFinalSpan(int y, int xmin, int xmax)
                     --nspans;
                 }
                 else {
-                    x->min = min(x->min, xmin);
-                    x->max = max(x->max, xmax);
+                    x->min = MIN(x->min, xmin);
+                    x->max = MAX(x->max, xmax);
                     oldx = x;
                 }
                 xmin = oldx->min;
@@ -3295,7 +3296,7 @@ drawArc(xArc * tarc, int l, int a0, int a1, miArcFacePtr right,
             else
                 q0 = a0;
             if (a1 < 360 * 64)
-                q1 = min(a1, 90 * 64);
+                q1 = MIN(a1, 90 * 64);
             else
                 q1 = 90 * 64;
             if (curq == startq && a0 == q0 && rightq < 0) {
@@ -3311,11 +3312,11 @@ drawArc(xArc * tarc, int l, int a0, int a1, miArcFacePtr right,
             if (a1 < 90 * 64)
                 q0 = 0;
             else
-                q0 = 180 * 64 - min(a1, 180 * 64);
+                q0 = 180 * 64 - MIN(a1, 180 * 64);
             if (a0 > 180 * 64)
                 q1 = 90 * 64;
             else
-                q1 = 180 * 64 - max(a0, 90 * 64);
+                q1 = 180 * 64 - MAX(a0, 90 * 64);
             if (curq == startq && 180 * 64 - a0 == q1) {
                 righta = q1;
                 rightq = curq;
@@ -3329,11 +3330,11 @@ drawArc(xArc * tarc, int l, int a0, int a1, miArcFacePtr right,
             if (a0 > 270 * 64)
                 q0 = 0;
             else
-                q0 = max(a0, 180 * 64) - 180 * 64;
+                q0 = MAX(a0, 180 * 64) - 180 * 64;
             if (a1 < 180 * 64)
                 q1 = 90 * 64;
             else
-                q1 = min(a1, 270 * 64) - 180 * 64;
+                q1 = MIN(a1, 270 * 64) - 180 * 64;
             if (curq == startq && a0 - 180 * 64 == q0) {
                 righta = q0;
                 rightq = curq;
@@ -3347,8 +3348,8 @@ drawArc(xArc * tarc, int l, int a0, int a1, miArcFacePtr right,
             if (a1 < 270 * 64)
                 q0 = 0;
             else
-                q0 = 360 * 64 - min(a1, 360 * 64);
-            q1 = 360 * 64 - max(a0, 270 * 64);
+                q0 = 360 * 64 - MIN(a1, 360 * 64);
+            q1 = 360 * 64 - MAX(a0, 270 * 64);
             if (curq == startq && 360 * 64 - a0 == q1) {
                 righta = q1;
                 rightq = curq;

--- a/mi/mipoly.c
+++ b/mi/mipoly.c
@@ -51,6 +51,9 @@ SOFTWARE.
 #include <dix-config.h>
 
 #include <X11/X.h>
+
+#include "os/mathx_priv.h"
+
 #include "windowstr.h"
 #include "gcstruct.h"
 #include "pixmapstr.h"
@@ -224,8 +227,8 @@ miCreateETandAET(int count, DDXPointPtr pts, EdgeTable * ET,
                 return FALSE;
             }
 
-            ET->ymax = max(ET->ymax, PrevPt->y);
-            ET->ymin = min(ET->ymin, PrevPt->y);
+            ET->ymax = MAX(ET->ymax, PrevPt->y);
+            ET->ymin = MIN(ET->ymin, PrevPt->y);
             pETEs++;
         }
 
@@ -475,7 +478,7 @@ miFillConvexPoly(DrawablePtr dst, GCPtr pgc, int count, DDXPointPtr ptsIn)
          *  generate scans to fill while we still have
          *  a right edge as well as a left edge.
          */
-        i = min(ptsIn[nextleft].y, ptsIn[nextright].y) - y;
+        i = MIN(ptsIn[nextleft].y, ptsIn[nextright].y) - y;
         /* in case we're called with non-convex polygon */
         if (i < 0) {
             free(FirstWidth);

--- a/miext/damage/damage.c
+++ b/miext/damage/damage.c
@@ -26,6 +26,7 @@
 
 #include "dix/screen_hooks_priv.h"
 #include "include/mipict.h"
+#include "os/mathx_priv.h"
 #include "os/osdep.h"
 #include "Xext/render/glyphstr_priv.h"
 
@@ -597,8 +598,8 @@ damageAddTraps(PicturePtr pPicture,
         x = pPicture->pDrawable->x + x_off;
         y = pPicture->pDrawable->y + y_off;
         for (i = 0; i < ntrap; i++) {
-            pixman_fixed_t l = min(t->top.l, t->bot.l);
-            pixman_fixed_t r = max(t->top.r, t->bot.r);
+            pixman_fixed_t l = MIN(t->top.l, t->bot.l);
+            pixman_fixed_t r = MAX(t->top.r, t->bot.r);
             int x1 = x + pixman_fixed_to_int(l);
             int x2 = x + pixman_fixed_to_int(pixman_fixed_ceil(r));
             int y1 = y + pixman_fixed_to_int(t->top.y);

--- a/miext/rootless/rootlessCommon.c
+++ b/miext/rootless/rootlessCommon.c
@@ -35,6 +35,7 @@
 #include <limits.h>             /* For CHAR_BIT */
 
 #include "dix/colormap_priv.h"
+#include "os/mathx_priv.h"
 
 #include "rootlessCommon.h"
 
@@ -106,8 +107,8 @@ RootlessResolveColormap(ScreenPtr pScreen, int first_color,
     if (map == NULL || map->class != PseudoColor)
         return FALSE;
 
-    last = min(map->pVisual->ColormapEntries, first_color + n_colors);
-    for (i = max(0, first_color); i < last; i++) {
+    last = MIN(map->pVisual->ColormapEntries, first_color + n_colors);
+    for (i = MAX(0, first_color); i < last; i++) {
         Entry *ent = map->red + i;
         uint16_t red, green, blue;
 

--- a/miext/rootless/rootlessGC.c
+++ b/miext/rootless/rootlessGC.c
@@ -32,6 +32,12 @@
 #include <dix-config.h>
 
 #include <stddef.h>             /* For NULL */
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "os/mathx_priv.h"
+
 #include "mi.h"
 #include "scrnintstr.h"
 #include "gcstruct.h"
@@ -39,10 +45,6 @@
 #include "windowstr.h"
 #include "dixfontstr.h"
 #include "fb.h"
-
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 
 #include "rootlessCommon.h"
 
@@ -1180,8 +1182,8 @@ RootlessImageText8(DrawablePtr dst, GCPtr pGC,
         int top, bot, Min, Max;
         BoxRec box;
 
-        top = max(FONTMAXBOUNDS(pGC->font, ascent), FONTASCENT(pGC->font));
-        bot = max(FONTMAXBOUNDS(pGC->font, descent), FONTDESCENT(pGC->font));
+        top = MAX(FONTMAXBOUNDS(pGC->font, ascent), FONTASCENT(pGC->font));
+        bot = MAX(FONTMAXBOUNDS(pGC->font, descent), FONTDESCENT(pGC->font));
 
         Min = count * FONTMINBOUNDS(pGC->font, characterWidth);
         if (Min > 0)
@@ -1268,8 +1270,8 @@ RootlessImageText16(DrawablePtr dst, GCPtr pGC,
         int top, bot, Min, Max;
         BoxRec box;
 
-        top = max(FONTMAXBOUNDS(pGC->font, ascent), FONTASCENT(pGC->font));
-        bot = max(FONTMAXBOUNDS(pGC->font, descent), FONTDESCENT(pGC->font));
+        top = MAX(FONTMAXBOUNDS(pGC->font, ascent), FONTASCENT(pGC->font));
+        bot = MAX(FONTMAXBOUNDS(pGC->font, descent), FONTDESCENT(pGC->font));
 
         Min = count * FONTMINBOUNDS(pGC->font, characterWidth);
         if (Min > 0)
@@ -1359,8 +1361,8 @@ RootlessImageGlyphBlt(DrawablePtr dst, GCPtr pGC,
         unsigned int nglyph = nglyphInit;
         CharInfoPtr *ppci = ppciInit;
 
-        top = max(FONTMAXBOUNDS(pGC->font, ascent), FONTASCENT(pGC->font));
-        bot = max(FONTMAXBOUNDS(pGC->font, descent), FONTDESCENT(pGC->font));
+        top = MAX(FONTMAXBOUNDS(pGC->font, ascent), FONTASCENT(pGC->font));
+        bot = MAX(FONTMAXBOUNDS(pGC->font, descent), FONTDESCENT(pGC->font));
 
         box.x1 = ppci[0]->metrics.leftSideBearing;
         if (box.x1 > 0)

--- a/miext/rootless/rootlessScreen.c
+++ b/miext/rootless/rootlessScreen.c
@@ -42,6 +42,7 @@
 #include "include/colormapst.h"
 #include "include/mipict.h"
 #include "mi/mi_priv.h"
+#include "os/mathx_priv.h"
 
 #include "scrnintstr.h"
 #include "gcstruct.h"
@@ -194,10 +195,10 @@ RootlessGetImage(DrawablePtr pDrawable, int sx, int sy, int w, int h,
         x1 = x0 + w;
         y1 = y0 + h;
 
-        x0 = max(x0, winRec->x);
-        y0 = max(y0, winRec->y);
-        x1 = min(x1, winRec->x + winRec->width);
-        y1 = min(y1, winRec->y + winRec->height);
+        x0 = MAX(x0, winRec->x);
+        y0 = MAX(y0, winRec->y);
+        x1 = MIN(x1, winRec->x + winRec->width);
+        y1 = MIN(y1, winRec->y + winRec->height);
 
         sx = x0 - pDrawable->x;
         sy = y0 - pDrawable->y;
@@ -344,10 +345,10 @@ RootlessGlyphs(CARD8 op, PicturePtr pSrc, PicturePtr pDst,
                     x2 = x1 + glyph->info.width;
                     y2 = y1 + glyph->info.height;
 
-                    box.x1 = min(box.x1, x1);
-                    box.y1 = min(box.y1, y1);
-                    box.x2 = max(box.x2, x2);
-                    box.y2 = max(box.y2, y2);
+                    box.x1 = MIN(box.x1, x1);
+                    box.y1 = MIN(box.y1, y1);
+                    box.x2 = MAX(box.x2, x2);
+                    box.y2 = MAX(box.y2, y2);
 
                     x += glyph->info.xOff;
                     y += glyph->info.yOff;

--- a/os/WaitFor.c
+++ b/os/WaitFor.c
@@ -63,16 +63,17 @@ SOFTWARE.
 #include <X11/X.h>
 
 #include "dix/dix_priv.h"
+#include "dix/dixstruct_priv.h"
 #include "dix/screensaver_priv.h"
 #include "include/misc.h"
 #include "os/busfault.h"
 #include "os/client_priv.h"
+#include "os/mathx_priv.h"
+#include "os/osdep.h"
 #include "os/ossock.h"
 #include "os/screensaver.h"
 #include "Xext/dpms/dpms_priv.h"
 
-#include "osdep.h"
-#include "dixstruct_priv.h"
 #include "globals.h"
 
 #ifdef WIN32
@@ -453,7 +454,7 @@ ScreenSaverTimeoutExpire(OsTimerPtr timer, CARD32 now, void *arg)
 
     if (timeout < ScreenSaverTime) {
         return nextTimeout > 0 ?
-            min(ScreenSaverTime - timeout, nextTimeout) :
+            MIN(ScreenSaverTime - timeout, nextTimeout) :
             ScreenSaverTime - timeout;
     }
 
@@ -462,7 +463,7 @@ ScreenSaverTimeoutExpire(OsTimerPtr timer, CARD32 now, void *arg)
 
     if (ScreenSaverInterval > 0) {
         nextTimeout = nextTimeout > 0 ?
-            min(ScreenSaverInterval, nextTimeout) : ScreenSaverInterval;
+            MIN(ScreenSaverInterval, nextTimeout) : ScreenSaverInterval;
     }
 
     return nextTimeout;
@@ -502,7 +503,7 @@ SetScreenSaverTimer(void)
 #endif
 
     if (ScreenSaverTime > 0) {
-        timeout = timeout > 0 ? min(ScreenSaverTime, timeout) : ScreenSaverTime;
+        timeout = timeout > 0 ? MIN(ScreenSaverTime, timeout) : ScreenSaverTime;
     }
 
 #ifdef SCREENSAVER

--- a/os/utils.c
+++ b/os/utils.c
@@ -71,6 +71,8 @@ __stdcall unsigned long GetTickCount(void);
 #include <sys/resource.h>
 #endif
 #include <X11/X.h>
+
+#include "os/mathx_priv.h"
 #include "os/Xtrans.h"
 
 #include <libgen.h>
@@ -653,7 +655,7 @@ ProcessCommandLine(int argc, char *argv[])
             terminateDelay = -1;
             if ((i + 1 < argc) && (isdigit((unsigned char)*argv[i + 1])))
                terminateDelay = atoi(argv[++i]);
-            terminateDelay = max(0, terminateDelay);
+            terminateDelay = MAX(0, terminateDelay);
         }
         else if (strcmp(argv[i], "-tst") == 0) {
             noTestExtensions = TRUE;

--- a/test/xi2/protocol-xigetselectedevents.c
+++ b/test/xi2/protocol-xigetselectedevents.c
@@ -46,6 +46,7 @@
 
 #include "dix/exevents_priv.h"
 #include "miext/extinit_priv.h"            /* for XInputExtensionInit */
+#include "os/mathx_priv.h"
 #include "Xext/xinput/handlers.h"
 
 #include "inputstr.h"
@@ -195,7 +196,7 @@ test_XIGetSelectedEvents(void)
     /* devices 6 - MAXDEVICES don't exist, they mustn't be included in the
      * reply even if a mask is set */
     for (j = 0; j < MAXDEVICES; j++) {
-        test_data.num_masks_expected = min(j + 1, devices.num_devices + 2);
+        test_data.num_masks_expected = MIN(j + 1, devices.num_devices + 2);
         dev.id = j;
         mask = test_data.mask[j];
         /* bits one-by-one */


### PR DESCRIPTION
Replace public min/max macros by private MIN/MAX and deprecate them.
The few drivers still using them can trivially define them on their own.
Adding a new private header for all kind of math-ish definitions - future
commits will move more stuff there.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
