### PR TITLE
xext: namespace: fix printf format string

### DIFF
--- a/Xext/namespace/hook-init-rootwindow.c
+++ b/Xext/namespace/hook-init-rootwindow.c
@@ -35,7 +35,7 @@ void hookInitRootWindow(CallbackListPtr *pcbl, void *data, void *screen)
     xorg_list_for_each_entry(walk, &ns_list, entry) {
         if (strcmp(walk->name, NS_NAME_ROOT)==0) {
             walk->rootWindow = realRoot;
-            XNS_LOG("<%s> actual root 0x%0" PRIx32 "\n", walk->name, walk->rootWindow->drawable.id);
+            XNS_LOG("<%s> actual root 0x%0llx\n", walk->name, (unsigned long long)walk->rootWindow->drawable.id);
             continue;
         }
 
@@ -67,6 +67,6 @@ void hookInitRootWindow(CallbackListPtr *pcbl, void *data, void *screen)
         snprintf(buf, sizeof(buf)-1, "XNS-ROOT:%s", walk->name);
         setWinStrProp(pWin, XA_WM_NAME, buf);
 
-        XNS_LOG("<%s> virtual root 0x%0" PRIx32 "\n", walk->name, walk->rootWindow->drawable.id);
+        XNS_LOG("<%s> virtual root 0x%0llx\n", walk->name, (unsigned long long)walk->rootWindow->drawable.id);
     }
 }

--- a/Xext/namespace/hook-windowproperty.c
+++ b/Xext/namespace/hook-windowproperty.c
@@ -24,7 +24,7 @@ void hookWindowProperty(CallbackListPtr *pcbl, void *unused, void *calldata)
     if (!owner) {
         param->status = BadWindow;
         param->skip = TRUE;
-        XNS_HOOK_LOG("owner of window 0x%0" PRIx32 "doesn't exist\n", param->window);
+        XNS_HOOK_LOG("owner of window 0x%0llx doesn't exist\n", (unsigned long long)param->window);
         return;
     }
 


### PR DESCRIPTION
../Xext/namespace/hook-init-rootwindow.c: In function ‘hookInitRootWindow’:
../Xext/namespace/hook-init-rootwindow.c:38:21: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 3 has type ‘XID’ {aka ‘long unsigned int’} [-Wformat=]
   38 |             XNS_LOG("<%s> actual root 0x%0" PRIx32 "\n", walk->name, walk->rootWindow->drawable.id);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                                |
      |                                                                                                XID {aka long unsigned int}
../Xext/namespace/namespace.h:71:50: note: in definition of macro ‘XNS_LOG’
   71 | #define XNS_LOG(...) do { printf("XNS "); printf(__VA_ARGS__); } while (0)
      |                                                  ^~~~~~~~~~~
../Xext/namespace/hook-init-rootwindow.c:38:43: note: format string is defined here
   38 |             XNS_LOG("<%s> actual root 0x%0" PRIx32 "\n", walk->name, walk->rootWindow->drawable.id);
      |                                         ~~^
      |                                           |
      |                                           unsigned int
      |                                         %0lx
../Xext/namespace/hook-init-rootwindow.c:70:17: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 3 has type ‘XID’ {aka ‘long unsigned int’} [-Wformat=]
   70 |         XNS_LOG("<%s> virtual root 0x%0" PRIx32 "\n", walk->name, walk->rootWindow->drawable.id);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                             |
      |                                                                                             XID {aka long unsigned int}
../Xext/namespace/namespace.h:71:50: note: in definition of macro ‘XNS_LOG’
   71 | #define XNS_LOG(...) do { printf("XNS "); printf(__VA_ARGS__); } while (0)
      |                                                  ^~~~~~~~~~~
../Xext/namespace/hook-init-rootwindow.c:70:40: note: format string is defined here
   70 |         XNS_LOG("<%s> virtual root 0x%0" PRIx32 "\n", walk->name, walk->rootWindow->drawable.id);
      |                                      ~~^
      |                                        |
      |                                        unsigned int
      |                                      %0lx

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
