### PR TITLE
test: consistenly name reply structs "reply" instead of "rep"

### DIFF
--- a/test/xi1/protocol-xchangedevicecontrol.c
+++ b/test/xi1/protocol-xchangedevicecontrol.c
@@ -48,14 +48,14 @@ static ClientRec client_request;
 static void
 reply_ChangeDeviceControl(ClientPtr client, int len, void *data)
 {
-    xChangeDeviceControlReply *rep = (xChangeDeviceControlReply *) data;
+    xChangeDeviceControlReply *reply = (xChangeDeviceControlReply *) data;
 
     if (client->swapped) {
-        swapl(&rep->length);
-        swaps(&rep->sequenceNumber);
+        swapl(&reply->length);
+        swaps(&reply->sequenceNumber);
     }
 
-    reply_check_defaults(rep, len, ChangeDeviceControl);
+    reply_check_defaults(reply, len, ChangeDeviceControl);
 
     /* XXX: check status code in reply */
 }

--- a/test/xi2/protocol-xigetclientpointer.c
+++ b/test/xi2/protocol-xigetclientpointer.c
@@ -57,22 +57,22 @@ static ClientRec client_request;
 static void
 reply_XIGetClientPointer(ClientPtr client, int len, void *data)
 {
-    xXIGetClientPointerReply *reply = (xXIGetClientPointerReply *) data;
-    xXIGetClientPointerReply rep = *reply; /* copy so swapping doesn't touch the real reply */
+    xXIGetClientPointerReply *repptr = (xXIGetClientPointerReply *) data;
+    xXIGetClientPointerReply reply = *repptr; /* copy so swapping doesn't touch the real reply */
 
     assert(len < 0xffff); /* suspicious size, swapping bug */
 
     if (client->swapped) {
-        swapl(&rep.length);
-        swaps(&rep.sequenceNumber);
-        swaps(&rep.deviceid);
+        swapl(&reply.length);
+        swaps(&reply.sequenceNumber);
+        swaps(&reply.deviceid);
     }
 
-    reply_check_defaults(&rep, len, XIGetClientPointer);
+    reply_check_defaults(&reply, len, XIGetClientPointer);
 
-    assert(rep.set == test_data.cp_is_set);
-    if (rep.set)
-        assert(rep.deviceid == test_data.dev->id);
+    assert(reply.set == test_data.cp_is_set);
+    if (reply.set)
+        assert(reply.deviceid == test_data.dev->id);
 }
 
 static void

--- a/test/xi2/protocol-xigetselectedevents.c
+++ b/test/xi2/protocol-xigetselectedevents.c
@@ -76,20 +76,20 @@ override_AddResource(XID id, RESTYPE type, void *value)
 static void
 reply_XIGetSelectedEvents(ClientPtr client, int len, void *data)
 {
-    xXIGetSelectedEventsReply *reply = (xXIGetSelectedEventsReply *) data;
-    xXIGetSelectedEventsReply rep = *reply; /* copy so swapping doesn't touch the real reply */
+    xXIGetSelectedEventsReply *repptr = (xXIGetSelectedEventsReply *) data;
+    xXIGetSelectedEventsReply reply = *repptr; /* copy so swapping doesn't touch the real reply */
 
     assert(len < 0xffff); /* suspicious size, swapping bug */
 
     if (client->swapped) {
-        swapl(&rep.length);
-        swaps(&rep.sequenceNumber);
-        swaps(&rep.num_masks);
+        swapl(&reply.length);
+        swaps(&reply.sequenceNumber);
+        swaps(&reply.num_masks);
     }
 
-    reply_check_defaults(&rep, len, XIGetSelectedEvents);
+    reply_check_defaults(&reply, len, XIGetSelectedEvents);
 
-    assert(rep.num_masks == test_data.num_masks_expected);
+    assert(reply.num_masks == test_data.num_masks_expected);
 
     wrapped_WriteToClient = reply_XIGetSelectedEvents_data;
 }

