### PR TITLE
Xi: use REQUEST_HEAD_STRUCT and REQUEST_FIELD_* macros

### DIFF
--- a/Xi/allowev.c
+++ b/Xi/allowev.c
@@ -58,6 +58,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 /***********************************************************************
@@ -69,11 +70,8 @@ SOFTWARE.
 int
 ProcXAllowDeviceEvents(ClientPtr client)
 {
-    REQUEST(xAllowDeviceEventsReq);
-    REQUEST_SIZE_MATCH(xAllowDeviceEventsReq);
-
-    if (client->swapped)
-        swapl(&stuff->time);
+    X_REQUEST_HEAD_STRUCT(xAllowDeviceEventsReq);
+    X_REQUEST_FIELD_CARD32(time);
 
     TimeStamp time;
     DeviceIntPtr thisdev;

--- a/Xi/chgdctl.c
+++ b/Xi/chgdctl.c
@@ -75,11 +75,11 @@ SOFTWARE.
 int
 ProcXChangeDeviceControl(ClientPtr client)
 {
-    REQUEST(xChangeDeviceControlReq);
+    X_REQUEST_HEAD_AT_LEAST(xChangeDeviceControlReq);
     REQUEST_AT_LEAST_EXTRA_SIZE(xChangeDeviceControlReq, sizeof(xDeviceCtl));
+    X_REQUEST_FIELD_CARD16(control);
 
     if (client->swapped) {
-        swaps(&stuff->control);
         xDeviceCtl *ctl = (xDeviceCtl *) &stuff[1];
         swaps(&ctl->control);
         swaps(&ctl->length);

--- a/Xi/chgfctl.c
+++ b/Xi/chgfctl.c
@@ -56,6 +56,7 @@ SOFTWARE.
 #include <X11/extensions/XIproto.h>     /* control constants */
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "include/inputstr.h"           /* DeviceIntPtr      */
 #include "Xi/handlers.h"
 
