### PR TITLE
Xext: consistenly name reply structs "reply" instead of "rep"

### DIFF
--- a/Xext/damage/damageext.c
+++ b/Xext/damage/damageext.c
@@ -222,27 +222,27 @@ ProcDamageQueryVersion(ClientPtr client)
 
     DamageClientPtr pDamageClient = GetDamageClient(client);
 
-    xDamageQueryVersionReply rep = { 0 };
+    xDamageQueryVersionReply reply = { 0 };
     if (stuff->majorVersion < SERVER_DAMAGE_MAJOR_VERSION) {
-        rep.majorVersion = stuff->majorVersion;
-        rep.minorVersion = stuff->minorVersion;
+        reply.majorVersion = stuff->majorVersion;
+        reply.minorVersion = stuff->minorVersion;
     }
     else {
-        rep.majorVersion = SERVER_DAMAGE_MAJOR_VERSION;
+        reply.majorVersion = SERVER_DAMAGE_MAJOR_VERSION;
         if (stuff->majorVersion == SERVER_DAMAGE_MAJOR_VERSION &&
             stuff->minorVersion < SERVER_DAMAGE_MINOR_VERSION)
-            rep.minorVersion = stuff->minorVersion;
+            reply.minorVersion = stuff->minorVersion;
         else
-            rep.minorVersion = SERVER_DAMAGE_MINOR_VERSION;
+            reply.minorVersion = SERVER_DAMAGE_MINOR_VERSION;
     }
-    pDamageClient->major_version = rep.majorVersion;
-    pDamageClient->minor_version = rep.minorVersion;
+    pDamageClient->major_version = reply.majorVersion;
+    pDamageClient->minor_version = reply.minorVersion;
     if (client->swapped) {
-        swapl(&rep.majorVersion);
-        swapl(&rep.minorVersion);
+        swapl(&reply.majorVersion);
+        swapl(&reply.minorVersion);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 static void

--- a/Xext/panoramiXprocs.c
+++ b/Xext/panoramiXprocs.c
@@ -2528,21 +2528,21 @@ PanoramiXAllocColor(ClientPtr client)
 
         /* only send out reply for on first screen */
         if (!walkScreenIdx) {
-            xAllocColorReply rep; /* static init would confuse preprocessor */
-            rep.red = red;
-            rep.green = green;
-            rep.blue = blue;
-            rep.pixel = pixel;
+            xAllocColorReply reply; /* static init would confuse preprocessor */
+            reply.red = red;
+            reply.green = green;
+            reply.blue = blue;
+            reply.pixel = pixel;
 
             if (client->swapped) {
-                swaps(&rep.red);
-                swaps(&rep.green);
-                swaps(&rep.blue);
-                swapl(&rep.pixel);
+                swaps(&reply.red);
+                swaps(&reply.green);
+                swaps(&reply.blue);
+                swapl(&reply.pixel);
             }
 
             /* iterating backwards, first screen comes last, so we can return here */
-            return X_SEND_REPLY_SIMPLE(client, rep);
+            return X_SEND_REPLY_SIMPLE(client, reply);
         }
     });
 


### PR DESCRIPTION
Preparation for future use of generic reply assembly macros.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