--- a/test/xi2/protocol-xipassivegrabdevice.c
+++ b/test/xi2/protocol-xipassivegrabdevice.c
@@ -81,24 +81,24 @@ override_GrabButton(ClientPtr client, DeviceIntPtr dev,
 static void
 reply_XIPassiveGrabDevice(ClientPtr client, int len, void *data)
 {
-    xXIPassiveGrabDeviceReply *reply = (xXIPassiveGrabDeviceReply *) data;
-    xXIPassiveGrabDeviceReply rep = *reply; /* copy so swapping doesn't touch the real reply */
+    xXIPassiveGrabDeviceReply *repptr = (xXIPassiveGrabDeviceReply *) data;
+    xXIPassiveGrabDeviceReply reply = *repptr; /* copy so swapping doesn't touch the real reply */
 
     assert(len < 0xffff); /* suspicious size, swapping bug */
 
     if (client->swapped) {
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.length);
-        swaps(&rep.num_modifiers);
+        swaps(&reply.sequenceNumber);
+        swapl(&reply.length);
+        swaps(&reply.num_modifiers);
 
-        testdata.num_modifiers = rep.num_modifiers;
+        testdata.num_modifiers = reply.num_modifiers;
     }
 
-    reply_check_defaults(&rep, len, XIPassiveGrabDevice);
+    reply_check_defaults(&reply, len, XIPassiveGrabDevice);
 
     /* ProcXIPassiveGrabDevice sends the data in two batches, let the second
      * handler handle the modifier data */
-    if (rep.num_modifiers > 0)
+    if (reply.num_modifiers > 0)
         wrapped_WriteToClient = reply_XIPassiveGrabDevice_data;
 }
 

--- a/test/xi2/protocol-xiquerydevice.c
+++ b/test/xi2/protocol-xiquerydevice.c
@@ -68,27 +68,27 @@ static void reply_XIQueryDevice_data(ClientPtr client, int len, void *data);
 static void
 reply_XIQueryDevice(ClientPtr client, int len, void *data)
 {
-    xXIQueryDeviceReply *reply = (xXIQueryDeviceReply *) data;
-    xXIQueryDeviceReply rep = *reply; /* copy so swapping doesn't touch the real reply */
+    xXIQueryDeviceReply *repptr = (xXIQueryDeviceReply *) data;
+    xXIQueryDeviceReply reply = *repptr; /* copy so swapping doesn't touch the real reply */
 
     assert(len < 0xffff); /* suspicious size, swapping bug */
 
     if (client->swapped) {
-        swapl(&rep.length);
-        swaps(&rep.sequenceNumber);
-        swaps(&rep.num_devices);
+        swapl(&reply.length);
+        swaps(&reply.sequenceNumber);
+        swaps(&reply.num_devices);
     }
 
-    reply_check_defaults(&rep, len, XIQueryDevice);
+    reply_check_defaults(&reply, len, XIQueryDevice);
 
     if (test_data.which_device == XIAllDevices)
-        assert(rep.num_devices == devices.num_devices);
+        assert(reply.num_devices == devices.num_devices);
     else if (test_data.which_device == XIAllMasterDevices)
-        assert(rep.num_devices == devices.num_master_devices);
+        assert(reply.num_devices == devices.num_master_devices);
     else
-        assert(rep.num_devices == 1);
+        assert(reply.num_devices == 1);
 
-    test_data.num_devices_in_reply = rep.num_devices;
+    test_data.num_devices_in_reply = reply.num_devices;
 
     wrapped_WriteToClient = reply_XIQueryDevice_data;
 }

