### PR TITLE
 [25.0] .github: switch dependencies to our new mirrors

### DIFF
--- a/.github/scripts/install-prereq.sh
+++ b/.github/scripts/install-prereq.sh
@@ -7,19 +7,19 @@ set -e
 mkdir -p $X11_BUILD_DIR
 cd $X11_BUILD_DIR
 
-build_meson   rendercheck       https://github.com/X11Libre/rendercheck                  rendercheck-1.6
+build_meson   rendercheck       $(fdo_mirror rendercheck)                  rendercheck-1.6
 if [ "$X11_OS" = "Linux" ]; then
-build_meson   drm               https://github.com/X11Libre/drm                          libdrm-2.4.121   -Domap=enabled
+build_meson   drm               $(fdo_mirror drm)                          libdrm-2.4.121   -Domap=enabled
 fi
-build_meson   libxcvt           https://github.com/X11Libre/libxcvt                      libxcvt-0.1.0
-build_ac      xorgproto         https://github.com/X11Libre/xorgproto                    xorgproto-2024.1
+build_meson   libxcvt           $(fdo_mirror libxcvt)                      libxcvt-0.1.0
+build_ac      xorgproto         $(fdo_mirror xorgproto)                    xorgproto-2024.1
 if [ "$X11_OS" = "Darwin" ]; then
-build_ac      xset              https://github.com/X11Libre/xset                         xset-1.2.5
+build_ac      xset              $(fdo_mirror xset)                         xset-1.2.5
 fi
 # really must be build via autoconf instead of meson, otherwise piglit wont find the test programs
-build_ac_xts  xts               https://github.com/X11Libre/xts                          12a887c2c72c4258962b56ced7b0aec782f1ffed
+build_ac_xts  xts               $(fdo_mirror xts)                          12a887c2c72c4258962b56ced7b0aec782f1ffed
 
-clone_source piglit             https://github.com/X11Libre/piglit                       28d1349844eacda869f0f82f551bcd4ac0c4edfe
+clone_source piglit             $(fdo_mirror piglit)                       28d1349844eacda869f0f82f551bcd4ac0c4edfe
 
 echo '[xts]' > piglit/piglit.conf
 echo "path=$X11_BUILD_DIR/xts" >> piglit/piglit.conf

--- a/.github/scripts/util.sh
+++ b/.github/scripts/util.sh
@@ -114,3 +114,8 @@ build_ac_xts() {
         echo "::endgroup::"
     fi
 }
+
+fdo_mirror() {
+    local repo="$1"
+    echo -n "https://github.com/X11Libre/mirror.fdo.$1"
+}

--- a/.gitlab-ci/cross-prereqs-build.sh
+++ b/.gitlab-ci/cross-prereqs-build.sh
@@ -3,6 +3,8 @@
 set -e
 set -o xtrace
 
+. .github/scripts/util.sh
+
 HOST=$1
 
 # Debian's cross-pkg-config wrappers are broken for MinGW targets, since
@@ -45,32 +47,38 @@ build() {
     rm -rf ${OLDPWD}
 }
 
-build 'https://gitlab.freedesktop.org/pixman/pixman.git' 'pixman-0.38.4'
-build 'https://gitlab.freedesktop.org/xorg/lib/pthread-stubs.git' '0.4'
+build_fdo() {
+    local name="$1"
+    shift
+    build $(fdo_mirror $name) "$@"
+}
+
+build_fdo 'pixman' 'pixman-0.38.4'
+build_fdo 'pthread-stubs' '0.4'
 # we can't use the xorgproto pkgconfig files from /usr/share/pkgconfig, because
 # these would add -I/usr/include to CFLAGS, which breaks cross-compilation
-build 'https://gitlab.freedesktop.org/xorg/proto/xorgproto.git' 'xorgproto-2024.1' '--datadir=/lib'
-build 'https://gitlab.freedesktop.org/xorg/lib/libXau.git' 'libXau-1.0.9'
-build 'https://gitlab.freedesktop.org/xorg/proto/xcbproto.git' 'xcb-proto-1.14.1'
-build 'https://gitlab.freedesktop.org/xorg/lib/libxcb.git' 'libxcb-1.14'
-build 'https://gitlab.freedesktop.org/xorg/lib/libxtrans.git' 'xtrans-1.4.0'
+build_fdo 'xorgproto' 'xorgproto-2024.1' '--datadir=/lib'
+build_fdo 'libXau' 'libXau-1.0.9'
+build_fdo 'xcbproto' 'xcb-proto-1.14.1'
+build_fdo 'libxcb' 'libxcb-1.14'
+build_fdo 'libxtrans' 'xtrans-1.4.0'
 # the default value of keysymdefdir is taken from the includedir variable for
 # xproto, which isn't adjusted by pkg-config for the sysroot
 # Using -fcommon to address build failure when cross-compiling for windows.
 # See discussion at https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/913
