### PR TITLE
os: utils: ‘VerifyDisplayName: fix array subscript signedness

### DIFF
--- a/os/utils.c
+++ b/os/utils.c
@@ -336,7 +336,7 @@ UseMsg(void)
 static int
 VerifyDisplayName(const char *d)
 {
-    int i;
+    unsigned int i;
     int period_found = FALSE;
     int after_period = 0;
 


### PR DESCRIPTION
../os/utils.c: In function ‘VerifyDisplayName’:
../os/utils.c:624:23: warning: array subscript has type ‘char’ [-Wchar-subscripts]
  624 |         if (!isdigit(d[i])) {
      |                       ^

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
