### PR TITLE
xfree86: doc: drop mentioning xf86MapPciMem()

### DIFF
--- a/hw/xfree86/doc/ddxDesign.xml
+++ b/hw/xfree86/doc/ddxDesign.xml
@@ -8176,7 +8176,7 @@ ZZZPreInit(ScrnInfoPtr pScrn, int flags)
 static Bool
 ZZZMapMem(ScrnInfoPtr pScrn)
 {
-    /* Call xf86MapPciMem() to map each PCI memory area */
+    /* map each PCI memory area */
     ...
     return TRUE or FALSE;
 }


### PR DESCRIPTION
This function has been removed decades ago.

Fixes: 46f55f5dead5d70cdff30531d80a72f6be042315
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
