### PR TITLE
treewide: don't include <region.h> anymore

### DIFF
--- a/Xext/xace.h
+++ b/Xext/xace.h
@@ -25,10 +25,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "dix/selection_priv.h"
 #include "include/callback.h"
+#include "include/regionstr.h"
 
 #include "extnsionst.h"
 #include "pixmap.h"
-#include "region.h"
 #include "window.h"
 #include "property.h"
 

--- a/Xi/exevents.c
+++ b/Xi/exevents.c
@@ -107,7 +107,6 @@ SOFTWARE.
 #include "inputstr.h"
 #include "windowstr.h"
 #include "miscstruct.h"
-#include "region.h"
 #include "extnsionst.h"
 #include "exglobals.h"
 #include "eventstr.h"

--- a/dix/gc.c
+++ b/dix/gc.c
@@ -60,7 +60,6 @@ SOFTWARE.
 #include "pixmapstr.h"
 #include "dixfontstr.h"
 #include "scrnintstr.h"
-#include "region.h"
 #include "dixstruct.h"
 #include "privates.h"
 #include "dix.h"

--- a/fb/fb.h
+++ b/fb/fb.h
@@ -30,7 +30,7 @@
 #include "scrnintstr.h"
 #include "pixmap.h"
 #include "pixmapstr.h"
-#include "region.h"
+#include "regionstr.h"
 #include "gcstruct.h"
 #include "colormap.h"
 #include "miscstruct.h"

--- a/hw/xnest/GC.c
+++ b/hw/xnest/GC.c
@@ -15,6 +15,7 @@ is" without express or implied warranty.
 
 #include <stdint.h>
 
+#include <X11/fonts/fontstruct.h>
 #include <X11/X.h>
 #include <X11/Xdefs.h>
 #include <X11/Xproto.h>
@@ -22,13 +23,13 @@ is" without express or implied warranty.
 #include <xcb/xcb.h>
 #include <xcb/xcb_aux.h>
 
+#include "include/regionstr.h"
+
 #include "gcstruct.h"
 #include "windowstr.h"
 #include "pixmapstr.h"
 #include "scrnintstr.h"
-#include <X11/fonts/fontstruct.h>
 #include "mistruct.h"
-#include "region.h"
 
 #include "xnest-xcb.h"
 

--- a/hw/xnest/GCOps.c
+++ b/hw/xnest/GCOps.c
@@ -28,7 +28,6 @@ is" without express or implied warranty.
 #include "scrnintstr.h"
 #include "windowstr.h"
 #include "pixmapstr.h"
-#include "region.h"
 #include "servermd.h"
 
 #include "xnest-xcb.h"

--- a/hw/xnest/Window.c
+++ b/hw/xnest/Window.c
@@ -21,6 +21,7 @@ is" without express or implied warranty.
 #include <X11/Xdefs.h>
 #include <X11/Xproto.h>
 
+#include "include/regionstr.h"
 #include "mi/mi_priv.h"
 
 #include "gcstruct.h"
@@ -28,7 +29,6 @@ is" without express or implied warranty.
 #include "windowstr.h"
 #include "pixmapstr.h"
 #include "scrnintstr.h"
-#include "region.h"
 
 #include "xnest-xcb.h"
 

--- a/hw/xwin/win.h
+++ b/hw/xwin/win.h
@@ -150,7 +150,6 @@
 #include "scrnintstr.h"
 #include "pixmapstr.h"
 #include "pixmap.h"
-#include "region.h"
 #include "gcstruct.h"
 #include "colormap.h"
 #include "miscstruct.h"

--- a/include/gcstruct.h
+++ b/include/gcstruct.h
@@ -47,14 +47,13 @@ SOFTWARE.
 #ifndef GCSTRUCT_H
 #define GCSTRUCT_H
 
-#include "gc.h"
+#include <X11/Xprotostr.h>
 
-#include "regionstr.h"
-#include "region.h"
+#include "gc.h"
 #include "pixmap.h"
+#include "regionstr.h"
 #include "screenint.h"
 #include "privates.h"
-#include <X11/Xprotostr.h>
 
 #define GCAllBits ((1 << (GCLastBit + 1)) - 1)
 

--- a/include/window.h
+++ b/include/window.h
@@ -47,10 +47,11 @@ SOFTWARE.
 #ifndef WINDOW_H
 #define WINDOW_H
 
-#include "misc.h"
-#include "region.h"
-#include "screenint.h"
 #include <X11/Xproto.h>
+
+#include "misc.h"
+#include "regionstr.h"
+#include "screenint.h"
 
 #define TOTALLY_OBSCURED 0
 #define UNOBSCURED 1

--- a/mi/mi.h
+++ b/mi/mi.h
@@ -46,12 +46,14 @@ SOFTWARE.
 
 #ifndef MI_H
 #define MI_H
+
 #include <X11/X.h>
-#include "region.h"
+#include <X11/fonts/font.h>
+
+#include "regionstr.h"
 #include "validate.h"
 #include "window.h"
 #include "gc.h"
-#include <X11/fonts/font.h>
 #include "input.h"
 #include "cursor.h"
 #include "privates.h"

--- a/mi/miwindow.c
+++ b/mi/miwindow.c
@@ -52,10 +52,9 @@ SOFTWARE.
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
+#include "include/regionstr.h"
 #include "mi/mi_priv.h"
 
-#include "regionstr.h"
-#include "region.h"
 #include "windowstr.h"
 #include "scrnintstr.h"
 #include "pixmapstr.h"


### PR DESCRIPTION
Nothing in there that we need, include <regionstr.h> instead.
But keeping the file in place, until all external consumer have
been migrated.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
