### PR TITLE
dix: add macros for request handlers and swapping

### DIFF
--- a/dix/request_priv.h
+++ b/dix/request_priv.h
@@ -101,4 +101,60 @@ static inline int __write_reply_hdr_simple(
 #define X_SEND_REPLY_SIMPLE(client, hdrstruct) \
     __write_reply_hdr_simple(client, &(hdrstruct), sizeof(hdrstruct));
 
+/*
+ * macros for request handlers
+ *
+ * these are handling request packet checking and swapping of multi-byte
+ * values, if necessary. (length field is already swapped earlier)
+ */
+
+/* declare request struct and check size */
+#define X_REQUEST_HEAD_STRUCT(type) \
+    REQUEST(type); \
+    if (stuff == NULL) return (BadLength); \
+    REQUEST_SIZE_MATCH(type);
+
+/* declare request struct and check size (at least as big) */
+#define X_REQUEST_HEAD_AT_LEAST(type) \
+    REQUEST(type); \
+    if (stuff == NULL) return (BadLength); \
+    REQUEST_AT_LEAST_SIZE(type); \
+
+/* declare request struct, do NOT check size !*/
+#define X_REQUEST_HEAD_NO_CHECK(type) \
+    REQUEST(type); \
+    if (stuff == NULL) return (BadLength); \
+
+/* swap a CARD16 request struct field if necessary */
+#define X_REQUEST_FIELD_CARD16(field) \
+    do { if (client->swapped) swaps(&stuff->field); } while (0)
+
+/* swap a CARD32 request struct field if necessary */
+#define X_REQUEST_FIELD_CARD32(field) \
+    do { if (client->swapped) swapl(&stuff->field); } while (0)
+
+/* swap a CARD64 request struct field if necessary */
+#define X_REQUEST_FIELD_CARD64(field) \
+    do { if (client->swapped) swapll(&stuff->field); } while (0)
+
+/* swap CARD16 rest of request (after the struct) */
+#define X_REQUEST_REST_CARD16() \
+    do { if (client->swapped) SwapRestS(stuff); } while (0)
+
+/* swap CARD32 rest of request (after the struct) */
+#define X_REQUEST_REST_CARD32() \
+    do { if (client->swapped) SwapRestL(stuff); } while (0)
+
+/* swap CARD16 rest of request (after the struct) - check fixed count */
+#define X_REQUEST_REST_COUNT_CARD16(count) \
+    REQUEST_FIXED_SIZE(*stuff, count * sizeof(CARD16)); \
+    CARD32 *request_rest = (CARD16 *) (&stuff[1]); \
+    do { if (client->swapped) SwapShorts(request_rest, count); } while (0)
+
+/* swap CARD32 rest of request (after the struct) - check fixed count */
+#define X_REQUEST_REST_COUNT_CARD32(count) \
+    REQUEST_FIXED_SIZE(*stuff, count * sizeof(CARD32)); \
+    CARD32 *request_rest = (CARD32 *) (&stuff[1]); \
+    do { if (client->swapped) SwapLongs(request_rest, count); } while (0) \
+
 #endif /* _XSERVER_DIX_REQUEST_PRIV_H */


### PR DESCRIPTION
add some macros for making request handlers easier:

    * REQUEST_HEAD_STRUCT() declares a struct and checks size (assuming
      length field already had been swapped)
    * REQUEST_FIELD_CARD16() swaps a CARD16 (word) if neccessary
    * REQUEST_FIELD_CARD32() swaps a CARD32 (dword) if neccessary

How to use them:

    1. move swapping of lengths field into the SProc*Dispatch() and drop it
       from the individual SProc*()'s
    2. put REQUEST_HEAD_STRUCT() ontop of each Proc*()
    3. add REQUEST_FIELD_*() below, for all fields to be swapped and
       drop their swapping from the SProc*()'s
    4. clean up unnecessary wrappers (SProc*()'s just be just call the
       corresponding Proc*() by now)
    5. let demux SProc just swap length field and call the normal Proc*Dispatch()

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
