### PR TITLE
xkb: fix printf argument size mismatch warning

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -6005,7 +6005,7 @@ ProcXkbGetKbdByName(ClientPtr client)
             return BadAlloc;
 
         if (childbuf.wpos != (mrep.length * 4))
-            LogMessage(X_WARNING, "ProcXkbGetKbdByName() childbuf size (%ld) mismatch mrep size (%ld // %d units)\n",
+            LogMessage(X_WARNING, "ProcXkbGetKbdByName() childbuf size (%ld) mismatch mrep size (%ld // %ld units)\n",
                        (unsigned long)childbuf.wpos, (unsigned long)mrep.length * 4, mrep.length);
 
         if (client->swapped) {
@@ -6026,7 +6026,7 @@ ProcXkbGetKbdByName(ClientPtr client)
         XkbAssembleCompatMap(client, new->compat, crep, &childbuf);
 
         if (childbuf.wpos != (crep.length * 4))
-            LogMessage(X_WARNING, "ProcXkbGetKbdByName() childbuf size (%ld) mismatch crep size (%ld // %d units)\n",
+            LogMessage(X_WARNING, "ProcXkbGetKbdByName() childbuf size (%ld) mismatch crep size (%ld // %ld units)\n",
                        (unsigned long)childbuf.wpos, (unsigned long)crep.length * 4, crep.length);
 
         if (client->swapped) {
@@ -6050,7 +6050,7 @@ ProcXkbGetKbdByName(ClientPtr client)
             return BadAlloc;
 
         if (childbuf.wpos != (irep.length * 4))
-            LogMessage(X_WARNING, "ProcXkbGetKbdByName() childbuf size (%ld) mismatch irep size (%ld // %d units)\n",
+            LogMessage(X_WARNING, "ProcXkbGetKbdByName() childbuf size (%ld) mismatch irep size (%ld // %ld units)\n",
                        (unsigned long)childbuf.wpos, (unsigned long)irep.length * 4, irep.length);
 
         if (client->swapped) {
@@ -6070,7 +6070,7 @@ ProcXkbGetKbdByName(ClientPtr client)
         XkbAssembleNames(client, new, nrep, &childbuf);
 
         if (childbuf.wpos != (nrep.length * 4))
-            LogMessage(X_WARNING, "ProcXkbGetKbdByName() childbuf size (%ld) mismatch nrep size (%ld // %d units)\n",
+            LogMessage(X_WARNING, "ProcXkbGetKbdByName() childbuf size (%ld) mismatch nrep size (%ld // %ld units)\n",
                        (unsigned long)childbuf.wpos, (unsigned long)nrep.length * 4, nrep.length);
 
         if (client->swapped) {


### PR DESCRIPTION
> ../xkb/xkb.c:6008:106: warning: format ‘%d’ expects argument of type ‘int’, but argument 5 has type ‘CARD32’ {aka ‘long unsigned int’} [-Wformat=]
>  6008 |             LogMessage(X_WARNING, "ProcXkbGetKbdByName() childbuf size (%ld) mismatch mrep size (%ld // %d units)\n",
>       |                                                                                                         ~^
>       |                                                                                                          |
>       |                                                                                                          int
>       |                                                                                                         %ld
>  6009 |                        (unsigned long)childbuf.wpos, (unsigned long)mrep.length * 4, mrep.length);
>       |                                                                                      ~~~~~~~~~~~
>       |                                                                                          |
>       |                                                                                          CARD32 {aka long unsigned int}
[...]

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
