### PR TITLE
xfree86: silence warnings on SYSCALL() macro

### DIFF
--- a/hw/xfree86/os-support/xf86_OSlib.h
+++ b/hw/xfree86/os-support/xf86_OSlib.h
@@ -234,7 +234,7 @@ struct pcvtid {
 #define MAP_FAILED ((void *)-1)
 #endif
 
-#define SYSCALL(call) while(((call) == -1) && (errno == EINTR))
+#define SYSCALL(call) while(((call) == -1) && (errno == EINTR)) {}
 
 #include "xf86_OSproc.h"
 


### PR DESCRIPTION
> ../hw/xfree86/os-support/shared/posix_tty.c:366:38: warning: while loop has empty body [-Wempty-body]
>    366 |     SYSCALL(r = read(fd, buf, count));
>        |                                      ^

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
