### PR TITLE
test: fix signess warning

### DIFF
--- a/test/xi2/protocol-xiwarppointer.c
+++ b/test/xi2/protocol-xiwarppointer.c
@@ -98,6 +98,9 @@ request_XIWarpPointer(ClientPtr client, xXIWarpPointerReq * req, int error)
                client->errorValue == req->src_win);
 }
 
+/* Invalid coordinate marker for XIWarpPointer */
+#define XI_INVALID_COORD ((int32_t)0xFFFF0000)
+
 static void
 test_XIWarpPointer(void)
 {
@@ -166,7 +169,7 @@ test_XIWarpPointer(void)
     request.deviceid = devices.vcp->id;
     request_XIWarpPointer(&client_request, &request, Success);
 
-    request.dst_x = -1 << 16;
+    request.dst_x = XI_INVALID_COORD;
     expected_x = SPRITE_X - 1;
     request.deviceid = devices.vcp->id;
     request_XIWarpPointer(&client_request, &request, Success);
@@ -179,7 +182,7 @@ test_XIWarpPointer(void)
     request.deviceid = devices.vcp->id;
     request_XIWarpPointer(&client_request, &request, Success);
 
-    request.dst_y = -1 << 16;
+    request.dst_y = XI_INVALID_COORD;
     expected_y = SPRITE_Y - 1;
     request.deviceid = devices.vcp->id;
     request_XIWarpPointer(&client_request, &request, Success);


### PR DESCRIPTION
> ../test/xi2/protocol-xiwarppointer.c:169:24: warning: shifting a negative signed value is undefined [-Wshift-negative-value]
>     169 | request.dst_x = -1 << 16;
>         | ~~ ^
> ../test/xi2/protocol-xiwarppointer.c:182:24: warning: shifting a negative signed value is undefined [-Wshift-negative-value]
>     182 | request.dst_y = -1 << 16;
>         | ~~ ^

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
