### PR TITLE
composite: Skip copying parent pixmap contents when possible 

### DIFF
--- a/composite/compalloc.c
+++ b/composite/compalloc.c
@@ -527,6 +527,15 @@ compUnredirectOneSubwindow(WindowPtr pParent, WindowPtr pWin)
     return Success;
 }
 
+static unsigned
+compGetBackgroundState(WindowPtr pWin)
+{
+    while (pWin->backgroundState == ParentRelative)
+        pWin = pWin->parent;
+
+    return pWin->backgroundState;
+}
+
 static PixmapPtr
 compNewPixmap(WindowPtr pWin, int x, int y, int w, int h)
 {
@@ -568,7 +577,7 @@ compNewPixmap(WindowPtr pWin, int x, int y, int w, int h)
             FreeScratchGC(pGC);
         }
     }
-    else {
+    else if (compGetBackgroundState(pWin) == None) {
         PictFormatPtr pSrcFormat = PictureWindowFormat(pParent);
         PictFormatPtr pDstFormat = PictureWindowFormat(pWin);
         XID inferiors = IncludeInferiors;


### PR DESCRIPTION
If the parent window has a different depth (which means pWin can't have valid contents yet) and pWin has effective background other than None.

Ported https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2092 from Xorg.

@guiodic If you still have an Xlibre machine to test, I'm guessing the lighter version of this, https://gitlab.freedesktop.org/xorg/xserver/-/commit/7e6c55cc9f5f26ef8afa74b2e86e883ce2ec1163#note_3148366 , still breaks, as described in https://gitlab.freedesktop.org/xorg/xserver/-/commit/7e6c55cc9f5f26ef8afa74b2e86e883ce2ec1163#note_3148404 ?

@metux I wonder what exact circumstances are occurring here, such that not populating a pixmap with effective background not None leads to breakages? Do you have an idea what cases other than effective background None might need these copies?