### PR TITLE
meson.build: move creating conf_data object to toplevel

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -8,9 +8,6 @@ release = 1 * 10000000 + major * 100000 + minor * 1000 + patch
 
 dri_dep = dependency('dri', required: build_glx)
 
-conf_data = configuration_data()
-conf_data.set('_DIX_CONFIG_H_', '1')
-
 # For feature macros we're using either false (boolean) or '1', which correspond to the macro being
 # not defined at all and defined to 1. This is to match autotools behavior and thus preserve
 # backwards  compatibility with all the existing code that uses #ifdef to check if feature is

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,10 @@ add_project_arguments('-fno-common', language: 'c')
 
 add_project_link_arguments('-fvisibility=hidden', language : 'c')
 
+# global config data -- needs to be declared early
+conf_data = configuration_data()
+conf_data.set('_DIX_CONFIG_H_', '1')
+
 if cc.get_id() == 'gcc' or cc.get_id() == 'clang'
     test_wflags = [
         '-Wall',


### PR DESCRIPTION
create it very early, so we're free to move around call sites
between subdirectories. preparation for untwisting the whole
probing logic.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
