### PR TITLE
include: windowstr.h: unexport w*() macros

### DIFF
--- a/Xext/shm.c
+++ b/Xext/shm.c
@@ -47,6 +47,7 @@ in this Software without prior written authorization from The Open Group.
 #include "dix/screenint_priv.h"
 #include "dix/screen_hooks_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/window_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/auth.h"
 #include "os/busfault.h"

--- a/Xext/xtest.c
+++ b/Xext/xtest.c
@@ -41,6 +41,7 @@
 #include "dix/inpututils_priv.h"
 #include "dix/request_priv.h"
 #include "dix/screensaver_priv.h"
+#include "dix/window_priv.h"
 #include "mi/mi_priv.h"
 #include "mi/mipointer_priv.h"
 #include "miext/extinit_priv.h"

--- a/Xi/chgprop.c
+++ b/Xi/chgprop.c
@@ -57,6 +57,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
+#include "dix/window_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */

--- a/Xi/closedev.c
+++ b/Xi/closedev.c
@@ -57,6 +57,7 @@ SOFTWARE.
 
 #include "dix/resource_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/window_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */

--- a/Xi/getprop.c
+++ b/Xi/getprop.c
@@ -58,6 +58,7 @@ SOFTWARE.
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
+#include "dix/window_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */

--- a/Xi/getselev.c
+++ b/Xi/getselev.c
@@ -59,6 +59,7 @@ SOFTWARE.
 #include "dix/resource_priv.h"
 #include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
+#include "dix/window_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */

--- a/Xi/xiselectev.c
+++ b/Xi/xiselectev.c
@@ -32,6 +32,7 @@
 #include "dix/inpututils_priv.h"
 #include "dix/request_priv.h"
 #include "dix/resource_priv.h"
+#include "dix/window_priv.h"
 #include "Xi/handlers.h"
 
 #include "dixstruct.h"

--- a/composite/compwindow.c
+++ b/composite/compwindow.c
@@ -46,6 +46,7 @@
 #include "dix/dix_priv.h"
 #include "dix/resource_priv.h"
 #include "dix/screensaver_priv.h"
+#include "dix/window_priv.h"
 #include "include/extinit.h"
 #include "os/osdep.h"
 #include "Xext/panoramiXsrv.h"

--- a/dbe/dbe.c
+++ b/dbe/dbe.c
@@ -42,6 +42,7 @@
 #include "dix/rpcbuf_priv.h"
 #include "dix/screen_hooks_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/window_priv.h"
 #include "miext/extinit_priv.h"
 
 #include "scrnintstr.h"

--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -56,6 +56,7 @@ SOFTWARE.
 #include "dix/colormap_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/resource_priv.h"
+#include "dix/window_priv.h"
 #include "os/osdep.h"
 #include "os/bug_priv.h"
 

--- a/dix/enterleave.c
+++ b/dix/enterleave.c
@@ -37,6 +37,7 @@
 #include "dix/input_priv.h"
 #include "dix/inpututils_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/window_priv.h"
 #include "include/extinit.h"
 #include "os/bug_priv.h"
 

--- a/dix/gestures.c
+++ b/dix/gestures.c
@@ -32,6 +32,7 @@
 #include "dix/inpututils_priv.h"
 #include "dix/resource_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/window_priv.h"
 #include "mi/mi_priv.h"
 #include "os/bug_priv.h"
 

--- a/dix/touch.c
+++ b/dix/touch.c
@@ -34,6 +34,7 @@
 #include "dix/inpututils_priv.h"
 #include "dix/resource_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/window_priv.h"
 #include "mi/mi_priv.h"
 #include "os/bug_priv.h"
 #include "os/log_priv.h"

--- a/dix/window_priv.h
+++ b/dix/window_priv.h
@@ -9,6 +9,28 @@
 
 #include "include/dix.h"
 #include "include/window.h"
+#include "include/windowstr.h"
+
+#define wTrackParent(w,field)   ((w)->optional ? \
+                                    (w)->optional->field \
+                                 : FindWindowWithOptional(w)->optional->field)
+#define wUseDefault(w,field,def)        ((w)->optional ? \
+                                    (w)->optional->field \
+                                 : def)
+
+#define wVisual(w)              wTrackParent(w, visual)
+#define wCursor(w)              ((w)->cursorIsNone ? None : wTrackParent(w, cursor))
+#define wColormap(w)            ((w)->drawable.class == InputOnly ? None : wTrackParent(w, colormap))
+#define wDontPropagateMask(w)   wUseDefault(w, dontPropagateMask, DontPropagateMasks[(w)->dontPropagate])
+#define wOtherEventMasks(w)     wUseDefault(w, otherEventMasks, 0)
+#define wOtherClients(w)        wUseDefault(w, otherClients, NULL)
+#define wOtherInputMasks(w)     wUseDefault(w, inputMasks, NULL)
+#define wPassiveGrabs(w)        wUseDefault(w, passiveGrabs, NULL)
+#define wBackingBitPlanes(w)    wUseDefault(w, backingBitPlanes, ~0L)
+#define wBackingPixel(w)        wUseDefault(w, backingPixel, 0)
+#define wBoundingShape(w)       wUseDefault(w, boundingShape, NULL)
+#define wClipShape(w)           wUseDefault(w, clipShape, NULL)
+#define wInputShape(w)          wUseDefault(w, inputShape, NULL)
 
 /*
  * @brief create a window

--- a/glx/glxcmds.c
+++ b/glx/glxcmds.c
@@ -40,6 +40,7 @@
 #include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/window_priv.h"
 #include "os/bug_priv.h"
 #include "present/present_priv.h"
 

--- a/hw/xnest/Color.c
+++ b/hw/xnest/Color.c
@@ -21,6 +21,7 @@ is" without express or implied warranty.
 
 #include "dix/colormap_priv.h"
 #include "os/osdep.h"
+#include "dix/window_priv.h"
 
 #include "scrnintstr.h"
 #include "window.h"

--- a/hw/xnest/Window.c
+++ b/hw/xnest/Window.c
@@ -21,6 +21,7 @@ is" without express or implied warranty.
 #include <X11/Xdefs.h>
 #include <X11/Xproto.h>
 
+#include "dix/window_priv.h"
 #include "include/regionstr.h"
 #include "mi/mi_priv.h"
 

--- a/hw/xwin/winmultiwindowshape.c
+++ b/hw/xwin/winmultiwindowshape.c
@@ -33,6 +33,7 @@
 #include <xwin-config.h>
 #endif
 
+#include "dix/window_priv.h"
 #include "mi/mi_priv.h"
 
 #include "win.h"

--- a/hw/xwin/winwindow.c
+++ b/hw/xwin/winwindow.c
@@ -33,11 +33,11 @@
 #include <xwin-config.h>
 #endif
 
+#include "dix/window_priv.h"
 #include "mi/mi_priv.h"
 
 #include "win.h"
 
-#include "mi/mi_priv.h"
 
 /*
  * Prototypes for local functions

--- a/include/windowstr.h
+++ b/include/windowstr.h
@@ -164,33 +164,8 @@ typedef struct _Window {
     PropertyPtr properties;     /* default: NULL */
 } WindowRec;
 