@@ -405,11 +406,8 @@ ChangeLedFeedback(ClientPtr client, DeviceIntPtr dev, long unsigned int mask,
 int
 ProcXChangeFeedbackControl(ClientPtr client)
 {
-    REQUEST(xChangeFeedbackControlReq);
-    REQUEST_AT_LEAST_SIZE(xChangeFeedbackControlReq);
-
-    if (client->swapped)
-        swapl(&stuff->mask);
+    X_REQUEST_HEAD_AT_LEAST(xChangeFeedbackControlReq);
+    X_REQUEST_FIELD_CARD32(mask);
 
     unsigned len;
     DeviceIntPtr dev;

--- a/Xi/chgkbd.c
+++ b/Xi/chgkbd.c
@@ -55,6 +55,7 @@ SOFTWARE.
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XIproto.h>
 
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
@@ -72,8 +73,7 @@ SOFTWARE.
 int
 ProcXChangeKeyboardDevice(ClientPtr client)
 {
-    /* REQUEST(xChangeKeyboardDeviceReq); */
-    REQUEST_SIZE_MATCH(xChangeKeyboardDeviceReq);
+    X_REQUEST_HEAD_STRUCT(xChangeKeyboardDeviceReq);
 
     return BadDevice;
 }

--- a/Xi/chgkmap.c
+++ b/Xi/chgkmap.c
@@ -57,6 +57,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
@@ -71,14 +72,9 @@ SOFTWARE.
 int
 ProcXChangeDeviceKeyMapping(ClientPtr client)
 {
-    REQUEST(xChangeDeviceKeyMappingReq);
-    REQUEST_AT_LEAST_SIZE(xChangeDeviceKeyMappingReq);
-
+    X_REQUEST_HEAD_AT_LEAST(xChangeDeviceKeyMappingReq);
     unsigned count = stuff->keyCodes * stuff->keySymsPerKeyCode;
-    REQUEST_FIXED_SIZE(xChangeDeviceKeyMappingReq, count * sizeof(CARD32));
-
-    if (client->swapped)
-        SwapLongs((CARD32 *) (&stuff[1]), count);
+    X_REQUEST_REST_COUNT_CARD32(count);
 
     int ret;
     unsigned len;

--- a/Xi/chgprop.c
+++ b/Xi/chgprop.c
@@ -57,6 +57,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
+#include "dix/request_priv.h"
 #include "dix/window_priv.h"
 #include "Xi/handlers.h"
 
@@ -75,19 +76,10 @@ SOFTWARE.
 int
 ProcXChangeDeviceDontPropagateList(ClientPtr client)
 {
-    REQUEST(xChangeDeviceDontPropagateListReq);
-    REQUEST_AT_LEAST_SIZE(xChangeDeviceDontPropagateListReq);
-
-    if (client->swapped) {
-        swapl(&stuff->window);
-        swaps(&stuff->count);
-    }
-
-    REQUEST_FIXED_SIZE(xChangeDeviceDontPropagateListReq,
-                       stuff->count * sizeof(CARD32));
-
-    if (client->swapped)
-        SwapLongs((CARD32 *) (&stuff[1]), stuff->count);
+    X_REQUEST_HEAD_AT_LEAST(xChangeDeviceDontPropagateListReq);
+    X_REQUEST_FIELD_CARD32(window);
+    X_REQUEST_FIELD_CARD16(count);
+    X_REQUEST_REST_COUNT_CARD32(stuff->count);
 
     int i, rc;
     WindowPtr pWin;

--- a/Xi/chgptr.c
+++ b/Xi/chgptr.c
@@ -55,6 +55,7 @@ SOFTWARE.
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XIproto.h>
 
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
@@ -74,8 +75,7 @@ SOFTWARE.
 int
 ProcXChangePointerDevice(ClientPtr client)
 {
-    /* REQUEST(xChangePointerDeviceReq); */
-    REQUEST_SIZE_MATCH(xChangePointerDeviceReq);
+    X_REQUEST_HEAD_STRUCT(xChangePointerDeviceReq);
 
     return BadDevice;
 }

--- a/Xi/closedev.c
+++ b/Xi/closedev.c
@@ -55,6 +55,7 @@ SOFTWARE.
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XIproto.h>
 
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "dix/screenint_priv.h"
 #include "dix/window_priv.h"
@@ -124,8 +125,7 @@ ProcXCloseDevice(ClientPtr client)
     int rc;
     DeviceIntPtr d;
 
-    REQUEST(xCloseDeviceReq);
-    REQUEST_SIZE_MATCH(xCloseDeviceReq);
+    X_REQUEST_HEAD_STRUCT(xCloseDeviceReq);
 
     rc = dixLookupDevice(&d, stuff->deviceid, client, DixUseAccess);
     if (rc != Success)

--- a/Xi/devbell.c
+++ b/Xi/devbell.c
@@ -57,6 +57,7 @@ SOFTWARE.
 
 #include "inputstr.h"           /* DeviceIntPtr      */
 
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 /***********************************************************************
@@ -77,8 +78,7 @@ ProcXDeviceBell(ClientPtr client)
     void *ctrl;
     BellProcPtr proc;
 
-    REQUEST(xDeviceBellReq);
-    REQUEST_SIZE_MATCH(xDeviceBellReq);
+    X_REQUEST_HEAD_STRUCT(xDeviceBellReq);
 
     rc = dixLookupDevice(&dev, stuff->deviceid, client, DixBellAccess);
     if (rc != Success) {

--- a/Xi/getbmap.c
+++ b/Xi/getbmap.c
@@ -75,8 +75,7 @@ ProcXGetDeviceButtonMapping(ClientPtr client)
     ButtonClassPtr b;
     int rc;
 
-    REQUEST(xGetDeviceButtonMappingReq);
-    REQUEST_SIZE_MATCH(xGetDeviceButtonMappingReq);
+    X_REQUEST_HEAD_STRUCT(xGetDeviceButtonMappingReq);
 
     rc = dixLookupDevice(&dev, stuff->deviceid, client, DixGetAttrAccess);
     if (rc != Success)

--- a/Xi/getdctl.c
+++ b/Xi/getdctl.c
@@ -109,17 +109,14 @@ ProcXGetDeviceControl(ClientPtr client)
 {
     DeviceIntPtr dev;
 
-    REQUEST(xGetDeviceControlReq);
-    REQUEST_SIZE_MATCH(xGetDeviceControlReq);
+    X_REQUEST_HEAD_STRUCT(xGetDeviceControlReq);
+    X_REQUEST_FIELD_CARD16(control);
 
     int rc = dixLookupDevice(&dev, stuff->deviceid, client, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
-
-    if (rpcbuf.swapped)
-        swaps(&stuff->control);
 
     switch (stuff->control) {
     case DEVICE_RESOLUTION:

--- a/Xi/getfctl.c
+++ b/Xi/getfctl.c
@@ -256,8 +256,7 @@ ProcXGetFeedbackControl(ClientPtr client)
     BellFeedbackPtr b;
     LedFeedbackPtr l;
 
-    REQUEST(xGetFeedbackControlReq);
-    REQUEST_SIZE_MATCH(xGetFeedbackControlReq);
+    X_REQUEST_HEAD_STRUCT(xGetFeedbackControlReq);
 
     rc = dixLookupDevice(&dev, stuff->deviceid, client, DixGetAttrAccess);
     if (rc != Success)

--- a/Xi/getfocus.c
+++ b/Xi/getfocus.c
@@ -76,8 +76,7 @@ ProcXGetDeviceFocus(ClientPtr client)
     FocusClassPtr focus;
     int rc;
 
-    REQUEST(xGetDeviceFocusReq);
-    REQUEST_SIZE_MATCH(xGetDeviceFocusReq);
+    X_REQUEST_HEAD_STRUCT(xGetDeviceFocusReq);
 
     rc = dixLookupDevice(&dev, stuff->deviceid, client, DixGetFocusAccess);
     if (rc != Success)

--- a/Xi/getkmap.c
+++ b/Xi/getkmap.c
@@ -79,8 +79,7 @@ ProcXGetDeviceKeyMapping(ClientPtr client)
     KeySymsPtr syms;
     int rc;
 
-    REQUEST(xGetDeviceKeyMappingReq);
-    REQUEST_SIZE_MATCH(xGetDeviceKeyMappingReq);
+    X_REQUEST_HEAD_STRUCT(xGetDeviceKeyMappingReq);
 
     rc = dixLookupDevice(&dev, stuff->deviceid, client, DixGetAttrAccess);
     if (rc != Success)

--- a/Xi/getmmap.c
+++ b/Xi/getmmap.c
@@ -56,6 +56,7 @@ SOFTWARE.
 #include <X11/extensions/XIproto.h>     /* Request macro     */
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "dix/request_priv.h"
 #include "Xi/handlers.h"
@@ -75,8 +76,7 @@ ProcXGetDeviceModifierMapping(ClientPtr client)
     KeyCode *modkeymap = NULL;
     int ret, max_keys_per_mod;
 
-    REQUEST(xGetDeviceModifierMappingReq);
-    REQUEST_SIZE_MATCH(xGetDeviceModifierMappingReq);
+    X_REQUEST_HEAD_STRUCT(xGetDeviceModifierMappingReq);
 
     ret = dixLookupDevice(&dev, stuff->deviceid, client, DixGetAttrAccess);
     if (ret != Success)

--- a/Xi/getvers.c
+++ b/Xi/getvers.c
@@ -73,11 +73,8 @@ XExtensionVersion XIVersion;
 int
 ProcXGetExtensionVersion(ClientPtr client)
 {
-    REQUEST(xGetExtensionVersionReq);
-    REQUEST_AT_LEAST_SIZE(xGetExtensionVersionReq);
-
-    if (client->swapped)
-        swaps(&stuff->nbytes);
+    X_REQUEST_HEAD_AT_LEAST(xGetExtensionVersionReq);
+    X_REQUEST_FIELD_CARD16(nbytes);
 
     if (client->req_len != bytes_to_int32(sizeof(xGetExtensionVersionReq) +
                                         stuff->nbytes))

--- a/Xi/grabdev.c
+++ b/Xi/grabdev.c
@@ -76,21 +76,11 @@ extern int ExtEventIndex;
 int
 ProcXGrabDevice(ClientPtr client)
 {
-    REQUEST(xGrabDeviceReq);
-    REQUEST_AT_LEAST_SIZE(xGrabDeviceReq);
-
-    if (client->swapped) {
-        swapl(&stuff->grabWindow);
-        swapl(&stuff->time);
-        swaps(&stuff->event_count);
-    }
-
-    if (client->req_len !=
-        bytes_to_int32(sizeof(xGrabDeviceReq)) + stuff->event_count)
-        return BadLength;
-
-    if (client->swapped)
-        SwapLongs((CARD32 *) (&stuff[1]), stuff->event_count);
+    X_REQUEST_HEAD_AT_LEAST(xGrabDeviceReq);
+    X_REQUEST_FIELD_CARD32(grabWindow);
+    X_REQUEST_FIELD_CARD32(time);
+    X_REQUEST_FIELD_CARD16(event_count);
+    X_REQUEST_REST_COUNT_CARD32(stuff->event_count);
 
     int rc;
     DeviceIntPtr dev;

--- a/Xi/grabdevb.c
+++ b/Xi/grabdevb.c
@@ -59,6 +59,7 @@ SOFTWARE.
 #include "dix/devices_priv.h"
 #include "dix/exevents_priv.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
@@ -74,21 +75,6 @@ SOFTWARE.
 int
 ProcXGrabDeviceButton(ClientPtr client)
 {
-    REQUEST(xGrabDeviceButtonReq);
-    REQUEST_AT_LEAST_SIZE(xGrabDeviceButtonReq);
-
-    if (client->swapped) {
-        swapl(&stuff->grabWindow);
-        swaps(&stuff->modifiers);
-        swaps(&stuff->event_count);
-    }
-
-    REQUEST_FIXED_SIZE(xGrabDeviceButtonReq,
-                       stuff->event_count * sizeof(CARD32));
-
-    if (client->swapped)
-        SwapLongs((CARD32 *) (&stuff[1]), stuff->event_count);
-
     int ret;
     DeviceIntPtr dev;
     DeviceIntPtr mdev;
@@ -96,9 +82,11 @@ ProcXGrabDeviceButton(ClientPtr client)
     struct tmask tmp[EMASKSIZE];
     GrabMask mask;
 
-    if (client->req_len !=
-        bytes_to_int32(sizeof(xGrabDeviceButtonReq)) + stuff->event_count)
-        return BadLength;
+    X_REQUEST_HEAD_AT_LEAST(xGrabDeviceButtonReq);
+    X_REQUEST_FIELD_CARD32(grabWindow);
+    X_REQUEST_FIELD_CARD16(modifiers);
+    X_REQUEST_FIELD_CARD16(event_count);
+    X_REQUEST_REST_COUNT_CARD32(stuff->event_count);
 
     ret = dixLookupDevice(&dev, stuff->grabbed_device, client, DixGrabAccess);
     if (ret != Success)

--- a/Xi/grabdevk.c
+++ b/Xi/grabdevk.c
@@ -59,6 +59,7 @@ SOFTWARE.
 #include "dix/devices_priv.h"
 #include "dix/exevents_priv.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
@@ -74,19 +75,11 @@ SOFTWARE.
 int
 ProcXGrabDeviceKey(ClientPtr client)
 {
-    REQUEST(xGrabDeviceKeyReq);
-    REQUEST_AT_LEAST_SIZE(xGrabDeviceKeyReq);
-
-    if (client->swapped) {
-        swapl(&stuff->grabWindow);
-        swaps(&stuff->modifiers);
-        swaps(&stuff->event_count);
-    }
-
-    REQUEST_FIXED_SIZE(xGrabDeviceKeyReq, stuff->event_count * sizeof(CARD32));
-
-    if (client->swapped)
-        SwapLongs((CARD32 *) (&stuff[1]), stuff->event_count);
+    X_REQUEST_HEAD_AT_LEAST(xGrabDeviceKeyReq);
+    X_REQUEST_FIELD_CARD32(grabWindow);
+    X_REQUEST_FIELD_CARD16(modifiers);
+    X_REQUEST_FIELD_CARD16(event_count);
+    X_REQUEST_REST_COUNT_CARD32(stuff->event_count);
 
     int ret;
     DeviceIntPtr dev;

--- a/Xi/gtmotion.c
+++ b/Xi/gtmotion.c
@@ -72,13 +72,9 @@ SOFTWARE.
 int
 ProcXGetDeviceMotionEvents(ClientPtr client)
 {
-    REQUEST(xGetDeviceMotionEventsReq);
-    REQUEST_SIZE_MATCH(xGetDeviceMotionEventsReq);
-
-    if (client->swapped) {
-        swapl(&stuff->start);
-        swapl(&stuff->stop);
-    }
+    X_REQUEST_HEAD_STRUCT(xGetDeviceMotionEventsReq);
+    X_REQUEST_FIELD_CARD32(start);
+    X_REQUEST_FIELD_CARD32(stop);
 
     DeviceIntPtr dev;
     int rc = dixLookupDevice(&dev, stuff->deviceid, client, DixReadAccess);

--- a/Xi/listdev.c
+++ b/Xi/listdev.c
@@ -330,7 +330,7 @@ ProcXListInputDevices(ClientPtr client)
     xDeviceInfo *dev;
     DeviceIntPtr d;
 
-    REQUEST_SIZE_MATCH(xListInputDevicesReq);
+    X_REQUEST_HEAD_STRUCT(xListInputDevicesReq);
 
     /* allocate space for saving skip value */
     skip = calloc(inputInfo.numDevices, sizeof(Bool));

--- a/Xi/opendev.c
+++ b/Xi/opendev.c
@@ -88,8 +88,7 @@ ProcXOpenDevice(ClientPtr client)
     int status = Success;
     DeviceIntPtr dev;
 
-    REQUEST(xOpenDeviceReq);
-    REQUEST_SIZE_MATCH(xOpenDeviceReq);
+    X_REQUEST_HEAD_STRUCT(xOpenDeviceReq);
 
     status = dixLookupDevice(&dev, stuff->deviceid, client, DixUseAccess);
 

--- a/Xi/queryst.c
+++ b/Xi/queryst.c
@@ -70,8 +70,7 @@ ProcXQueryDeviceState(ClientPtr client)
     DeviceIntPtr dev;
     double *values;
 
-    REQUEST(xQueryDeviceStateReq);
-    REQUEST_SIZE_MATCH(xQueryDeviceStateReq);
+    X_REQUEST_HEAD_STRUCT(xQueryDeviceStateReq);
 
     rc = dixLookupDevice(&dev, stuff->deviceid, client, DixReadAccess);
     if (rc != Success && rc != BadAccess)

--- a/Xi/selectev.c
+++ b/Xi/selectev.c
@@ -58,6 +58,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
@@ -120,18 +121,10 @@ HandleDevicePresenceMask(ClientPtr client, WindowPtr win,
 int
 ProcXSelectExtensionEvent(ClientPtr client)
 {
-    REQUEST(xSelectExtensionEventReq);
-    REQUEST_AT_LEAST_SIZE(xSelectExtensionEventReq);
-
-    if (client->swapped) {
-        swapl(&stuff->window);
-        swaps(&stuff->count);
-    }
-
-    REQUEST_FIXED_SIZE(xSelectExtensionEventReq, stuff->count * sizeof(CARD32));
-
-    if (client->swapped)
-        SwapLongs((CARD32 *) (&stuff[1]), stuff->count);
+    X_REQUEST_HEAD_AT_LEAST(xSelectExtensionEventReq);
+    X_REQUEST_FIELD_CARD32(window);
+    X_REQUEST_FIELD_CARD16(count);
+    X_REQUEST_REST_COUNT_CARD32(stuff->count);
 
     int ret;
     int i;

--- a/Xi/sendexev.c
+++ b/Xi/sendexev.c
@@ -57,6 +57,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
@@ -76,13 +77,9 @@ extern int lastEvent;           /* Defined in extension.c */
 int
 ProcXSendExtensionEvent(ClientPtr client)
 {
-    REQUEST(xSendExtensionEventReq);
-    REQUEST_AT_LEAST_SIZE(xSendExtensionEventReq);
-
-    if (client->swapped) {
-        swapl(&stuff->destination);
-        swaps(&stuff->count);
-    }
+    X_REQUEST_HEAD_AT_LEAST(xSendExtensionEventReq);
+    X_REQUEST_FIELD_CARD32(destination);
+    X_REQUEST_FIELD_CARD16(count);
 
     if (client->req_len !=
         bytes_to_int32(sizeof(xSendExtensionEventReq)) + stuff->count +

--- a/Xi/setbmap.c
+++ b/Xi/setbmap.c
@@ -75,8 +75,7 @@ ProcXSetDeviceButtonMapping(ClientPtr client)
     int ret;
     DeviceIntPtr dev;
 
-    REQUEST(xSetDeviceButtonMappingReq);
-    REQUEST_AT_LEAST_SIZE(xSetDeviceButtonMappingReq);
+    X_REQUEST_HEAD_AT_LEAST(xSetDeviceButtonMappingReq);
 
     if (client->req_len !=
         bytes_to_int32(sizeof(xSetDeviceButtonMappingReq) + stuff->map_length))

--- a/Xi/setdval.c
+++ b/Xi/setdval.c
@@ -76,8 +76,7 @@ ProcXSetDeviceValuators(ClientPtr client)
     DeviceIntPtr dev;
     int rc;
 
-    REQUEST(xSetDeviceValuatorsReq);
-    REQUEST_AT_LEAST_SIZE(xSetDeviceValuatorsReq);
+    X_REQUEST_HEAD_AT_LEAST(xSetDeviceValuatorsReq);
 
     xSetDeviceValuatorsReply reply = {
         .RepType = X_SetDeviceValuators,

--- a/Xi/setfocus.c
+++ b/Xi/setfocus.c
@@ -59,6 +59,7 @@ SOFTWARE.
 #include "inputstr.h"           /* DeviceIntPtr      */
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "exglobals.h"
@@ -72,13 +73,9 @@ SOFTWARE.
 int
 ProcXSetDeviceFocus(ClientPtr client)
 {
-    REQUEST(xSetDeviceFocusReq);
-    REQUEST_SIZE_MATCH(xSetDeviceFocusReq);
-
-    if (client->swapped) {
-        swapl(&stuff->focus);
-        swapl(&stuff->time);
-    }
+    X_REQUEST_HEAD_STRUCT(xSetDeviceFocusReq);
+    X_REQUEST_FIELD_CARD32(focus);
+    X_REQUEST_FIELD_CARD32(time);
 
     int ret;
     DeviceIntPtr dev;

--- a/Xi/setmmap.c
+++ b/Xi/setmmap.c
@@ -76,8 +76,7 @@ ProcXSetDeviceModifierMapping(ClientPtr client)
     int ret;
     DeviceIntPtr dev;
 
-    REQUEST(xSetDeviceModifierMappingReq);
-    REQUEST_AT_LEAST_SIZE(xSetDeviceModifierMappingReq);
+    X_REQUEST_HEAD_AT_LEAST(xSetDeviceModifierMappingReq);
 
     if (client->req_len != bytes_to_int32(sizeof(xSetDeviceModifierMappingReq)) +
         (stuff->numKeyPerModifier << 1))

--- a/Xi/setmode.c
+++ b/Xi/setmode.c
@@ -77,8 +77,7 @@ ProcXSetDeviceMode(ClientPtr client)
     DeviceIntPtr dev;
     int rc;
 
-    REQUEST(xSetDeviceModeReq);
-    REQUEST_SIZE_MATCH(xSetDeviceModeReq);
+    X_REQUEST_HEAD_STRUCT(xSetDeviceModeReq);
 
     xSetDeviceModeReply reply = {
         .RepType = X_SetDeviceMode,

--- a/Xi/ungrdev.c
+++ b/Xi/ungrdev.c
@@ -54,6 +54,7 @@ SOFTWARE.
 
 #include <X11/extensions/XIproto.h>
 
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "Xi/handlers.h"
 
@@ -69,11 +70,8 @@ SOFTWARE.
 int
 ProcXUngrabDevice(ClientPtr client)
 {
-    REQUEST(xUngrabDeviceReq);
-    REQUEST_SIZE_MATCH(xUngrabDeviceReq);
-
-    if (client->swapped)
-        swapl(&stuff->time);
+    X_REQUEST_HEAD_STRUCT(xUngrabDeviceReq);
+    X_REQUEST_FIELD_CARD32(time);
 
     DeviceIntPtr dev;
     GrabPtr grab;

--- a/Xi/ungrdevb.c
+++ b/Xi/ungrdevb.c
@@ -57,6 +57,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/dixgrabs_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
@@ -76,13 +77,9 @@ SOFTWARE.
 int
 ProcXUngrabDeviceButton(ClientPtr client)
 {
-    REQUEST(xUngrabDeviceButtonReq);
-    REQUEST_SIZE_MATCH(xUngrabDeviceButtonReq);
-
-    if (client->swapped) {
-        swapl(&stuff->grabWindow);
-        swaps(&stuff->modifiers);
-    }
+    X_REQUEST_HEAD_STRUCT(xUngrabDeviceButtonReq);
+    X_REQUEST_FIELD_CARD32(grabWindow);
+    X_REQUEST_FIELD_CARD16(modifiers);
 
     DeviceIntPtr dev;
     DeviceIntPtr mdev;

--- a/Xi/ungrdevk.c
+++ b/Xi/ungrdevk.c
@@ -57,6 +57,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "dix/dixgrabs_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
@@ -78,13 +79,9 @@ SOFTWARE.
 int
 ProcXUngrabDeviceKey(ClientPtr client)
 {
-    REQUEST(xUngrabDeviceKeyReq);
-    REQUEST_SIZE_MATCH(xUngrabDeviceKeyReq);
-
-    if (client->swapped) {
-        swapl(&stuff->grabWindow);
-        swaps(&stuff->modifiers);
-    }
+    X_REQUEST_HEAD_STRUCT(xUngrabDeviceKeyReq);
+    X_REQUEST_FIELD_CARD32(grabWindow);
+    X_REQUEST_FIELD_CARD16(modifiers);
 
     DeviceIntPtr dev;
     DeviceIntPtr mdev;

--- a/Xi/xiallowev.c
+++ b/Xi/xiallowev.c
@@ -37,6 +37,7 @@
 #include "dix/dix_priv.h"
 #include "dix/exevents_priv.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "os/fmt.h"
 #include "Xi/handlers.h"
 
@@ -49,20 +50,6 @@
 int
 ProcXIAllowEvents(ClientPtr client)
 {
-    if (client->swapped) {
-        REQUEST(xXIAllowEventsReq);
-        REQUEST_AT_LEAST_SIZE(xXIAllowEventsReq);
-        swaps(&stuff->deviceid);
-        swapl(&stuff->time);
-        if (client->req_len > 3) {
-            xXI2_2AllowEventsReq *req_xi22 = (xXI2_2AllowEventsReq *) stuff;
-
-            REQUEST_AT_LEAST_SIZE(xXI2_2AllowEventsReq);
-            swapl(&req_xi22->touchid);
-            swapl(&req_xi22->grab_window);
-        }
-    }
-
     Bool have_xi22 = FALSE;
     CARD32 clientTime;
     int deviceId;
@@ -77,8 +64,12 @@ ProcXIAllowEvents(ClientPtr client)
     if (version_compare(xi_client->major_version,
                         xi_client->minor_version, 2, 2) >= 0) {
         // Xi >= v2.2 request
-        REQUEST(xXI2_2AllowEventsReq);
-        REQUEST_AT_LEAST_SIZE(xXI2_2AllowEventsReq);
+        X_REQUEST_HEAD_AT_LEAST(xXI2_2AllowEventsReq);
+        X_REQUEST_FIELD_CARD16(deviceid);
+        X_REQUEST_FIELD_CARD32(time);
+        X_REQUEST_FIELD_CARD32(touchid);
+        X_REQUEST_FIELD_CARD32(grab_window);
+
         have_xi22 = TRUE;
         clientTime = stuff->time;
         deviceId = stuff->deviceid;
@@ -88,8 +79,10 @@ ProcXIAllowEvents(ClientPtr client)
     }
     else {
         // Xi < v2.2 request
-        REQUEST(xXIAllowEventsReq);
-        REQUEST_AT_LEAST_SIZE(xXIAllowEventsReq);
+        X_REQUEST_HEAD_AT_LEAST(xXIAllowEventsReq);
+        X_REQUEST_FIELD_CARD16(deviceid);
+        X_REQUEST_FIELD_CARD32(time);
+
         clientTime = stuff->time;
         deviceId = stuff->deviceid;
         mode = stuff->mode;

--- a/Xi/xibarriers.c
+++ b/Xi/xibarriers.c
@@ -46,6 +46,7 @@
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "dix/resource_priv.h"
 #include "mi/mi_priv.h"
 #include "os/bug_priv.h"
@@ -853,11 +854,8 @@ XIDestroyPointerBarrier(ClientPtr client,
 int
 ProcXIBarrierReleasePointer(ClientPtr client)
 {
-    REQUEST(xXIBarrierReleasePointerReq);
-    REQUEST_AT_LEAST_SIZE(xXIBarrierReleasePointerReq);
-
-    if (client->swapped)
-        swapl(&stuff->num_barriers);
+    X_REQUEST_HEAD_AT_LEAST(xXIBarrierReleasePointerReq);
+    X_REQUEST_FIELD_CARD32(num_barriers);
 
     if (stuff->num_barriers > UINT32_MAX / sizeof(xXIBarrierReleasePointerInfo))
         return BadLength;

--- a/Xi/xichangecursor.c
+++ b/Xi/xichangecursor.c
@@ -38,6 +38,7 @@
 
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
@@ -57,14 +58,10 @@
 int
 ProcXIChangeCursor(ClientPtr client)
 {
-    REQUEST(xXIChangeCursorReq);
-    REQUEST_SIZE_MATCH(xXIChangeCursorReq);
-
-    if (client->swapped) {
-        swapl(&stuff->win);
-        swapl(&stuff->cursor);
-        swaps(&stuff->deviceid);
-    }
+    X_REQUEST_HEAD_STRUCT(xXIChangeCursorReq);
+    X_REQUEST_FIELD_CARD32(win);
+    X_REQUEST_FIELD_CARD32(cursor);
+    X_REQUEST_FIELD_CARD16(deviceid);
 
     int rc;
     WindowPtr pWin = NULL;

--- a/Xi/xichangehierarchy.c
+++ b/Xi/xichangehierarchy.c
@@ -42,6 +42,7 @@
 #include "dix/exevents_priv.h"
 #include "dix/extension_priv.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "os/bug_priv.h"
 #include "Xi/handlers.h"
 
@@ -437,8 +438,7 @@ ProcXIChangeHierarchy(ClientPtr client)
         CHANGED,
     } changes = NO_CHANGE;
 
-    REQUEST(xXIChangeHierarchyReq);
-    REQUEST_AT_LEAST_SIZE(xXIChangeHierarchyReq);
+    X_REQUEST_HEAD_AT_LEAST(xXIChangeHierarchyReq);
 
     if (!stuff->num_changes)
         return rc;

--- a/Xi/xigetclientpointer.c
+++ b/Xi/xigetclientpointer.c
@@ -49,14 +49,11 @@
 int
 ProcXIGetClientPointer(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXIGetClientPointerReq);
+    X_REQUEST_FIELD_CARD32(win);
+
     int rc;
     ClientPtr winclient;
-
-    REQUEST(xXIGetClientPointerReq);
-    REQUEST_SIZE_MATCH(xXIGetClientPointerReq);
-
-    if (client->swapped)
-        swapl(&stuff->win);
 
     if (stuff->win != None) {
         rc = dixLookupResourceOwner(&winclient, stuff->win, client, DixGetAttrAccess);

--- a/Xi/xigrabdev.c
+++ b/Xi/xigrabdev.c
@@ -48,16 +48,12 @@
 int
 ProcXIGrabDevice(ClientPtr client)
 {
-    REQUEST(xXIGrabDeviceReq);
-    REQUEST_AT_LEAST_SIZE(xXIGrabDeviceReq);
-
-    if (client->swapped) {
-        swaps(&stuff->deviceid);
-        swapl(&stuff->grab_window);
-        swapl(&stuff->cursor);
-        swapl(&stuff->time);
-        swaps(&stuff->mask_len);
-    }
+    X_REQUEST_HEAD_AT_LEAST(xXIGrabDeviceReq);
+    X_REQUEST_FIELD_CARD16(deviceid);
+    X_REQUEST_FIELD_CARD32(grab_window);
+    X_REQUEST_FIELD_CARD32(cursor);
+    X_REQUEST_FIELD_CARD32(time);
+    X_REQUEST_FIELD_CARD16(mask_len);
 
     DeviceIntPtr dev;
     int ret = Success;
@@ -125,13 +121,9 @@ ProcXIGrabDevice(ClientPtr client)
 int
 ProcXIUngrabDevice(ClientPtr client)
 {
-    REQUEST(xXIUngrabDeviceReq);
-    REQUEST_SIZE_MATCH(xXIUngrabDeviceReq);
-
-    if (client->swapped) {
-        swaps(&stuff->deviceid);
-        swapl(&stuff->time);
-    }
+    X_REQUEST_HEAD_STRUCT(xXIUngrabDeviceReq);
+    X_REQUEST_FIELD_CARD16(deviceid);
+    X_REQUEST_FIELD_CARD32(time);
 
     DeviceIntPtr dev;
     GrabPtr grab;

--- a/Xi/xipassivegrab.c
+++ b/Xi/xipassivegrab.c
@@ -51,27 +51,17 @@
 int
 ProcXIPassiveGrabDevice(ClientPtr client)
 {
-    REQUEST(xXIPassiveGrabDeviceReq);
-    REQUEST_AT_LEAST_SIZE(xXIPassiveGrabDeviceReq);
-
-    if (client->swapped) {
-        swaps(&stuff->deviceid);
-        swapl(&stuff->grab_window);
-        swapl(&stuff->cursor);
-        swapl(&stuff->time);
-        swapl(&stuff->detail);
-        swaps(&stuff->mask_len);
-        swaps(&stuff->num_modifiers);
-    }
-
+    X_REQUEST_HEAD_AT_LEAST(xXIPassiveGrabDeviceReq);
+    X_REQUEST_FIELD_CARD16(deviceid);
+    X_REQUEST_FIELD_CARD32(grab_window);
+    X_REQUEST_FIELD_CARD32(cursor);
+    X_REQUEST_FIELD_CARD32(time);
+    X_REQUEST_FIELD_CARD32(detail);
+    X_REQUEST_FIELD_CARD16(mask_len);
+    X_REQUEST_FIELD_CARD16(num_modifiers);
     REQUEST_FIXED_SIZE(xXIPassiveGrabDeviceReq,
         ((uint32_t) stuff->mask_len + stuff->num_modifiers) *4);
-
-    if (client->swapped) {
-        uint32_t *mods = (uint32_t *) &stuff[1] + stuff->mask_len;
-        for (int i = 0; i < stuff->num_modifiers; i++, mods++)
-            swapl(mods);
-    }
+    X_REQUEST_REST_CARD32(); /* event mask and modifiers list */
 
     DeviceIntPtr dev, mod_dev;
     xXIPassiveGrabDeviceReply reply = {
@@ -247,24 +237,14 @@ ProcXIPassiveGrabDevice(ClientPtr client)
 int
 ProcXIPassiveUngrabDevice(ClientPtr client)
 {
-    REQUEST(xXIPassiveUngrabDeviceReq);
-    REQUEST_AT_LEAST_SIZE(xXIPassiveUngrabDeviceReq);
-
-    if (client->swapped) {
-        swapl(&stuff->grab_window);
-        swaps(&stuff->deviceid);
-        swapl(&stuff->detail);
-        swaps(&stuff->num_modifiers);
-    }
-
+    X_REQUEST_HEAD_AT_LEAST(xXIPassiveUngrabDeviceReq);
+    X_REQUEST_FIELD_CARD32(grab_window);
+    X_REQUEST_FIELD_CARD16(deviceid);
+    X_REQUEST_FIELD_CARD32(detail);
+    X_REQUEST_FIELD_CARD16(num_modifiers);
     REQUEST_FIXED_SIZE(xXIPassiveUngrabDeviceReq,
                        ((uint32_t) stuff->num_modifiers) << 2);
-
-    if (client->swapped) {
-        uint32_t *modifiers = (uint32_t *) &stuff[1];
-        for (int i = 0; i < stuff->num_modifiers; i++, modifiers++)
-            swapl(modifiers);
-    }
+    X_REQUEST_REST_CARD32(); /* modifiers list */
 
     DeviceIntPtr dev, mod_dev;
     WindowPtr win;

--- a/Xi/xiproperty.c
+++ b/Xi/xiproperty.c
@@ -842,8 +842,7 @@ static int _writeDevProps(x_rpcbuf_t *rpcbuf, XID devId,
 int
 ProcXListDeviceProperties(ClientPtr client)
 {
-    REQUEST(xListDevicePropertiesReq);
-    REQUEST_SIZE_MATCH(xListDevicePropertiesReq);
+    X_REQUEST_HEAD_STRUCT(xListDevicePropertiesReq);
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
@@ -867,14 +866,10 @@ ProcXListDeviceProperties(ClientPtr client)
 int
 ProcXChangeDeviceProperty(ClientPtr client)
 {
-    REQUEST(xChangeDevicePropertyReq);
-    REQUEST_AT_LEAST_SIZE(xChangeDevicePropertyReq);
-
-    if (client->swapped) {
-        swapl(&stuff->property);
-        swapl(&stuff->type);
-        swapl(&stuff->nUnits);
-    }
+    X_REQUEST_HEAD_AT_LEAST(xChangeDevicePropertyReq);
+    X_REQUEST_FIELD_CARD32(property);
+    X_REQUEST_FIELD_CARD32(type);
+    X_REQUEST_FIELD_CARD32(nUnits);
 
     DeviceIntPtr dev;
     unsigned long len;
@@ -907,11 +902,8 @@ ProcXChangeDeviceProperty(ClientPtr client)
 int
 ProcXDeleteDeviceProperty(ClientPtr client)
 {
-    REQUEST(xDeleteDevicePropertyReq);
-    REQUEST_SIZE_MATCH(xDeleteDevicePropertyReq);
-
-    if (client->swapped)
-        swapl(&stuff->property);
+    X_REQUEST_HEAD_STRUCT(xDeleteDevicePropertyReq);
+    X_REQUEST_FIELD_CARD32(property);
 
     DeviceIntPtr dev;
     int rc;
@@ -933,15 +925,11 @@ ProcXDeleteDeviceProperty(ClientPtr client)
 int
 ProcXGetDeviceProperty(ClientPtr client)
 {
-    REQUEST(xGetDevicePropertyReq);
-    REQUEST_SIZE_MATCH(xGetDevicePropertyReq);
-
-    if (client->swapped) {
-        swapl(&stuff->property);
-        swapl(&stuff->type);
-        swapl(&stuff->longOffset);
-        swapl(&stuff->longLength);
-    }
+    X_REQUEST_HEAD_STRUCT(xGetDevicePropertyReq);
+    X_REQUEST_FIELD_CARD32(property);
+    X_REQUEST_FIELD_CARD32(type);
+    X_REQUEST_FIELD_CARD32(longOffset);
+    X_REQUEST_FIELD_CARD32(longLength);
 
     DeviceIntPtr dev;
     int length;
@@ -1018,11 +1006,8 @@ ProcXGetDeviceProperty(ClientPtr client)
 int
 ProcXIListProperties(ClientPtr client)
 {
-    REQUEST(xXIListPropertiesReq);
-    REQUEST_SIZE_MATCH(xXIListPropertiesReq);
-
-    if (client->swapped)
-        swaps(&stuff->deviceid);
+    X_REQUEST_HEAD_STRUCT(xXIListPropertiesReq);
+    X_REQUEST_FIELD_CARD16(deviceid);
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
@@ -1046,15 +1031,11 @@ ProcXIListProperties(ClientPtr client)
 int
 ProcXIChangeProperty(ClientPtr client)
 {
-    REQUEST(xXIChangePropertyReq);
-    REQUEST_AT_LEAST_SIZE(xXIChangePropertyReq);
-
-    if (client->swapped) {
-        swaps(&stuff->deviceid);
-        swapl(&stuff->property);
-        swapl(&stuff->type);
-        swapl(&stuff->num_items);
-    }
+    X_REQUEST_HEAD_AT_LEAST(xXIChangePropertyReq);
+    X_REQUEST_FIELD_CARD16(deviceid);
+    X_REQUEST_FIELD_CARD32(property);
+    X_REQUEST_FIELD_CARD32(type);
+    X_REQUEST_FIELD_CARD32(num_items);
 
     int rc;
     DeviceIntPtr dev;
@@ -1087,13 +1068,9 @@ ProcXIChangeProperty(ClientPtr client)
 int
 ProcXIDeleteProperty(ClientPtr client)
 {
-    REQUEST(xXIDeletePropertyReq);
-    REQUEST_SIZE_MATCH(xXIDeletePropertyReq);
-
-    if (client->swapped) {
-        swaps(&stuff->deviceid);
-        swapl(&stuff->property);
-    }
+    X_REQUEST_HEAD_STRUCT(xXIDeletePropertyReq);
+    X_REQUEST_FIELD_CARD16(deviceid);
+    X_REQUEST_FIELD_CARD32(property);
 
     DeviceIntPtr dev;
     int rc;
@@ -1115,16 +1092,12 @@ ProcXIDeleteProperty(ClientPtr client)
 int
 ProcXIGetProperty(ClientPtr client)
 {
-    REQUEST(xXIGetPropertyReq);
-    REQUEST_SIZE_MATCH(xXIGetPropertyReq);
-
-    if (client->swapped) {
-        swaps(&stuff->deviceid);
-        swapl(&stuff->property);
-        swapl(&stuff->type);
-        swapl(&stuff->offset);
-        swapl(&stuff->len);
-    }
+    X_REQUEST_HEAD_STRUCT(xXIGetPropertyReq);
+    X_REQUEST_FIELD_CARD16(deviceid);
+    X_REQUEST_FIELD_CARD32(property);
+    X_REQUEST_FIELD_CARD32(type);
+    X_REQUEST_FIELD_CARD32(offset);
+    X_REQUEST_FIELD_CARD32(len);
 
     DeviceIntPtr dev;
     int length;

--- a/Xi/xiquerydevice.c
+++ b/Xi/xiquerydevice.c
@@ -61,11 +61,8 @@ static void SwapDeviceInfo(DeviceIntPtr dev, xXIDeviceInfo * info);
 int
 ProcXIQueryDevice(ClientPtr client)
 {
-    REQUEST(xXIQueryDeviceReq);
-    REQUEST_SIZE_MATCH(xXIQueryDeviceReq);
-
-    if (client->swapped)
-        swaps(&stuff->deviceid);
+    X_REQUEST_HEAD_STRUCT(xXIQueryDeviceReq);
+    X_REQUEST_FIELD_CARD16(deviceid);
 
     DeviceIntPtr dev = NULL;
     int rc = Success;

--- a/Xi/xiquerypointer.c
+++ b/Xi/xiquerypointer.c
@@ -65,13 +65,9 @@
 int
 ProcXIQueryPointer(ClientPtr client)
 {
-    REQUEST(xXIQueryPointerReq);
-    REQUEST_SIZE_MATCH(xXIQueryPointerReq);
-
-    if (client->swapped) {
-        swaps(&stuff->deviceid);
-        swapl(&stuff->win);
-    }
+    X_REQUEST_HEAD_STRUCT(xXIQueryPointerReq);
+    X_REQUEST_FIELD_CARD16(deviceid);
+    X_REQUEST_FIELD_CARD32(win);
 
     int rc;
     DeviceIntPtr pDev, kbd;

--- a/Xi/xiqueryversion.c
+++ b/Xi/xiqueryversion.c
@@ -56,13 +56,9 @@ extern XExtensionVersion XIVersion;     /* defined in getvers.c */
 int
 ProcXIQueryVersion(ClientPtr client)
 {
-    REQUEST(xXIQueryVersionReq);
-    REQUEST_SIZE_MATCH(xXIQueryVersionReq);
-
-    if (client->swapped) {
-        swaps(&stuff->major_version);
-        swaps(&stuff->minor_version);
-    }
+    X_REQUEST_HEAD_AT_LEAST(xXIQueryVersionReq);
+    X_REQUEST_FIELD_CARD16(major_version);
+    X_REQUEST_FIELD_CARD16(minor_version);
 
     int major, minor;
 

--- a/Xi/xiselectev.c
+++ b/Xi/xiselectev.c
@@ -117,13 +117,11 @@ XICheckInvalidMaskBits(ClientPtr client, unsigned char *mask, int len)
 int
 ProcXISelectEvents(ClientPtr client)
 {
-    REQUEST(xXISelectEventsReq);
-    REQUEST_AT_LEAST_SIZE(xXISelectEventsReq);
+    X_REQUEST_HEAD_AT_LEAST(xXISelectEventsReq);
+    X_REQUEST_FIELD_CARD32(win);
+    X_REQUEST_FIELD_CARD16(num_masks);
 
     if (client->swapped) {
-        swapl(&stuff->win);
-        swaps(&stuff->num_masks);
-
         int len = client->req_len - bytes_to_int32(sizeof(xXISelectEventsReq));
         xXIEventMask *evmask = (xXIEventMask *) &stuff[1];
         for (int i = 0; i < stuff->num_masks; i++) {
@@ -321,11 +319,8 @@ ProcXISelectEvents(ClientPtr client)
 int
 ProcXIGetSelectedEvents(ClientPtr client)
 {
-    REQUEST(xXIGetSelectedEventsReq);
-    REQUEST_SIZE_MATCH(xXIGetSelectedEventsReq);
-
-    if (client->swapped)
-        swapl(&stuff->win);
+    X_REQUEST_HEAD_STRUCT(xXIGetSelectedEventsReq);
+    X_REQUEST_FIELD_CARD32(win);
 
     int rc, i;
     WindowPtr win;

--- a/Xi/xisetclientpointer.c
+++ b/Xi/xisetclientpointer.c
@@ -38,6 +38,7 @@
 #include <X11/extensions/XI2proto.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "Xi/handlers.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
@@ -50,17 +51,13 @@
 int
 ProcXISetClientPointer(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xXISetClientPointerReq);
+    X_REQUEST_FIELD_CARD32(win);
+    X_REQUEST_FIELD_CARD16(deviceid);
+
     DeviceIntPtr pDev;
     ClientPtr targetClient;
     int rc;
-
-    REQUEST(xXISetClientPointerReq);
-    REQUEST_SIZE_MATCH(xXISetClientPointerReq);
-
-    if (client->swapped) {
-        swapl(&stuff->win);
-        swaps(&stuff->deviceid);
-    }
 
     rc = dixLookupDevice(&pDev, stuff->deviceid, client, DixManageAccess);
     if (rc != Success) {

--- a/Xi/xisetdevfocus.c
+++ b/Xi/xisetdevfocus.c
@@ -44,17 +44,13 @@
 int
 ProcXISetFocus(ClientPtr client)
 {
+    X_REQUEST_HEAD_AT_LEAST(xXISetFocusReq);
+    X_REQUEST_FIELD_CARD16(deviceid);
+    X_REQUEST_FIELD_CARD32(focus);
+    X_REQUEST_FIELD_CARD32(time);
+
     DeviceIntPtr dev;
     int ret;
-
-    REQUEST(xXISetFocusReq);
-    REQUEST_AT_LEAST_SIZE(xXISetFocusReq);
-
-    if (client->swapped) {
-        swaps(&stuff->deviceid);
-        swapl(&stuff->focus);
-        swapl(&stuff->time);
-    }
 
     ret = dixLookupDevice(&dev, stuff->deviceid, client, DixSetFocusAccess);
     if (ret != Success)
@@ -69,14 +65,11 @@ ProcXISetFocus(ClientPtr client)
 int
 ProcXIGetFocus(ClientPtr client)
 {
+    X_REQUEST_HEAD_AT_LEAST(xXIGetFocusReq);
+    X_REQUEST_FIELD_CARD16(deviceid);
+
     DeviceIntPtr dev;
     int ret;
-
-    REQUEST(xXIGetFocusReq);
-    REQUEST_AT_LEAST_SIZE(xXIGetFocusReq);
-
-    if (client->swapped)
-        swaps(&stuff->deviceid);
 
     ret = dixLookupDevice(&dev, stuff->deviceid, client, DixGetFocusAccess);
     if (ret != Success)

--- a/Xi/xiwarppointer.c
+++ b/Xi/xiwarppointer.c
@@ -39,6 +39,7 @@
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
+#include "dix/request_priv.h"
 #include "mi/mipointer_priv.h"
 #include "Xi/handlers.h"
 
@@ -59,20 +60,16 @@
 int
 ProcXIWarpPointer(ClientPtr client)
 {
-    REQUEST(xXIWarpPointerReq);
-    REQUEST_SIZE_MATCH(xXIWarpPointerReq);
-
-    if (client->swapped) {
-        swapl(&stuff->src_win);
-        swapl(&stuff->dst_win);
-        swapl(&stuff->src_x);
-        swapl(&stuff->src_y);
-        swaps(&stuff->src_width);
-        swaps(&stuff->src_height);
-        swapl(&stuff->dst_x);
-        swapl(&stuff->dst_y);
-        swaps(&stuff->deviceid);
-    }
+    X_REQUEST_HEAD_STRUCT(xXIWarpPointerReq);
+    X_REQUEST_FIELD_CARD32(src_win);
+    X_REQUEST_FIELD_CARD32(dst_win);
+    X_REQUEST_FIELD_CARD32(src_x);
+    X_REQUEST_FIELD_CARD32(src_y);
+    X_REQUEST_FIELD_CARD16(src_width);
+    X_REQUEST_FIELD_CARD16(src_height);
+    X_REQUEST_FIELD_CARD32(dst_x);
+    X_REQUEST_FIELD_CARD32(dst_y);
+    X_REQUEST_FIELD_CARD16(deviceid);
 
     int rc;
     int x, y;


### PR DESCRIPTION
Use the new macros to make request struct parsing / field swapping
much easier.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
