### PR TITLE
xfixes: use REQUEST_HEAD_STRUCT and REQUEST_FIELD_* macros

### DIFF
--- a/xfixes/cursor.c
+++ b/xfixes/cursor.c
@@ -259,16 +259,12 @@ XFixesSelectCursorInput(ClientPtr pClient, WindowPtr pWindow, CARD32 eventMask)
 int
 ProcXFixesSelectCursorInput(ClientPtr client)
 {
-    REQUEST(xXFixesSelectCursorInputReq);
+    X_REQUEST_HEAD_STRUCT(xXFixesSelectCursorInputReq);
+    X_REQUEST_FIELD_CARD32(window);
+    X_REQUEST_FIELD_CARD32(eventMask);
+
     WindowPtr pWin;
     int rc;
-
-    REQUEST_SIZE_MATCH(xXFixesSelectCursorInputReq);
-
-    if (client->swapped) {
-        swapl(&stuff->window);
-        swapl(&stuff->eventMask);
-    }
 
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
     if (rc != Success)
@@ -351,11 +347,11 @@ CopyCursorToImage(CursorPtr pCursor, CARD32 *image)
 int
 ProcXFixesGetCursorImage(ClientPtr client)
 {
-/*    REQUEST(xXFixesGetCursorImageReq); */
+    X_REQUEST_HEAD_STRUCT(xXFixesGetCursorImageReq);
+
     CursorPtr pCursor;
     int npixels, width, height, rc, x, y;
 
-    REQUEST_SIZE_MATCH(xXFixesGetCursorImageReq);
     pCursor = CursorForClient(client);
     if (!pCursor)
         return BadCursor;
@@ -406,16 +402,12 @@ ProcXFixesSetCursorName(ClientPtr client)
 {
     CursorPtr pCursor;
     char *tchar;
-
-    REQUEST(xXFixesSetCursorNameReq);
     Atom atom;
 
+    X_REQUEST_HEAD_AT_LEAST(xXFixesSetCursorNameReq);
+    X_REQUEST_FIELD_CARD32(cursor);
+    X_REQUEST_FIELD_CARD16(nbytes);
     REQUEST_FIXED_SIZE(xXFixesSetCursorNameReq, stuff->nbytes);
-
-    if (client->swapped) {
-        swapl(&stuff->cursor);
-        swaps(&stuff->nbytes);
-    }
 
     VERIFY_CURSOR(pCursor, stuff->cursor, client, DixSetAttrAccess);
     tchar = (char *) &stuff[1];
@@ -430,15 +422,11 @@ ProcXFixesSetCursorName(ClientPtr client)
 int
 ProcXFixesGetCursorName(ClientPtr client)
 {
-    REQUEST(xXFixesGetCursorNameReq);
+    X_REQUEST_HEAD_STRUCT(xXFixesGetCursorNameReq);
+    X_REQUEST_FIELD_CARD32(cursor);
 
     CursorPtr pCursor;
     const char *str;
-
-    REQUEST_SIZE_MATCH(xXFixesGetCursorNameReq);
-
-    if (client->swapped)
-        swapl(&stuff->cursor);
 
     VERIFY_CURSOR(pCursor, stuff->cursor, client, DixGetAttrAccess);
     if (pCursor->name)
@@ -464,14 +452,14 @@ ProcXFixesGetCursorName(ClientPtr client)
 int
 ProcXFixesGetCursorImageAndName(ClientPtr client)
 {
-/*    REQUEST(xXFixesGetCursorImageAndNameReq); */
+    X_REQUEST_HEAD_STRUCT(xXFixesGetCursorImageAndNameReq);
+
     CursorPtr pCursor;
     int npixels;
     const char *name;
     int width, height;
     int rc, x, y;
 
-    REQUEST_SIZE_MATCH(xXFixesGetCursorImageAndNameReq);
     pCursor = CursorForClient(client);
     if (!pCursor)
         return BadCursor;
@@ -634,13 +622,9 @@ ProcXFixesChangeCursor(ClientPtr client)
 {
     CursorPtr pSource, pDestination;
 
-    REQUEST(xXFixesChangeCursorReq);
-    REQUEST_SIZE_MATCH(xXFixesChangeCursorReq);
-
-    if (client->swapped) {
-        swapl(&stuff->source);
-        swapl(&stuff->destination);
-    }
+    X_REQUEST_HEAD_STRUCT(xXFixesChangeCursorReq);
+    X_REQUEST_FIELD_CARD32(source);
+    X_REQUEST_FIELD_CARD32(destination);
 
     VERIFY_CURSOR(pSource, stuff->source, client,
                   DixReadAccess | DixGetAttrAccess);
@@ -662,17 +646,14 @@ TestForCursorName(CursorPtr pCursor, void *closure)
 int
 ProcXFixesChangeCursorByName(ClientPtr client)
 {
+    X_REQUEST_HEAD_AT_LEAST(xXFixesChangeCursorByNameReq);
+    X_REQUEST_FIELD_CARD32(source);
+    X_REQUEST_FIELD_CARD16(nbytes);
+    REQUEST_FIXED_SIZE(xXFixesChangeCursorByNameReq, stuff->nbytes);
+
     CursorPtr pSource;
     Atom name;
     char *tchar;
-
-    REQUEST(xXFixesChangeCursorByNameReq);
-    REQUEST_FIXED_SIZE(xXFixesChangeCursorByNameReq, stuff->nbytes);
-
-    if (client->swapped) {
-        swapl(&stuff->source);
-        swaps(&stuff->nbytes);
-    }
 
     VERIFY_CURSOR(pSource, stuff->source, client,
                   DixReadAccess | DixGetAttrAccess);
@@ -779,16 +760,12 @@ deleteCursorHideCountsForScreen(ScreenPtr pScreen)
 int
 ProcXFixesHideCursor(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXFixesHideCursorReq);
+    X_REQUEST_FIELD_CARD32(window);
+
     WindowPtr pWin;
     CursorHideCountPtr pChc;
-
-    REQUEST(xXFixesHideCursorReq);
     int ret;
-
-    REQUEST_SIZE_MATCH(xXFixesHideCursorReq);
-
-    if (client->swapped)
-        swapl(&stuff->window);
 
     ret = dixLookupResourceByType((void **) &pWin, stuff->window, X11_RESTYPE_WINDOW,
                                   client, DixGetAttrAccess);
@@ -834,15 +811,12 @@ ProcXFixesHideCursor(ClientPtr client)
 int
 ProcXFixesShowCursor(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXFixesShowCursorReq);
+    X_REQUEST_FIELD_CARD32(window);
+
     WindowPtr pWin;
     CursorHideCountPtr pChc;
     int rc;
-
-    REQUEST(xXFixesShowCursorReq);
-    REQUEST_SIZE_MATCH(xXFixesShowCursorReq);
-
-    if (client->swapped)
-        swapl(&stuff->window);
 
     rc = dixLookupResourceByType((void **) &pWin, stuff->window, X11_RESTYPE_WINDOW,
                                  client, DixGetAttrAccess);
@@ -922,31 +896,17 @@ CursorFreeWindow(void *data, XID id)
 int
 ProcXFixesCreatePointerBarrier(ClientPtr client)
 {
-    REQUEST(xXFixesCreatePointerBarrierReq);
+    X_REQUEST_HEAD_AT_LEAST(xXFixesCreatePointerBarrierReq);
 
-    if (client->swapped) {
-        REQUEST_AT_LEAST_SIZE(xXFixesCreatePointerBarrierReq);
-
-        swaps(&stuff->num_devices);
-        REQUEST_FIXED_SIZE(xXFixesCreatePointerBarrierReq,
-                           pad_to_int32(stuff->num_devices * sizeof(CARD16)));
-
-        swapl(&stuff->barrier);
-        swapl(&stuff->window);
-        swaps(&stuff->x1);
-        swaps(&stuff->y1);
-        swaps(&stuff->x2);
-        swaps(&stuff->y2);
-        swapl(&stuff->directions);
-
-        CARD16 *in_devices = (CARD16 *) &stuff[1];
-        for (int i = 0; i < stuff->num_devices; i++) {
-            swaps(in_devices + i);
-        }
-    }
-
-    REQUEST_FIXED_SIZE(xXFixesCreatePointerBarrierReq,
-                       pad_to_int32(stuff->num_devices * sizeof(CARD16)));
+    X_REQUEST_FIELD_CARD16(num_devices);
+    X_REQUEST_FIELD_CARD32(barrier);
+    X_REQUEST_FIELD_CARD32(window);
+    X_REQUEST_FIELD_CARD16(x1);
+    X_REQUEST_FIELD_CARD16(y1);
+    X_REQUEST_FIELD_CARD16(x2);
+    X_REQUEST_FIELD_CARD16(y2);
+    X_REQUEST_FIELD_CARD32(directions);
+    X_REQUEST_REST_COUNT_CARD16(stuff->num_devices);
 
     LEGAL_NEW_RESOURCE(stuff->barrier, client);
 
@@ -956,12 +916,8 @@ ProcXFixesCreatePointerBarrier(ClientPtr client)
 int
 ProcXFixesDestroyPointerBarrier(ClientPtr client)
 {
-    REQUEST(xXFixesDestroyPointerBarrierReq);
-    REQUEST_SIZE_MATCH(xXFixesDestroyPointerBarrierReq);
-
-    if (client->swapped)
-        swapl(&stuff->barrier);
-
+    X_REQUEST_HEAD_STRUCT(xXFixesDestroyPointerBarrierReq);
+    X_REQUEST_FIELD_CARD32(barrier);
     return XIDestroyPointerBarrier(client, stuff);
 }
 

--- a/xfixes/disconnect.c
+++ b/xfixes/disconnect.c
@@ -64,14 +64,10 @@ typedef struct _ClientDisconnect {
 int
 ProcXFixesSetClientDisconnectMode(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXFixesSetClientDisconnectModeReq);
+    X_REQUEST_FIELD_CARD32(disconnect_mode);
+
     ClientDisconnectPtr pDisconnect = GetClientDisconnect(client);
-
-    REQUEST(xXFixesSetClientDisconnectModeReq);
-    REQUEST_SIZE_MATCH(xXFixesSetClientDisconnectModeReq);
-
-    if (client->swapped)
-        swapl(&stuff->disconnect_mode);
-
     pDisconnect->disconnect_mode = stuff->disconnect_mode;
 
     return Success;
@@ -80,9 +76,9 @@ ProcXFixesSetClientDisconnectMode(ClientPtr client)
 int
 ProcXFixesGetClientDisconnectMode(ClientPtr client)
 {
-    ClientDisconnectPtr pDisconnect = GetClientDisconnect(client);
+    X_REQUEST_HEAD_STRUCT(xXFixesGetClientDisconnectModeReq);
 
-    REQUEST_SIZE_MATCH(xXFixesGetClientDisconnectModeReq);
+    ClientDisconnectPtr pDisconnect = GetClientDisconnect(client);
 
     xXFixesGetClientDisconnectModeReply reply = {
         .disconnect_mode = pDisconnect->disconnect_mode,

--- a/xfixes/region.c
+++ b/xfixes/region.c
@@ -74,16 +74,12 @@ XFixesRegionInit(void)
 int
 ProcXFixesCreateRegion(ClientPtr client)
 {
+    X_REQUEST_HEAD_AT_LEAST(xXFixesCreateRegionReq);
+    X_REQUEST_FIELD_CARD32(region);
+    X_REQUEST_REST_CARD16();
+
     int things;
     RegionPtr pRegion;
-
-    REQUEST(xXFixesCreateRegionReq);
-    REQUEST_AT_LEAST_SIZE(xXFixesCreateRegionReq);
-
-    if (client->swapped) {
-        swapl(&stuff->region);
-        SwapRestS(stuff);
-    }
 
     LEGAL_NEW_RESOURCE(stuff->region, client);
 
@@ -104,17 +100,13 @@ ProcXFixesCreateRegion(ClientPtr client)
 int
 ProcXFixesCreateRegionFromBitmap(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXFixesCreateRegionFromBitmapReq);
+    X_REQUEST_FIELD_CARD32(region);
+    X_REQUEST_FIELD_CARD32(bitmap);
+
     RegionPtr pRegion;
     PixmapPtr pPixmap;
     int rc;
-
-    REQUEST(xXFixesCreateRegionFromBitmapReq);
-    REQUEST_SIZE_MATCH(xXFixesCreateRegionFromBitmapReq);
-
-    if (client->swapped) {
-        swapl(&stuff->region);
-        swapl(&stuff->bitmap);
-    }
 
     LEGAL_NEW_RESOURCE(stuff->region, client);
 
@@ -141,18 +133,14 @@ ProcXFixesCreateRegionFromBitmap(ClientPtr client)
 int
 ProcXFixesCreateRegionFromWindow(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXFixesCreateRegionFromWindowReq);
+    X_REQUEST_FIELD_CARD32(region);
+    X_REQUEST_FIELD_CARD32(window);
+
     RegionPtr pRegion;
     Bool copy = TRUE;
     WindowPtr pWin;
     int rc;
-
-    REQUEST(xXFixesCreateRegionFromWindowReq);
-    REQUEST_SIZE_MATCH(xXFixesCreateRegionFromWindowReq);
-
-    if (client->swapped) {
-        swapl(&stuff->region);
-        swapl(&stuff->window);
-    }
 
     LEGAL_NEW_RESOURCE(stuff->region, client);
     rc = dixLookupResourceByType((void **) &pWin, stuff->window, X11_RESTYPE_WINDOW,
@@ -193,17 +181,13 @@ ProcXFixesCreateRegionFromWindow(ClientPtr client)
 int
 ProcXFixesCreateRegionFromGC(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXFixesCreateRegionFromGCReq);
+    X_REQUEST_FIELD_CARD32(region);
+    X_REQUEST_FIELD_CARD32(gc);
+
     RegionPtr pRegion, pClip;
     GCPtr pGC;
     int rc;
-
-    REQUEST(xXFixesCreateRegionFromGCReq);
-    REQUEST_SIZE_MATCH(xXFixesCreateRegionFromGCReq);
-
-    if (client->swapped) {
-        swapl(&stuff->region);
-        swapl(&stuff->gc);
-    }
 
     LEGAL_NEW_RESOURCE(stuff->region, client);
 
@@ -229,16 +213,12 @@ ProcXFixesCreateRegionFromGC(ClientPtr client)
 int
 ProcXFixesCreateRegionFromPicture(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXFixesCreateRegionFromPictureReq);
+    X_REQUEST_FIELD_CARD32(region);
+    X_REQUEST_FIELD_CARD32(picture);
+
     RegionPtr pRegion;
     PicturePtr pPicture;
-
-    REQUEST(xXFixesCreateRegionFromPictureReq);
-    REQUEST_SIZE_MATCH(xXFixesCreateRegionFromPictureReq);
-
-    if (client->swapped) {
-        swapl(&stuff->region);
-        swapl(&stuff->picture);
-    }
 
     LEGAL_NEW_RESOURCE(stuff->region, client);
 
@@ -264,13 +244,10 @@ ProcXFixesCreateRegionFromPicture(ClientPtr client)
 int
 ProcXFixesDestroyRegion(ClientPtr client)
 {
-    REQUEST(xXFixesDestroyRegionReq);
+    X_REQUEST_HEAD_STRUCT(xXFixesDestroyRegionReq);
+    X_REQUEST_FIELD_CARD32(region);
+
     RegionPtr pRegion;
-
-    REQUEST_SIZE_MATCH(xXFixesDestroyRegionReq);
-
-    if (client->swapped)
-        swapl(&stuff->region);
 
     VERIFY_REGION(pRegion, stuff->region, client, DixWriteAccess);
     FreeResource(stuff->region, X11_RESTYPE_NONE);
@@ -280,16 +257,12 @@ ProcXFixesDestroyRegion(ClientPtr client)
 int
 ProcXFixesSetRegion(ClientPtr client)
 {
+    X_REQUEST_HEAD_AT_LEAST(xXFixesSetRegionReq);
+    X_REQUEST_FIELD_CARD32(region);
+    X_REQUEST_REST_CARD16();
+
     int things;
     RegionPtr pRegion, pNew;
-
-    REQUEST(xXFixesSetRegionReq);
-    REQUEST_AT_LEAST_SIZE(xXFixesSetRegionReq);
-
-    if (client->swapped) {
-        swapl(&stuff->region);
-        SwapRestS(stuff);
-    }
 
     VERIFY_REGION(pRegion, stuff->region, client, DixWriteAccess);
 
@@ -312,15 +285,11 @@ ProcXFixesSetRegion(ClientPtr client)
 int
 ProcXFixesCopyRegion(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXFixesCopyRegionReq);
+    X_REQUEST_FIELD_CARD32(source);
+    X_REQUEST_FIELD_CARD32(destination);
+
     RegionPtr pSource, pDestination;
-
-    REQUEST(xXFixesCopyRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesCopyRegionReq);
-
-    if (client->swapped) {
-        swapl(&stuff->source);
-        swapl(&stuff->destination);
-    }
 
     VERIFY_REGION(pSource, stuff->source, client, DixReadAccess);
     VERIFY_REGION(pDestination, stuff->destination, client, DixWriteAccess);
@@ -334,16 +303,12 @@ ProcXFixesCopyRegion(ClientPtr client)
 int
 ProcXFixesCombineRegion(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXFixesCombineRegionReq);
+    X_REQUEST_FIELD_CARD32(source1);
+    X_REQUEST_FIELD_CARD32(source2);
+    X_REQUEST_FIELD_CARD32(destination);
+
     RegionPtr pSource1, pSource2, pDestination;
-
-    REQUEST(xXFixesCombineRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesCombineRegionReq);
-
-    if (client->swapped) {
-        swapl(&stuff->source1);
-        swapl(&stuff->source2);
-        swapl(&stuff->destination);
-    }
 
     VERIFY_REGION(pSource1, stuff->source1, client, DixReadAccess);
     VERIFY_REGION(pSource2, stuff->source2, client, DixReadAccess);
@@ -370,20 +335,16 @@ ProcXFixesCombineRegion(ClientPtr client)
 int
 ProcXFixesInvertRegion(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXFixesInvertRegionReq);
+    X_REQUEST_FIELD_CARD32(source);
+    X_REQUEST_FIELD_CARD16(x);
+    X_REQUEST_FIELD_CARD16(y);
+    X_REQUEST_FIELD_CARD16(width);
+    X_REQUEST_FIELD_CARD16(height);
+    X_REQUEST_FIELD_CARD32(destination);
+
     RegionPtr pSource, pDestination;
     BoxRec bounds;
-
-    REQUEST(xXFixesInvertRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesInvertRegionReq);
-
-    if (client->swapped) {
-        swapl(&stuff->source);
-        swaps(&stuff->x);
-        swaps(&stuff->y);
-        swaps(&stuff->width);
-        swaps(&stuff->height);
-        swapl(&stuff->destination);
-    }
 
     VERIFY_REGION(pSource, stuff->source, client, DixReadAccess);
     VERIFY_REGION(pDestination, stuff->destination, client, DixWriteAccess);
@@ -410,16 +371,12 @@ ProcXFixesInvertRegion(ClientPtr client)
 int
 ProcXFixesTranslateRegion(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXFixesTranslateRegionReq);
+    X_REQUEST_FIELD_CARD32(region);
+    X_REQUEST_FIELD_CARD16(dx);
+    X_REQUEST_FIELD_CARD16(dy);
+
     RegionPtr pRegion;
-
-    REQUEST(xXFixesTranslateRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesTranslateRegionReq);
-
-    if (client->swapped) {
-        swapl(&stuff->region);
-        swaps(&stuff->dx);
-        swaps(&stuff->dy);
-    }
 
     VERIFY_REGION(pRegion, stuff->region, client, DixWriteAccess);
 
@@ -430,15 +387,11 @@ ProcXFixesTranslateRegion(ClientPtr client)
 int
 ProcXFixesRegionExtents(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXFixesRegionExtentsReq);
+    X_REQUEST_FIELD_CARD32(source);
+    X_REQUEST_FIELD_CARD32(destination);
+
     RegionPtr pSource, pDestination;
-
-    REQUEST(xXFixesRegionExtentsReq);
-    REQUEST_SIZE_MATCH(xXFixesRegionExtentsReq);
-
-    if (client->swapped) {
-        swapl(&stuff->source);
-        swapl(&stuff->destination);
-    }
 
     VERIFY_REGION(pSource, stuff->source, client, DixReadAccess);
     VERIFY_REGION(pDestination, stuff->destination, client, DixWriteAccess);
@@ -451,17 +404,13 @@ ProcXFixesRegionExtents(ClientPtr client)
 int
 ProcXFixesFetchRegion(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXFixesFetchRegionReq);
+    X_REQUEST_FIELD_CARD32(region);
+
     RegionPtr pRegion;
     BoxPtr pExtent;
     BoxPtr pBox;
     int i, nBox;
-
-    REQUEST(xXFixesFetchRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesFetchRegionReq);
-
-    if (client->swapped) {
-        swapl(&stuff->region);
-    }
 
     VERIFY_REGION(pRegion, stuff->region, client, DixReadAccess);
 
@@ -509,15 +458,11 @@ SingleXFixesSetGCClipRegion(ClientPtr client, xXFixesSetGCClipRegionReq *stuff);
 int
 ProcXFixesSetGCClipRegion(ClientPtr client)
 {
-    REQUEST(xXFixesSetGCClipRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesSetGCClipRegionReq);
-
-    if (client->swapped) {
-        swapl(&stuff->gc);
-        swapl(&stuff->region);
-        swaps(&stuff->xOrigin);
-        swaps(&stuff->yOrigin);
-    }
+    X_REQUEST_HEAD_STRUCT(xXFixesSetGCClipRegionReq);
+    X_REQUEST_FIELD_CARD32(gc);
+    X_REQUEST_FIELD_CARD32(region);
+    X_REQUEST_FIELD_CARD16(xOrigin);
+    X_REQUEST_FIELD_CARD16(yOrigin);
 
 #ifdef XINERAMA
     if (XFixesUseXinerama)
@@ -636,15 +581,11 @@ PanoramiXFixesSetWindowShapeRegion(ClientPtr client, xXFixesSetWindowShapeRegion
 int
 ProcXFixesSetWindowShapeRegion(ClientPtr client)
 {
-    REQUEST(xXFixesSetWindowShapeRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesSetWindowShapeRegionReq);
-
-    if (client->swapped) {
-        swapl(&stuff->dest);
-        swaps(&stuff->xOff);
-        swaps(&stuff->yOff);
-        swapl(&stuff->region);
-    }
+    X_REQUEST_HEAD_STRUCT(xXFixesSetWindowShapeRegionReq);
+    X_REQUEST_FIELD_CARD32(dest);
+    X_REQUEST_FIELD_CARD16(xOff);
+    X_REQUEST_FIELD_CARD16(yOff);
+    X_REQUEST_FIELD_CARD32(region);
 
 #ifdef XINERAMA
     if (XFixesUseXinerama)
@@ -664,15 +605,11 @@ PanoramiXFixesSetPictureClipRegion(ClientPtr client, xXFixesSetPictureClipRegion
 int
 ProcXFixesSetPictureClipRegion(ClientPtr client)
 {
-    REQUEST(xXFixesSetPictureClipRegionReq);
-    REQUEST_SIZE_MATCH(xXFixesSetPictureClipRegionReq);
-
-    if (client->swapped) {
-        swapl(&stuff->picture);
-        swapl(&stuff->region);
-        swaps(&stuff->xOrigin);
-        swaps(&stuff->yOrigin);
-    }
+    X_REQUEST_HEAD_STRUCT(xXFixesSetPictureClipRegionReq);
+    X_REQUEST_FIELD_CARD32(picture);
+    X_REQUEST_FIELD_CARD32(region);
+    X_REQUEST_FIELD_CARD16(xOrigin);
+    X_REQUEST_FIELD_CARD16(yOrigin);
 
 #ifdef XINERAMA
     if (XFixesUseXinerama)
@@ -700,24 +637,20 @@ SingleXFixesSetPictureClipRegion(ClientPtr client, xXFixesSetPictureClipRegionRe
 int
 ProcXFixesExpandRegion(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXFixesExpandRegionReq);
+    X_REQUEST_FIELD_CARD32(source);
+    X_REQUEST_FIELD_CARD32(destination);
+    X_REQUEST_FIELD_CARD16(left);
+    X_REQUEST_FIELD_CARD16(right);
+    X_REQUEST_FIELD_CARD16(top);
+    X_REQUEST_FIELD_CARD16(bottom);
+
     RegionPtr pSource, pDestination;
 
-    REQUEST(xXFixesExpandRegionReq);
     BoxPtr pTmp;
     BoxPtr pSrc;
     int nBoxes;
     int i;
-
-    REQUEST_SIZE_MATCH(xXFixesExpandRegionReq);
-
-    if (client->swapped) {
-        swapl(&stuff->source);
-        swapl(&stuff->destination);
-        swaps(&stuff->left);
-        swaps(&stuff->right);
-        swaps(&stuff->top);
-        swaps(&stuff->bottom);
-    }
 
     VERIFY_REGION(pSource, stuff->source, client, DixReadAccess);
     VERIFY_REGION(pDestination, stuff->destination, client, DixWriteAccess);

--- a/xfixes/saveset.c
+++ b/xfixes/saveset.c
@@ -23,6 +23,7 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 
 #include "xfixesint.h"
@@ -30,15 +31,12 @@
 int
 ProcXFixesChangeSaveSet(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXFixesChangeSaveSetReq);
+    X_REQUEST_FIELD_CARD32(window);
+
     Bool toRoot, map;
     int result;
     WindowPtr pWin;
-
-    REQUEST(xXFixesChangeSaveSetReq);
-    REQUEST_SIZE_MATCH(xXFixesChangeSaveSetReq);
-
-    if (client->swapped)
-        swapl(&stuff->window);
 
     result = dixLookupWindow(&pWin, stuff->window, client, DixManageAccess);
     if (result != Success)

--- a/xfixes/select.c
+++ b/xfixes/select.c
@@ -23,6 +23,7 @@
 #include <dix-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/selection_priv.h"
 
 #include "xfixesint.h"
@@ -132,14 +133,10 @@ CheckSelectionCallback(void)
 int
 ProcXFixesSelectSelectionInput(ClientPtr client)
 {
-    REQUEST(xXFixesSelectSelectionInputReq);
-    REQUEST_SIZE_MATCH(xXFixesSelectSelectionInputReq);
-
-    if (client->swapped) {
-        swapl(&stuff->window);
-        swapl(&stuff->selection);
-        swapl(&stuff->eventMask);
-    }
+    X_REQUEST_HEAD_STRUCT(xXFixesSelectSelectionInputReq);
+    X_REQUEST_FIELD_CARD32(window);
+    X_REQUEST_FIELD_CARD32(selection);
+    X_REQUEST_FIELD_CARD32(eventMask);
 
     /* allow extensions to intercept */
     SelectionFilterParamRec param = {

--- a/xfixes/xfixes.c
+++ b/xfixes/xfixes.c
@@ -65,17 +65,12 @@ static DevPrivateKeyRec XFixesClientPrivateKeyRec;
 static int
 ProcXFixesQueryVersion(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXFixesQueryVersionReq);
+    X_REQUEST_FIELD_CARD32(majorVersion);
+    X_REQUEST_FIELD_CARD32(minorVersion);
+
     int major, minor;
     XFixesClientPtr pXFixesClient = GetXFixesClient(client);
-
-    REQUEST(xXFixesQueryVersionReq);
-    REQUEST_SIZE_MATCH(xXFixesQueryVersionReq);
-
-    if (client->swapped) {
-        swapl(&stuff->majorVersion);
-        swapl(&stuff->minorVersion);
-    }
-
     if (version_compare(stuff->majorVersion, stuff->minorVersion,
                         SERVER_XFIXES_MAJOR_VERSION,
                         SERVER_XFIXES_MINOR_VERSION) < 0) {


### PR DESCRIPTION
Use the new macros to make request struct parsing / field swapping
much easier.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
