### PR TITLE
os: enable UNIX sockets on Mingw32

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -200,7 +200,7 @@ if conf_data.get('HAVE_GETPEEREID').to_int() == 0 and conf_data.get('HAVE_GETPEE
     endif
 endif
 
-conf_data.set('UNIXCONN', host_machine.system() != 'windows' ? '1' : false)
+conf_data.set('UNIXCONN', '1')
 conf_data.set('IPv6', build_ipv6 ? '1' : false)
 
 # potentially tunable - needed also in places that cannot include misc.h

--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -73,12 +73,14 @@ from the copyright holders.
 #ifdef XTHREADS
 #include <X11/Xthreads.h>
 #endif
+#include <sys/stat.h>
 
 #include "os/ossock.h"
 
 #ifndef WIN32
 
 #if defined(UNIXCONN)
+#include <sys/un.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -89,12 +91,6 @@ from the copyright holders.
 #define XOS_USE_NO_LOCKING
 #include <X11/Xos_r.h>
 #endif
-
-#ifdef UNIXCONN
-#include <sys/un.h>
-#include <sys/stat.h>
-#endif
-
 
 #ifndef NO_TCP_H
 #if defined(linux) || defined(__GLIBC__)
@@ -119,6 +115,8 @@ from the copyright holders.
 #include <X11/Xwinsock.h>
 #include <X11/Xwindows.h>
 #include <X11/Xw32defs.h>
+
+#include <afunix.h>
 
 #undef EADDRINUSE
 #define EADDRINUSE WSAEADDRINUSE


### PR DESCRIPTION
Mingw32 also supports unix sockets, so no need to disable them here.

Since it's now always enabled, follow-up commits can now drop all the
extra #ifdef's on UNIXCONN and so reduce complexity.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