-/*
- * Ok, a bunch of macros for accessing the optional record
- * fields (or filling the appropriate default value)
- */
-
 extern _X_EXPORT Mask DontPropagateMasks[];
 
-#define wTrackParent(w,field)	((w)->optional ? \
-				    (w)->optional->field \
- 				 : FindWindowWithOptional(w)->optional->field)
-#define wUseDefault(w,field,def)	((w)->optional ? \
-				    (w)->optional->field \
-				 : def)
-
-#define wVisual(w)		wTrackParent(w, visual)
-#define wCursor(w)		((w)->cursorIsNone ? None : wTrackParent(w, cursor))
-#define wColormap(w)		((w)->drawable.class == InputOnly ? None : wTrackParent(w, colormap))
-#define wDontPropagateMask(w)	wUseDefault(w, dontPropagateMask, DontPropagateMasks[(w)->dontPropagate])
-#define wOtherEventMasks(w)	wUseDefault(w, otherEventMasks, 0)
-#define wOtherClients(w)	wUseDefault(w, otherClients, NULL)
-#define wOtherInputMasks(w)	wUseDefault(w, inputMasks, NULL)
-#define wPassiveGrabs(w)	wUseDefault(w, passiveGrabs, NULL)
-#define wBackingBitPlanes(w)	wUseDefault(w, backingBitPlanes, ~0L)
-#define wBackingPixel(w)	wUseDefault(w, backingPixel, 0)
-#define wBoundingShape(w)	wUseDefault(w, boundingShape, NULL)
-#define wClipShape(w)		wUseDefault(w, clipShape, NULL)
-#define wInputShape(w)          wUseDefault(w, inputShape, NULL)
 #define wBorderWidth(w)		((int) (w)->borderWidth)
 
 static inline PropertyPtr wUserProps(WindowPtr pWin) { return pWin->properties; }

--- a/mi/miexpose.c
+++ b/mi/miexpose.c
@@ -80,6 +80,7 @@ Equipment Corporation.
 
 #include "dix/dix_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/window_priv.h"
 #include "include/extinit.h"
 #include "mi/mi_priv.h"
 #include "Xext/panoramiX.h"

--- a/mi/mioverlay.c
+++ b/mi/mioverlay.c
@@ -9,6 +9,7 @@
 #include "dix/dix_priv.h"
 #include "dix/screen_hooks_priv.h"
 #include "dix/screensaver_priv.h"
+#include "dix/window_priv.h"
 #include "mi/mi_priv.h"
 
 #include "scrnintstr.h"

--- a/mi/mivaltree.c
+++ b/mi/mivaltree.c
@@ -92,7 +92,8 @@ Equipment Corporation.
 
 #include    <X11/X.h>
 
-#include    "mi/mi_priv.h"
+#include "dix/window_priv.h"
+#include "mi/mi_priv.h"
 
 #include    "scrnintstr.h"
 #include    "validate.h"

--- a/mi/miwindow.c
+++ b/mi/miwindow.c
@@ -52,6 +52,7 @@ SOFTWARE.
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
+#include "dix/window_priv.h"
 #include "include/regionstr.h"
 #include "mi/mi_priv.h"
 

--- a/miext/rootless/rootlessValTree.c
+++ b/miext/rootless/rootlessValTree.c
@@ -94,6 +94,7 @@ Equipment Corporation.
 #include <stddef.h>             /* For NULL */
 #include <X11/X.h>
 
+#include "dix/window_priv.h"
 #include "mi/mi_priv.h"
 
 #include    "scrnintstr.h"

--- a/miext/rootless/rootlessWindow.c
+++ b/miext/rootless/rootlessWindow.c
@@ -40,6 +40,7 @@
 #include "dix/property_priv.h"
 #include "dix/screen_hooks_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/window_priv.h"
 #include "fb/fb_priv.h"
 #include "mi/mi_priv.h"
 


### PR DESCRIPTION
These aren't used by any drivers, so no need to keep them public.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
