### PR TITLE
dri: use static struct init on declaration & drop useless assignments

### DIFF
--- a/hw/xfree86/dri/xf86dri.c
+++ b/hw/xfree86/dri/xf86dri.c
@@ -158,8 +158,6 @@ ProcXF86DRIOpenConnection(register ClientPtr client)
         .hSAREALow = (CARD32) (hSAREA & 0xffffffff),
 #if defined(LONG64) && !defined(__linux__)
         .hSAREAHigh = (CARD32) (hSAREA >> 32),
-#else
-        .hSAREAHigh = 0
 #endif
     };
 
@@ -449,8 +447,6 @@ ProcXF86DRIGetDeviceInfo(register ClientPtr client)
     rep.hFrameBufferLow = (CARD32) (hFrameBuffer & 0xffffffff);
 #if defined(LONG64) && !defined(__linux__)
     rep.hFrameBufferHigh = (CARD32) (hFrameBuffer >> 32);
-#else
-    rep.hFrameBufferHigh = 0;
 #endif
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };


### PR DESCRIPTION
Make the code a bit easier to read by using initialization of the reply
structs, at the point of declaration. Most of them aren't written to later,
just passed into WriteReplyToClient(). Also dropping some useless zero
assignments (struct initializers automatically zero-out unmentioned fields).

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
