### PR TITLE
.github: scripts: compile-drivers.sh: consolidate driver list

### DIFF
--- a/.github/scripts/compile-drivers.sh
+++ b/.github/scripts/compile-drivers.sh
@@ -6,27 +6,26 @@ set -e
 
 export PKG_CONFIG_PATH="/usr/local/lib/x86_64-linux-gnu/pkgconfig/:$PKG_CONFIG_PATH"
 export ACLOCAL_PATH="/usr/share/aclocal:/usr/local/share/aclocal"
-export X11L_DRV_GIT=https://github.com/X11Libre/
 
 mkdir -p $DRV_BUILD_DIR
 cd $DRV_BUILD_DIR
 
-build_drv_ac xf86-input-elographics $X11L_DRV_GIT/xf86-input-elographics xlibre-xf86-input-elographics-1.4.4.2
-build_drv_ac xf86-input-evdev       $X11L_DRV_GIT/xf86-input-evdev       xlibre-xf86-input-evdev-2.11.0.2
-build_drv_ac xf86-input-keyboard    $X11L_DRV_GIT/xf86-input-keyboard    xlibre-xf86-input-keyboard-2.1.0.2
-build_drv_ac xf86-input-libinput    $X11L_DRV_GIT/xf86-input-libinput    xlibre-xf86-input-libinput-1.5.1.0
-build_drv_ac xf86-input-mouse       $X11L_DRV_GIT/xf86-input-mouse       xlibre-xf86-input-mouse-1.9.6
-build_drv_ac xf86-input-synaptics   $X11L_DRV_GIT/xf86-input-synaptics   xlibre-xf86-input-synaptics-1.10.0.2
+build_xf86drv_ac    input-elographics       1.4.4.2
+build_xf86drv_ac    input-evdev             2.11.0.2
+build_xf86drv_ac    input-keyboard          2.1.0.2
+build_xf86drv_ac    input-libinput          1.5.1.0
+build_xf86drv_ac    input-mouse             1.9.6
+build_xf86drv_ac    input-synaptics         1.10.0.2
 
-build_drv_ac xf86-video-amdgpu      $X11L_DRV_GIT/xf86-video-amdgpu      xlibre-xf86-video-amdgpu-23.0.0.5
-build_drv_ac xf86-video-apm         $X11L_DRV_GIT/xf86-video-apm         xlibre-xf86-video-apm-1.3.0.3
-build_drv_ac xf86-video-ati         $X11L_DRV_GIT/xf86-video-ati         xlibre-xf86-video-ati-22.0.0.3
-build_drv_ac xf86-video-dummy       $X11L_DRV_GIT/xf86-video-dummy       xlibre-xf86-video-dummy-0.4.1.3
-build_drv_ac xf86-video-geode       $X11L_DRV_GIT/xf86-video-geode       xlibre-xf86-video-geode-2.18.1.3
-build_drv_ac xf86-video-intel       $X11L_DRV_GIT/xf86-video-intel       xlibre-xf86-video-intel-3.0.0.3
-build_drv_ac xf86-video-nouveau     $X11L_DRV_GIT/xf86-video-nouveau     xlibre-xf86-video-nouveau-1.0.18.3
-build_drv_ac xf86-video-omap        $X11L_DRV_GIT/xf86-video-omap        xlibre-xf86-video-omap-0.4.5.2
-build_drv_ac xf86-video-qxl         $X11L_DRV_GIT/xf86-video-qxl         xlibre-xf86-video-qxl-0.1.6.2
-build_drv_ac xf86-video-r128        $X11L_DRV_GIT/xf86-video-r128        xlibre-xf86-video-r128-6.13.0.2
-build_drv_ac xf86-video-vesa        $X11L_DRV_GIT/xf86-video-vesa        xlibre-xf86-video-vesa-2.6.0.2
-build_drv_ac xf86-video-vmware      $X11L_DRV_GIT/xf86-video-vmware      xlibre-xf86-video-vmware-13.4.0.3
+build_xf86drv_ac    video-amdgpu            23.0.0.5
+build_xf86drv_ac    video-apm               1.3.0.3
+build_xf86drv_ac    video-ati               22.0.0.3
+build_xf86drv_ac    video-dummy             0.4.1.3
+build_xf86drv_ac    video-geode             2.18.1.3
+build_xf86drv_ac    video-intel             3.0.0.3
+build_xf86drv_ac    video-nouveau           1.0.18.3
+build_xf86drv_ac    video-omap              0.4.5.2
+build_xf86drv_ac    video-qxl               0.1.6.2
+build_xf86drv_ac    video-r128              6.13.0.2
+build_xf86drv_ac    video-vesa              2.6.0.2
+build_xf86drv_ac    video-vmware            13.4.0.3

--- a/.github/scripts/util.sh
+++ b/.github/scripts/util.sh
@@ -103,3 +103,22 @@ fdo_mirror() {
     local repo="$1"
     echo -n "https://github.com/X11Libre/mirror.fdo.$1"
 }
+
+xl_mirror() {
+    local repo="$1"
+    echo -n "https://github.com/X11Libre/$1"
+}
+
+drv_tag() {
+    local name="$1"
+    local version="$2"
+    echo -n "xlibre-xf86-$name-$version"
+}
+
+build_xf86drv_ac() {
+    local drv_name="$1"
+    local version="$2"
+    local repo_name="xf86-$drv_name"
+    local tag_name="xlibre-xf86-$drv_name-$version"
+    build_drv_ac "xf86-$name" "$(xl_mirror $repo_name)" "$(drv_tag $drv_name $version)"
+}


### PR DESCRIPTION
Since all repo URLs and tags are following a common scheme, we can
reduce boilderplate by computing them by driver and and version only.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
