### PR TITLE
os: drop symbol TCPCONN

### DIFF
--- a/hw/xfree86/xorg-server.h.meson.in
+++ b/hw/xfree86/xorg-server.h.meson.in
@@ -88,9 +88,6 @@
 /* Define to 1 on systems derived from System V Release 4 */
 #mesondefine SVR4
 
-/* Support TCP socket connections */
-#mesondefine TCPCONN
-
 /* Support UNIX socket connections */
 #mesondefine UNIXCONN
 

--- a/include/meson.build
+++ b/include/meson.build
@@ -200,7 +200,6 @@ if conf_data.get('HAVE_GETPEEREID').to_int() == 0 and conf_data.get('HAVE_GETPEE
     endif
 endif
 
-conf_data.set('TCPCONN', '1')
 conf_data.set('UNIXCONN', host_machine.system() != 'windows' ? '1' : false)
 conf_data.set('IPv6', build_ipv6 ? '1' : false)
 

--- a/os/Xtrans.c
+++ b/os/Xtrans.c
@@ -85,13 +85,11 @@ from The Open Group.
 
 static
 Xtransport_table Xtransports[] = {
-#if defined(TCPCONN)
     { &_XSERVTransSocketTCPFuncs,	TRANS_SOCKET_TCP_INDEX },
 #if defined(IPv6)
     { &_XSERVTransSocketINET6Funcs,	TRANS_SOCKET_INET6_INDEX },
 #endif /* IPv6 */
     { &_XSERVTransSocketINETFuncs,	TRANS_SOCKET_INET_INDEX },
-#endif /* TCPCONN */
 #if defined(UNIXCONN)
     { &_XSERVTransSocketLocalFuncs,	TRANS_SOCKET_LOCAL_INDEX },
     { &_XSERVTransSocketUNIXFuncs,	TRANS_SOCKET_UNIX_INDEX },

--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -78,13 +78,13 @@ from the copyright holders.
 
 #ifndef WIN32
 
-#if defined(TCPCONN) || defined(UNIXCONN)
+#if defined(UNIXCONN)
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #endif
 
-#if defined(TCPCONN) || defined(UNIXCONN)
+#if defined(UNIXCONN)
 #define X_INCLUDE_NETDB_H
 #define XOS_USE_NO_LOCKING
 #include <X11/Xos_r.h>
@@ -186,7 +186,6 @@ typedef struct _Sockettrans2dev {
  *  local   Platform preferred local connection method
  */
 static Sockettrans2dev Sockettrans2devtab[] = {
-#ifdef TCPCONN
     {"inet",AF_INET,SOCK_STREAM,SOCK_DGRAM,0},
 #ifndef IPv6
     {"tcp",AF_INET,SOCK_STREAM,SOCK_DGRAM,0},
@@ -195,7 +194,6 @@ static Sockettrans2dev Sockettrans2devtab[] = {
     {"tcp",AF_INET,SOCK_STREAM,SOCK_DGRAM,0}, /* fallback */
     {"inet6",AF_INET6,SOCK_STREAM,SOCK_DGRAM,0},
 #endif
-#endif /* TCPCONN */
 #ifdef UNIXCONN
     {"unix",AF_UNIX,SOCK_STREAM,SOCK_DGRAM,0},
     {"local",AF_UNIX,SOCK_STREAM,SOCK_DGRAM,0},
@@ -204,9 +202,7 @@ static Sockettrans2dev Sockettrans2devtab[] = {
 
 #define NUMSOCKETFAMILIES (sizeof(Sockettrans2devtab)/sizeof(Sockettrans2dev))
 
-#ifdef TCPCONN
-static int _XSERVTransSocketINETClose (XtransConnInfo ciptr);
-#endif
+
 
 static int
 is_numeric (const char *str)
@@ -713,7 +709,6 @@ static int _XSERVTransSocketCreateListener (XtransConnInfo ciptr,
     return 0;
 }
 
-#ifdef TCPCONN
 static int _XSERVTransSocketINETCreateListener (
     XtransConnInfo ciptr, const char *port, unsigned int flags)
 {
@@ -829,9 +824,6 @@ static int _XSERVTransSocketINETCreateListener (
 
     return 0;
 }
-
-#endif /* TCPCONN */
-
 
 #ifdef UNIXCONN
 
@@ -1018,8 +1010,6 @@ static int _XSERVTransSocketUNIXResetListener (XtransConnInfo ciptr)
 #endif /* UNIXCONN */
 
 
-#ifdef TCPCONN
-
 static XtransConnInfo _XSERVTransSocketINETAccept (
     XtransConnInfo ciptr)
 {
@@ -1084,9 +1074,6 @@ static XtransConnInfo _XSERVTransSocketINETAccept (
 
     return newciptr;
 }
-
-#endif /* TCPCONN */
-
 
 #ifdef UNIXCONN
 static XtransConnInfo _XSERVTransSocketUNIXAccept (
@@ -1382,15 +1369,6 @@ static int _XSERVTransSocketDisconnect (XtransConnInfo ciptr)
 #endif
 }
 
-#ifdef TCPCONN
-static int _XSERVTransSocketINETClose (XtransConnInfo ciptr)
-{
-    prmsg (2,"SocketINETClose(%p,%d)\n", (void *) ciptr, ciptr->fd);
-    return ossock_close(ciptr->fd);
-}
-
-#endif /* TCPCONN */
-
 #ifdef UNIXCONN
 static int _XSERVTransSocketUNIXClose (XtransConnInfo ciptr)
 {
@@ -1438,8 +1416,12 @@ static int _XSERVTransSocketUNIXCloseForCloning (XtransConnInfo ciptr)
 
 #endif /* UNIXCONN */
 
+static int _XSERVTransSocketINETClose (XtransConnInfo ciptr)
+{
+    prmsg (2,"SocketINETClose(%p,%d)\n", (void *) ciptr, ciptr->fd);
+    return ossock_close(ciptr->fd);
+}
 
-#ifdef TCPCONN
 static const char* tcp_nolisten[] = {
 	"inet",
 #ifdef IPv6
@@ -1515,7 +1497,6 @@ static Xtransport _XSERVTransSocketINET6Funcs = {
 	_XSERVTransSocketINETClose,
 };
 #endif /* IPv6 */
-#endif /* TCPCONN */
 
 #ifdef UNIXCONN
 static Xtransport _XSERVTransSocketLocalFuncs = {

--- a/os/Xtransutil.c
+++ b/os/Xtransutil.c
@@ -102,7 +102,6 @@ int _XSERVTransConvertAddress(int *familyp, int *addrlenp, Xtransaddr **addrp)
 
     switch( *familyp )
     {
-#if defined(TCPCONN)
     case AF_INET:
     {
 	/*
@@ -165,7 +164,6 @@ int _XSERVTransConvertAddress(int *familyp, int *addrlenp, Xtransaddr **addrp)
 	break;
     }
 #endif /* IPv6 */
-#endif /* defined(TCPCONN) */
 
 
 #if defined(UNIXCONN)

--- a/os/access.c
+++ b/os/access.c
@@ -105,9 +105,7 @@ SOFTWARE.
 #include <pwd.h>
 #endif
 
-#if defined(TCPCONN)
 #include <netinet/in.h>
-#endif                          /* TCPCONN */
 
 #ifdef HAVE_GETPEERUCRED
 #include <ucred.h>
@@ -404,9 +402,6 @@ AccessUsingXdmcp(void)
 void
 DefineSelf(int fd)
 {
-#if !defined(TCPCONN) && !defined(UNIXCONN)
-    return;
-#else
     int len;
     caddr_t addr;
     int family;
@@ -519,7 +514,6 @@ DefineSelf(int fd)
             selfhosts = host;
         }
     }
-#endif                          /* !TCPCONN && !UNIXCONN */
 }
 
 #else
@@ -941,7 +935,6 @@ ResetHosts(const char *display)
                 NewHost(family, "", 0, FALSE);
                 LocalHostRequested = TRUE;      /* Fix for XFree86 bug #156 */
             }
-#if defined(TCPCONN)
             else if (!strncmp("inet:", lhostname, 5)) {
                 family = FamilyInternet;
                 hostname = ohostname + 5;
@@ -951,7 +944,6 @@ ResetHosts(const char *display)
                 family = FamilyInternet6;
                 hostname = ohostname + 6;
             }
-#endif
 #endif
             else if (!strncmp("si:", lhostname, 3)) {
                 family = FamilyServerInterpreted;
@@ -966,7 +958,6 @@ ResetHosts(const char *display)
                 }
             }
             else
-#if defined(TCPCONN)
             {
 #if defined(HAVE_GETADDRINFO)
                 if ((family == FamilyInternet) ||
@@ -1021,7 +1012,6 @@ ResetHosts(const char *display)
                 }
 #endif                          /* HAVE_GETADDRINFO */
             }
-#endif                          /* TCPCONN */
             family = FamilyWild;
         }
         fclose(fd);
@@ -1445,7 +1435,6 @@ CheckAddr(int family, const void *pAddr, unsigned length)
     int len;
 
     switch (family) {
-#if defined(TCPCONN)
     case FamilyInternet:
         if (length == sizeof(struct in_addr))
             len = length;
@@ -1459,7 +1448,6 @@ CheckAddr(int family, const void *pAddr, unsigned length)
         else
             len = -1;
         break;
-#endif
 #endif
     case FamilyServerInterpreted:
         len = siCheckAddr(pAddr, length);
@@ -1528,7 +1516,6 @@ ConvertAddr(register struct sockaddr *saddr, int *len, void **addr)
     case AF_UNIX:
 #endif
         return FamilyLocal;
-#if defined(TCPCONN)
     case AF_INET:
 #ifdef WIN32
         if (16777343 == *(long *) &((struct sockaddr_in *) saddr)->sin_addr)
@@ -1553,7 +1540,6 @@ ConvertAddr(register struct sockaddr *saddr, int *len, void **addr)
             return FamilyInternet6;
         }
     }
-#endif
 #endif
     default:
         return -1;

--- a/os/connection.c
+++ b/os/connection.c
@@ -79,7 +79,6 @@ SOFTWARE.
 #ifndef WIN32
 #include <sys/socket.h>
 
-#if defined(TCPCONN)
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #ifdef CSRG_BASED
@@ -88,8 +87,9 @@ SOFTWARE.
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
 #endif
+#ifndef WIN32
 #include <sys/uio.h>
-#endif                          /* WIN32 */
+#endif
 
 #include "dix/dix_priv.h"
 #include "dix/dixgrabs_priv.h"
@@ -351,7 +351,6 @@ AuthAudit(ClientPtr client, Bool letin,
 #endif
             strlcpy(addr, "local host", sizeof(addr));
             break;
-#if defined(TCPCONN)
         case AF_INET:{
 #if defined(HAVE_INET_NTOP)
             char ipaddr[INET_ADDRSTRLEN];
@@ -374,7 +373,6 @@ AuthAudit(ClientPtr client, Bool letin,
             snprintf(addr, sizeof(addr), "IP %s", ipaddr);
         }
             break;
-#endif
 #endif
         default:
             strlcpy(addr, "unknown address", sizeof(addr));

--- a/os/transport.c
+++ b/os/transport.c
@@ -62,9 +62,7 @@ from The Open Group.
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-#if defined(TCPCONN) || defined(UNIXCONN)
 #include "Xtranssock.c"
-#endif
 #include "Xtrans.c"
 #include "Xtransutil.c"
 

--- a/os/utils.c
+++ b/os/utils.c
@@ -88,10 +88,8 @@ OR PERFORMANCE OF THIS SOFTWARE.
 #include <stdarg.h>
 #include <stdlib.h>             /* for calloc() */
 
-#if defined(TCPCONN)
 #ifndef WIN32
 #include <netdb.h>
-#endif
 #endif
 
 #include "dix/dix_priv.h"
@@ -783,7 +781,6 @@ int
 set_font_authorizations(char **authorizations, int *authlen, void *client)
 {
 #define AUTHORIZATION_NAME "hp-hostname-1"
-#if defined(TCPCONN)
     static char *result = NULL;
     static char *p = NULL;
 
@@ -845,9 +842,6 @@ set_font_authorizations(char **authorizations, int *authlen, void *client)
     *authlen = p - result;
     *authorizations = result;
     return 1;
-#else                           /* TCPCONN */
-    return 0;
-#endif                          /* TCPCONN */
 }
 
 void

--- a/os/xdmauth.c
+++ b/os/xdmauth.c
@@ -282,7 +282,6 @@ XdmAuthorizationValidate(unsigned char *plain, int length,
         if (_XSERVTransGetPeerAddr(((OsCommPtr) xclient->osPrivate)->trans_conn,
                                    &family, &addr_len, &addr) == 0
             && _XSERVTransConvertAddress(&family, &addr_len, &addr) == 0) {
-#if defined(TCPCONN)
             if (family == FamilyInternet &&
                 memcmp((char *) addr, client->client, 4) != 0) {
                 free(client);
@@ -293,7 +292,6 @@ XdmAuthorizationValidate(unsigned char *plain, int length,
                 return NULL;
 
             }
-#endif
             free(addr);
         }
     }


### PR DESCRIPTION
It's been always enabled for aeons, so no practical need to
disable it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
