### PR TITLE
os: Xtranssock: fix (signed) char array subscript

### DIFF
--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -205,10 +205,8 @@ static Sockettrans2dev Sockettrans2devtab[] = {
 static int
 is_numeric (const char *str)
 {
-    int i;
-
-    for (i = 0; i < (int) strlen (str); i++)
-	if (!isdigit (str[i]))
+    for (unsigned int i = 0; i < (int) strlen (str); i++)
+	if (!isdigit ((unsigned char)(str[i])))
 	    return (0);
 
     return (1);


### PR DESCRIPTION
>  In file included from /usr/include/ctype.h:100,
>                   from ../include/misc.h:154,
>                   from ../include/os.h:51,
>                   from ../os/Xtransint.h:256,
>                   from ../os/transport.c:57:
> ../os/Xtranssock.c: In function ‘is_numeric’:
> ../os/Xtranssock.c:217:19: error: array subscript has type ‘char’ [-Werror=char-subscripts]
>    217 |  if (!isdigit (str[i]))
>        |                   ^

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
