### PR TITLE
os: xtrans: define trans_mkdir() when UNIXCONN is enabled

### DIFF
--- a/os/Xtransint.h
+++ b/os/Xtransint.h
@@ -235,12 +235,12 @@ typedef struct _Xtransport_table {
 #pragma clang diagnostic ignored "-Wunused-function"
 #endif
 
-#ifndef WIN32
+#ifdef UNIXCONN
 static int trans_mkdir (
     const char *,	/* path */
     int			/* mode */
 );
-#endif
+#endif /* UNIXCONN */
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/os/Xtransutil.c
+++ b/os/Xtransutil.c
@@ -240,7 +240,7 @@ int _XSERVTransConvertAddress(int *familyp, int *addrlenp, Xtransaddr **addrp)
  * it's not save if the directory has non-root ownership or the sticky
  * bit cannot be set and fail.
  */
-#ifndef WIN32
+#ifdef UNIXCONN
 static int
 trans_mkdir(const char *path, int mode)
 {
@@ -389,4 +389,4 @@ trans_mkdir(const char *path, int mode)
     /* In all other cases, fail */
     return -1;
 }
-#endif
+#endif /* UNIXCONN */


### PR DESCRIPTION
trans_mkdir() is needed for unix sockets, so the correct switch is
UNIXCONN, instead of WIN32.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
