### PR TITLE
Fixed out of bounds read.

### DIFF
--- a/hw/xfree86/loader/loadmod.c
+++ b/hw/xfree86/loader/loadmod.c
@@ -788,7 +788,7 @@ LoadModule(const char *module, void *options, const XF86ModReqInfo *modreq,
     LogMessageVerb(X_INFO, 3, "LoadModule: \"%s\"", module);
 
     /* Ignore abi check for the nvidia proprietary DDX driver */
-    is_nvidia_proprietary = !memcmp(module, "nvidia", sizeof("nvidia"));
+    is_nvidia_proprietary = !strcmp(module, "nvidia");
 
     patterns = InitPatterns(NULL);
     name = LoaderGetCanonicalName(module, patterns);


### PR DESCRIPTION
I was running xserver with a sanitizer, trying to debug something else and this poped up. Module name was "glx" and that caused sanitizer to panic.