### PR TITLE
kdrive: ephyr: add noreturn attribute to ephyrProcessErrorEvent()

### DIFF
--- a/hw/kdrive/ephyr/ephyr.c
+++ b/hw/kdrive/ephyr/ephyr.c
@@ -973,6 +973,9 @@ screen_from_window(Window w)
 }
 
 static void
+ephyrProcessErrorEvent(xcb_generic_event_t *xev) _X_NORETURN;
+
+static void
 ephyrProcessErrorEvent(xcb_generic_event_t *xev)
 {
     xcb_generic_error_t *e = (xcb_generic_error_t *)xev;


### PR DESCRIPTION
>  ../hw/kdrive/ephyr/ephyr.c:977:1: warning: function 'ephyrProcessErrorEvent' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
>    977 | {
>        | ^

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
