### PR TITLE
.github: *BSD: silence warning on duplicate typedef

### DIFF
--- a/.github/scripts/DragonFlyBSD/run-xserver-build.sh
+++ b/.github/scripts/DragonFlyBSD/run-xserver-build.sh
@@ -7,6 +7,8 @@ set -e
 echo "--> running xserver build ...."
 export MESON_BUILDDIR=_build
 
+CFLAGS="$CFLAGS -Wno-typedef-redefinition"
+
 rm -rf "$MESON_BUILDDIR"
 meson setup "$MESON_BUILDDIR" $MESON_ARGS
 meson configure "$MESON_BUILDDIR"

--- a/.github/scripts/freebsd/run-xserver-build.sh
+++ b/.github/scripts/freebsd/run-xserver-build.sh
@@ -7,6 +7,8 @@ set -e
 echo "--> running xserver build ...."
 export MESON_BUILDDIR=_build
 
+CFLAGS="$CFLAGS -Wno-typedef-redefinition"
+
 rm -rf "$MESON_BUILDDIR"
 meson setup "$MESON_BUILDDIR" $MESON_ARGS
 meson configure "$MESON_BUILDDIR"


### PR DESCRIPTION
>  In file included from ../glx/glxdricommon.c:35:
>  /usr/local/include/GL/internal/dri_interface.h:445:26: warning: redefinition of typedef 'GLsync' is a C11 feature [-Wtypedef-redefinition]
>    445 | typedef struct __GLsync *GLsync;
>        |                          ^
>  /usr/local/include/GL/glext.h:1367:26: note: previous definition is here
>   1367 | typedef struct __GLsync *GLsync;
>        |                          ^

Since it's coming from MESA, the only thing we can do here is
suppressing this warning explicitly.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
