### PR TITLE
.github: fix artifact cache key on mingw32

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -159,7 +159,7 @@ jobs:
                     ${{ env.X11_PREFIX }}
                     ${{ env.X11_BUILD_DIR }}/xts
                     ${{ env.X11_BUILD_DIR }}/piglit
-                key: ${{ runner.name }}-x11-deps-${{ hashFiles('.github/scripts/install-prereq.sh') }}
+                key: ${{ runner.name }}-x11-deps-${{ hashFiles('.github/scripts/mingw32/cross-prereqs-build.sh') }}
                 restore-keys: ${{ runner.name }}-x11-deps-
 
             - name: install crosscompiler


### PR DESCRIPTION
We're not calling install-prereq.sh, so no need to have it's
hash in the cache key.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
