### PR TITLE
xfree86: fix include of xf86VGAarbiter_priv.h

### DIFF
--- a/hw/xfree86/common/xf86Bus.c
+++ b/hw/xfree86/common/xf86Bus.c
@@ -50,9 +50,8 @@
 #include "xf86sbusBus_priv.h"
 
 #include "xf86_OSproc.h"
-#ifdef XSERVER_LIBPCIACCESS
 #include "xf86VGAarbiter_priv.h"
-#endif
+
 /* Entity data */
 EntityPtr *xf86Entities = NULL; /* Bus slots claimed by drivers */
 int xf86NumEntities = 0;

--- a/hw/xfree86/common/xf86DPMS.c
+++ b/hw/xfree86/common/xf86DPMS.c
@@ -44,9 +44,7 @@
 #include <X11/extensions/dpmsconst.h>
 #include "dpmsproc.h"
 #endif
-#ifdef XSERVER_LIBPCIACCESS
 #include "xf86VGAarbiter_priv.h"
-#endif
 
 #ifdef DPMSExtension
 static void


### PR DESCRIPTION
Needs to be included also in non-pciaccess case, so the dummy
functions are declared.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
