### PR TITLE
xwin: silence warning on missing prototype for OsVendorFatalError()

### DIFF
--- a/hw/xwin/winerror.c
+++ b/hw/xwin/winerror.c
@@ -32,6 +32,7 @@
 #include <xwin-config.h>
 #endif
 
+#include "os/ddx_priv.h"
 #include "os/log_priv.h"
 #include "os/osdep.h"
 


### PR DESCRIPTION
Just need to include ddx_priv.h

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
