### PR TITLE
mi: drop intToCoord() macro

### DIFF
--- a/mi/micoord.h
+++ b/mi/micoord.h
@@ -35,12 +35,10 @@
 #define GetHighWord(x) (((int) (x)) >> 16)
 
 #if IMAGE_BYTE_ORDER == MSBFirst
-#define intToCoord(i,x,y)   (((x) = GetHighWord(i)), ((y) = (int) ((short) (i))))
 #define coordToInt(x,y)	(((x) << 16) | ((y) & 0xffff))
 #define intToX(i)	(GetHighWord(i))
 #define intToY(i)	((int) ((short) i))
 #else
-#define intToCoord(i,x,y)   (((x) = (int) ((short) (i))), ((y) = GetHighWord(i)))
 #define coordToInt(x,y)	(((y) << 16) | ((x) & 0xffff))
 #define intToX(i)	((int) ((short) (i)))
 #define intToY(i)	(GetHighWord(i))


### PR DESCRIPTION
Not used anywhere, no need to keep it around any longer.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
