### PR TITLE
dix: Dispatch() separate variable for read result

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -522,10 +522,10 @@ Dispatch(void)
                 }
 
                 /* now, finally, deal with client requests */
-                result = ReadRequestFromClient(client);
-                if (result == 0)
+                long read_result = ReadRequestFromClient(client);
+                if (read_result == 0)
                     break;
-                else if (result == -1) {
+                else if (read_result == -1) {
                     CloseDownClient(client);
                     break;
                 }
@@ -547,7 +547,7 @@ Dispatch(void)
                                           client->index,
                                           client->requestBuffer);
 #endif
-                if (result < 0 || result > (maxBigRequestSize << 2))
+                if (read_result < 0 || read_result > (maxBigRequestSize << 2))
                     result = BadLength;
                 else {
                     result = Success;


### PR DESCRIPTION
Mixing result variables for separate things is making the code hard
to understand, so add a new local variable for temporarily storing
the result of ReadRequestFromClient().

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
