### PR TITLE
dix: combine alwaysCheckForInput initialization

### DIFF
--- a/dix/main.c
+++ b/dix/main.c
@@ -134,7 +134,6 @@ CallbackListPtr PostInitRootWindowCallback = NULL;
 int
 dix_main(int argc, char *argv[], char *envp[])
 {
-    HWEventQueueType alwaysCheckForInput[2];
 
     display = "0";
 
@@ -145,9 +144,6 @@ dix_main(int argc, char *argv[], char *envp[])
     CheckUserAuthorization();
 
     ProcessCommandLine(argc, argv);
-
-    alwaysCheckForInput[0] = 0;
-    alwaysCheckForInput[1] = 1;
 
         ScreenSaverTime = defaultScreenSaverTime;
         ScreenSaverInterval = defaultScreenSaverInterval;
@@ -184,6 +180,7 @@ dix_main(int argc, char *argv[], char *envp[])
         if (!InitClientResources(serverClient)) /* for root resources */
             FatalError("couldn't init server resources");
 
+        HWEventQueueType alwaysCheckForInput[2] = { 0, 1 };
         SetInputCheck(&alwaysCheckForInput[0], &alwaysCheckForInput[1]);
         screenInfo.numScreens = 0;
 


### PR DESCRIPTION
Based on
https://github.com/X11Libre/xserver/wiki/Code-Cleanup-Blueprints there's no reason to have alwaysCheckForInput declared on top and initializing it later (without any code touching it in the meantime). So combine the initialization and declaration in one line on top.