### PR TITLE
xfree86: common: move enum ActionEvent to private header

### DIFF
--- a/hw/xfree86/common/action_priv.h
+++ b/hw/xfree86/common/action_priv.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef __XSERVER_XFREE86_ACTION_PRIV_H
+#define __XSERVER_XFREE86_ACTION_PRIV_H
+
+typedef enum {
+    ACTION_TERMINATE          = 0,    /* Terminate Server */
+    ACTION_NEXT_MODE          = 10,   /* Switch to next video mode */
+    ACTION_PREV_MODE,
+    ACTION_SWITCHSCREEN       = 100,  /* VT switch */
+    ACTION_SWITCHSCREEN_NEXT,
+    ACTION_SWITCHSCREEN_PREV,
+} ActionEvent;
+
+void xf86ProcessActionEvent(ActionEvent action, void *arg);
+
+#endif /* __XSERVER_XFREE86_ACTION_PRIV_H */

--- a/hw/xfree86/common/xf86Events.c
+++ b/hw/xfree86/common/xf86Events.c
@@ -64,6 +64,7 @@
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
 #include "include/property.h"
+#include "hw/xfree86/common/action_priv.h"
 #include "mi/mi_priv.h"
 #include "os/log_priv.h"
 

--- a/hw/xfree86/common/xf86_priv.h
+++ b/hw/xfree86/common/xf86_priv.h
@@ -62,7 +62,6 @@ void xf86InitOrigins(void);
 
 /* xf86Events.c */
 InputHandlerProc xf86SetConsoleHandler(InputHandlerProc handler, void *data);
-void xf86ProcessActionEvent(ActionEvent action, void *arg);
 Bool xf86VTOwner(void);
 void xf86VTEnter(void);
 void xf86EnableInputDeviceForVTSwitch(InputInfoPtr pInfo);

--- a/hw/xfree86/common/xf86str.h
+++ b/hw/xfree86/common/xf86str.h
@@ -762,14 +762,4 @@ typedef void (*InputHandlerProc) (int fd, void *data);
 #define MF_CLEAR_DTR       1
 #define MF_CLEAR_RTS       2
 
-/* Action Events */
-typedef enum {
-    ACTION_TERMINATE = 0,       /* Terminate Server */
-    ACTION_NEXT_MODE = 10,      /* Switch to next video mode */
-    ACTION_PREV_MODE,
-    ACTION_SWITCHSCREEN = 100,  /* VT switch */
-    ACTION_SWITCHSCREEN_NEXT,
-    ACTION_SWITCHSCREEN_PREV,
-} ActionEvent;
-
 #endif                          /* _XF86STR_H */

--- a/hw/xfree86/xkb/xkbKillSrv.c
+++ b/hw/xfree86/xkb/xkbKillSrv.c
@@ -36,6 +36,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <X11/keysym.h>
 #include <X11/extensions/XI.h>
 
+#include "hw/xfree86/common/action_priv.h"
 #include "xkb/xkbsrv_priv.h"
 
 #include "inputstr.h"

--- a/hw/xfree86/xkb/xkbPrivate.c
+++ b/hw/xfree86/xkb/xkbPrivate.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <X11/X.h>
 
+#include "hw/xfree86/common/action_priv.h"
 #include "xkb/xkbsrv_priv.h"
 
 #include "windowstr.h"

--- a/hw/xfree86/xkb/xkbVT.c
+++ b/hw/xfree86/xkb/xkbVT.c
@@ -36,6 +36,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <X11/keysym.h>
 #include <X11/extensions/XI.h>
 
+#include "hw/xfree86/common/action_priv.h"
 #include "xkb/xkbsrv_priv.h"
 
 #include "inputstr.h"


### PR DESCRIPTION
Not needed by any driver - only use as parameter to xf86ProcessActionEvent(),
which already is private.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
