### PR TITLE
Xext: bigreq: use REQUEST_HEAD_STRUCT and REQUEST_FIELD_* macros

### DIFF
--- a/Xext/bigreq.c
+++ b/Xext/bigreq.c
@@ -45,8 +45,7 @@ from The Open Group.
 static int
 ProcBigReqDispatch(ClientPtr client)
 {
-    REQUEST(xBigReqEnableReq);
-    REQUEST_SIZE_MATCH(xBigReqEnableReq);
+    X_REQUEST_HEAD_STRUCT(xBigReqEnableReq);
 
     if (stuff->brReqType != X_BigReqEnable)
         return BadRequest;


### PR DESCRIPTION
Use the new macros to make request struct parsing / field swapping
much easier.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
