### PR TITLE
os: Xtranssock: fix printf format warning

### DIFF
--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -446,13 +446,13 @@ static XtransConnInfo _XSERVTransSocketReopen (
     size_t portlen = portnamelen;
 #ifdef SOCK_MAXADDRLEN
     if (portlen > (SOCK_MAXADDRLEN + 2)) {
-      prmsg (1, "SocketReopen: invalid portlen %d\n", portlen);
+      prmsg (1, "SocketReopen: invalid portlen %llu\n", (unsigned long long)portlen);
       return NULL;
     }
     if (portlen < 14) portlen = 14;
 #else
     if (portlen > 14) {
-      prmsg (1, "SocketReopen: invalid portlen %ld\n", (unsigned long)portlen);
+      prmsg (1, "SocketReopen: invalid portlen %llu\n", (unsigned long long)portlen);
       return NULL;
     }
 #endif /*SOCK_MAXADDRLEN*/


### PR DESCRIPTION
> ../os/Xtranssock.c: In function '_XSERVTransSocketReopen':
> ../os/Xtranssock.c:449:49: warning: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
>         prmsg (1, "SocketReopen: invalid portlen %d\n", portlen);
>                                                  ~^     ~~~~~~~
>                                                  %ld

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
