### PR TITLE
Xext: xcmisc: use REQUEST_HEAD_STRUCT and REQUEST_FIELD_* macros

### DIFF
--- a/Xext/xcmisc.c
+++ b/Xext/xcmisc.c
@@ -48,13 +48,9 @@ from The Open Group.
 static int
 ProcXCMiscGetVersion(ClientPtr client)
 {
-    REQUEST(xXCMiscGetVersionReq);
-    REQUEST_SIZE_MATCH(xXCMiscGetVersionReq);
-
-    if (client->swapped) {
-        swaps(&stuff->majorVersion);
-        swaps(&stuff->minorVersion);
-    }
+    X_REQUEST_HEAD_STRUCT(xXCMiscGetVersionReq);
+    X_REQUEST_FIELD_CARD16(majorVersion);
+    X_REQUEST_FIELD_CARD16(minorVersion);
 
     xXCMiscGetVersionReply reply = {
         .majorVersion = XCMiscMajorVersion,
@@ -72,7 +68,7 @@ ProcXCMiscGetVersion(ClientPtr client)
 static int
 ProcXCMiscGetXIDRange(ClientPtr client)
 {
-    REQUEST_SIZE_MATCH(xXCMiscGetXIDRangeReq);
+    X_REQUEST_HEAD_STRUCT(xXCMiscGetXIDRangeReq);
 
     XID min_id, max_id;
     GetXIDRange(client->index, FALSE, &min_id, &max_id);
@@ -92,11 +88,8 @@ ProcXCMiscGetXIDRange(ClientPtr client)
 static int
 ProcXCMiscGetXIDList(ClientPtr client)
 {
-    REQUEST(xXCMiscGetXIDListReq);
-    REQUEST_SIZE_MATCH(xXCMiscGetXIDListReq);
-
-    if (client->swapped)
-        swapl(&stuff->count);
+    X_REQUEST_HEAD_STRUCT(xXCMiscGetXIDListReq);
+    X_REQUEST_FIELD_CARD32(count);
 
     if (stuff->count > UINT32_MAX / sizeof(XID))
         return BadAlloc;


### PR DESCRIPTION
Use the new macros to make request struct parsing / field swapping
much easier.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