-CFLAGS="-fcommon" build 'https://gitlab.freedesktop.org/xorg/lib/libX11.git' 'libX11-1.6.9' "--with-keysymdefdir=/usr/${HOST}/include/X11"
-build 'https://gitlab.freedesktop.org/xorg/lib/libxkbfile.git' 'libxkbfile-1.1.0'
+CFLAGS="-fcommon" build_fdo 'libX11' 'libX11-1.6.9' "--with-keysymdefdir=/usr/${HOST}/include/X11"
+build_fdo 'libxkbfile' 'libxkbfile-1.1.0'
 # freetype needs an explicit --build to know it's cross-compiling
 # disable png as freetype tries to use libpng-config, even when cross-compiling
-build 'git://git.savannah.gnu.org/freetype/freetype2.git' 'VER-2-10-1' "--build=$(cc -dumpmachine) --with-png=no"
-build 'https://gitlab.freedesktop.org/xorg//font/util.git' 'font-util-1.3.2'
-build 'https://gitlab.freedesktop.org/xorg/lib/libfontenc.git' 'libfontenc-1.1.4'
-build 'https://gitlab.freedesktop.org/xorg/lib/libXfont.git'  'libXfont2-2.0.3'
-build 'https://gitlab.freedesktop.org/xorg/lib/libXdmcp.git' 'libXdmcp-1.1.3'
-build 'https://gitlab.freedesktop.org/xorg/lib/libXfixes.git' 'libXfixes-5.0.3'
-build 'https://gitlab.freedesktop.org/xorg/lib/libxcb-util.git' 'xcb-util-0.4.1-gitlab'
-build 'https://gitlab.freedesktop.org/xorg/lib/libxcb-image.git' 'xcb-util-image-0.4.1-gitlab'
-build 'https://gitlab.freedesktop.org/xorg/lib/libxcb-wm.git' 'xcb-util-wm-0.4.2'
+build_fdo 'freetype' 'VER-2-10-1' "--build=$(cc -dumpmachine) --with-png=no"
+build_fdo 'font-util' 'font-util-1.3.2'
+build_fdo 'libfontenc' 'libfontenc-1.1.4'
+build_fdo 'libXfont'  'libXfont2-2.0.3'
+build_fdo 'libXdmcp' 'libXdmcp-1.1.3'
+build_fdo 'libXfixes' 'libXfixes-5.0.3'
+build_fdo 'libxcb-util' 'xcb-util-0.4.1-gitlab'
+build_fdo 'libxcb-image' 'xcb-util-image-0.4.1-gitlab'
+build_fdo 'libxcb-wm' 'xcb-util-wm-0.4.2'
 
 # workaround xcb_windefs.h leaking all Windows API types into X server build
 # (some of which clash which types defined by Xmd.h) XXX: This is a bit of a

--- a/.gitlab-ci/debian-install.sh
+++ b/.gitlab-ci/debian-install.sh
@@ -129,8 +129,13 @@ apt-get install -y \
 
 cd /root
 
+fdo_mirror() {
+    local name="$1"
+    echo -n "https://github.com/X11Libre/mirror.fdo.$name"
+}
+
 # drm 2.4.116 for drmSyncobjEventfd
-git clone https://gitlab.freedesktop.org/mesa/drm --depth 1 --branch=libdrm-2.4.121
+git clone $(fdo_mirror drm) --depth 1 --branch=libdrm-2.4.121
 cd drm
 meson _build
 ninja -C _build -j${FDO_CI_CONCURRENT:-4} install
@@ -138,7 +143,7 @@ cd ..
 rm -rf drm
 
 # xserver requires libxcvt
-git clone https://gitlab.freedesktop.org/xorg/lib/libxcvt.git --depth 1 --branch=libxcvt-0.1.0
+git clone $(fdo_mirror libxcvt) --depth 1 --branch=libxcvt-0.1.0
 cd libxcvt
 meson _build
 ninja -C _build -j${FDO_CI_CONCURRENT:-4} install
@@ -146,26 +151,26 @@ cd ..
 rm -rf libxcvt
 
 # xserver requires xorgproto >= 2024.1
-git clone https://gitlab.freedesktop.org/xorg/proto/xorgproto.git --depth 1 --branch=xorgproto-2024.1
+git clone $(fdo_mirror xorgproto) --depth 1 --branch=xorgproto-2024.1
 pushd xorgproto
 ./autogen.sh
 make -j${FDO_CI_CONCURRENT:-4} install
 popd
 rm -rf xorgproto
 
-git clone https://gitlab.freedesktop.org/mesa/piglit.git
+git clone $(fdo_mirror piglit)
 cd piglit
 git checkout 265896c86f90cb72e8f218ba6a3617fca8b9a1e3
 cd ..
 
-git clone https://gitlab.freedesktop.org/xorg/test/xts
+git clone $(fdo_mirror xts)
 cd xts
 git checkout 12a887c2c72c4258962b56ced7b0aec782f1ffed
 ./autogen.sh
 xvfb-run make -j${FDO_CI_CONCURRENT:-4}
 cd ..
 
-git clone https://gitlab.freedesktop.org/xorg/test/rendercheck
+git clone $(fdo_mirror rendercheck)
 cd rendercheck
 git checkout 67a820621b1475ebfcf3d4f9d7f03a5fc3b9769a
 meson build


### PR DESCRIPTION
Our new automatic mirrors have a special prefix, so we need to
fixup the URLs.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
