### PR TITLE
os: xtrans: declare trans_mkdir() static function only if needed

### DIFF
--- a/os/Xtransint.h
+++ b/os/Xtransint.h
@@ -238,10 +238,12 @@ typedef struct _Xtransport_table {
 #pragma clang diagnostic ignored "-Wunused-function"
 #endif
 
+#ifndef WIN32
 static int trans_mkdir (
     const char *,	/* path */
     int			/* mode */
 );
+#endif
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/os/Xtransutil.c
+++ b/os/Xtransutil.c
@@ -240,6 +240,7 @@ int _XSERVTransConvertAddress(int *familyp, int *addrlenp, Xtransaddr **addrp)
  * it's not save if the directory has non-root ownership or the sticky
  * bit cannot be set and fail.
  */
+#ifndef WIN32
 static int
 trans_mkdir(const char *path, int mode)
 {
@@ -388,3 +389,4 @@ trans_mkdir(const char *path, int mode)
     /* In all other cases, fail */
     return -1;
 }
+#endif


### PR DESCRIPTION
Win32/mingw32 doesn't need it, so compiler warns on it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
