### PR TITLE
render: consistenly name reply structs "reply" instead of "rep"

### DIFF
--- a/render/render.c
+++ b/render/render.c
@@ -152,22 +152,22 @@ ProcRenderQueryVersion(ClientPtr client)
     pRenderClient->major_version = stuff->majorVersion;
     pRenderClient->minor_version = stuff->minorVersion;
 
-    xRenderQueryVersionReply rep = {
+    xRenderQueryVersionReply reply = {
         .majorVersion = SERVER_RENDER_MAJOR_VERSION,
         .minorVersion = SERVER_RENDER_MINOR_VERSION
     };
 
     if ((stuff->majorVersion * 1000 + stuff->minorVersion) <
         (SERVER_RENDER_MAJOR_VERSION * 1000 + SERVER_RENDER_MINOR_VERSION)) {
-        rep.majorVersion = stuff->majorVersion;
-        rep.minorVersion = stuff->minorVersion;
+        reply.majorVersion = stuff->majorVersion;
+        reply.minorVersion = stuff->minorVersion;
     }
 
     if (client->swapped) {
-        swapl(&rep.majorVersion);
-        swapl(&rep.minorVersion);
+        swapl(&reply.majorVersion);
+        swapl(&reply.minorVersion);
     }
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 static VisualPtr


### PR DESCRIPTION
Preparation for future use of generic reply assembly macros.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
