### PR TITLE
xwin: silence const char* assignment warnings

### DIFF
--- a/hw/xwin/winconfig.c
+++ b/hw/xwin/winconfig.c
@@ -340,14 +340,15 @@ winConfigKeyboard(DeviceIntPtr pDevice)
                        pLayout->xkbvariant ? pLayout->xkbvariant : "none",
                        pLayout->xkboptions ? pLayout->xkboptions : "none");
 
-                g_winInfo.xkb.model = pLayout->xkbmodel;
-                g_winInfo.xkb.layout = pLayout->xkblayout;
-                g_winInfo.xkb.variant = pLayout->xkbvariant;
-                g_winInfo.xkb.options = pLayout->xkboptions;
+                /* need the typecast to (char*) in order to silence const warning */
+                g_winInfo.xkb.model = (char*)pLayout->xkbmodel;
+                g_winInfo.xkb.layout = (char*)pLayout->xkblayout;
+                g_winInfo.xkb.variant = (char*)pLayout->xkbvariant;
+                g_winInfo.xkb.options = (char*)pLayout->xkboptions;
 
                 if (deviceIdentifier == 0xa000) {
                     winMsg(X_PROBED, "Windows keyboard layout device identifier indicates Macintosh, setting Model = \"macintosh\"");
-                    g_winInfo.xkb.model = "macintosh";
+                    g_winInfo.xkb.model = (char*)"macintosh";
                 }
 
                 break;


### PR DESCRIPTION
the target struct type defines char* fields, but we're sure they'll
never be written into, so just add typecast for silencing the warning.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
