### PR TITLE
include: fix warning on XNFvasprintf() prototype

### DIFF
--- a/include/Xprintf.h
+++ b/include/Xprintf.h
@@ -28,6 +28,8 @@
 #include <stdarg.h>
 #include <X11/Xfuncproto.h>
 
+#include "os.h"
+
 #ifndef _X_RESTRICT_KYWD
 #if defined(restrict) /* assume autoconf set it correctly */ || \
    (defined(__STDC__) && (__STDC_VERSION__ - 0 >= 199901L))     /* C99 */
@@ -53,6 +55,6 @@ XNFasprintf(char **ret, const char *_X_RESTRICT_KYWD fmt, ...)
 _X_ATTRIBUTE_PRINTF(2, 3);
 extern _X_EXPORT int
 XNFvasprintf(char **ret, const char *_X_RESTRICT_KYWD fmt, va_list va)
-_X_ATTRIBUTE_PRINTF(2, 0);
+_X_ATTRIBUTE_VPRINTF(2, 0);
 
 #endif                          /* XPRINTF_H */

--- a/include/os.h
+++ b/include/os.h
@@ -69,6 +69,15 @@ SOFTWARE.
 #define _X_ATTRIBUTE_NONNULL_ARG(...) __attribute__((nonnull(__VA_ARGS__)))
 #endif
 
+#ifndef _X_ATTRIBUTE_VPRINTF
+# if defined(__GNUC__) && (__GNUC__ >= 2)
+#  define _X_ATTRIBUTE_VPRINTF(fmt, firstarg) \
+          __attribute__((__format__(gnu_printf, fmt, firstarg)))
+# else
+#  define _X_ATTRIBUTE_VPRINTF(fmt, firstarg) _X_ATTRIBUTE_PRINTF(fmt,firstarg)
+# endif
+#endif
+
 #define SCREEN_SAVER_ON   0
 #define SCREEN_SAVER_OFF  1
 #define SCREEN_SAVER_FORCER 2

--- a/os/audit_priv.h
+++ b/os/audit_priv.h
@@ -8,11 +8,13 @@
 #include <stdarg.h>
 #include <X11/Xfuncproto.h>
 
+#include "include/os.h"
+
 extern int auditTrailLevel;
 
 void FreeAuditTimer(void);
 
 void AuditF(const char *f, ...) _X_ATTRIBUTE_PRINTF(1, 2);
-void VAuditF(const char *f, va_list args) _X_ATTRIBUTE_PRINTF(1, 0);
+void VAuditF(const char *f, va_list args) _X_ATTRIBUTE_VPRINTF(1, 0);
 
 #endif /* _XSERVER_OS_AUDIT_H */


### PR DESCRIPTION
> ../os/xprintf.c: In function ‘XNFvasprintf’:
> ../os/xprintf.c:84:5: warning: function ‘XNFvasprintf’ might be a candidate for ‘gnu_printf’ format attribute [-Wsuggest-attribute=format]
>    84 |     int size = vasprintf(ret, format, va);
>       |     ^~~

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
