### PR TITLE
test: simple-xinit: fix warning on unused result of write()

### DIFF
--- a/test/simple-xinit.c
+++ b/test/simple-xinit.c
@@ -66,7 +66,10 @@ static const char *server_dead = "server_dead";
 static void
 handle_sigchld(int sig)
 {
-    write(server_displayfd, server_dead, strlen(server_dead));
+    /* nasty trick to silence compiler warning on unused result.
+       we really have no practical use for it here */
+    if (write(server_displayfd, server_dead, strlen(server_dead)) == -1)
+        fprintf(stderr, "writing to server_displayfd failed: %s\n", strerror(errno));
 }
 
 /* Starts the X server, returning its pid. */


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
