### PR TITLE
Xext: shape: use REQUEST_HEAD_STRUCT and REQUEST_FIELD_* macros

### DIFF
--- a/Xext/shape.c
+++ b/Xext/shape.c
@@ -225,7 +225,7 @@ CreateClipShape(WindowPtr pWin)
 static int
 ProcShapeQueryVersion(ClientPtr client)
 {
-    REQUEST_SIZE_MATCH(xShapeQueryVersionReq);
+    X_REQUEST_HEAD_STRUCT(xShapeQueryVersionReq);
 
     xShapeQueryVersionReply reply = {
         .majorVersion = SERVER_SHAPE_MAJOR_VERSION,
@@ -308,15 +308,11 @@ ShapeRectangles(ClientPtr client, xShapeRectanglesReq *stuff)
 static int
 ProcShapeRectangles(ClientPtr client)
 {
-    REQUEST(xShapeRectanglesReq);
-    REQUEST_AT_LEAST_SIZE(xShapeRectanglesReq);
-
-    if (client->swapped) {
-        swapl(&stuff->dest);
-        swaps(&stuff->xOff);
-        swaps(&stuff->yOff);
-        SwapRestS(stuff);
-    }
+    X_REQUEST_HEAD_AT_LEAST(xShapeRectanglesReq);
+    X_REQUEST_FIELD_CARD32(dest);
+    X_REQUEST_FIELD_CARD16(xOff);
+    X_REQUEST_FIELD_CARD16(yOff);
+    X_REQUEST_REST_CARD16();
 
 #ifdef XINERAMA
     if (noPanoramiXExtension)
@@ -413,15 +409,11 @@ ShapeMask(ClientPtr client, xShapeMaskReq *stuff)
 static int
 ProcShapeMask(ClientPtr client)
 {
-    REQUEST(xShapeMaskReq);
-    REQUEST_SIZE_MATCH(xShapeMaskReq);
-
-    if (client->swapped) {
-        swapl(&stuff->dest);
-        swaps(&stuff->xOff);
-        swaps(&stuff->yOff);
-        swapl(&stuff->src);
-    }
+    X_REQUEST_HEAD_STRUCT(xShapeMaskReq);
+    X_REQUEST_FIELD_CARD32(dest);
+    X_REQUEST_FIELD_CARD16(xOff);
+    X_REQUEST_FIELD_CARD16(yOff);
+    X_REQUEST_FIELD_CARD32(src);
 
 #ifdef XINERAMA
     if (noPanoramiXExtension)
@@ -549,15 +541,11 @@ ShapeCombine(ClientPtr client, xShapeCombineReq *stuff)
 static int
 ProcShapeCombine(ClientPtr client)
 {
-    REQUEST(xShapeCombineReq);
-    REQUEST_AT_LEAST_SIZE(xShapeCombineReq);
-
-    if (client->swapped) {
-        swapl(&stuff->dest);
-        swaps(&stuff->xOff);
-        swaps(&stuff->yOff);
-        swapl(&stuff->src);
-    }
+    X_REQUEST_HEAD_AT_LEAST(xShapeCombineReq);
+    X_REQUEST_FIELD_CARD32(dest);
+    X_REQUEST_FIELD_CARD16(xOff);
+    X_REQUEST_FIELD_CARD16(yOff);
+    X_REQUEST_FIELD_CARD32(src);
 
 #ifdef XINERAMA
     if (noPanoramiXExtension)
@@ -626,14 +614,10 @@ ShapeOffset(ClientPtr client, xShapeOffsetReq *stuff)
 static int
 ProcShapeOffset(ClientPtr client)
 {
-    REQUEST(xShapeOffsetReq);
-    REQUEST_AT_LEAST_SIZE(xShapeOffsetReq);
-
-    if (client->swapped) {
-        swapl(&stuff->dest);
-        swaps(&stuff->xOff);
-        swaps(&stuff->yOff);
-    }
+    X_REQUEST_HEAD_AT_LEAST(xShapeOffsetReq);
+    X_REQUEST_FIELD_CARD32(dest);
+    X_REQUEST_FIELD_CARD16(yOff);
+    X_REQUEST_FIELD_CARD16(yOff);
 
 #ifdef XINERAMA
     PanoramiXRes *win;
@@ -663,11 +647,8 @@ ProcShapeOffset(ClientPtr client)
 static int
 ProcShapeQueryExtents(ClientPtr client)
 {
-    REQUEST(xShapeQueryExtentsReq);
-    REQUEST_SIZE_MATCH(xShapeQueryExtentsReq);
-
-    if (client->swapped)
-        swapl(&stuff->window);
+    X_REQUEST_HEAD_STRUCT(xShapeQueryExtentsReq);
+    X_REQUEST_FIELD_CARD32(window);
 
     WindowPtr pWin;
     int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
@@ -732,7 +713,9 @@ ProcShapeQueryExtents(ClientPtr client)
 static int
 ProcShapeSelectInput(ClientPtr client)
 {
-    REQUEST(xShapeSelectInputReq);
+    X_REQUEST_HEAD_STRUCT(xShapeSelectInputReq);
+    X_REQUEST_FIELD_CARD32(window);
+
     WindowPtr pWin;
     ShapeEventPtr pNewShapeEvent;
     int rc;
@@ -855,14 +838,11 @@ SendShapeNotify(WindowPtr pWin, int which)
 static int
 ProcShapeInputSelected(ClientPtr client)
 {
-    REQUEST(xShapeInputSelectedReq);
+    X_REQUEST_HEAD_STRUCT(xShapeInputSelectedReq);
+    X_REQUEST_FIELD_CARD32(window);
+
     WindowPtr pWin;
     int enabled, rc;
-
-    REQUEST_SIZE_MATCH(xShapeInputSelectedReq);
-
-    if (client->swapped)
-        swapl(&stuff->window);
 
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
     if (rc != Success)
@@ -889,15 +869,12 @@ ProcShapeInputSelected(ClientPtr client)
 static int
 ProcShapeGetRectangles(ClientPtr client)
 {
-    REQUEST(xShapeGetRectanglesReq);
+    X_REQUEST_HEAD_STRUCT(xShapeGetRectanglesReq);
+    X_REQUEST_FIELD_CARD32(window);
+
     WindowPtr pWin;
     int nrects, rc;
     RegionPtr region;
-
-    REQUEST_SIZE_MATCH(xShapeGetRectanglesReq);
-
-    if (client->swapped)
-        swapl(&stuff->window);
 
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
     if (rc != Success)


### PR DESCRIPTION
Use the new macros to make request struct parsing / field swapping
much easier.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
