### PR TITLE
xext: xvdisp: fix printf format

### DIFF
--- a/Xext/xvdisp.c
+++ b/Xext/xvdisp.c
@@ -1014,8 +1014,8 @@ ProcXvListImageFormats(ClientPtr client)
 
     /* use rpc.wpos here, in order to get how much we've really written */
     if (rpcbuf.wpos != (pPort->pAdaptor->nImages*sz_xvImageFormatInfo))
-        LogMessage(X_WARNING, "ProcXvListImageFormats() payload_len mismatch: %ld but shoud be %d\n",
-                   rpcbuf.wpos, (pPort->pAdaptor->nImages*sz_xvImageFormatInfo));
+        LogMessage(X_WARNING, "ProcXvListImageFormats() payload_len mismatch: %llu but shoud be %d\n",
+                   (long long unsigned)rpcbuf.wpos, (pPort->pAdaptor->nImages*sz_xvImageFormatInfo));
 
     xvListImageFormatsReply reply = {
         .num_formats = pPort->pAdaptor->nImages,


### PR DESCRIPTION
> ../Xext/xvdisp.c: In function ‘ProcXvListImageFormats’:
> ../Xext/xvdisp.c:1017:81: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 3 has type ‘size_t’ {aka ‘unsigned int’} [-Wformat=]
>  1017 |         LogMessage(X_WARNING, "ProcXvListImageFormats() payload_len mismatch: %ld but shoud be %d\n",
>       |                                                                               ~~^
>       |                                                                                 |
>       |                                                                                 long int
>       |                                                                               %d
>  1018 |                    rpcbuf.wpos, (pPort->pAdaptor->nImages*sz_xvImageFormatInfo));
>       |                    ~~~~~~~~~~~
>       |                          |
>       |                          size_t {aka unsigned int}

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
