### PR TITLE
randr: consistenly name reply structs "reply" instead of "rep"

### DIFF
--- a/randr/rrcrtc.c
+++ b/randr/rrcrtc.c
@@ -1168,7 +1168,7 @@ ProcRRGetCrtcInfo(ClientPtr client)
 
     RRModePtr mode = crtc->mode;
 
-    xRRGetCrtcInfoReply rep = {
+    xRRGetCrtcInfoReply reply = {
         .status = RRSetConfigSuccess,
         .timestamp = pScrPriv->lastSetTime.milliseconds,
         .rotation = crtc->rotation,
@@ -1178,34 +1178,34 @@ ProcRRGetCrtcInfo(ClientPtr client)
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
     if (leased) {
-        rep.rotation = RR_Rotate_0;
-        rep.rotations = RR_Rotate_0;
+        reply.rotation = RR_Rotate_0;
+        reply.rotations = RR_Rotate_0;
     } else {
         BoxRec panned_area;
         if (pScrPriv->rrGetPanning &&
             pScrPriv->rrGetPanning(pScreen, crtc, &panned_area, NULL, NULL) &&
             (panned_area.x2 > panned_area.x1) && (panned_area.y2 > panned_area.y1))
         {
-            rep.x = panned_area.x1;
-            rep.y = panned_area.y1;
-            rep.width = panned_area.x2 - panned_area.x1;
-            rep.height = panned_area.y2 - panned_area.y1;
+            reply.x = panned_area.x1;
+            reply.y = panned_area.y1;
+            reply.width = panned_area.x2 - panned_area.x1;
+            reply.height = panned_area.y2 - panned_area.y1;
         }
         else {
             int width, height;
             RRCrtcGetScanoutSize(crtc, &width, &height);
-            rep.x = crtc->x;
-            rep.y = crtc->y;
-            rep.width = width;
-            rep.height = height;
+            reply.x = crtc->x;
+            reply.y = crtc->y;
+            reply.width = width;
+            reply.height = height;
         }
-        rep.mode = mode ? mode->mode.id : 0;
-        rep.nOutput = crtc->numOutputs;
+        reply.mode = mode ? mode->mode.id : 0;
+        reply.nOutput = crtc->numOutputs;
         for (int i = 0; i < pScrPriv->numOutputs; i++) {
             if (!RROutputIsLeased(pScrPriv->outputs[i])) {
                 for (int j = 0; j < pScrPriv->outputs[i]->numCrtcs; j++)
                     if (pScrPriv->outputs[i]->crtcs[j] == crtc)
-                        rep.nPossibleOutput++;
+                        reply.nPossibleOutput++;
             }
         }
 
@@ -1224,22 +1224,22 @@ ProcRRGetCrtcInfo(ClientPtr client)
     }
 
     if (pScrPriv->rrCrtcGet)
-        pScrPriv->rrCrtcGet(pScreen, crtc, &rep);
+        pScrPriv->rrCrtcGet(pScreen, crtc, &reply);
 
     if (client->swapped) {
-        swapl(&rep.timestamp);
-        swaps(&rep.x);
-        swaps(&rep.y);
-        swaps(&rep.width);
-        swaps(&rep.height);
-        swapl(&rep.mode);
-        swaps(&rep.rotation);
-        swaps(&rep.rotations);
-        swaps(&rep.nOutput);
-        swaps(&rep.nPossibleOutput);
+        swapl(&reply.timestamp);
+        swaps(&reply.x);
+        swaps(&reply.y);
+        swaps(&reply.width);
+        swaps(&reply.height);
+        swapl(&reply.mode);
+        swaps(&reply.rotation);
+        swaps(&reply.rotations);
+        swaps(&reply.nOutput);
+        swaps(&reply.nPossibleOutput);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -1449,16 +1449,16 @@ ProcRRSetCrtcConfig(ClientPtr client)
  sendReply:
     free(outputs);
 
-    xRRSetCrtcConfigReply rep = {
+    xRRSetCrtcConfigReply reply = {
         .status = status,
         .newTimestamp = pScrPriv->lastSetTime.milliseconds
     };
 
     if (client->swapped) {
-        swapl(&rep.newTimestamp);
+        swapl(&reply.newTimestamp);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -1488,43 +1488,43 @@ ProcRRGetPanning(ClientPtr client)
     if (!pScrPriv)
         return RRErrorBase + BadRRCrtc;
 
-    xRRGetPanningReply rep = {
+    xRRGetPanningReply reply = {
         .status = RRSetConfigSuccess,
         .timestamp = pScrPriv->lastSetTime.milliseconds
     };
 
     if (pScrPriv->rrGetPanning &&
         pScrPriv->rrGetPanning(pScreen, crtc, &total, &tracking, border)) {
-        rep.left = total.x1;
-        rep.top = total.y1;
-        rep.width = total.x2 - total.x1;
-        rep.height = total.y2 - total.y1;
-        rep.track_left = tracking.x1;
-        rep.track_top = tracking.y1;
-        rep.track_width = tracking.x2 - tracking.x1;
-        rep.track_height = tracking.y2 - tracking.y1;
-        rep.border_left = border[0];
-        rep.border_top = border[1];
-        rep.border_right = border[2];
-        rep.border_bottom = border[3];
+        reply.left = total.x1;
+        reply.top = total.y1;
+        reply.width = total.x2 - total.x1;
+        reply.height = total.y2 - total.y1;
+        reply.track_left = tracking.x1;
+        reply.track_top = tracking.y1;
+        reply.track_width = tracking.x2 - tracking.x1;
+        reply.track_height = tracking.y2 - tracking.y1;
+        reply.border_left = border[0];
+        reply.border_top = border[1];
+        reply.border_right = border[2];
+        reply.border_bottom = border[3];
     }
 
     if (client->swapped) {
-        swapl(&rep.timestamp);
-        swaps(&rep.left);
-        swaps(&rep.top);
-        swaps(&rep.width);
-        swaps(&rep.height);
-        swaps(&rep.track_left);
-        swaps(&rep.track_top);
-        swaps(&rep.track_width);
-        swaps(&rep.track_height);
-        swaps(&rep.border_left);
-        swaps(&rep.border_top);
-        swaps(&rep.border_right);
-        swaps(&rep.border_bottom);
+        swapl(&reply.timestamp);
+        swaps(&reply.left);
+        swaps(&reply.top);
+        swaps(&reply.width);
+        swaps(&reply.height);
+        swaps(&reply.track_left);
+        swaps(&reply.track_top);
+        swaps(&reply.track_width);
+        swaps(&reply.track_height);
+        swaps(&reply.border_left);
+        swaps(&reply.border_top);
+        swaps(&reply.border_right);
+        swaps(&reply.border_bottom);
     }
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -1602,15 +1602,15 @@ ProcRRSetPanning(ClientPtr client)
     status = RRSetConfigSuccess;
 
 sendReply: ;
-    xRRSetPanningReply rep = {
+    xRRSetPanningReply reply = {
         .status = status,
         .newTimestamp = pScrPriv->lastSetTime.milliseconds
     };
 
     if (client->swapped) {
-        swapl(&rep.newTimestamp);
+        swapl(&reply.newTimestamp);
     }
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -1779,37 +1779,37 @@ ProcRRGetCrtcTransform(ClientPtr client)
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
-    xRRGetCrtcTransformReply rep = {
+    xRRGetCrtcTransformReply reply = {
         .hasTransforms = crtc->transforms,
     };
 
-    xRenderTransform_from_PictTransform(&rep.pendingTransform, &pending->transform);
-    xRenderTransform_from_PictTransform(&rep.currentTransform, &current->transform);
+    xRenderTransform_from_PictTransform(&reply.pendingTransform, &pending->transform);
+    xRenderTransform_from_PictTransform(&reply.currentTransform, &current->transform);
 
     if (pending->filter) {
-        rep.pendingNbytesFilter = strlen(pending->filter->name);
-        rep.pendingNparamsFilter = pending->nparams;
+        reply.pendingNbytesFilter = strlen(pending->filter->name);
+        reply.pendingNparamsFilter = pending->nparams;
         x_rpcbuf_write_string_pad(&rpcbuf, pending->filter->name);
         x_rpcbuf_write_CARD32s(&rpcbuf, (CARD32*)pending->params, pending->nparams);
     }
 
     if (current->filter) {
-        rep.currentNbytesFilter = strlen(current->filter->name);
-        rep.currentNparamsFilter = current->nparams;
+        reply.currentNbytesFilter = strlen(current->filter->name);
+        reply.currentNparamsFilter = current->nparams;
         x_rpcbuf_write_string_pad(&rpcbuf, current->filter->name);
         x_rpcbuf_write_CARD32s(&rpcbuf, (CARD32*)current->params, current->nparams);
     }
 
     if (client->swapped) {
-        SwapLongs((CARD32 *) &rep.pendingTransform, bytes_to_int32(sizeof(xRenderTransform)));
-        SwapLongs((CARD32 *) &rep.currentTransform, bytes_to_int32(sizeof(xRenderTransform)));
-        swaps(&rep.pendingNbytesFilter);
-        swaps(&rep.currentNbytesFilter);
-        swaps(&rep.pendingNparamsFilter);
-        swaps(&rep.currentNparamsFilter);
+        SwapLongs((CARD32 *) &reply.pendingTransform, bytes_to_int32(sizeof(xRenderTransform)));
+        SwapLongs((CARD32 *) &reply.currentTransform, bytes_to_int32(sizeof(xRenderTransform)));
+        swaps(&reply.pendingNbytesFilter);
+        swaps(&reply.currentNbytesFilter);
+        swaps(&reply.pendingNparamsFilter);
+        swaps(&reply.currentNparamsFilter);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static Bool

--- a/randr/rrdispatch.c
+++ b/randr/rrdispatch.c
@@ -54,7 +54,7 @@ ProcRRQueryVersion(ClientPtr client)
     pRRClient->major_version = stuff->majorVersion;
     pRRClient->minor_version = stuff->minorVersion;
 
-    xRRQueryVersionReply rep = {
+    xRRQueryVersionReply reply = {
         .majorVersion = SERVER_RANDR_MAJOR_VERSION,
         .minorVersion = SERVER_RANDR_MINOR_VERSION
     };
@@ -62,16 +62,16 @@ ProcRRQueryVersion(ClientPtr client)
     if (version_compare(stuff->majorVersion, stuff->minorVersion,
                         SERVER_RANDR_MAJOR_VERSION,
                         SERVER_RANDR_MINOR_VERSION) < 0) {
-        rep.majorVersion = stuff->majorVersion;
-        rep.minorVersion = stuff->minorVersion;
+        reply.majorVersion = stuff->majorVersion;
+        reply.minorVersion = stuff->minorVersion;
     }
 
     if (client->swapped) {
-        swapl(&rep.majorVersion);
-        swapl(&rep.minorVersion);
+        swapl(&reply.majorVersion);
+        swapl(&reply.minorVersion);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int

--- a/randr/rrlease.c
+++ b/randr/rrlease.c
@@ -342,11 +342,11 @@ leaseReturned:
 
     RRLeaseChangeState(lease, RRLeaseCreating, RRLeaseRunning);
 
-    xRRCreateLeaseReply rep = {
+    xRRCreateLeaseReply reply = {
         .nfd = 1,
     };
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 
 bail_lease:
     free(lease);

--- a/randr/rrmode.c
+++ b/randr/rrmode.c
@@ -333,7 +333,7 @@ ProcRRCreateMode(ClientPtr client)
     if (!mode)
         return error;
 
-    xRRCreateModeReply rep = {
+    xRRCreateModeReply reply = {
         .mode = mode->mode.id
     };
 
@@ -341,10 +341,10 @@ ProcRRCreateMode(ClientPtr client)
     RRModeDestroy(mode);
 
     if (client->swapped) {
-        swapl(&rep.mode);
+        swapl(&reply.mode);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int

--- a/randr/rrmonitor.c
+++ b/randr/rrmonitor.c
@@ -641,19 +641,19 @@ ProcRRGetMonitors(ClientPtr client)
     }
     RRMonitorFreeList(monitors, nmonitors);
 
-    xRRGetMonitorsReply rep = {
+    xRRGetMonitorsReply reply = {
         .timestamp = RRMonitorTimestamp(screen),
         .nmonitors = nmonitors,
         .noutputs = noutputs,
     };
 
     if (client->swapped) {
-        swapl(&rep.timestamp);
-        swapl(&rep.nmonitors);
-        swapl(&rep.noutputs);
+        swapl(&reply.timestamp);
+        swapl(&reply.nmonitors);
+        swapl(&reply.noutputs);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int

--- a/randr/rroutput.c
+++ b/randr/rroutput.c
@@ -466,7 +466,7 @@ ProcRRGetOutputInfo(ClientPtr client)
     pScreen = output->pScreen;
     pScrPriv = rrGetScrPriv(pScreen);
 
-    xRRGetOutputInfoReply rep = {
+    xRRGetOutputInfoReply reply = {
         .status = RRSetConfigSuccess,
         .timestamp = pScrPriv->lastSetTime.milliseconds,
         .nameLength = output->nameLength,
@@ -475,18 +475,18 @@ ProcRRGetOutputInfo(ClientPtr client)
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
     if (leased) {
-        rep.connection = RR_Disconnected;
-        rep.subpixelOrder = SubPixelUnknown;
+        reply.connection = RR_Disconnected;
+        reply.subpixelOrder = SubPixelUnknown;
     } else {
-        rep.crtc = output->crtc ? output->crtc->id : None;
-        rep.mmWidth = output->mmWidth;
-        rep.mmHeight = output->mmHeight;
-        rep.connection = output->nonDesktop ? RR_Disconnected : output->connection;
-        rep.subpixelOrder = output->subpixelOrder;
-        rep.nCrtcs = output->numCrtcs;
-        rep.nModes = output->numModes + output->numUserModes;
-        rep.nPreferred = output->numPreferred;
-        rep.nClones = output->numClones;
+        reply.crtc = output->crtc ? output->crtc->id : None;
+        reply.mmWidth = output->mmWidth;
+        reply.mmHeight = output->mmHeight;
+        reply.connection = output->nonDesktop ? RR_Disconnected : output->connection;
+        reply.subpixelOrder = output->subpixelOrder;
+        reply.nCrtcs = output->numCrtcs;
+        reply.nModes = output->numModes + output->numUserModes;
+        reply.nPreferred = output->numPreferred;
+        reply.nClones = output->numClones;
 
         for (i = 0; i < output->numCrtcs; i++)
             x_rpcbuf_write_CARD32(&rpcbuf, output->crtcs[i]->id);
@@ -505,18 +505,18 @@ ProcRRGetOutputInfo(ClientPtr client)
     x_rpcbuf_write_string_pad(&rpcbuf, output->name); /* indeed 0-terminated */
 
     if (client->swapped) {
-        swapl(&rep.timestamp);
-        swapl(&rep.crtc);
-        swapl(&rep.mmWidth);
-        swapl(&rep.mmHeight);
-        swaps(&rep.nCrtcs);
-        swaps(&rep.nModes);
-        swaps(&rep.nPreferred);
-        swaps(&rep.nClones);
-        swaps(&rep.nameLength);
+        swapl(&reply.timestamp);
+        swapl(&reply.crtc);
+        swapl(&reply.mmWidth);
+        swapl(&reply.mmHeight);
+        swaps(&reply.nCrtcs);
+        swaps(&reply.nModes);
+        swaps(&reply.nPreferred);
+        swaps(&reply.nClones);
+        swaps(&reply.nameLength);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static void
@@ -617,13 +617,13 @@ ProcRRGetOutputPrimary(ClientPtr client)
     if (pScrPriv)
         primary = pScrPriv->primaryOutput;
 
-    xRRGetOutputPrimaryReply rep = {
+    xRRGetOutputPrimaryReply reply = {
         .output = primary ? primary->id : None
     };
 
     if (client->swapped) {
-        swapl(&rep.output);
+        swapl(&reply.output);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }

--- a/randr/rrproviderproperty.c
+++ b/randr/rrproviderproperty.c
@@ -359,14 +359,14 @@ ProcRRListProviderProperties(ClientPtr client)
         numProps++;
     }
 
-    xRRListProviderPropertiesReply rep = {
+    xRRListProviderPropertiesReply reply = {
         .nAtoms = numProps
     };
 
     if (client->swapped)
-        swaps(&rep.nAtoms);
+        swaps(&reply.nAtoms);
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -392,13 +392,13 @@ ProcRRQueryProviderProperty(ClientPtr client)
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
     x_rpcbuf_write_INT32s(&rpcbuf, prop->valid_values, prop->num_valid);
 
-    xRRQueryProviderPropertyReply rep = {
+    xRRQueryProviderPropertyReply reply = {
         .pending = prop->is_pending,
         .range = prop->range,
         .immutable = prop->immutable
     };
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int

--- a/randr/rrxinerama.c
+++ b/randr/rrxinerama.c
@@ -98,17 +98,17 @@ Bool noRRXineramaExtension = FALSE;
 int
 ProcRRXineramaQueryVersion(ClientPtr client)
 {
-    xPanoramiXQueryVersionReply rep = {
+    xPanoramiXQueryVersionReply reply = {
         .majorVersion = SERVER_RRXINERAMA_MAJOR_VERSION,
         .minorVersion = SERVER_RRXINERAMA_MINOR_VERSION
     };
 
     REQUEST_SIZE_MATCH(xPanoramiXQueryVersionReq);
     if (client->swapped) {
-        swaps(&rep.majorVersion);
-        swaps(&rep.minorVersion);
+        swaps(&reply.majorVersion);
+        swaps(&reply.minorVersion);
     }
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -137,14 +137,14 @@ ProcRRXineramaGetState(ClientPtr client)
         active = TRUE;
     }
 
-    xPanoramiXGetStateReply rep = {
+    xPanoramiXGetStateReply reply = {
         .state = active,
         .window = stuff->window
     };
     if (client->swapped) {
-        swapl(&rep.window);
+        swapl(&reply.window);
     }
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 static int
@@ -175,14 +175,14 @@ ProcRRXineramaGetScreenCount(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xPanoramiXGetScreenCountReply rep = {
+    xPanoramiXGetScreenCountReply reply = {
         .ScreenCount = RRXineramaScreenCount(pWin->drawable.pScreen),
         .window = stuff->window
     };
     if (client->swapped) {
-        swapl(&rep.window);
+        swapl(&reply.window);
     }
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -207,19 +207,19 @@ ProcRRXineramaGetScreenSize(ClientPtr client)
     pScreen = pWin->drawable.pScreen;
     pRoot = pScreen->root;
 
-    xPanoramiXGetScreenSizeReply rep = {
+    xPanoramiXGetScreenSizeReply reply = {
         .width = pRoot->drawable.width,
         .height = pRoot->drawable.height,
         .window = stuff->window,
         .screen = stuff->screen
     };
     if (client->swapped) {
-        swapl(&rep.width);
-        swapl(&rep.height);
-        swapl(&rep.window);
-        swapl(&rep.screen);
+        swapl(&reply.width);
+        swapl(&reply.height);
+        swapl(&reply.window);
+        swapl(&reply.screen);
     }
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -227,13 +227,13 @@ ProcRRXineramaIsActive(ClientPtr client)
 {
     REQUEST_SIZE_MATCH(xXineramaIsActiveReq);
 
-    xXineramaIsActiveReply rep = {
+    xXineramaIsActiveReply reply = {
         .state = RRXineramaScreenActive(screenInfo.screens[RR_XINERAMA_SCREEN])
     };
     if (client->swapped) {
-        swapl(&rep.state);
+        swapl(&reply.state);
     }
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -254,11 +254,11 @@ ProcRRXineramaQueryScreens(ClientPtr client)
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
-    xXineramaQueryScreensReply rep = {
+    xXineramaQueryScreensReply reply = {
         .number = nmonitors
     };
     if (client->swapped) {
-        swapl(&rep.number);
+        swapl(&reply.number);
     }
 
     for (m = 0; m < nmonitors; m++) {
@@ -274,7 +274,7 @@ ProcRRXineramaQueryScreens(ClientPtr client)
     if (monitors)
         RRMonitorFreeList(monitors, nmonitors);
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static int


### PR DESCRIPTION
Preparation for future use of generic reply assembly macros.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
