### PR TITLE
Xext: geext: use REQUEST_HEAD_STRUCT and REQUEST_FIELD_* macros

### DIFF
--- a/Xext/geext.c
+++ b/Xext/geext.c
@@ -67,15 +67,11 @@ static void SGEGenericEvent(xEvent *from, xEvent *to);
 static int
 ProcGEQueryVersion(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xGEQueryVersionReq);
+    X_REQUEST_FIELD_CARD16(majorVersion);
+    X_REQUEST_FIELD_CARD16(minorVersion);
+
     GEClientInfoPtr pGEClient = GEGetClient(client);
-
-    REQUEST(xGEQueryVersionReq);
-    REQUEST_SIZE_MATCH(xGEQueryVersionReq);
-
-    if (client->swapped) {
-        swaps(&stuff->majorVersion);
-        swaps(&stuff->minorVersion);
-    }
 
     xGEQueryVersionReply reply = {
         .RepType = X_GEQueryVersion,


### PR DESCRIPTION
Use the new macros to make request struct parsing / field swapping
much easier.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
