### PR TITLE
treewide: drop including <dix-config.h> from private includes

### DIFF
--- a/dix/inpututils_priv.h
+++ b/dix/inpututils_priv.h
@@ -24,8 +24,6 @@
 #ifndef _XSERVER_DIX_INPUTUTILS_PRIV_H
 #define _XSERVER_DIX_INPUTUTILS_PRIV_H
 
-#include "dix-config.h"
-
 #include "input.h"
 #include "eventstr.h"
 #include <X11/extensions/XI2proto.h>

--- a/dri3/dri3_priv.h
+++ b/dri3/dri3_priv.h
@@ -23,7 +23,6 @@
 #ifndef _DRI3PRIV_H_
 #define _DRI3PRIV_H_
 
-#include "dix-config.h"
 #include <X11/X.h>
 #include "scrnintstr.h"
 #include "misc.h"

--- a/exa/exa_priv.h
+++ b/exa/exa_priv.h
@@ -26,8 +26,6 @@
 #ifndef EXAPRIV_H
 #define EXAPRIV_H
 
-#include <dix-config.h>
-
 #include "exa.h"
 
 #include <X11/X.h>

--- a/glamor/glamor_priv.h
+++ b/glamor/glamor_priv.h
@@ -27,8 +27,6 @@
 #ifndef GLAMOR_PRIV_H
 #define GLAMOR_PRIV_H
 
-#include "dix-config.h"
-
 #include <X11/Xfuncproto.h>
 
 #include "os/bug_priv.h"

--- a/hw/kdrive/ephyr/ephyr_glamor.c
+++ b/hw/kdrive/ephyr/ephyr_glamor.c
@@ -25,6 +25,8 @@
  *
  * Glamor support and EGL setup.
  */
+#include <dix-config.h>
+
 #define MESA_EGL_NO_X11_HEADERS
 #define EGL_NO_X11
 

--- a/os/probes_priv.h
+++ b/os/probes_priv.h
@@ -24,10 +24,6 @@
 #ifndef XORG_PROBES_H
 #define XORG_PROBES_H
 
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 /* definitions needed to include Dtrace probes in a source file */
 
 #ifdef XSERVER_DTRACE


### PR DESCRIPTION
All .c sources must include <dix-config.h> at the very first.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
