### PR TITLE
xfree86: dri2: drop unused variable

### DIFF
--- a/hw/xfree86/dri2/dri2ext.c
+++ b/hw/xfree86/dri2/dri2ext.c
@@ -191,7 +191,6 @@ static int
 send_buffers_reply(ClientPtr client, DrawablePtr pDrawable,
                    DRI2BufferPtr * buffers, int count, int width, int height)
 {
-    xDRI2GetBuffersReply rep;
     int skip = 0;
     int i;
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
