### PR TITLE
dix: set errorValue correctly when XID lookup fails in ChangeGCXIDs()

### DIFF
--- a/dix/gc.c
+++ b/dix/gc.c
@@ -438,6 +438,7 @@ ChangeGCXIDs(ClientPtr client, GCPtr pGC, BITS32 mask, CARD32 *pC32)
         vals[i].val = pC32[i];
     for (int i = 0; i < ARRAY_SIZE(xidfields); ++i) {
         int offset, rc;
+        XID id;
 
         if (!(mask & xidfields[i].mask))
             continue;
@@ -446,11 +447,13 @@ ChangeGCXIDs(ClientPtr client, GCPtr pGC, BITS32 mask, CARD32 *pC32)
             vals[offset].ptr = NullPixmap;
             continue;
         }
-        rc = dixLookupResourceByType(&vals[offset].ptr, vals[offset].val,
+        /* save the id, since dixLookupResourceByType overwrites &vals[offset] */
+        id = vals[offset].val;
+        rc = dixLookupResourceByType(&vals[offset].ptr, id,
                                      xidfields[i].type, client,
                                      xidfields[i].access_mode);
         if (rc != Success) {
-            client->errorValue = vals[offset].val;
+            client->errorValue = id;
             return rc;
         }
     }


### PR DESCRIPTION
dixLookupResourceByType always overwrites the pointer passed in as the first arg, so we shouldn't use the union it's in after that to get the requested XID value to put in the errorValue.

Closes: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1857
Fixes: https://github.com/stefan11111/xserver/commit/2d7eb4a19b773d0406c0c2e018a7da97f3565fd5 ("Pre-validate ChangeGC XIDs.")
Reported-by: Mouse <mouse@Rodents-Montreal.ORG>

Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2111>

Backported from Xorg