### PR TITLE
os: move OsCommRec/Ptr and related functions into own header

### DIFF
--- a/os/access.c
+++ b/os/access.c
@@ -93,6 +93,7 @@ SOFTWARE.
 #include <sys/types.h>
 
 #include "dix/server_priv.h"
+#include "os/io_priv.h"
 #include "os/xhostname.h"
 
 #ifndef WIN32

--- a/os/connection.c
+++ b/os/connection.c
@@ -97,6 +97,7 @@ SOFTWARE.
 #include "os/audit_priv.h"
 #include "os/auth.h"
 #include "os/client_priv.h"
+#include "os/io_priv.h"
 #include "os/log_priv.h"
 #include "os/osdep.h"
 #include "os/probes_priv.h"
@@ -582,11 +583,7 @@ AllocNewConnection(XtransConnInfo trans_conn, int fd, CARD32 conn_time)
         return NULL;
     oc->trans_conn = trans_conn;
     oc->fd = fd;
-    oc->input = (ConnectionInputPtr) NULL;
-    oc->output = (ConnectionOutputPtr) NULL;
-    oc->auth_id = None;
     oc->conn_time = conn_time;
-    oc->flags = 0;
     if (!(client = NextAvailableClient((void *) oc))) {
         free(oc);
         return NULL;

--- a/os/io.c
+++ b/os/io.c
@@ -75,6 +75,7 @@ SOFTWARE.
 #include "dix/dix_priv.h"
 #include "os/bug_priv.h"
 #include "os/client_priv.h"
+#include "os/io_priv.h"
 #include "os/osdep.h"
 #include "os/ossock.h"
 

--- a/os/io_priv.h
+++ b/os/io_priv.h
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef __XORG_OS_IO_H
+#define __XORG_OS_IO_H
+
+#include <X11/Xdefs.h>
+
+#include "include/dix.h" /* ClientPtr */
+
+struct _XtransConnInfo;
+
+typedef struct _connectionInput *ConnectionInputPtr;
+typedef struct _connectionOutput *ConnectionOutputPtr;
+
+typedef struct {
+    int fd;
+    ConnectionInputPtr input;
+    ConnectionOutputPtr output;
+    XID auth_id;
+    CARD32 conn_time;
+    struct _XtransConnInfo *trans_conn;
+    int flags;
+} OsCommRec, *OsCommPtr;
+
+int FlushClient(ClientPtr who, OsCommPtr oc);
+void FreeOsBuffers(OsCommPtr oc);
+void CloseDownFileDescriptor(OsCommPtr oc);
+
+#endif /* __XORG_OS_IO_H */

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -70,27 +70,6 @@ SOFTWARE.
 # define __has_builtin(x) 0     /* Compatibility with older compilers */
 #endif
 
-typedef struct _connectionInput *ConnectionInputPtr;
-typedef struct _connectionOutput *ConnectionOutputPtr;
-
-typedef struct _osComm {
-    int fd;
-    ConnectionInputPtr input;
-    ConnectionOutputPtr output;
-    XID auth_id;                /* authorization id */
-    CARD32 conn_time;           /* timestamp if not established, else 0  */
-    struct _XtransConnInfo *trans_conn; /* transport connection object */
-    int flags;
-} OsCommRec, *OsCommPtr;
-
-int FlushClient(ClientPtr who, OsCommPtr oc);
-
-extern void FreeOsBuffers(OsCommPtr     /*oc */
-    );
-
-void
-CloseDownFileDescriptor(OsCommPtr oc);
-
 #define MILLI_PER_MIN (1000 * 60)
 #define MILLI_PER_SECOND (1000)
 

--- a/os/xdmauth.c
+++ b/os/xdmauth.c
@@ -39,6 +39,7 @@ from The Open Group.
 #include <X11/X.h>
 
 #include "os/auth.h"
+#include "os/io_priv.h"
 #include "os/Xtrans.h"
 
 #include "os.h"


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
