### PR TITLE
include: don't install client.h anymore

### DIFF
--- a/dix/dixstruct_priv.h
+++ b/dix/dixstruct_priv.h
@@ -6,7 +6,8 @@
 #ifndef _XSERVER_DIXSTRUCT_PRIV_H
 #define _XSERVER_DIXSTRUCT_PRIV_H
 
-#include "client.h"
+#include <X11/Xmd.h>
+
 #include "dix.h"
 #include "resource.h"
 #include "cursor.h"
@@ -14,7 +15,6 @@
 #include "pixmap.h"
 #include "privates.h"
 #include "dixstruct.h"
-#include <X11/Xmd.h>
 
 static inline void
 SetReqFds(ClientPtr client, int req_fds) {

--- a/hw/xfree86/sdksyms.sh
+++ b/hw/xfree86/sdksyms.sh
@@ -218,7 +218,6 @@ cat > sdksyms.c << EOF
 #include "closure.h"
 #include "colormap.h"
 #include "colormapst.h"
-#include "client.h"
 #include "cursor.h"
 #include "cursorstr.h"
 #include "dix.h"

--- a/include/dixstruct.h
+++ b/include/dixstruct.h
@@ -27,14 +27,15 @@ SOFTWARE.
 #include <X11/Xmd.h>
 
 #include "callback.h"
-
-#include "client.h"
 #include "dix.h"
 #include "resource.h"
 #include "cursor.h"
 #include "gc.h"
 #include "pixmap.h"
 #include "privates.h"
+
+struct _Client;
+typedef struct _ClientId *ClientIdPtr;
 
 /*
  * 	direct-mapped hash table, used by resource manager to store

--- a/include/meson.build
+++ b/include/meson.build
@@ -432,7 +432,6 @@ if build_xorg
         [
             'Xprintf.h',
             'callback.h',
-            'client.h',
             'closure.h',
             'colormap.h',
             'colormapst.h',


### PR DESCRIPTION
not included by any drivers, so doesn't need to be in SDK anymore.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
