### PR TITLE
xwin: drop wrapping on ScreenRec->CloseScreen()

### DIFF
--- a/hw/xwin/win.h
+++ b/hw/xwin/win.h
@@ -428,8 +428,6 @@ typedef struct _winPrivScreenRec {
 
     int iConnectedClients;
 
-    CloseScreenProcPtr CloseScreen;
-
     DWORD dwRedMask;
     DWORD dwGreenMask;
     DWORD dwBlueMask;

--- a/hw/xwin/winscrinit.c
+++ b/hw/xwin/winscrinit.c
@@ -430,7 +430,6 @@ winFinishScreenInitFB(int i, ScreenPtr pScreen, int argc, char **argv)
     }
 
     /* Wrap either fb's or shadow's CloseScreen with our CloseScreen */
-    pScreenPriv->CloseScreen = pScreen->CloseScreen;
     pScreen->CloseScreen = pScreenPriv->pwinCloseScreen;
 
     /* Create a mutex for modules in separate threads to wait for */

--- a/hw/xwin/winshadddnl.c
+++ b/hw/xwin/winshadddnl.c
@@ -663,9 +663,7 @@ winCloseScreenShadowDDNL(ScreenPtr pScreen)
     pScreenPriv->fActive = FALSE;
 
     /* Call the wrapped CloseScreen procedure */
-    WIN_UNWRAP(CloseScreen);
-    if (pScreen->CloseScreen)
-        fReturn = (*pScreen->CloseScreen) (pScreen);
+    fReturn = fbCloseScreen(pScreen);
 
     winFreeFBShadowDDNL(pScreen);
 

--- a/hw/xwin/winshadgdi.c
+++ b/hw/xwin/winshadgdi.c
@@ -582,10 +582,7 @@ winCloseScreenShadowGDI(ScreenPtr pScreen)
     pScreenPriv->fClosed = TRUE;
     pScreenPriv->fActive = FALSE;
 
-    /* Call the wrapped CloseScreen procedure */
-    WIN_UNWRAP(CloseScreen);
-    if (pScreen->CloseScreen)
-        fReturn = (*pScreen->CloseScreen) (pScreen);
+    fReturn = fbCloseScreen(pScreen);
 
     /* Delete the window property */
     RemoveProp(pScreenPriv->hwndScreen, WIN_SCR_PROP);


### PR DESCRIPTION
Instead of complicated wrapping, just call fbCloseScreen() directly.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
