### PR TITLE
.github: switch dependencies to our new mirrors

### DIFF
--- a/.github/scripts/install-prereq.sh
+++ b/.github/scripts/install-prereq.sh
@@ -7,17 +7,17 @@ set -e
 mkdir -p $X11_BUILD_DIR
 cd $X11_BUILD_DIR
 
-build_meson   rendercheck       https://github.com/X11Libre/rendercheck                  rendercheck-1.6
+build_meson   rendercheck       $(fdo_mirror rendercheck)                  rendercheck-1.6
 if [ "$X11_OS" = "Linux" ]; then
-build_meson   drm               https://github.com/X11Libre/drm                          libdrm-2.4.121   -Domap=enabled
+build_meson   drm               $(fdo_mirror drm)                          libdrm-2.4.121   -Domap=enabled
 fi
-build_meson   libxcvt           https://github.com/X11Libre/libxcvt                      libxcvt-0.1.0
-build_meson   xorgproto         https://github.com/X11Libre/xorgproto                    xorgproto-2024.1
+build_meson   libxcvt           $(fdo_mirror libxcvt)                      libxcvt-0.1.0
+build_meson   xorgproto         $(fdo_mirror xorgproto)                    xorgproto-2024.1
 
 # really must be build via autoconf instead of meson, otherwise piglit wont find the test programs
-build_ac_xts  xts               https://github.com/X11Libre/xts                          aae51229af810efba24412511f60602fab53eded
+build_ac_xts  xts               $(fdo_mirror xts)                          aae51229af810efba24412511f60602fab53eded
 
-clone_source piglit             https://github.com/X11Libre/piglit                       28d1349844eacda869f0f82f551bcd4ac0c4edfe
+clone_source piglit             $(fdo_mirror piglit)                       28d1349844eacda869f0f82f551bcd4ac0c4edfe
 
 echo '[xts]' > piglit/piglit.conf
 echo "path=$X11_BUILD_DIR/xts" >> piglit/piglit.conf

--- a/.github/scripts/macos/install-prereq.sh
+++ b/.github/scripts/macos/install-prereq.sh
@@ -7,7 +7,7 @@ set -e
 mkdir -p $X11_BUILD_DIR
 cd $X11_BUILD_DIR
 
-build_meson   rendercheck       https://github.com/X11Libre/rendercheck                  rendercheck-1.6
-build_meson   libxcvt           https://github.com/X11Libre/libxcvt                      libxcvt-0.1.0
-build_meson   xorgproto         https://github.com/X11Libre/xorgproto                    xorgproto-2024.1
-build_ac      xset              https://github.com/X11Libre/xset                         xset-1.2.5
+build_meson   rendercheck       $(fdo_mirror rendercheck)                  rendercheck-1.6
+build_meson   libxcvt           $(fdo_mirror libxcvt)                      libxcvt-0.1.0
+build_meson   xorgproto         $(fdo_mirror xorgproto)                    xorgproto-2024.1
+build_ac      xset              $(fdo_mirror xset)                         xset-1.2.5

--- a/.github/scripts/mingw32/cross-prereqs-build.sh
+++ b/.github/scripts/mingw32/cross-prereqs-build.sh
@@ -3,6 +3,8 @@
 set -e
 set -o xtrace
 
+. .github/scripts/util.sh
+
 HOST=$1
 
 # Debian's cross-pkg-config wrappers are broken for MinGW targets, since
@@ -75,34 +77,40 @@ build() {
     rm -rf ${OLDPWD}
 }
 
-build 'https://github.com/X11Libre/pixman.git'                  'pixman-0.38.4'
-build 'https://github.com/X11Libre/pthread-stubs.git'           '0.4'
+build_fdo() {
+    local name="$1"
+    shift
+    build $(fdo_mirror $name) "$@"
+}
+
+build_fdo 'pixman'                  'pixman-0.38.4'
+build_fdo 'pthread-stubs'           '0.4'
 # we can't use the xorgproto pkgconfig files from /usr/share/pkgconfig, because
 # these would add -I/usr/include to CFLAGS, which breaks cross-compilation
