### PR TITLE
Fix glx crash when multiple resources have the same XID

### DIFF
--- a/glx/glxcmds.c
+++ b/glx/glxcmds.c
@@ -1146,6 +1146,9 @@ DoCreateGLXDrawable(ClientPtr client, __GLXscreen * pGlxScreen,
     if (pGlxScreen->pScreen != pDraw->pScreen)
         return BadMatch;
 
+    LEGAL_NEW_RESOURCE(glxDrawableId, client);
+    LEGAL_NEW_RESOURCE(pDraw->id, client);
+
     pGlxDraw = pGlxScreen->createDrawable(client, pGlxScreen, pDraw,
                                           drawableId, type,
                                           glxDrawableId, config);


### PR DESCRIPTION
So I managed to make it not crash. #1491 
But,
this all feels sus to me. I'm not realy sure what are the
expectations for clientTable resources hash table stuf are.
1. Is it expected that there are multiple XID with different RESTYPE?
2. Is it expected that there are multiple XID with the same RESTYPE?
3. After the table is rebuild RebuildTable(int client) should the resources be in the same buckets?
4. Is it expected that bucket with index 1 is prefered? ( I have 300/700 elements in the bucket with index 1 )

I'd prefer that this fix is not accepted.
I think that real fix would be somewhere in here:
glx/glxcmds.c:1139
```c
static int
DoCreateGLXDrawable(ClientPtr client, __GLXscreen * pGlxScreen,
                    __GLXconfig * config, DrawablePtr pDraw, XID drawableId,
                    XID glxDrawableId, int type)
{
    __GLXdrawable *pGlxDraw;

    if (pGlxScreen->pScreen != pDraw->pScreen)
        return BadMatch;

    pGlxDraw = pGlxScreen->createDrawable(client, pGlxScreen, pDraw,
                                          drawableId, type,
                                          glxDrawableId, config);
    if (pGlxDraw == NULL)
        return BadAlloc;

    if (!AddResource(glxDrawableId, __glXDrawableRes, pGlxDraw))
        return BadAlloc;

    /*
     * Windows aren't refcounted, so track both the X and the GLX window
     * so we get called regardless of destruction order.
     */
    if (drawableId != glxDrawableId && type == GLX_DRAWABLE_WINDOW &&
        !AddResource(pDraw->id, __glXDrawableRes, pGlxDraw))
        return BadAlloc;

    return Success;
}
```

pGlxDraw is set as value to 2 different resources. And they both have the same destructor functions:

glx/glxext.c:96

```c
static Bool
DrawableGone(__GLXdrawable * glxPriv, XID xid)
{
    __GLXcontext *c, *next;

    if (glxPriv->type == GLX_DRAWABLE_WINDOW) {
        /* If this was created by glXCreateWindow, free the matching resource */
        if (glxPriv->drawId != glxPriv->pDraw->id) {
            if (xid == glxPriv->drawId)
                FreeResourceByType(glxPriv->pDraw->id, __glXDrawableRes, TRUE);
            else
                FreeResourceByType(glxPriv->drawId, __glXDrawableRes, TRUE);
        }
        /* otherwise this window was implicitly created by MakeCurrent */
    }

    for (c = glxAllContexts; c; c = next) {
        next = c->next;
        if (c->currentClient &&
		(c->drawPriv == glxPriv || c->readPriv == glxPriv)) {
            /* flush the context */
            glFlush();
            /* just force a re-bind the next time through */
            (*c->loseCurrent) (c);
            lastGLContext = NULL;
        }
        if (c->drawPriv == glxPriv)
            c->drawPriv = NULL;
        if (c->readPriv == glxPriv)
            c->readPriv = NULL;
    }

    /* drop our reference to any backing pixmap */
    if (glxPriv->type == GLX_DRAWABLE_PIXMAP)
        glxPriv->pDraw->pScreen->DestroyPixmap((PixmapPtr) glxPriv->pDraw);

    glxPriv->destroy(glxPriv);

    return TRUE;
}
```

This ```glxPriv->destroy(glxPriv);``` is in fact ```egl_drawable_destroy``` function and ```egl_drawable_destroy``` only calls free on glxPriv.

I think maybe new RESTYPE should be created to diferentiate 
```if (!AddResource(glxDrawableId, __glXDrawableRes, pGlxDraw))``` and
```!AddResource(pDraw->id, __glXDrawableRes, pGlxDraw))```

Or as a comment suggests pGlxDraw should be ref counted or something..
