### PR TITLE
Xext: xf86bigfont: add missing include of os/osdep.h

### DIFF
--- a/Xext/xf86bigfont.c
+++ b/Xext/xf86bigfont.c
@@ -58,6 +58,7 @@
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
 #include "miext/extinit_priv.h"
+#include "os/osdep.h"
 
 #include "misc.h"
 #include "os.h"


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
