### PR TITLE
Xi: consistenly name reply structs "reply" instead of "rep"

### DIFF
--- a/Xi/getfctl.c
+++ b/Xi/getfctl.c
@@ -263,33 +263,33 @@ ProcXGetFeedbackControl(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xGetFeedbackControlReply rep = {
+    xGetFeedbackControlReply reply = {
         .RepType = X_GetFeedbackControl,
     };
 
     for (k = dev->kbdfeed; k; k = k->next) {
-        rep.num_feedbacks++;
+        reply.num_feedbacks++;
         total_length += sizeof(xKbdFeedbackState);
     }
     for (p = dev->ptrfeed; p; p = p->next) {
-        rep.num_feedbacks++;
+        reply.num_feedbacks++;
         total_length += sizeof(xPtrFeedbackState);
     }
     for (s = dev->stringfeed; s; s = s->next) {
-        rep.num_feedbacks++;
+        reply.num_feedbacks++;
         total_length += sizeof(xStringFeedbackState) +
             (s->ctrl.num_symbols_supported * sizeof(KeySym));
     }
     for (i = dev->intfeed; i; i = i->next) {
-        rep.num_feedbacks++;
+        reply.num_feedbacks++;
         total_length += sizeof(xIntegerFeedbackState);
     }
     for (l = dev->leds; l; l = l->next) {
-        rep.num_feedbacks++;
+        reply.num_feedbacks++;
         total_length += sizeof(xLedFeedbackState);
     }
     for (b = dev->bell; b; b = b->next) {
-        rep.num_feedbacks++;
+        reply.num_feedbacks++;
         total_length += sizeof(xBellFeedbackState);
     }
 
@@ -313,7 +313,7 @@ ProcXGetFeedbackControl(ClientPtr client)
         CopySwapBellFeedback(client, b, &buf);
 
     if (client->swapped) {
-        swaps(&rep.num_feedbacks);
+        swaps(&reply.num_feedbacks);
     }
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }

--- a/Xi/getfocus.c
+++ b/Xi/getfocus.c
@@ -87,25 +87,25 @@ ProcXGetDeviceFocus(ClientPtr client)
 
     focus = dev->focus;
 
-    xGetDeviceFocusReply rep = {
+    xGetDeviceFocusReply reply = {
         .RepType = X_GetDeviceFocus,
         .time = focus->time.milliseconds,
         .revertTo = focus->revert,
     };
 
     if (focus->win == NoneWin)
-        rep.focus = None;
+        reply.focus = None;
     else if (focus->win == PointerRootWin)
-        rep.focus = PointerRoot;
+        reply.focus = PointerRoot;
     else if (focus->win == FollowKeyboardWin)
-        rep.focus = FollowKeyboard;
+        reply.focus = FollowKeyboard;
     else
-        rep.focus = focus->win->drawable.id;
+        reply.focus = focus->win->drawable.id;
 
     if (client->swapped) {
-        swapl(&rep.focus);
-        swapl(&rep.time);
+        swapl(&reply.focus);
+        swapl(&reply.time);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }

--- a/Xi/getkmap.c
+++ b/Xi/getkmap.c
@@ -117,10 +117,10 @@ ProcXGetDeviceKeyMapping(ClientPtr client)
     free(syms->map);
     free(syms);
 
-    xGetDeviceKeyMappingReply rep = {
+    xGetDeviceKeyMappingReply reply = {
         .RepType = X_GetDeviceKeyMapping,
         .keySymsPerKeyCode = mapWidth,
     };
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }

--- a/Xi/getprop.c
+++ b/Xi/getprop.c
@@ -90,7 +90,7 @@ ProcXGetDeviceDontPropagateList(ClientPtr client)
     WindowPtr pWin;
     OtherInputMasks *others;
 
-    xGetDeviceDontPropagateListReply rep = {
+    xGetDeviceDontPropagateListReply reply = {
         .RepType = X_GetDeviceDontPropagateList,
     };
 
@@ -104,8 +104,8 @@ ProcXGetDeviceDontPropagateList(ClientPtr client)
         for (i = 0; i < EMASKSIZE; i++)
             ClassFromMask(NULL, others->dontPropagateMask[i], i, &count, COUNT);
         if (count) {
-            rep.count = count;
-            buf = calloc(rep.count, sizeof(XEventClass));
+            reply.count = count;
+            buf = calloc(count, sizeof(XEventClass));
             if (!buf)
                 return BadAlloc;
 
@@ -120,10 +120,10 @@ ProcXGetDeviceDontPropagateList(ClientPtr client)
     }
 
     if (client->swapped) {
-        swaps(&rep.count);
+        swaps(&reply.count);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 /***********************************************************************

--- a/Xi/getselev.c
+++ b/Xi/getselev.c
@@ -91,7 +91,7 @@ ProcXGetSelectedExtensionEvents(ClientPtr client)
     OtherInputMasks *pOthers;
     InputClientsPtr others;
 
-    xGetSelectedExtensionEventsReply rep = {
+    xGetSelectedExtensionEventsReply reply = {
         .RepType = X_GetSelectedExtensionEvents,
     };
 
@@ -105,24 +105,24 @@ ProcXGetSelectedExtensionEvents(ClientPtr client)
         for (others = pOthers->inputClients; others; others = others->next)
             for (i = 0; i < EMASKSIZE; i++)
                 ClassFromMask(NULL, others->mask[i], i,
-                              &rep.all_clients_count, COUNT);
+                              &reply.all_clients_count, COUNT);
 
         for (others = pOthers->inputClients; others; others = others->next)
             if (SameClient(others, client)) {
                 for (i = 0; i < EMASKSIZE; i++)
                     ClassFromMask(NULL, others->mask[i], i,
-                                  &rep.this_client_count, COUNT);
+                                  &reply.this_client_count, COUNT);
                 break;
             }
 
-        size_t total_count = rep.all_clients_count + rep.this_client_count;
+        size_t total_count = reply.all_clients_count + reply.this_client_count;
         size_t total_length = total_count * sizeof(XEventClass);
         buf = calloc(1, total_length);
         if (!buf) /* rpcbuf still empty */
             return BadAlloc;
 
         tclient = buf;
-        aclient = buf + rep.this_client_count;
+        aclient = buf + reply.this_client_count;
         if (others)
             for (i = 0; i < EMASKSIZE; i++)
                 tclient =
@@ -138,9 +138,9 @@ ProcXGetSelectedExtensionEvents(ClientPtr client)
     }
 
     if (client->swapped) {
-        swaps(&rep.this_client_count);
-        swaps(&rep.all_clients_count);
+        swaps(&reply.this_client_count);
+        swaps(&reply.all_clients_count);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }

--- a/Xi/getvers.c
+++ b/Xi/getvers.c
@@ -83,7 +83,7 @@ ProcXGetExtensionVersion(ClientPtr client)
                                         stuff->nbytes))
         return BadLength;
 
-    xGetExtensionVersionReply rep = {
+    xGetExtensionVersionReply reply = {
         .RepType = X_GetExtensionVersion,
         .major_version = XIVersion.major_version,
         .minor_version = XIVersion.minor_version,
@@ -91,9 +91,9 @@ ProcXGetExtensionVersion(ClientPtr client)
     };
 
     if (client->swapped) {
-        swaps(&rep.major_version);
-        swaps(&rep.minor_version);
+        swaps(&reply.major_version);
+        swaps(&reply.minor_version);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }

--- a/Xi/grabdev.c
+++ b/Xi/grabdev.c
@@ -97,7 +97,7 @@ ProcXGrabDevice(ClientPtr client)
     GrabMask mask;
     struct tmask tmp[EMASKSIZE];
 
-    xGrabDeviceReply rep = {
+    xGrabDeviceReply reply = {
         .RepType = X_GrabDevice,
     };
 
@@ -115,12 +115,12 @@ ProcXGrabDevice(ClientPtr client)
     rc = GrabDevice(client, dev, stuff->other_devices_mode,
                     stuff->this_device_mode, stuff->grabWindow,
                     stuff->ownerEvents, stuff->time,
-                    &mask, XI, None, None, &rep.status);
+                    &mask, XI, None, None, &reply.status);
 
     if (rc != Success)
         return rc;
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 /***********************************************************************

--- a/Xi/gtmotion.c
+++ b/Xi/gtmotion.c
@@ -92,7 +92,7 @@ ProcXGetDeviceMotionEvents(ClientPtr client)
     if (dev->valuator->motionHintWindow)
         MaybeStopDeviceHint(dev, client);
 
-    xGetDeviceMotionEventsReply rep = {
+    xGetDeviceMotionEventsReply reply = {
         .RepType = X_GetDeviceMotionEvents,
         .axes = v->numAxes,
         .mode = Absolute        /* XXX we don't do relative at the moment */
@@ -110,17 +110,17 @@ ProcXGetDeviceMotionEvents(ClientPtr client)
         if (v->numMotionEvents) {
             const int size = sizeof(Time) + (v->numAxes * sizeof(INT32));
             INT32 *coords = NULL;
-            rep.nEvents = GetMotionHistory(dev, (xTimecoord **) &coords,   /* XXX */
+            reply.nEvents = GetMotionHistory(dev, (xTimecoord **) &coords,   /* XXX */
                                            start.milliseconds, stop.milliseconds,
                                            (ScreenPtr) NULL, FALSE);
-            x_rpcbuf_write_INT32s(&rpcbuf, coords, bytes_to_int32(rep.nEvents * size));
+            x_rpcbuf_write_INT32s(&rpcbuf, coords, bytes_to_int32(reply.nEvents * size));
             free(coords);
         }
     }
 
     if (client->swapped) {
-        swapl(&rep.nEvents);
+        swapl(&reply.nEvents);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }

--- a/Xi/setbmap.c
+++ b/Xi/setbmap.c
@@ -95,10 +95,10 @@ ProcXSetDeviceButtonMapping(ClientPtr client)
     if ((ret != Success) && (ret != MappingBusy))
         return ret;
 
-    xSetDeviceButtonMappingReply rep = {
+    xSetDeviceButtonMappingReply reply = {
         .RepType = X_SetDeviceButtonMapping,
         .status = (ret == Success ? MappingSuccess : MappingBusy),
     };
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }

--- a/Xi/setdval.c
+++ b/Xi/setdval.c
@@ -79,7 +79,7 @@ ProcXSetDeviceValuators(ClientPtr client)
     REQUEST(xSetDeviceValuatorsReq);
     REQUEST_AT_LEAST_SIZE(xSetDeviceValuatorsReq);
 
-    xSetDeviceValuatorsReply rep = {
+    xSetDeviceValuatorsReply reply = {
         .RepType = X_SetDeviceValuators,
         .status = Success
     };
@@ -101,14 +101,14 @@ ProcXSetDeviceValuators(ClientPtr client)
         return BadValue;
 
     if ((dev->deviceGrab.grab) && !SameClient(dev->deviceGrab.grab, client))
-        rep.status = AlreadyGrabbed;
+        reply.status = AlreadyGrabbed;
     else
-        rep.status = SetDeviceValuators(client, dev, (int *) &stuff[1],
+        reply.status = SetDeviceValuators(client, dev, (int *) &stuff[1],
                                         stuff->first_valuator,
                                         stuff->num_valuators);
 
-    if (rep.status != Success && rep.status != AlreadyGrabbed)
-        return rep.status;
+    if (reply.status != Success && reply.status != AlreadyGrabbed)
+        return reply.status;
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }

--- a/Xi/setmmap.c
+++ b/Xi/setmmap.c
@@ -95,10 +95,10 @@ ProcXSetDeviceModifierMapping(ClientPtr client)
     if (ret != MappingSuccess && ret != MappingBusy && ret != MappingFailed)
         return ret;
 
-    xSetDeviceModifierMappingReply rep = {
+    xSetDeviceModifierMappingReply reply = {
         .RepType = X_SetDeviceModifierMapping,
         .success = ret,
     };
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }

--- a/Xi/setmode.c
+++ b/Xi/setmode.c
@@ -80,7 +80,7 @@ ProcXSetDeviceMode(ClientPtr client)
     REQUEST(xSetDeviceModeReq);
     REQUEST_SIZE_MATCH(xSetDeviceModeReq);
 
-    xSetDeviceModeReply rep = {
+    xSetDeviceModeReply reply = {
         .RepType = X_SetDeviceMode,
     };
 
@@ -94,23 +94,23 @@ ProcXSetDeviceMode(ClientPtr client)
         return BadMatch;
 
     if ((dev->deviceGrab.grab) && !SameClient(dev->deviceGrab.grab, client))
-        rep.status = AlreadyGrabbed;
+        reply.status = AlreadyGrabbed;
     else
-        rep.status = SetDeviceMode(client, dev, stuff->mode);
+        reply.status = SetDeviceMode(client, dev, stuff->mode);
 
-    if (rep.status == Success)
+    if (reply.status == Success)
         valuator_set_mode(dev, VALUATOR_MODE_ALL_AXES, stuff->mode);
-    else if (rep.status != AlreadyGrabbed) {
-        switch (rep.status) {
+    else if (reply.status != AlreadyGrabbed) {
+        switch (reply.status) {
         case BadMatch:
         case BadImplementation:
         case BadAlloc:
             break;
         default:
-            rep.status = BadMode;
+            reply.status = BadMode;
         }
-        return rep.status;
+        return reply.status;
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }

--- a/Xi/xigetclientpointer.c
+++ b/Xi/xigetclientpointer.c
@@ -67,15 +67,15 @@ ProcXIGetClientPointer(ClientPtr client)
     else
         winclient = client;
 
-    xXIGetClientPointerReply rep = {
+    xXIGetClientPointerReply reply = {
         .RepType = X_XIGetClientPointer,
         .set = (winclient->clientPtr != NULL),
         .deviceid = (winclient->clientPtr) ? winclient->clientPtr->id : 0
     };
 
     if (client->swapped) {
-        swaps(&rep.deviceid);
+        swaps(&reply.deviceid);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }

--- a/Xi/xigrabdev.c
+++ b/Xi/xigrabdev.c
@@ -114,12 +114,12 @@ ProcXIGrabDevice(ClientPtr client)
     if (ret != Success)
         return ret;
 
-    xXIGrabDeviceReply rep = {
+    xXIGrabDeviceReply reply = {
         .RepType = X_XIGrabDevice,
         .status = status
     };
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int

--- a/Xi/xipassivegrab.c
+++ b/Xi/xipassivegrab.c
@@ -74,7 +74,7 @@ ProcXIPassiveGrabDevice(ClientPtr client)
     }
 
     DeviceIntPtr dev, mod_dev;
-    xXIPassiveGrabDeviceReply rep = {
+    xXIPassiveGrabDeviceReply reply = {
         .repType = X_Reply,
         .RepType = X_XIPassiveGrabDevice,
         .sequenceNumber = client->sequence,
@@ -226,17 +226,17 @@ ProcXIPassiveGrabDevice(ClientPtr client)
             x_rpcbuf_write_CARD8(&rpcbuf, 0); /* pad0 */
             x_rpcbuf_write_CARD16(&rpcbuf, 0); /* pad1 */
 
-            rep.num_modifiers++;
+            reply.num_modifiers++;
         }
     }
 
     xi2mask_free(&mask.xi2mask);
 
     if (client->swapped) {
-        swaps(&rep.num_modifiers);
+        swaps(&reply.num_modifiers);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 
  out:
     xi2mask_free(&mask.xi2mask);

--- a/Xi/xiproperty.c
+++ b/Xi/xiproperty.c
@@ -852,16 +852,16 @@ ProcXListDeviceProperties(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xListDevicePropertiesReply rep = {
+    xListDevicePropertiesReply reply = {
         .RepType = X_ListDeviceProperties,
         .nAtoms = natoms
     };
 
     if (client->swapped) {
-        swaps(&rep.nAtoms);
+        swaps(&reply.nAtoms);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -963,7 +963,7 @@ ProcXGetDeviceProperty(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xGetDevicePropertyReply rep = {
+    xGetDevicePropertyReply reply = {
         .RepType = X_GetDeviceProperty,
         .propertyType = type,
         .bytesAfter = bytes_after,
@@ -972,13 +972,13 @@ ProcXGetDeviceProperty(ClientPtr client)
         .deviceid = dev->id
     };
 
-    if (stuff->delete && (rep.bytesAfter == 0))
+    if (stuff->delete && (reply.bytesAfter == 0))
         send_property_event(dev, stuff->property, XIPropertyDeleted);
 
     if (client->swapped) {
-        swapl(&rep.propertyType);
-        swapl(&rep.bytesAfter);
-        swapl(&rep.nItems);
+        swapl(&reply.propertyType);
+        swapl(&reply.bytesAfter);
+        swapl(&reply.nItems);
     }
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
@@ -998,7 +998,7 @@ ProcXGetDeviceProperty(ClientPtr client)
     }
 
     /* delete the Property */
-    if (stuff->delete && (rep.bytesAfter == 0)) {
+    if (stuff->delete && (reply.bytesAfter == 0)) {
         XIPropertyPtr prop, *prev;
 
         for (prev = &dev->properties.properties; (prop = *prev);
@@ -1011,7 +1011,7 @@ ProcXGetDeviceProperty(ClientPtr client)
         }
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 /* XI2 Request/reply handling */
@@ -1031,16 +1031,16 @@ ProcXIListProperties(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xXIListPropertiesReply rep = {
+    xXIListPropertiesReply reply = {
         .RepType = X_XIListProperties,
         .num_properties = natoms
     };
 
     if (client->swapped) {
-        swaps(&rep.num_properties);
+        swaps(&reply.num_properties);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -1146,7 +1146,7 @@ ProcXIGetProperty(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xXIGetPropertyReply rep = {
+    xXIGetPropertyReply reply = {
         .RepType = X_XIGetProperty,
         .type = type,
         .bytes_after = bytes_after,
@@ -1154,13 +1154,13 @@ ProcXIGetProperty(ClientPtr client)
         .format = format
     };
 
-    if (length && stuff->delete && (rep.bytes_after == 0))
+    if (length && stuff->delete && (reply.bytes_after == 0))
         send_property_event(dev, stuff->property, XIPropertyDeleted);
 
     if (client->swapped) {
-        swapl(&rep.type);
-        swapl(&rep.bytes_after);
-        swapl(&rep.num_items);
+        swapl(&reply.type);
+        swapl(&reply.bytes_after);
+        swapl(&reply.num_items);
     }
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
@@ -1179,12 +1179,12 @@ ProcXIGetProperty(ClientPtr client)
         }
     }
 
-    rc = X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    rc = X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     if (rc != Success)
         return rc;
 
     /* delete the Property */
-    if (stuff->delete && (rep.bytes_after == 0)) {
+    if (stuff->delete && (reply.bytes_after == 0)) {
         XIPropertyPtr prop, *prev;
 
         for (prev = &dev->properties.properties; (prop = *prev);

--- a/Xi/xiquerydevice.c
+++ b/Xi/xiquerydevice.c
@@ -108,7 +108,7 @@ ProcXIQueryDevice(ClientPtr client)
         return BadAlloc;
     }
 
-    xXIQueryDeviceReply rep = {
+    xXIQueryDeviceReply reply = {
         .RepType = X_XIQueryDevice,
     };
 
@@ -117,7 +117,7 @@ ProcXIQueryDevice(ClientPtr client)
         if (client->swapped)
             SwapDeviceInfo(dev, (xXIDeviceInfo *) info);
         info += len;
-        rep.num_devices = 1;
+        reply.num_devices = 1;
     }
     else {
         i = 0;
@@ -127,7 +127,7 @@ ProcXIQueryDevice(ClientPtr client)
                 if (client->swapped)
                     SwapDeviceInfo(dev, (xXIDeviceInfo *) info);
                 info += len;
-                rep.num_devices++;
+                reply.num_devices++;
             }
         }
 
@@ -137,7 +137,7 @@ ProcXIQueryDevice(ClientPtr client)
                 if (client->swapped)
                     SwapDeviceInfo(dev, (xXIDeviceInfo *) info);
                 info += len;
-                rep.num_devices++;
+                reply.num_devices++;
             }
         }
     }
@@ -145,10 +145,10 @@ ProcXIQueryDevice(ClientPtr client)
     free(skip);
 
     if (client->swapped) {
-        swaps(&rep.num_devices);
+        swaps(&reply.num_devices);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 /**

--- a/Xi/xiqueryversion.c
+++ b/Xi/xiqueryversion.c
@@ -118,16 +118,16 @@ ProcXIQueryVersion(ClientPtr client)
         pXIClient->minor_version = minor;
     }
 
-    xXIQueryVersionReply rep = {
+    xXIQueryVersionReply reply = {
         .RepType = X_XIQueryVersion,
         .major_version = major,
         .minor_version = minor
     };
 
     if (client->swapped) {
-        swaps(&rep.major_version);
-        swaps(&rep.minor_version);
+        swaps(&reply.major_version);
+        swaps(&reply.minor_version);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }

--- a/Xi/xiselectev.c
+++ b/Xi/xiselectev.c
@@ -337,7 +337,7 @@ ProcXIGetSelectedEvents(ClientPtr client)
     if (rc != Success)
         return rc;
 
-    xXIGetSelectedEventsReply rep = {
+    xXIGetSelectedEventsReply reply = {
         .RepType = X_XIGetSelectedEvents,
     };
 
@@ -381,7 +381,7 @@ ProcXIGetSelectedEvents(ClientPtr client)
                 CARD8 zero[8] = { 0 };
                 x_rpcbuf_write_CARD8s(&rpcbuf, zero, (mask_len*4) - (j+1));
 
-                rep.num_masks++;
+                reply.num_masks++;
 
                 /* found out the mask size and written it, so break out here */
                 break;
@@ -392,8 +392,8 @@ ProcXIGetSelectedEvents(ClientPtr client)
 finish: ;
 
     if (client->swapped) {
-        swaps(&rep.num_masks);
+        swaps(&reply.num_masks);
     }
 
-    return X_SEND_REPLY_WITH_RPCBUF(client, rep, rpcbuf);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }

--- a/Xi/xisetdevfocus.c
+++ b/Xi/xisetdevfocus.c
@@ -84,22 +84,22 @@ ProcXIGetFocus(ClientPtr client)
     if (!dev->focus)
         return BadDevice;
 
-    xXIGetFocusReply rep = {
+    xXIGetFocusReply reply = {
         .RepType = X_XIGetFocus,
     };
 
     if (dev->focus->win == NoneWin)
-        rep.focus = None;
+        reply.focus = None;
     else if (dev->focus->win == PointerRootWin)
-        rep.focus = PointerRoot;
+        reply.focus = PointerRoot;
     else if (dev->focus->win == FollowKeyboardWin)
-        rep.focus = FollowKeyboard;
+        reply.focus = FollowKeyboard;
     else
-        rep.focus = dev->focus->win->drawable.id;
+        reply.focus = dev->focus->win->drawable.id;
 
     if (client->swapped) {
-        swapl(&rep.focus);
+        swapl(&reply.focus);
     }
 
-    return X_SEND_REPLY_SIMPLE(client, rep);
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }


### PR DESCRIPTION
Preparation for future use of generic reply assembly macros.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
