### PR TITLE
Xext: shm: use REQUEST_HEAD_STRUCT and REQUEST_FIELD_* macros

### DIFF
--- a/Xext/shm.c
+++ b/Xext/shm.c
@@ -238,6 +238,8 @@ ShmRegisterFbFuncs(ScreenPtr pScreen)
 static int
 ProcShmQueryVersion(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xShmQueryVersionReq);
+
     xShmQueryVersionReply reply = {
         .sharedPixmaps = sharedPixmaps,
         .majorVersion = SERVER_SHM_MAJOR_VERSION,
@@ -246,8 +248,6 @@ ProcShmQueryVersion(ClientPtr client)
         .gid = getegid(),
         .pixmapFormat = sharedPixmaps ? ZPixmap : 0
     };
-
-    REQUEST_SIZE_MATCH(xShmQueryVersionReq);
 
     if (client->swapped) {
         swaps(&reply.majorVersion);
@@ -328,8 +328,9 @@ shm_access(ClientPtr client, SHMPERM_TYPE * perm, int readonly)
 static int
 ProcShmAttach(ClientPtr client)
 {
-    REQUEST(xShmAttachReq);
-    REQUEST_SIZE_MATCH(xShmAttachReq);
+    X_REQUEST_HEAD_STRUCT(xShmAttachReq);
+    X_REQUEST_FIELD_CARD32(shmseg);
+    X_REQUEST_FIELD_CARD32(shmid);
 
     if (!client->local)
         return BadRequest;
@@ -416,8 +417,8 @@ ShmDetachSegment(void *value, /* must conform to DeleteType */
 static int
 ProcShmDetach(ClientPtr client)
 {
-    REQUEST(xShmDetachReq);
-    REQUEST_SIZE_MATCH(xShmDetachReq);
+    X_REQUEST_HEAD_STRUCT(xShmDetachReq);
+    X_REQUEST_FIELD_CARD32(shmseg);
 
     if (!client->local)
         return BadRequest;
@@ -688,8 +689,19 @@ ShmGetImage(ClientPtr client, xShmGetImageReq *stuff)
 static int
 ProcShmPutImage(ClientPtr client)
 {
-    REQUEST(xShmPutImageReq);
-    REQUEST_SIZE_MATCH(xShmPutImageReq);
+    X_REQUEST_HEAD_STRUCT(xShmPutImageReq);
+    X_REQUEST_FIELD_CARD32(drawable);
+    X_REQUEST_FIELD_CARD32(gc);
+    X_REQUEST_FIELD_CARD16(totalWidth);
+    X_REQUEST_FIELD_CARD16(totalHeight);
+    X_REQUEST_FIELD_CARD16(srcX);
+    X_REQUEST_FIELD_CARD16(srcY);
+    X_REQUEST_FIELD_CARD16(srcWidth);
+    X_REQUEST_FIELD_CARD16(srcHeight);
+    X_REQUEST_FIELD_CARD16(dstX);
+    X_REQUEST_FIELD_CARD16(dstY);
+    X_REQUEST_FIELD_CARD32(shmseg);
+    X_REQUEST_FIELD_CARD32(offset);
 
     if (!client->local)
         return BadRequest;
@@ -742,8 +754,15 @@ ProcShmPutImage(ClientPtr client)
 static int
 ProcShmGetImage(ClientPtr client)
 {
-    REQUEST(xShmGetImageReq);
-    REQUEST_SIZE_MATCH(xShmGetImageReq);
+    X_REQUEST_HEAD_STRUCT(xShmGetImageReq);
+    X_REQUEST_FIELD_CARD32(drawable);
+    X_REQUEST_FIELD_CARD16(x);
+    X_REQUEST_FIELD_CARD16(y);
+    X_REQUEST_FIELD_CARD16(width);
+    X_REQUEST_FIELD_CARD16(height);
+    X_REQUEST_FIELD_CARD32(planeMask);
+    X_REQUEST_FIELD_CARD32(shmseg);
+    X_REQUEST_FIELD_CARD32(offset);
 
     if (!client->local)
         return BadRequest;
@@ -887,8 +906,13 @@ ProcShmGetImage(ClientPtr client)
 static int
 ProcShmCreatePixmap(ClientPtr client)
 {
-    REQUEST(xShmCreatePixmapReq);
-    REQUEST_SIZE_MATCH(xShmCreatePixmapReq);
+    X_REQUEST_HEAD_STRUCT(xShmCreatePixmapReq);
+    X_REQUEST_FIELD_CARD32(pid);
+    X_REQUEST_FIELD_CARD32(drawable);
+    X_REQUEST_FIELD_CARD16(width);
+    X_REQUEST_FIELD_CARD16(height);
+    X_REQUEST_FIELD_CARD32(shmseg);
+    X_REQUEST_FIELD_CARD32(offset);
 
     if (!client->local)
         return BadRequest;
@@ -1119,8 +1143,8 @@ ShmBusfaultNotify(void *context)
 static int
 ProcShmAttachFd(ClientPtr client)
 {
-    REQUEST(xShmAttachFdReq);
-    REQUEST_SIZE_MATCH(xShmAttachFdReq);
+    X_REQUEST_HEAD_STRUCT(xShmAttachFdReq);
+    X_REQUEST_FIELD_CARD32(shmseg);
 
     if (!client->local)
         return BadRequest;
@@ -1238,8 +1262,9 @@ shm_tmpfile(void)
 static int
 ProcShmCreateSegment(ClientPtr client)
 {
-    REQUEST(xShmCreateSegmentReq);
-    REQUEST_SIZE_MATCH(xShmCreateSegmentReq);
+    X_REQUEST_HEAD_STRUCT(xShmCreateSegmentReq);
+    X_REQUEST_FIELD_CARD32(shmseg);
+    X_REQUEST_FIELD_CARD32(size);
 
     if (!client->local)
         return BadRequest;


### PR DESCRIPTION
Use the new macros to make request struct parsing / field swapping
much easier.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
