### PR TITLE
xfree86: drop obsolete xf86SetTVOut() and xf86SetRGBOut()

### DIFF
--- a/hw/xfree86/os-support/bsd/i386_video.c
+++ b/hw/xfree86/os-support/bsd/i386_video.c
@@ -268,30 +268,3 @@ xf86DisableIO(void)
 }
 
 #endif
-
-#ifdef __NetBSD__
-/***************************************************************************/
-/* Set TV output mode                                                      */
-/***************************************************************************/
-void
-xf86SetTVOut(int mode)
-{
-    switch (xf86Info.consType) {
-    default:
-        FatalError("Xf86SetTVOut: Unsupported console");
-        break;
-    }
-    return;
-}
-
-void
-xf86SetRGBOut(void)
-{
-    switch (xf86Info.consType) {
-    default:
-        FatalError("Xf86SetTVOut: Unsupported console");
-        break;
-    }
-    return;
-}
-#endif

--- a/hw/xfree86/os-support/xf86_OSproc.h
+++ b/hw/xfree86/os-support/xf86_OSproc.h
@@ -101,10 +101,6 @@ _XFUNCPROTOBEGIN
 extern _X_EXPORT Bool xf86EnableIO(void);
 extern _X_EXPORT void xf86DisableIO(void);
 
-#ifdef __NetBSD__
-extern _X_EXPORT void xf86SetTVOut(int);
-extern _X_EXPORT void xf86SetRGBOut(void);
-#endif
 extern _X_EXPORT void xf86SlowBcopy(unsigned char *, unsigned char *, int);
 extern _X_EXPORT int xf86OpenSerial(XF86OptionPtr options);
 extern _X_EXPORT int xf86SetSerial(int fd, XF86OptionPtr options);


### PR DESCRIPTION
These are only defined on NetBSD and not used anywhere, and not
functional at all (just killing the Xserver). No need to carry
them around any longer.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
