### PR TITLE
os: add header for math related functions (possibly OS optimized)

### DIFF
--- a/include/misc.h
+++ b/include/misc.h
@@ -122,7 +122,7 @@ typedef int XRetCode;
 
 #undef min
 #undef max
-
+/* @deprecated */
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 #define max(a, b) (((a) > (b)) ? (a) : (b))
 /* abs() is a function, not a macro; include the file declaring

--- a/os/mathx_priv.h
+++ b/os/mathx_priv.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef _XSERVER_OS_MATHX_PRIV_H_
+#define _XSERVER_OS_MATHX_PRIV_H_
+
+#ifndef MIN
+#define MIN(a,b) (((a)<(b))?(a):(b))
+#endif
+
+#ifndef MAX
+#define MAX(a,b) (((a)>(b))?(a):(b))
+#endif
+
+#endif /* _XSERVER_OS_MATHX_PRIV_H_ */


### PR DESCRIPTION
Adding a new header for math related functions, beginning with new
MIN/MAX macros, which will be used by subsequent commits.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
