### PR TITLE
sdk: install xlibre-server.pc in addition to xorg-server.pc

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -862,6 +862,15 @@ if build_xorg
                                 'pkgconfig'),
     )
 
+    configure_file(
+        input: 'xlibre-server.pc.in',
+        output: 'xlibre-server.pc',
+        configuration: sdkconfig,
+        install_dir: join_paths(get_option('prefix'),
+                                get_option('libdir'),
+                                'pkgconfig'),
+    )
+
     install_data('xorg-server.m4',
                  install_dir: join_paths(get_option('datadir'), 'aclocal'))
 endif

--- a/xlibre-server.pc.in
+++ b/xlibre-server.pc.in
@@ -1,0 +1,21 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+datarootdir=@datarootdir@
+moduledir=@moduledir@
+sdkdir=@sdkdir@
+sysconfigdir=@sysconfigdir@
+
+abi_ansic=@abi_ansic@
+abi_videodrv=@abi_videodrv@
+abi_xinput=@abi_xinput@
+abi_extension=@abi_extension@
+
+Name: xlibre-server
+Description: Modular XLibre X Server
+URL: https://github.com/X11Libre/xserver/
+Version: @PACKAGE_VERSION@
+Requires.private: @SDK_REQUIRED_MODULES@
+Cflags: -I${sdkdir} @symbol_visibility@
+Libs: -L${libdir} @XORG_DRIVER_LIBS@


### PR DESCRIPTION
A little step forward in completely separating our SDK from old
legacy Xorg.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
