### PR TITLE
xfree86/modes: reduce excess precision xf86ModeHSync and xf86ModeVRefresh

### DIFF
--- a/hw/xfree86/modes/xf86EdidModes.c
+++ b/hw/xfree86/modes/xf86EdidModes.c
@@ -486,7 +486,7 @@ DDCModesFromStandardTiming(DisplayModePtr pool, struct std_timings *timing,
         /* If we already have a detailed timing for this size, don't add more */
         for (p = pool; p; p = p->next) {
             if (p->HDisplay == hsize && p->VDisplay == vsize &&
-                refresh == round(xf86ModeVRefresh(p)))
+                refresh == roundf(xf86ModeVRefresh(p)))
                 break;
         }
         if (p)
@@ -895,10 +895,10 @@ xf86DDCSetPreferredRefresh(int scrnIndex, DisplayModePtr modes,
             continue;
         }
         if (mode->HDisplay * mode->VDisplay == best->HDisplay * best->VDisplay) {
-            double mode_refresh = xf86ModeVRefresh(mode);
-            double best_refresh = xf86ModeVRefresh(best);
-            double mode_dist = fabs(mode_refresh - target_refresh);
-            double best_dist = fabs(best_refresh - target_refresh);
+            float mode_refresh = xf86ModeVRefresh(mode);
+            float best_refresh = xf86ModeVRefresh(best);
+            float mode_dist = fabsf(mode_refresh - target_refresh);
+            float best_dist = fabsf(best_refresh - target_refresh);
 
             if (mode_dist < best_dist) {
                 best = mode;

--- a/hw/xfree86/modes/xf86Modes.c
+++ b/hw/xfree86/modes/xf86Modes.c
@@ -39,10 +39,10 @@
 /**
  * Calculates the horizontal sync rate of a mode.
  */
-double
+float
 xf86ModeHSync(const DisplayModeRec * mode)
 {
-    double hsync = 0.0;
+    float hsync = 0.0f;
 
     if (mode->HSync > 0.0)
         hsync = mode->HSync;
@@ -55,19 +55,19 @@ xf86ModeHSync(const DisplayModeRec * mode)
 /**
  * Calculates the vertical refresh rate of a mode.
  */
-double
+float
 xf86ModeVRefresh(const DisplayModeRec * mode)
 {
-    double refresh = 0.0;
+    float refresh = 0.0f;
 
     if (mode->VRefresh > 0.0)
         refresh = mode->VRefresh;
     else if (mode->HTotal > 0 && mode->VTotal > 0) {
-        refresh = mode->Clock * 1000.0 / mode->HTotal / mode->VTotal;
+        refresh = mode->Clock * 1000.0f / mode->HTotal / mode->VTotal;
         if (mode->Flags & V_INTERLACE)
-            refresh *= 2.0;
+            refresh *= 2.0f;
         if (mode->Flags & V_DBLSCAN)
-            refresh /= 2.0;
+            refresh /= 2.0f;
         if (mode->VScan > 1)
             refresh /= (float) (mode->VScan);
     }

--- a/hw/xfree86/modes/xf86Modes.h
+++ b/hw/xfree86/modes/xf86Modes.h
@@ -37,8 +37,8 @@
 #include "edid.h"
 #include "xf86Parser.h"
 
-extern _X_EXPORT double xf86ModeHSync(const DisplayModeRec * mode);
-extern _X_EXPORT double xf86ModeVRefresh(const DisplayModeRec * mode);
+extern _X_EXPORT float xf86ModeHSync(const DisplayModeRec * mode);
+extern _X_EXPORT float xf86ModeVRefresh(const DisplayModeRec * mode);
 extern _X_EXPORT unsigned int xf86ModeBandwidth(DisplayModePtr mode, int depth);
 
 extern _X_EXPORT int


### PR DESCRIPTION
References:
1.  **When to use float vs. double:** [https://softwareengineering.stackexchange.com/questions/188721/when-do-you-use-float-and-when-do-you-use-double](https://softwareengineering.stackexchange.com/questions/188721/when-do-you-use-float-and-when-do-you-use-double)
2. **Is it more efficient to use floats instead of doubles in C/C++ programs for speed?** [https://www.quora.com/Is-it-more-efficient-to-use-floats-instead-of-doubles-in-C-C-programs-for-speed](https://www.quora.com/Is-it-more-efficient-to-use-floats-instead-of-doubles-in-C-C-programs-for-speed)