--- a/test/xi2/protocol-xiquerypointer.c
+++ b/test/xi2/protocol-xiquerypointer.c
@@ -58,40 +58,40 @@ static struct {
 static void
 reply_XIQueryPointer(ClientPtr client, int len, void *data)
 {
-    xXIQueryPointerReply *reply = (xXIQueryPointerReply *) data;
-    xXIQueryPointerReply rep = *reply; /* copy so swapping doesn't touch the real reply */
+    xXIQueryPointerReply *repptr = (xXIQueryPointerReply *) data;
+    xXIQueryPointerReply reply = *repptr; /* copy so swapping doesn't touch the real reply */
     SpritePtr sprite;
 
     assert(len < 0xffff); /* suspicious size, swapping bug */
 
-    if (!rep.repType)
+    if (!reply.repType)
         return;
 
     if (client->swapped) {
-        swapl(&rep.length);
-        swaps(&rep.sequenceNumber);
-        swapl(&rep.root);
-        swapl(&rep.child);
-        swapl(&rep.root_x);
-        swapl(&rep.root_y);
-        swapl(&rep.win_x);
-        swapl(&rep.win_y);
-        swaps(&rep.buttons_len);
+        swapl(&reply.length);
+        swaps(&reply.sequenceNumber);
+        swapl(&reply.root);
+        swapl(&reply.child);
+        swapl(&reply.root_x);
+        swapl(&reply.root_y);
+        swapl(&reply.win_x);
+        swapl(&reply.win_y);
+        swaps(&reply.buttons_len);
     }
 
-    reply_check_defaults(&rep, len, XIQueryPointer);
+    reply_check_defaults(&reply, len, XIQueryPointer);
 
-    assert(rep.root == root.drawable.id);
-    assert(rep.same_screen == xTrue);
+    assert(reply.root == root.drawable.id);
+    assert(reply.same_screen == xTrue);
 
     sprite = test_data.dev->spriteInfo->sprite;
-    assert((rep.root_x >> 16) == sprite->hot.x);
-    assert((rep.root_y >> 16) == sprite->hot.y);
+    assert((reply.root_x >> 16) == sprite->hot.x);
+    assert((reply.root_y >> 16) == sprite->hot.y);
 
     if (test_data.win == &root) {
-        assert(rep.root_x == rep.win_x);
-        assert(rep.root_y == rep.win_y);
-        assert(rep.child == window.drawable.id);
+        assert(reply.root_x == reply.win_x);
+        assert(reply.root_y == reply.win_y);
+        assert(reply.child == window.drawable.id);
     }
     else {
         int x, y;
@@ -99,12 +99,12 @@ reply_XIQueryPointer(ClientPtr client, int len, void *data)
         x = sprite->hot.x - window.drawable.x;
         y = sprite->hot.y - window.drawable.y;
 
-        assert((rep.win_x >> 16) == x);
-        assert((rep.win_y >> 16) == y);
-        assert(rep.child == None);
+        assert((reply.win_x >> 16) == x);
+        assert((reply.win_y >> 16) == y);
+        assert(reply.child == None);
     }
 
-    assert(rep.same_screen == xTrue);
+    assert(reply.same_screen == xTrue);
 
     wrapped_WriteToClient = reply_XIQueryPointer_data;
 }

--- a/test/xi2/protocol-xiqueryversion.c
+++ b/test/xi2/protocol-xiqueryversion.c
@@ -70,27 +70,27 @@ extern ClientRec client_window;
 static void
 reply_XIQueryVersion(ClientPtr client, int len, void *data)
 {
-    xXIQueryVersionReply *reply = (xXIQueryVersionReply *) data;
-    xXIQueryVersionReply rep = *reply; /* copy so swapping doesn't touch the real reply */
+    xXIQueryVersionReply *repptr = (xXIQueryVersionReply *) data;
+    xXIQueryVersionReply reply = *repptr ; /* copy so swapping doesn't touch the real reply */
 
     unsigned int sver, cver, ver;
 
     assert(len < 0xffff); /* suspicious size, swapping bug */
 
     if (client->swapped) {
-        swapl(&rep.length);
-        swaps(&rep.sequenceNumber);
-        swaps(&rep.major_version);
-        swaps(&rep.minor_version);
+        swapl(&reply.length);
+        swaps(&reply.sequenceNumber);
+        swaps(&reply.major_version);
+        swaps(&reply.minor_version);
     }
 
-    reply_check_defaults(&rep, len, XIQueryVersion);
+    reply_check_defaults(&reply, len, XIQueryVersion);
 
-    assert(rep.length == 0);
+    assert(reply.length == 0);
 
     sver = versions.major_server * 1000 + versions.minor_server;
     cver = versions.major_client * 1000 + versions.minor_client;
-    ver = rep.major_version * 1000 + rep.minor_version;
+    ver = reply.major_version * 1000 + reply.minor_version;
 
     assert(ver >= 2000);
     assert((sver > cver) ? ver == cver : ver == sver);
@@ -99,14 +99,14 @@ reply_XIQueryVersion(ClientPtr client, int len, void *data)
 static void
 reply_XIQueryVersion_multiple(ClientPtr client, int len, void *data)
 {
-    xXIQueryVersionReply *reply = (xXIQueryVersionReply *) data;
-    xXIQueryVersionReply rep = *reply; /* copy so swapping doesn't touch the real reply */
+    xXIQueryVersionReply *repptr = (xXIQueryVersionReply *) data;
+    xXIQueryVersionReply reply = *repptr; /* copy so swapping doesn't touch the real reply */
 
-    reply_check_defaults(&rep, len, XIQueryVersion);
-    assert(rep.length == 0);
+    reply_check_defaults(&reply, len, XIQueryVersion);
+    assert(reply.length == 0);
 
-    assert(versions.major_expected == rep.major_version);
-    assert(versions.minor_expected == rep.minor_version);
+    assert(versions.major_expected == reply.major_version);
+    assert(versions.minor_expected == reply.minor_version);
 }
 
 /**


### PR DESCRIPTION
Preparation for future use of generic reply assembly macros.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
