### PR TITLE
test: fix tautological constant out of range warning

### DIFF
--- a/test/misc.c
+++ b/test/misc.c
@@ -169,7 +169,7 @@ dix_request_fixed_size_overflow(ClientRec *client)
     xReq req = { 0 };
 
     client->req_len = req.length = 1;
-    REQUEST_FIXED_SIZE(req, SIZE_MAX);
+    REQUEST_FIXED_SIZE(req, 4096);
     return Success;
 }
 


### PR DESCRIPTION
>  ../test/misc.c:172:5: warning: result of comparison of constant 4611686018427387903 with expression of type 'CARD32' (aka 'unsigned int') is always true [-Wtautological-constant-out-of-range-compare]
>     172 |     REQUEST_FIXED_SIZE(req, SIZE_MAX);
>         |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
>   ../include/dix.h:88:25: note: expanded from macro 'REQUEST_FIXED_SIZE'
>      88 |             (((n) >> 2) >= client->req_len) ||                         \
>         |              ~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~

We don't really need SIZE_MAX (platform specific) for this job, just a big
enough number.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
