### PR TITLE
composite: dont include <dix-config.h> from headers

### DIFF
--- a/composite/compint.h
+++ b/composite/compint.h
@@ -40,13 +40,8 @@
  * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  * PERFORMANCE OF THIS SOFTWARE.
  */
-
 #ifndef _COMPINT_H_
 #define _COMPINT_H_
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
 
 #include "dix/screen_hooks_priv.h"
 

--- a/composite/compositeext.h
+++ b/composite/compositeext.h
@@ -20,13 +20,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 #ifndef _COMPOSITEEXT_H_
 #define _COMPOSITEEXT_H_
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
 
 #include "misc.h"
 #include "scrnintstr.h"


### PR DESCRIPTION
This file is supposed to be included from each source file at the
very top.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
