### PR TITLE
xquartz: consistenly name reply structs "reply" instead of "rep"

### DIFF
--- a/hw/xquartz/xpr/appledri.c
+++ b/hw/xquartz/xpr/appledri.c
@@ -301,7 +301,7 @@ ProcAppleDRICreatePixmap(ClientPtr client)
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
     x_rpcbuf_write_CARD8s(&rpcbuf, path, stringLength);
 
-    xAppleDRICreatePixmapReply rep = {
+    xAppleDRICreatePixmapReply reply = {
         .stringLength = stringLength,
         .width = width,
         .height = height,
@@ -311,15 +311,15 @@ ProcAppleDRICreatePixmap(ClientPtr client)
     };
 
     if (client->swapped) {
-        swapl(&rep.stringLength);
-        swapl(&rep.width);
-        swapl(&rep.height);
-        swapl(&rep.pitch);
-        swapl(&rep.bpp);
-        swapl(&rep.size);
+        swapl(&reply.stringLength);
+        swapl(&reply.width);
+        swapl(&reply.height);
+        swapl(&reply.pitch);
+        swapl(&reply.bpp);
+        swapl(&reply.size);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static int


### PR DESCRIPTION
Preparation for future use of generic reply assembly macros.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
