### PR TITLE
modesetting: Use don't skip planes that are not on the current crtc

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -2685,9 +2685,9 @@ drmmode_crtc_create_planes(xf86CrtcPtr crtc, int num)
             /* Get the SIZE_HINT dimensions, if supported. */
             int size_hint = drmmode_prop_get_value(&tmp_props[DRMMODE_PLANE_SIZE_HINTS], props, 0);
             drmmode_populate_cursor_size_hints(drmmode, drmmode_crtc, size_hint);
+#endif
             drmModeFreePlane(kplane);
             drmModeFreeObjectProperties(props);
-#endif
             continue;
         }
         case DRMMODE_PLANE_TYPE_PRIMARY:


### PR DESCRIPTION
This breaks on some nvidia cards.

Fixes: https://github.com/X11Libre/xserver/commit/ed49ae8fe7f919998a3f6db64899cf2294b9d145