### PR TITLE
dix: inline SProcCreateGlyphCursor()

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -3197,12 +3197,26 @@ ProcCreateCursor(ClientPtr client)
 int
 ProcCreateGlyphCursor(ClientPtr client)
 {
+    REQUEST(xCreateGlyphCursorReq);
+    REQUEST_SIZE_MATCH(xCreateGlyphCursorReq);
+
+    if (client->swapped) {
+        swapl(&stuff->cid);
+        swapl(&stuff->source);
+        swapl(&stuff->mask);
+        swaps(&stuff->sourceChar);
+        swaps(&stuff->maskChar);
+        swaps(&stuff->foreRed);
+        swaps(&stuff->foreGreen);
+        swaps(&stuff->foreBlue);
+        swaps(&stuff->backRed);
+        swaps(&stuff->backGreen);
+        swaps(&stuff->backBlue);
+    }
+
     CursorPtr pCursor;
     int res;
 
-    REQUEST(xCreateGlyphCursorReq);
-
-    REQUEST_SIZE_MATCH(xCreateGlyphCursorReq);
     LEGAL_NEW_RESOURCE(stuff->cid, client);
 
     res = AllocGlyphCursor(stuff->source, stuff->sourceChar,

--- a/dix/swapreq.c
+++ b/dix/swapreq.c
@@ -703,25 +703,6 @@ SProcCreateCursor(ClientPtr client)
 }
 
 int _X_COLD
-SProcCreateGlyphCursor(ClientPtr client)
-{
-    REQUEST(xCreateGlyphCursorReq);
-    REQUEST_SIZE_MATCH(xCreateGlyphCursorReq);
-    swapl(&stuff->cid);
-    swapl(&stuff->source);
-    swapl(&stuff->mask);
-    swaps(&stuff->sourceChar);
-    swaps(&stuff->maskChar);
-    swaps(&stuff->foreRed);
-    swaps(&stuff->foreGreen);
-    swaps(&stuff->foreBlue);
-    swaps(&stuff->backRed);
-    swaps(&stuff->backGreen);
-    swaps(&stuff->backBlue);
-    return ((*ProcVector[X_CreateGlyphCursor]) (client));
-}
-
-int _X_COLD
 SProcRecolorCursor(ClientPtr client)
 {
     REQUEST(xRecolorCursorReq);

--- a/dix/swapreq.h
+++ b/dix/swapreq.h
@@ -49,7 +49,6 @@ int SProcCopyPlane(ClientPtr client);
 int SProcCreateColormap(ClientPtr client);
 int SProcCreateCursor(ClientPtr client);
 int SProcCreateGC(ClientPtr client);
-int SProcCreateGlyphCursor(ClientPtr client);
 int SProcCreatePixmap(ClientPtr client);
 int SProcCreateWindow(ClientPtr client);
 int SProcFillPoly(ClientPtr client);

--- a/dix/tables.c
+++ b/dix/tables.c
@@ -426,7 +426,7 @@ int (*SwappedProcVector[256]) (ClientPtr /* client */) = {
     SProcQueryColors,
     SProcLookupColor,
     SProcCreateCursor,
-    SProcCreateGlyphCursor,
+    ProcCreateGlyphCursor,
     ProcFreeCursor,                     /* 95 */
     SProcRecolorCursor,
     SProcQueryBestSize,


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
