### PR TITLE
xwin: drop unused variable

### DIFF
--- a/hw/xwin/winmultiwindowwindow.c
+++ b/hw/xwin/winmultiwindowwindow.c
@@ -1048,7 +1048,6 @@ winModifyPixmapHeaderMultiwindow(PixmapPtr pPixmap,
                                  int depth,
                                  int bitsPerPixel, int devKind, void *pPixData)
 {
-    int i;
     winPrivPixmapPtr pPixmapPriv = winGetPixmapPriv(pPixmap);
 
     /* reinitialize everything */


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
