### PR TITLE
include: windowstr.h: unexport SameBackground() and SamBorder() macros

### DIFF
--- a/dix/window_priv.h
+++ b/dix/window_priv.h
@@ -10,6 +10,13 @@
 #include "include/dix.h"
 #include "include/window.h"
 
+#define SameBackground(as, a, bs, b)				\
+    ((as) == (bs) && ((as) == None ||				\
+                      (as) == ParentRelative ||			\
+                      SamePixUnion(a,b,as == BackgroundPixel)))
+
+#define SameBorder(as, a, bs, b) EqualPixUnion(as, a, bs, b)
+
 /*
  * @brief create a window
  *

--- a/include/windowstr.h
+++ b/include/windowstr.h
@@ -60,14 +60,6 @@ SOFTWARE.
 #include "opaque.h"
 
 
-#define SameBackground(as, a, bs, b)				\
-    ((as) == (bs) && ((as) == None ||				\
-		      (as) == ParentRelative ||			\
- 		      SamePixUnion(a,b,as == BackgroundPixel)))
-
-#define SameBorder(as, a, bs, b)				\
-    EqualPixUnion(as, a, bs, b)
-
 /* used as NULL-terminated list */
 typedef struct _DevCursorNode {
     CursorPtr cursor;


### PR DESCRIPTION
Not used by any drivers, so no need to keep them public.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