-build 'https://github.com/X11Libre/xorgproto.git'               'xorgproto-2024.1' '--datadir=/lib'
-build 'https://github.com/X11Libre/libXau.git'                  'libXau-1.0.9'
-build 'https://github.com/X11Libre/xcbproto.git'                'xcb-proto-1.17.0'
-build 'https://github.com/X11Libre/libxcb.git'                  'libxcb-1.17.0'
-build 'https://github.com/X11Libre/libxtrans.git'               'xtrans-1.6.0'
+build_fdo 'xorgproto'               'xorgproto-2024.1' '--datadir=/lib'
+build_fdo 'libXau'                  'libXau-1.0.9'
+build_fdo 'xcbproto'                'xcb-proto-1.17.0'
+build_fdo 'libxcb'                  'libxcb-1.17.0'
+build_fdo 'libxtrans'               'xtrans-1.6.0'
 # the default value of keysymdefdir is taken from the includedir variable for
 # xproto, which isn't adjusted by pkg-config for the sysroot
 # Using -fcommon to address build failure when cross-compiling for windows.
 # See discussion at https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/913
-CFLAGS="-fcommon" build 'https://github.com/X11Libre/libX11.git' 'libX11-1.6.9' "--with-keysymdefdir=/usr/${HOST}/include/X11"
-build 'https://github.com/X11Libre/libxkbfile.git'              'libxkbfile-1.1.0'
+CFLAGS="-fcommon" build_fdo 'libX11' 'libX11-1.6.9' "--with-keysymdefdir=/usr/${HOST}/include/X11"
+build_fdo 'libxkbfile'              'libxkbfile-1.1.0'
 # freetype needs an explicit --build to know it's cross-compiling
 # disable png as freetype tries to use libpng-config, even when cross-compiling
-build 'https://github.com/X11Libre/freetype.git'                'VER-2-10-1' "--build=$(cc -dumpmachine) --with-png=no"
-build 'https://github.com/X11Libre/font-util.git'               'font-util-1.3.2'
-build 'https://github.com/X11Libre/libfontenc.git'              'libfontenc-1.1.4'
-build 'https://github.com/X11Libre/libXfont.git'                'libXfont2-2.0.3'
-build 'https://github.com/X11Libre/libXdmcp.git'                'libXdmcp-1.1.3'
-build 'https://github.com/X11Libre/libXfixes.git'               'libXfixes-5.0.3'
-build 'https://github.com/X11Libre/libxcb-util.git'             'xcb-util-0.4.1-gitlab'
-build 'https://github.com/X11Libre/libxcb-image.git'            'xcb-util-image-0.4.1-gitlab'
-build 'https://github.com/X11Libre/libxcb-wm.git'               'xcb-util-wm-0.4.2'
-build 'https://github.com/X11Libre/libxcb-render-util.git'      'master'
-build 'https://github.com/X11Libre/libxcb-keysyms.git'          'master'
+build_fdo 'freetype'                'VER-2-10-1' "--build=$(cc -dumpmachine) --with-png=no"
+build_fdo 'font-util'               'font-util-1.3.2'
+build_fdo 'libfontenc'              'libfontenc-1.1.4'
+build_fdo 'libXfont'                'libXfont2-2.0.3'
+build_fdo 'libXdmcp'                'libXdmcp-1.1.3'
+build_fdo 'libXfixes'               'libXfixes-5.0.3'
+build_fdo 'libxcb-util'             'xcb-util-0.4.1-gitlab'
+build_fdo 'libxcb-image'            'xcb-util-image-0.4.1-gitlab'
+build_fdo 'libxcb-wm'               'xcb-util-wm-0.4.2'
+build_fdo 'libxcb-render-util'      'master'
+build_fdo 'libxcb-keysyms'          'master'
 
 # workaround xcb_windefs.h leaking all Windows API types into X server build
 # (some of which clash which types defined by Xmd.h) XXX: This is a bit of a

--- a/.github/scripts/util.sh
+++ b/.github/scripts/util.sh
@@ -95,3 +95,8 @@ build_ac_xts() {
         echo "::endgroup::"
     fi
 }
+
+fdo_mirror() {
+    local repo="$1"
+    echo -n "https://github.com/X11Libre/mirror.fdo.$1"
+}


### PR DESCRIPTION
Our new automatic mirrors have a special prefix, so we need to
fixup the URLs.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
