### PR TITLE
os: merge os/xstrans.c and os/transport.c

### DIFF
--- a/os/meson.build
+++ b/os/meson.build
@@ -16,11 +16,11 @@ srcs_os = [
     'ossock.c',
     'serverlock.c',
     'string.c',
+    'transport.c',
     'utils.c',
     'xdmauth.c',
     'xhostname.c',
     'xsha1.c',
-    'xstrans.c',
     'xprintf.c',
     'log.c',
 ]

--- a/os/transport.c
+++ b/os/transport.c
@@ -46,8 +46,10 @@ from The Open Group.
  * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
+#include <dix-config.h>
 
 #include <stdlib.h>
+#include <X11/Xfuncproto.h>
 
 #define XTRANS_TRANSPORT_C  /* used to flag Xtransint.h that it's being used
 			       here, not just #included in another file */

--- a/os/xstrans.c
+++ b/os/xstrans.c
@@ -1,5 +1,0 @@
-#include <dix-config.h>
-
-#include <X11/Xfuncproto.h>
-
-#include "os/transport.c"


### PR DESCRIPTION
Since xtrans is now in-tree and already have been trimmed down
for only things needed by the Xserver, the split between xstrans.c
and transport.c isn't needed anymore.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
