### PR TITLE
include: dix.h: declare clients[] array prototype without size

### DIFF
--- a/include/dix.h
+++ b/include/dix.h
@@ -98,7 +98,7 @@ typedef struct _Client *ClientPtr;
 #define _XTYPEDEF_CLIENTPTR
 #endif
 
-extern _X_EXPORT ClientPtr clients[MAXCLIENTS];
+extern _X_EXPORT ClientPtr clients[];
 extern _X_EXPORT ClientPtr serverClient;
 extern _X_EXPORT int currentMaxClients;
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
