### PR TITLE
os: xtrans: drop status pointer from *Accept() functions

### DIFF
--- a/os/Xtrans.c
+++ b/os/Xtrans.c
@@ -674,13 +674,13 @@ int _XSERVTransResetListener (XtransConnInfo ciptr)
 	return TRANS_RESET_NOOP;
 }
 
-XtransConnInfo _XSERVTransAccept (XtransConnInfo ciptr, int *status)
+XtransConnInfo _XSERVTransAccept (XtransConnInfo ciptr)
 {
     XtransConnInfo	newciptr;
 
     prmsg (2,"Accept(%d)\n", ciptr->fd);
 
-    newciptr = ciptr->transptr->Accept (ciptr, status);
+    newciptr = ciptr->transptr->Accept(ciptr);
 
     if (newciptr)
 	newciptr->transptr = ciptr->transptr;

--- a/os/Xtrans.h
+++ b/os/Xtrans.h
@@ -123,15 +123,6 @@ typedef struct _XtransConnInfo *XtransConnInfo;
 
 
 /*
- * Return values of Accept (0 is success)
- */
-
-#define TRANS_ACCEPT_BAD_MALLOC			-1
-#define TRANS_ACCEPT_FAILED 			-2
-#define TRANS_ACCEPT_MISC_ERROR			-3
-
-
-/*
  * ResetListener return values
  */
 
@@ -192,10 +183,7 @@ int _XSERVTransResetListener (
     XtransConnInfo	/* ciptr */
 );
 
-XtransConnInfo _XSERVTransAccept (
-    XtransConnInfo,	/* ciptr */
-    int *		/* status */
-);
+XtransConnInfo _XSERVTransAccept (XtransConnInfo ciptr);
 
 int _XSERVTransRead (
     XtransConnInfo,	/* ciptr */

--- a/os/Xtransint.h
+++ b/os/Xtransint.h
@@ -165,10 +165,7 @@ typedef struct _Xtransport {
 	XtransConnInfo		/* connection */
     );
 
-    XtransConnInfo (*Accept)(
-	XtransConnInfo,		/* connection */
-        int *			/* status */
-    );
+    XtransConnInfo (*Accept)(XtransConnInfo ciptr);
 
     int	(*Read)(
 	XtransConnInfo,		/* connection */

--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -1023,7 +1023,7 @@ static int _XSERVTransSocketUNIXResetListener (XtransConnInfo ciptr)
 #ifdef TCPCONN
 
 static XtransConnInfo _XSERVTransSocketINETAccept (
-    XtransConnInfo ciptr, int *status)
+    XtransConnInfo ciptr)
 {
     XtransConnInfo	newciptr;
     struct sockaddr_in	sockname;
@@ -1034,7 +1034,6 @@ static XtransConnInfo _XSERVTransSocketINETAccept (
     if ((newciptr = calloc (1, sizeof(struct _XtransConnInfo))) == NULL)
     {
 	prmsg (1, "SocketINETAccept: malloc failed\n");
-	*status = TRANS_ACCEPT_BAD_MALLOC;
 	return NULL;
     }
 
@@ -1046,7 +1045,6 @@ static XtransConnInfo _XSERVTransSocketINETAccept (
 #endif
 	prmsg (1, "SocketINETAccept: accept() failed\n");
 	free (newciptr);
-	*status = TRANS_ACCEPT_FAILED;
 	return NULL;
     }
 
@@ -1073,7 +1071,6 @@ static XtransConnInfo _XSERVTransSocketINETAccept (
 	    "SocketINETAccept: ...SocketINETGetAddr() failed:\n");
 	ossock_close(newciptr->fd);
 	free (newciptr);
-	*status = TRANS_ACCEPT_MISC_ERROR;
         return NULL;
     }
 
@@ -1084,11 +1081,8 @@ static XtransConnInfo _XSERVTransSocketINETAccept (
 	ossock_close(newciptr->fd);
 	if (newciptr->addr) free (newciptr->addr);
 	free (newciptr);
-	*status = TRANS_ACCEPT_MISC_ERROR;
         return NULL;
     }
-
-    *status = 0;
 
     return newciptr;
 }
@@ -1098,7 +1092,7 @@ static XtransConnInfo _XSERVTransSocketINETAccept (
 
 #ifdef UNIXCONN
 static XtransConnInfo _XSERVTransSocketUNIXAccept (
-    XtransConnInfo ciptr, int *status)
+    XtransConnInfo ciptr)
 {
     XtransConnInfo	newciptr;
     struct sockaddr_un	sockname;
@@ -1109,7 +1103,6 @@ static XtransConnInfo _XSERVTransSocketUNIXAccept (
     if ((newciptr = calloc (1, sizeof(struct _XtransConnInfo))) == NULL)
     {
 	prmsg (1, "SocketUNIXAccept: malloc() failed\n");
-	*status = TRANS_ACCEPT_BAD_MALLOC;
 	return NULL;
     }
 
@@ -1118,7 +1111,6 @@ static XtransConnInfo _XSERVTransSocketUNIXAccept (
     {
 	prmsg (1, "SocketUNIXAccept: accept() failed\n");
 	free (newciptr);
-	*status = TRANS_ACCEPT_FAILED;
 	return NULL;
     }
 
@@ -1134,7 +1126,6 @@ static XtransConnInfo _XSERVTransSocketUNIXAccept (
         "SocketUNIXAccept: Can't allocate space for the addr\n");
 	ossock_close(newciptr->fd);
 	free (newciptr);
-	*status = TRANS_ACCEPT_BAD_MALLOC;
         return NULL;
     }
 
@@ -1153,7 +1144,6 @@ static XtransConnInfo _XSERVTransSocketUNIXAccept (
 	ossock_close(newciptr->fd);
 	if (newciptr->addr) free (newciptr->addr);
 	free (newciptr);
-	*status = TRANS_ACCEPT_BAD_MALLOC;
         return NULL;
     }
 
@@ -1161,8 +1151,6 @@ static XtransConnInfo _XSERVTransSocketUNIXAccept (
     memcpy (newciptr->peeraddr, ciptr->addr, newciptr->addrlen);
 
     newciptr->family = AF_UNIX;
-
-    *status = 0;
 
     return newciptr;
 }

--- a/os/connection.c
+++ b/os/connection.c
@@ -621,7 +621,6 @@ EstablishNewConnections(int curconn, int ready, void *data)
     ClientPtr client;
     OsCommPtr oc;
     XtransConnInfo trans_conn, new_trans_conn;
-    int status;
 
     connect_time = GetTimeInMillis();
     /* kill off stragglers */
@@ -638,7 +637,7 @@ EstablishNewConnections(int curconn, int ready, void *data)
     if ((trans_conn = lookup_trans_conn(curconn)) == NULL)
         return;
 
-    if ((new_trans_conn = _XSERVTransAccept(trans_conn, &status)) == NULL)
+    if ((new_trans_conn = _XSERVTransAccept(trans_conn)) == NULL)
         return;
 
     newconn = _XSERVTransGetConnectionNumber(new_trans_conn);
@@ -1008,7 +1007,6 @@ ListenOnOpenFD(int fd, int noxauth)
     ListenTransCount++;
 }
 
-/* based on _XSERVTransSocketUNIXAccept (XtransConnInfo ciptr, int *status) */
 Bool
 AddClientOnOpenFD(int fd)
 {


### PR DESCRIPTION
Nobody's ever looking at this value, so no need to keep it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
