### PR TITLE
dix: consistenly name reply structs "reply" instead of "rep"

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -1746,11 +1746,11 @@ ProcSetModifierMapping(ClientPtr client)
     if (rc != MappingSuccess && rc != MappingFailed && rc != MappingBusy)
         return rc;
 
-    xSetModifierMappingReply rep = {
+    xSetModifierMappingReply reply = {
         .success = rc,
     };
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -1880,11 +1880,11 @@ ProcSetPointerMapping(ClientPtr client)
     if (ret != Success && ret != MappingBusy)
         return ret;
 
-    xSetPointerMappingReply rep = {
+    xSetPointerMappingReply reply = {
         .success = (ret == MappingBusy) ? MappingBusy : MappingSuccess,
     };
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -1920,7 +1920,7 @@ ProcGetKeyboardMapping(ClientPtr client)
 
     const int count = syms->mapWidth * stuff->count;
 
-    xGetKeyboardMappingReply rep = {
+    xGetKeyboardMappingReply reply = {
         .keySymsPerKeyCode = syms->mapWidth,
     };
 
@@ -1933,7 +1933,7 @@ ProcGetKeyboardMapping(ClientPtr client)
     free(syms->map);
     free(syms);
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -2195,7 +2195,7 @@ ProcGetKeyboardControl(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xGetKeyboardControlReply rep = {
+    xGetKeyboardControlReply reply = {
         .globalAutoRepeat = ctrl->autoRepeat,
         .ledMask = ctrl->leds,
         .keyClickPercent = ctrl->click,
@@ -2204,15 +2204,15 @@ ProcGetKeyboardControl(ClientPtr client)
         .bellDuration = ctrl->bell_duration
     };
     for (int i = 0; i < 32; i++)
-        rep.map[i] = ctrl->autoRepeats[i];
+        reply.map[i] = ctrl->autoRepeats[i];
 
     if (client->swapped) {
-        swapl(&rep.ledMask);
-        swaps(&rep.bellPitch);
-        swaps(&rep.bellDuration);
+        swapl(&reply.ledMask);
+        swaps(&reply.bellPitch);
+        swaps(&reply.bellDuration);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -2350,19 +2350,19 @@ ProcGetPointerControl(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xGetPointerControlReply rep = {
+    xGetPointerControlReply reply = {
         .accelNumerator = ctrl->num,
         .accelDenominator = ctrl->den,
         .threshold = ctrl->threshold
     };
 
     if (client->swapped) {
-        swaps(&rep.accelNumerator);
-        swaps(&rep.accelDenominator);
-        swaps(&rep.threshold);
+        swaps(&reply.accelNumerator);
+        swaps(&reply.accelDenominator);
+        swaps(&reply.threshold);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 void
@@ -2460,7 +2460,7 @@ ProcQueryKeymap(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xReq);
 
-    xQueryKeymapReply rep = { 0 };
+    xQueryKeymapReply reply = { 0 };
 
     rc = dixCallDeviceAccessCallback(client, keybd, DixReadAccess);
     /* If rc is Success, we're allowed to copy out the keymap.
@@ -2468,12 +2468,12 @@ ProcQueryKeymap(ClientPtr client)
      */
     if (rc == Success) {
         for (int i = 0; i < 32; i++)
-            rep.map[i] = down[i];
+            reply.map[i] = down[i];
     }
     else if (rc != BadAccess)
         return rc;
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 /**

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -1034,7 +1034,7 @@ ProcGetGeometry(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xGetGeometryReply rep = {
+    xGetGeometryReply reply = {
         .root = pDraw->pScreen->root->drawable.id,
         .depth = pDraw->depth,
         .width = pDraw->width,
@@ -1044,21 +1044,21 @@ ProcGetGeometry(ClientPtr client)
     if (WindowDrawable(pDraw->type)) {
         WindowPtr pWin = (WindowPtr) pDraw;
 
-        rep.x = pWin->origin.x - wBorderWidth(pWin);
-        rep.y = pWin->origin.y - wBorderWidth(pWin);
-        rep.borderWidth = pWin->borderWidth;
+        reply.x = pWin->origin.x - wBorderWidth(pWin);
+        reply.y = pWin->origin.y - wBorderWidth(pWin);
+        reply.borderWidth = pWin->borderWidth;
     }
 
     if (client->swapped) {
-        swapl(&rep.root);
-        swaps(&rep.x);
-        swaps(&rep.y);
-        swaps(&rep.width);
-        swaps(&rep.height);
-        swaps(&rep.borderWidth);
+        swapl(&reply.root);
+        swaps(&reply.x);
+        swaps(&reply.y);
+        swaps(&reply.width);
+        swaps(&reply.height);
+        swaps(&reply.borderWidth);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -1087,19 +1087,19 @@ ProcQueryTree(ClientPtr client)
         numChildren++;
     }
 
-    xQueryTreeReply rep = {
+    xQueryTreeReply reply = {
         .root = pWin->drawable.pScreen->root->drawable.id,
         .parent = (pWin->parent) ? pWin->parent->drawable.id : (Window) None,
         .nChildren = numChildren,
     };
 
     if (client->swapped) {
-        swapl(&rep.root);
-        swapl(&rep.parent);
-        swaps(&rep.nChildren);
+        swapl(&reply.root);
+        swapl(&reply.parent);
+        swaps(&reply.nChildren);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -1123,15 +1123,15 @@ ProcInternAtom(ClientPtr client)
     if (atom == BAD_RESOURCE)
         return BadAlloc;
 
-    xInternAtomReply rep = {
+    xInternAtomReply reply = {
         .atom = atom
     };
 
     if (client->swapped) {
-        swapl(&rep.atom);
+        swapl(&reply.atom);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -1155,15 +1155,15 @@ ProcGetAtomName(ClientPtr client)
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
     x_rpcbuf_write_CARD8s(&rpcbuf, (CARD8*)str, len);
 
-    xGetAtomNameReply rep = {
+    xGetAtomNameReply reply = {
         .nameLength = len
     };
 
     if (client->swapped) {
-        swaps(&rep.nameLength);
+        swaps(&reply.nameLength);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -1248,17 +1248,17 @@ ProcTranslateCoords(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xTranslateCoordsReply rep = { 0 };
+    xTranslateCoordsReply reply = { 0 };
     if (!SAME_SCREENS(pWin->drawable, pDst->drawable)) {
-        rep.sameScreen = xFalse;
-        rep.child = None;
-        rep.dstX = rep.dstY = 0;
+        reply.sameScreen = xFalse;
+        reply.child = None;
+        reply.dstX = reply.dstY = 0;
     }
     else {
         INT16 x, y;
 
-        rep.sameScreen = xTrue;
-        rep.child = None;
+        reply.sameScreen = xTrue;
+        reply.child = None;
         /* computing absolute coordinates -- adjust to destination later */
         x = pWin->drawable.x + stuff->srcX;
         y = pWin->drawable.y + stuff->srcY;
@@ -1285,24 +1285,24 @@ ProcTranslateCoords(ClientPtr client)
                                         x - pWin->drawable.x,
                                         y - pWin->drawable.y, &box))
                 ) {
-                rep.child = pWin->drawable.id;
+                reply.child = pWin->drawable.id;
                 pWin = (WindowPtr) NULL;
             }
             else
                 pWin = pWin->nextSib;
         }
         /* adjust to destination coordinates */
-        rep.dstX = x - pDst->drawable.x;
-        rep.dstY = y - pDst->drawable.y;
+        reply.dstX = x - pDst->drawable.x;
+        reply.dstY = y - pDst->drawable.y;
     }
 
     if (client->swapped) {
-        swapl(&rep.child);
-        swaps(&rep.dstX);
-        swaps(&rep.dstY);
+        swapl(&reply.child);
+        swaps(&reply.dstX);
+        swaps(&reply.dstY);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -1429,7 +1429,7 @@ ProcQueryTextExtents(ClientPtr client)
     if (!xfont2_query_text_extents(pFont, length, (unsigned char *) &stuff[1], &info))
         return BadAlloc;
 
-    xQueryTextExtentsReply rep = {
+    xQueryTextExtentsReply reply = {
         .drawDirection = info.drawDirection,
         .fontAscent = info.fontAscent,
         .fontDescent = info.fontDescent,
@@ -1441,16 +1441,16 @@ ProcQueryTextExtents(ClientPtr client)
     };
 
     if (client->swapped) {
-        swaps(&rep.fontAscent);
-        swaps(&rep.fontDescent);
-        swaps(&rep.overallAscent);
-        swaps(&rep.overallDescent);
-        swapl(&rep.overallWidth);
-        swapl(&rep.overallLeft);
-        swapl(&rep.overallRight);
+        swaps(&reply.fontAscent);
+        swaps(&reply.fontDescent);
+        swaps(&reply.overallAscent);
+        swaps(&reply.overallDescent);
+        swapl(&reply.overallWidth);
+        swapl(&reply.overallLeft);
+        swapl(&reply.overallRight);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -2243,7 +2243,7 @@ DoGetImage(ClientPtr client, int format, Drawable drawable,
     if (rc != Success)
         return rc;
 
-    xGetImageReply rep = { 0 };
+    xGetImageReply reply = { 0 };
 
     relx = x;
     rely = y;
@@ -2278,11 +2278,11 @@ DoGetImage(ClientPtr client, int format, Drawable drawable,
             pBoundingDraw = (DrawablePtr) pDraw->pScreen->root;
         }
 
-        rep.visual = wVisual(pWin);
+        reply.visual = wVisual(pWin);
     }
     else {
         pBoundingDraw = pDraw;
-        rep.visual = None;
+        reply.visual = None;
     }
 
     /* "If the drawable is a pixmap, the given rectangle must be wholly
@@ -2300,7 +2300,7 @@ DoGetImage(ClientPtr client, int format, Drawable drawable,
         rely < 0 || rely + height > (int) pBoundingDraw->height)
         return BadMatch;
 
-    rep.depth = pDraw->depth;
+    reply.depth = pDraw->depth;
     if (format == ZPixmap) {
         widthBytesLine = PixmapBytePad(width, pDraw->depth);
         length = widthBytesLine * height;
@@ -2313,7 +2313,7 @@ DoGetImage(ClientPtr client, int format, Drawable drawable,
             Ones(planemask & (plane | (plane - 1)));
     }
 
-    rep.length = bytes_to_int32(length);
+    reply.length = bytes_to_int32(length);
 
     if (widthBytesLine == 0 || height == 0)
         linesPerBuf = 0;
@@ -2415,10 +2415,10 @@ DoGetImage(ClientPtr client, int format, Drawable drawable,
     }
 
     if (client->swapped) {
-        swapl(&rep.visual);
+        swapl(&reply.visual);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -2678,15 +2678,15 @@ ProcListInstalledColormaps(ClientPtr client)
     x_rpcbuf_write_CARD32s(&rpcbuf, cm, nummaps); /* Colormap is an XID, thus CARD32  */
     free(cm);
 
-    xListInstalledColormapsReply rep = {
+    xListInstalledColormapsReply reply = {
         .nColormaps = nummaps,
     };
 
     if (client->swapped) {
-        swaps(&rep.nColormaps);
+        swaps(&reply.nColormaps);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int dixAllocColor(ClientPtr client, Colormap cmap, CARD16 *red,
@@ -2717,26 +2717,27 @@ ProcAllocColor(ClientPtr client)
         swaps(&stuff->blue);
     }
 
-    xAllocColorReply rep = {
+    xAllocColorReply reply = {
         .red = stuff->red,
         .green = stuff->green,
         .blue = stuff->blue,
     };
 
-    int rc = dixAllocColor(client, stuff->cmap, &rep.red, &rep.green, &rep.blue, &rep.pixel);
+    int rc = dixAllocColor(client, stuff->cmap,
+                           &reply.red, &reply.green, &reply.blue, &reply.pixel);
     if (rc != Success) {
         client->errorValue = stuff->cmap;
         return rc;
     }
 
     if (client->swapped) {
-        swaps(&rep.red);
-        swaps(&rep.green);
-        swaps(&rep.blue);
-        swapl(&rep.pixel);
+        swaps(&reply.red);
+        swaps(&reply.green);
+        swaps(&reply.blue);
+        swapl(&reply.pixel);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -2755,38 +2756,41 @@ ProcAllocNamedColor(ClientPtr client)
         return rc;
     }
 
-    xAllocNamedColorReply rep = { 0 };
+    xAllocNamedColorReply reply = { 0 };
 
     if (!dixLookupBuiltinColor
             ((char *) &stuff[1], stuff->nbytes,
-             &rep.exactRed, &rep.exactGreen, &rep.exactBlue))
+             &reply.exactRed, &reply.exactGreen, &reply.exactBlue))
         return BadName;
 
-    rep.screenRed = rep.exactRed;
-    rep.screenGreen = rep.exactGreen;
-    rep.screenBlue = rep.exactBlue;
+    reply.screenRed = reply.exactRed;
+    reply.screenGreen = reply.exactGreen;
+    reply.screenBlue = reply.exactBlue;
 
     if ((rc = AllocColor(pcmp,
-                         &rep.screenRed, &rep.screenGreen,
-                         &rep.screenBlue, &rep.pixel, client->index)))
+                         &reply.screenRed,
+                         &reply.screenGreen,
+                         &reply.screenBlue,
+                         &reply.pixel,
+                         client->index)))
         return rc;
 
     if (client->swapped) {
-        swapl(&rep.pixel);
-        swaps(&rep.exactRed);
-        swaps(&rep.exactGreen);
-        swaps(&rep.exactBlue);
-        swaps(&rep.screenRed);
-        swaps(&rep.screenGreen);
-        swaps(&rep.screenBlue);
+        swapl(&reply.pixel);
+        swaps(&reply.exactRed);
+        swaps(&reply.exactGreen);
+        swaps(&reply.exactBlue);
+        swaps(&reply.screenRed);
+        swaps(&reply.screenGreen);
+        swaps(&reply.screenBlue);
     }
 
 #ifdef XINERAMA
     if (noPanoramiXExtension || !pcmp->pScreen->myNum)
-        return X_SEND_REPLY_SIMPLE(client, rep);
+        return X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 #else
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 #endif /* XINERAMA */
 }
 
@@ -2834,17 +2838,17 @@ ProcAllocColorCells(ClientPtr client)
         if (noPanoramiXExtension || !pcmp->pScreen->myNum)
 #endif /* XINERAMA */
         {
-            xAllocColorCellsReply rep = {
+            xAllocColorCellsReply reply = {
                 .nPixels = npixels,
                 .nMasks = nmasks
             };
             if (client->swapped) {
-                swaps(&rep.nPixels);
-                swaps(&rep.nMasks);
+                swaps(&reply.nPixels);
+                swaps(&reply.nMasks);
                 SwapLongs(ppixels, length / 4);
             }
 
-            return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+            return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
         }
         x_rpcbuf_clear(&rpcbuf);
         return Success;
@@ -2880,7 +2884,7 @@ ProcAllocColorPlanes(ClientPtr client)
             return BadValue;
         }
 
-        xAllocColorPlanesReply rep = {
+        xAllocColorPlanesReply reply = {
             .nPixels = npixels
         };
         length = (long) npixels *sizeof(Pixel);
@@ -2892,25 +2896,25 @@ ProcAllocColorPlanes(ClientPtr client)
         if ((rc = AllocColorPlanes(client->index, pcmp, npixels,
                                    (int) stuff->red, (int) stuff->green,
                                    (int) stuff->blue, (Bool) stuff->contiguous,
-                                   ppixels, &rep.redMask, &rep.greenMask,
-                                   &rep.blueMask))) {
+                                   ppixels, &reply.redMask, &reply.greenMask,
+                                   &reply.blueMask))) {
             x_rpcbuf_clear(&rpcbuf);
             return rc;
         }
 
         if (client->swapped) {
             SwapLongs(ppixels, length / 4);
-            swaps(&rep.nPixels);
-            swapl(&rep.redMask);
-            swapl(&rep.greenMask);
-            swapl(&rep.blueMask);
+            swaps(&reply.nPixels);
+            swapl(&reply.redMask);
+            swapl(&reply.greenMask);
+            swapl(&reply.blueMask);
         }
 
 #ifdef XINERAMA
         if (noPanoramiXExtension || !pcmp->pScreen->myNum)
 #endif /* XINERAMA */
         {
-            return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+            return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
         }
         x_rpcbuf_clear(&rpcbuf);
         return Success;
@@ -3030,16 +3034,16 @@ ProcQueryColors(ClientPtr client)
             return rc;
         }
 
-        xQueryColorsReply rep = {
+        xQueryColorsReply reply = {
             .nColors = count
         };
 
         if (client->swapped) {
-            swaps(&rep.nColors);
+            swaps(&reply.nColors);
             SwapShorts((short*)prgbs, count * 4); // xrgb = 4 shorts
         }
 
-        return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+        return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     }
     else {
         client->errorValue = stuff->cmap;
@@ -3069,7 +3073,7 @@ ProcLookupColor(ClientPtr client)
                                &exactBlue))
         return BadName;
 
-    xLookupColorReply rep = {
+    xLookupColorReply reply = {
         .exactRed = exactRed,
         .exactGreen = exactGreen,
         .exactBlue = exactBlue,
@@ -3078,21 +3082,21 @@ ProcLookupColor(ClientPtr client)
         .screenBlue = exactBlue
     };
 
-    pcmp->pScreen->ResolveColor(&rep.screenRed,
-                                &rep.screenGreen,
-                                &rep.screenBlue,
+    pcmp->pScreen->ResolveColor(&reply.screenRed,
+                                &reply.screenGreen,
+                                &reply.screenBlue,
                                 pcmp->pVisual);
 
     if (client->swapped) {
-        swaps(&rep.exactRed);
-        swaps(&rep.exactGreen);
-        swaps(&rep.exactBlue);
-        swaps(&rep.screenRed);
-        swaps(&rep.screenGreen);
-        swaps(&rep.screenBlue);
+        swaps(&reply.exactRed);
+        swaps(&reply.exactGreen);
+        swaps(&reply.exactBlue);
+        swaps(&reply.screenRed);
+        swaps(&reply.screenGreen);
+        swaps(&reply.screenBlue);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -3274,17 +3278,17 @@ ProcQueryBestSize(ClientPtr client)
     (*pScreen->QueryBestSize) (stuff->class, &stuff->width,
                                &stuff->height, pScreen);
 
-    xQueryBestSizeReply rep = {
+    xQueryBestSizeReply reply = {
         .width = stuff->width,
         .height = stuff->height
     };
 
     if (client->swapped) {
-        swaps(&rep.width);
-        swaps(&rep.height);
+        swaps(&reply.width);
+        swaps(&reply.height);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -3357,7 +3361,7 @@ ProcGetScreenSaver(ClientPtr client)
             return rc;
     });
 
-    xGetScreenSaverReply rep = {
+    xGetScreenSaverReply reply = {
         .timeout = ScreenSaverTime / MILLI_PER_SECOND,
         .interval = ScreenSaverInterval / MILLI_PER_SECOND,
         .preferBlanking = ScreenSaverBlanking,
@@ -3365,11 +3369,11 @@ ProcGetScreenSaver(ClientPtr client)
     };
 
     if (client->swapped) {
-        swaps(&rep.timeout);
-        swaps(&rep.interval);
+        swaps(&reply.timeout);
+        swaps(&reply.interval);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -3409,7 +3413,7 @@ ProcListHosts(ClientPtr client)
     if (result != Success)
         return result;
 
-    xListHostsReply rep = {
+    xListHostsReply reply = {
         .enabled = enabled,
         .nHosts = nHosts
     };
@@ -3427,13 +3431,13 @@ ProcListHosts(ClientPtr client)
             bufT += sizeof(xHostEntry) + pad_to_int32(l1);
         }
 
-        swaps(&rep.nHosts);
+        swaps(&reply.nHosts);
     }
 
     x_rpcbuf_write_CARD8s(&rpcbuf, pdata, len);
     free(pdata);
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -3540,15 +3544,15 @@ ProcGetFontPath(ClientPtr client)
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
-    xGetFontPathReply rep = {
+    xGetFontPathReply reply = {
         .nPaths = FillFontPath(&rpcbuf)
     };
 
     if (client->swapped) {
-        swaps(&rep.nPaths);
+        swaps(&reply.nPaths);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -3938,7 +3942,7 @@ void
 SendErrorToClient(ClientPtr client, CARD8 majorCode, CARD16 minorCode,
                   XID resId, BYTE errorCode)
 {
-    xError rep = {
+    xError reply = {
         .type = X_Error,
         .errorCode = errorCode,
         .resourceID = resId,
@@ -3946,7 +3950,7 @@ SendErrorToClient(ClientPtr client, CARD8 majorCode, CARD16 minorCode,
         .majorCode = majorCode
     };
 
-    WriteEventsToClient(client, 1, (xEvent *) &rep);
+    WriteEventsToClient(client, 1, (xEvent *) &reply);
 }
 
 void

--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -731,14 +731,14 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
     names = c->names;
     client = c->client;
 
-    xListFontsReply rep = {
+    xListFontsReply reply = {
         .nFonts = names->nnames,
     };
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
     for (int i = 0; i < names->nnames; i++) {
         if (names->length[i] > 255)
-            rep.nFonts--;
+            reply.nFonts--;
         else {
             /* write a pascal string */
             x_rpcbuf_write_CARD8(&rpcbuf, names->length[i]);
@@ -752,10 +752,10 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
     }
 
     if (client->swapped) {
-        swaps(&rep.nFonts);
+        swaps(&reply.nFonts);
     }
 
-    X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 
  bail:
     ClientWakeup(client);
@@ -829,7 +829,6 @@ doListFontsWithInfo(ClientPtr client, LFWIclosurePtr c)
     int namelen;
     int numFonts;
     FontInfoRec fontInfo, *pFontInfo;
-    xListFontsWithInfoReply *reply;
     int length;
     xFontProp *pFP;
     int aliascount = 0;
@@ -941,7 +940,7 @@ doListFontsWithInfo(ClientPtr client, LFWIclosurePtr c)
         }
         else if (err == Successful) {
             length = sizeof(xListFontsWithInfoReply) + pFontInfo->nprops * sizeof(xFontProp);
-            reply = c->reply;
+            xListFontsWithInfoReply *reply = c->reply;
             if (c->length < length) {
                 reply = (xListFontsWithInfoReply *) realloc(c->reply, length);
                 if (!reply) {
@@ -1033,8 +1032,8 @@ doListFontsWithInfo(ClientPtr client, LFWIclosurePtr c)
     }
  finish: ;
     /* finish it the replies series sending an empty reply */
-    xListFontsWithInfoReply rep = { 0 };
-    X_SEND_REPLY_SIMPLE(client, rep);
+    xListFontsWithInfoReply reply = { 0 };
+    X_SEND_REPLY_SIMPLE(client, reply);
  bail:
     ClientWakeup(client);
     for (int i = 0; i < c->num_fpes; i++)

--- a/dix/events.c
+++ b/dix/events.c
@@ -4980,22 +4980,22 @@ ProcGetInputFocus(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xGetInputFocusReply rep = {
+    xGetInputFocusReply reply = {
         .revertTo = focus->revert
     };
 
     if (focus->win == NoneWin)
-        rep.focus = None;
+        reply.focus = None;
     else if (focus->win == PointerRootWin)
-        rep.focus = PointerRoot;
+        reply.focus = PointerRoot;
     else
-        rep.focus = focus->win->drawable.id;
+        reply.focus = focus->win->drawable.id;
 
     if (client->swapped) {
-        swapl(&rep.focus);
+        swapl(&reply.focus);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 /**
@@ -5046,11 +5046,11 @@ ProcGrabPointer(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xGrabPointerReply rep = {
+    xGrabPointerReply reply = {
         .status = status,
     };
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 /**
@@ -5288,11 +5288,11 @@ ProcGrabKeyboard(ClientPtr client)
     if (result != Success)
         return result;
 
-    xGrabKeyboardReply rep = {
+    xGrabKeyboardReply reply = {
         .status = status,
     };
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 /**
@@ -5359,7 +5359,7 @@ ProcQueryPointer(ClientPtr client)
     if (mouse->valuator->motionHintWindow)
         MaybeStopHint(mouse, client);
 
-    xQueryPointerReply rep = {
+    xQueryPointerReply reply = {
         .mask = event_get_corestate(mouse, keyboard),
         .root = (InputDevCurrentRootWindow(mouse))->drawable.id,
         .rootX = pSprite->hot.x,
@@ -5367,51 +5367,51 @@ ProcQueryPointer(ClientPtr client)
         .child = None
     };
     if (pSprite->hot.pScreen == pWin->drawable.pScreen) {
-        rep.sameScreen = xTrue;
-        rep.winX = pSprite->hot.x - pWin->drawable.x;
-        rep.winY = pSprite->hot.y - pWin->drawable.y;
+        reply.sameScreen = xTrue;
+        reply.winX = pSprite->hot.x - pWin->drawable.x;
+        reply.winY = pSprite->hot.y - pWin->drawable.y;
         for (WindowPtr t = pSprite->win; t; t = t->parent)
             if (t->parent == pWin) {
-                rep.child = t->drawable.id;
+                reply.child = t->drawable.id;
                 break;
             }
     }
     else {
-        rep.sameScreen = xFalse;
+        reply.sameScreen = xFalse;
     }
 
 #ifdef XINERAMA
     if (!noPanoramiXExtension) {
         ScreenPtr masterScreen = dixGetMasterScreen();
-        rep.rootX += masterScreen->x;
-        rep.rootY += masterScreen->y;
-        if (stuff->id == rep.root) {
-            rep.winX += masterScreen->x;
-            rep.winY += masterScreen->y;
+        reply.rootX += masterScreen->x;
+        reply.rootY += masterScreen->y;
+        if (stuff->id == reply.root) {
+            reply.winX += masterScreen->x;
+            reply.winY += masterScreen->y;
         }
     }
 #endif /* XINERAMA */
 
     if (rc == BadAccess) {
-        rep.mask = 0;
-        rep.child = None;
-        rep.rootX = 0;
-        rep.rootY = 0;
-        rep.winX = 0;
-        rep.winY = 0;
+        reply.mask = 0;
+        reply.child = None;
+        reply.rootX = 0;
+        reply.rootY = 0;
+        reply.winX = 0;
+        reply.winY = 0;
     }
 
     if (client->swapped) {
-        swapl(&rep.root);
-        swapl(&rep.child);
-        swaps(&rep.rootX);
-        swaps(&rep.rootY);
-        swaps(&rep.winX);
-        swaps(&rep.winY);
-        swaps(&rep.mask);
+        swapl(&reply.root);
+        swapl(&reply.child);
+        swaps(&reply.rootX);
+        swaps(&reply.rootY);
+        swaps(&reply.winX);
+        swaps(&reply.winY);
+        swaps(&reply.mask);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 /**

--- a/dix/extension.c
+++ b/dix/extension.c
@@ -294,26 +294,22 @@ ProcQueryExtension(ClientPtr client)
     REQUEST(xQueryExtensionReq);
     REQUEST_FIXED_SIZE(xQueryExtensionReq, stuff->nbytes);
 
-    xQueryExtensionReply rep = { 0 };
+    xQueryExtensionReply reply = { 0 };
 
-    if (!NumExtensions || !extensions)
-        rep.present = xFalse;
-    else {
+    if (NumExtensions && extensions) {
         char extname[PATH_MAX] = { 0 };
         strncpy(extname, (char *) &stuff[1], min(stuff->nbytes, sizeof(extname)-1));
         ExtensionEntry *extEntry = CheckExtension(extname);
 
-        if (!extEntry || !ExtensionAvailable(client, extEntry))
-            rep.present = xFalse;
-        else {
-            rep.present = xTrue;
-            rep.major_opcode = extEntry->base;
-            rep.first_event = extEntry->eventBase;
-            rep.first_error = extEntry->errorBase;
+        if (extEntry && ExtensionAvailable(client, extEntry)) {
+            reply.present = xTrue;
+            reply.major_opcode = extEntry->base;
+            reply.first_event = extEntry->eventBase;
+            reply.first_error = extEntry->errorBase;
         }
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int
@@ -321,7 +317,7 @@ ProcListExtensions(ClientPtr client)
 {
     REQUEST_SIZE_MATCH(xReq);
 
-    xListExtensionsReply rep = { 0 };
+    xListExtensionsReply reply = { 0 };
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
@@ -332,7 +328,7 @@ ProcListExtensions(ClientPtr client)
 
             int len = strlen(extensions[i]->name);
 
-            rep.nExtensions++;
+            reply.nExtensions++;
 
             /* write a pascal string */
             x_rpcbuf_write_CARD8(&rpcbuf, len);
@@ -340,5 +336,5 @@ ProcListExtensions(ClientPtr client)
         }
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }

--- a/dix/property.c
+++ b/dix/property.c
@@ -566,8 +566,8 @@ ProcGetProperty(ClientPtr client)
 
     rc = dixLookupProperty(&pProp, pWin, p.property, p.client, prop_mode);
     if (rc == BadMatch) {
-        xGetPropertyReply rep = { 0 };
-        return X_SEND_REPLY_SIMPLE(client, rep);
+        xGetPropertyReply reply = { 0 };
+        return X_SEND_REPLY_SIMPLE(client, reply);
     }
     else if (rc != Success)
         return rc;
@@ -576,16 +576,16 @@ ProcGetProperty(ClientPtr client)
        property information, but not the data. */
 
     if (((p.type != pProp->type) && (p.type != AnyPropertyType))) {
-        xGetPropertyReply rep = {
+        xGetPropertyReply reply = {
             .bytesAfter = pProp->size,
             .format = pProp->format,
             .propertyType = pProp->type
         };
         if (client->swapped) {
-            swapl(&rep.propertyType);
-            swapl(&rep.bytesAfter);
+            swapl(&reply.propertyType);
+            swapl(&reply.bytesAfter);
         }
-        return X_SEND_REPLY_SIMPLE(client, rep);
+        return X_SEND_REPLY_SIMPLE(client, reply);
     }
 
 /*
@@ -604,14 +604,14 @@ ProcGetProperty(ClientPtr client)
 
     len = min(n - ind, 4 * p.longLength);
 
-    xGetPropertyReply rep = {
+    xGetPropertyReply reply = {
         .bytesAfter = n - (ind + len),
         .format = pProp->format,
         .nItems = len / (pProp->format / 8),
         .propertyType = pProp->type
     };
 
-    if (p.delete && (rep.bytesAfter == 0)) {
+    if (p.delete && (reply.bytesAfter == 0)) {
         deliverPropertyNotifyEvent(pWin, PropertyDelete, pProp);
         notifyVRRMode(client, pWin, PropertyDelete, pProp);
     }
@@ -635,7 +635,7 @@ ProcGetProperty(ClientPtr client)
     if (rpcbuf.error)
         return BadAlloc;
 
-    if (p.delete && (rep.bytesAfter == 0)) {
+    if (p.delete && (reply.bytesAfter == 0)) {
         /* Delete the Property */
         if (pWin->properties == pProp) {
             /* Takes care of head */
@@ -655,12 +655,12 @@ ProcGetProperty(ClientPtr client)
     }
 
     if (client->swapped) {
-        swapl(&rep.propertyType);
-        swapl(&rep.bytesAfter);
-        swapl(&rep.nItems);
+        swapl(&reply.propertyType);
+        swapl(&reply.bytesAfter);
+        swapl(&reply.nItems);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -690,15 +690,15 @@ ProcListProperties(ClientPtr client)
         }
     }
 
-    xListPropertiesReply rep = {
+    xListPropertiesReply reply = {
         .nProperties = numProps
     };
 
     if (client->swapped) {
-        swaps(&rep.nProperties);
+        swaps(&reply.nProperties);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int

--- a/dix/selection.c
+++ b/dix/selection.c
@@ -271,21 +271,21 @@ ProcGetSelectionOwner(ClientPtr client)
         goto out;
     }
 
-    xGetSelectionOwnerReply rep = { 0 };
+    xGetSelectionOwnerReply reply = { 0 };
 
     param.status = dixLookupSelection(&pSel, param.selection, param.client, DixGetAttrAccess);
     if (param.status == Success)
-        rep.owner = pSel->window;
+        reply.owner = pSel->window;
     else if (param.status == BadMatch)
-        rep.owner = None;
+        reply.owner = None;
     else
         goto out;
 
     if (client->swapped) {
-        swapl(&rep.owner);
+        swapl(&reply.owner);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 
 out:
     if (param.status != Success)

--- a/dix/window.c
+++ b/dix/window.c
@@ -1579,7 +1579,7 @@ ProcGetWindowAttributes(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xGetWindowAttributesReply rep = {
+    xGetWindowAttributesReply reply = {
         .bitGravity = pWin->bitGravity,
         .winGravity = pWin->winGravity,
         .backingStore = pWin->backingStore,
@@ -1600,17 +1600,17 @@ ProcGetWindowAttributes(ClientPtr client)
     };
 
     if (client->swapped) {
-        swapl(&rep.visualID);
-        swaps(&rep.class);
-        swapl(&rep.backingBitPlanes);
-        swapl(&rep.backingPixel);
-        swapl(&rep.colormap);
-        swapl(&rep.allEventMasks);
-        swapl(&rep.yourEventMask);
-        swaps(&rep.doNotPropagateMask);
+        swapl(&reply.visualID);
+        swaps(&reply.class);
+        swapl(&reply.backingBitPlanes);
+        swapl(&reply.backingPixel);
+        swapl(&reply.colormap);
+        swapl(&reply.allEventMasks);
+        swapl(&reply.yourEventMask);
+        swaps(&reply.doNotPropagateMask);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 WindowPtr


### PR DESCRIPTION
Preparation for future use of generic reply assembly macros.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
