### PR TITLE
xquartz: declare variables when needed

### DIFF
--- a/hw/xquartz/GL/indirect.c
+++ b/hw/xquartz/GL/indirect.c
@@ -549,9 +549,7 @@ __glXAquaScreenCreateDrawable(ClientPtr client,
                               XID glxDrawId,
                               __GLXconfig *conf)
 {
-    __GLXAquaDrawable *glxPriv;
-
-    glxPriv = calloc(1, sizeof *glxPriv);
+    __GLXAquaDrawable *glxPriv = calloc(1, sizeof *glxPriv);
 
     if (glxPriv == NULL)
         return NULL;

--- a/hw/xquartz/applewm.c
+++ b/hw/xquartz/applewm.c
@@ -220,7 +220,7 @@ static int
 ProcAppleWMSelectInput(register ClientPtr client)
 {
     REQUEST(xAppleWMSelectInputReq);
-    WMEventPtr pEvent, pNewEvent, *pHead;
+    WMEventPtr pEvent, *pHead;
     XID clientResource;
     int i;
 
@@ -242,7 +242,7 @@ ProcAppleWMSelectInput(register ClientPtr client)
         }
 
         /* build the entry */
-        pNewEvent = calloc(1, sizeof(WMEventRec));
+        WMEventPtr pNewEvent = calloc(1, sizeof(WMEventRec));
         if (!pNewEvent)
             return BadAlloc;
         pNewEvent->next = 0;
@@ -278,7 +278,7 @@ ProcAppleWMSelectInput(register ClientPtr client)
     else if (stuff->mask == 0) {
         /* delete the interest */
         if (i == Success && pHead) {
-            pNewEvent = 0;
+            WMEventPtr pNewEvent = 0;
             for (pEvent = *pHead; pEvent; pEvent = pEvent->next) {
                 if (pEvent->client == client)
                     break;
@@ -371,7 +371,7 @@ ProcAppleWMSetWindowMenu(register ClientPtr client)
     REQUEST_AT_LEAST_SIZE(xAppleWMSetWindowMenuReq);
 
     nitems = stuff->nitems;
-    char **items = calloc(nitems, sizeof(char *));
+    const char **items = calloc(nitems, sizeof(char *));
     char *shortcuts = calloc(nitems, sizeof(char));
 
     if (!items || !shortcuts) {

--- a/hw/xquartz/mach-startup/bundle-main.c
+++ b/hw/xquartz/mach-startup/bundle-main.c
@@ -321,11 +321,9 @@ static int launchd_socket_handed_off = 0;
 kern_return_t
 do_request_fd_handoff_socket(mach_port_t port, string_t filename)
 {
-    socket_handoff_t *handoff_data;
-
     launchd_socket_handed_off = 1;
 
-    handoff_data = (socket_handoff_t *)calloc(1, sizeof(socket_handoff_t));
+    socket_handoff_t *handoff_data = calloc(1, sizeof(socket_handoff_t));
     if (!handoff_data) {
         ErrorF("X11.app: Error allocating memory for handoff_data\n");
         return KERN_FAILURE;


### PR DESCRIPTION
Declare some more variables when actually needed / assigned first time.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
