### PR TITLE
Xext: xf86bigfont: use REQUEST_HEAD_STRUCT and REQUEST_FIELD_* macros

### DIFF
--- a/Xext/xf86bigfont.c
+++ b/Xext/xf86bigfont.c
@@ -267,7 +267,7 @@ XF86BigfontResetProc(ExtensionEntry * extEntry)
 static int
 ProcXF86BigfontQueryVersion(ClientPtr client)
 {
-    REQUEST_SIZE_MATCH(xXF86BigfontQueryVersionReq);
+    X_REQUEST_HEAD_STRUCT(xXF86BigfontQueryVersionReq);
 
     xXF86BigfontQueryVersionReply reply = {
         .majorVersion = SERVER_XF86BIGFONT_MAJOR_VERSION,
@@ -320,14 +320,10 @@ static inline void writeCharInfo(x_rpcbuf_t *rpcbuf, xCharInfo CI) {
 static int
 ProcXF86BigfontQueryFont(ClientPtr client)
 {
-    REQUEST(xXF86BigfontQueryFontReq);
-    REQUEST_SIZE_MATCH(xXF86BigfontQueryFontReq);
-
-    if (client->swapped)
-        swapl(&stuff->id);
+    X_REQUEST_HEAD_STRUCT(xXF86BigfontQueryFontReq);
+    X_REQUEST_FIELD_CARD32(id);
 
     FontPtr pFont;
-
     CARD32 stuff_flags;
     xCharInfo *pmax;
     xCharInfo *pmin;


### PR DESCRIPTION
Use the new macros to make request struct parsing / field swapping
much easier.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
