### PR TITLE
meson.build: enable -Wshift-negative-value

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,7 @@ add_project_arguments('-fno-strict-aliasing', language : 'c')
 add_project_arguments('-fvisibility=hidden', language : 'c')
 add_project_arguments('-Wvla', language: 'c')
 add_project_arguments('-fno-common', language: 'c')
+add_project_arguments('-Wshift-negative-value', language: 'c')
 
 add_project_link_arguments('-fvisibility=hidden', language : 'c')
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
