### PR TITLE
os.h: fix _X_ATTRIBUTE_VPRINTF() macro on MacOS and FreeBSD

### DIFF
--- a/include/os.h
+++ b/include/os.h
@@ -70,7 +70,7 @@ SOFTWARE.
 #endif
 
 #ifndef _X_ATTRIBUTE_VPRINTF
-# if defined(__GNUC__) && (__GNUC__ >= 2)
+# if defined(__GNUC__) && (__GNUC__ >= 2) && (!defined(__APPLE__)) && (!defined(__FreeBSD__))
 #  define _X_ATTRIBUTE_VPRINTF(fmt, firstarg) \
           __attribute__((__format__(gnu_printf, fmt, firstarg)))
 # else


### PR DESCRIPTION
their compiler doesn't seem to support gnu_printf attribute.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
