### PR TITLE
Xext: saver: use REQUEST_HEAD_STRUCT and REQUEST_FIELD_* macros

### DIFF
--- a/Xext/saver.c
+++ b/Xext/saver.c
@@ -591,12 +591,12 @@ ScreenSaverHandle(ScreenPtr pScreen, int xstate, Bool force)
 static int
 ProcScreenSaverQueryVersion(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xScreenSaverQueryVersionReq);
+
     xScreenSaverQueryVersionReply reply = {
         .majorVersion = SERVER_SAVER_MAJOR_VERSION,
         .minorVersion = SERVER_SAVER_MINOR_VERSION
     };
-
-    REQUEST_SIZE_MATCH(xScreenSaverQueryVersionReq);
 
     if (client->swapped) {
         swaps(&reply.majorVersion);
@@ -609,11 +609,8 @@ ProcScreenSaverQueryVersion(ClientPtr client)
 static int
 ProcScreenSaverQueryInfo(ClientPtr client)
 {
-    REQUEST(xScreenSaverQueryInfoReq);
-    REQUEST_SIZE_MATCH(xScreenSaverQueryInfoReq);
-
-    if (client->swapped)
-        swapl(&stuff->drawable);
+    X_REQUEST_HEAD_STRUCT(xScreenSaverQueryInfoReq);
+    X_REQUEST_FIELD_CARD32(drawable);
 
     int rc;
     ScreenSaverStuffPtr pSaver;
@@ -674,17 +671,12 @@ ProcScreenSaverQueryInfo(ClientPtr client)
 static int
 ProcScreenSaverSelectInput(ClientPtr client)
 {
-    REQUEST(xScreenSaverSelectInputReq);
+    X_REQUEST_HEAD_STRUCT(xScreenSaverSelectInputReq);
+    X_REQUEST_FIELD_CARD32(drawable);
+    X_REQUEST_FIELD_CARD32(eventMask);
+
     DrawablePtr pDraw;
     int rc;
-
-    REQUEST_SIZE_MATCH(xScreenSaverSelectInputReq);
-
-    if (client->swapped) {
-        swapl(&stuff->drawable);
-        swapl(&stuff->eventMask);
-    }
-
     rc = dixLookupDrawable(&pDraw, stuff->drawable, client, 0,
                            DixGetAttrAccess);
     if (rc != Success)
@@ -1062,20 +1054,16 @@ ScreenSaverUnsetAttributes(ClientPtr client, Drawable drawable)
 static int
 ProcScreenSaverSetAttributes(ClientPtr client)
 {
-    REQUEST(xScreenSaverSetAttributesReq);
-    REQUEST_AT_LEAST_SIZE(xScreenSaverSetAttributesReq);
-
-    if (client->swapped) {
-        swapl(&stuff->drawable);
-        swaps(&stuff->x);
-        swaps(&stuff->y);
-        swaps(&stuff->width);
-        swaps(&stuff->height);
-        swaps(&stuff->borderWidth);
-        swapl(&stuff->visualID);
-        swapl(&stuff->mask);
-        SwapRestL(stuff);
-    }
+    X_REQUEST_HEAD_AT_LEAST(xScreenSaverSetAttributesReq);
+    X_REQUEST_FIELD_CARD32(drawable);
+    X_REQUEST_FIELD_CARD16(x);
+    X_REQUEST_FIELD_CARD16(y);
+    X_REQUEST_FIELD_CARD16(width);
+    X_REQUEST_FIELD_CARD16(height);
+    X_REQUEST_FIELD_CARD16(borderWidth);
+    X_REQUEST_FIELD_CARD32(visualID);
+    X_REQUEST_FIELD_CARD32(mask);
+    X_REQUEST_REST_CARD32();
 
 #ifdef XINERAMA
     if (!noPanoramiXExtension) {
@@ -1161,11 +1149,8 @@ ProcScreenSaverSetAttributes(ClientPtr client)
 static int
 ProcScreenSaverUnsetAttributes(ClientPtr client)
 {
-    REQUEST(xScreenSaverUnsetAttributesReq);
-    REQUEST_SIZE_MATCH(xScreenSaverUnsetAttributesReq);
-
-    if (client->swapped)
-        swapl(&stuff->drawable);
+    X_REQUEST_HEAD_STRUCT(xScreenSaverUnsetAttributesReq);
+    X_REQUEST_FIELD_CARD32(drawable);
 
 #ifdef XINERAMA
     if (!noPanoramiXExtension) {
@@ -1192,15 +1177,11 @@ ProcScreenSaverUnsetAttributes(ClientPtr client)
 static int
 ProcScreenSaverSuspend(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xScreenSaverSuspendReq);
+    X_REQUEST_FIELD_CARD32(suspend);
+
     ScreenSaverSuspensionPtr *prev, this;
     BOOL suspend;
-
-    REQUEST(xScreenSaverSuspendReq);
-    REQUEST_SIZE_MATCH(xScreenSaverSuspendReq);
-
-    if (client->swapped)
-        swapl(&stuff->suspend);
-
     /*
      * Old versions of XCB encode suspend as 1 byte followed by three
      * pad bytes (which are always cleared), instead of a 4 byte


### PR DESCRIPTION
Use the new macros to make request struct parsing / field swapping
much easier.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
