### PR TITLE
xwin: fix compiler warning on potential buffer read overflow

### DIFF
--- a/hw/xwin/InitOutput.c
+++ b/hw/xwin/InitOutput.c
@@ -139,7 +139,9 @@ void XwinExtensionInit(void)
     }
 #endif
 
-    LoadExtensionList(xwinExtensions, ARRAY_SIZE(xwinExtensions), TRUE);
+    /* need this to prevent compiler warning */
+    if (ARRAY_SIZE(xwinExtensions) > 0)
+        LoadExtensionList(xwinExtensions, ARRAY_SIZE(xwinExtensions), TRUE);
 }
 
 /*


### PR DESCRIPTION
> ../hw/xwin/InitOutput.c: In function ‘XwinExtensionInit’:
> ../hw/xwin/InitOutput.c:142:5: warning: ‘LoadExtensionList’ reading 12 bytes from a region of size 0 [-Wstringop-overread]
>   142 |     LoadExtensionList(xwinExtensions, ARRAY_SIZE(xwinExtensions), TRUE);
>       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> ../hw/xwin/InitOutput.c:142:5: note: referencing argument 1 of type ‘const ExtensionModule[0]’
> In file included from ../include/extnsionst.h:53,
>                  from ../randr/randrstr.h:40,
>                  from ../hw/xwin/win.h:174,
>                  from ../hw/xwin/InitOutput.c:35:
> ../include/extension.h:100:23: note: in a call to function ‘LoadExtensionList’
>   100 | extern _X_EXPORT void LoadExtensionList(const ExtensionModule ext[],
>       |                       ^~~~~~~~~~~~~~~~~

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
