### PR TITLE
.github: compile xf86-input-vmmouse driver

### DIFF
--- a/.github/scripts/compile-drivers.sh
+++ b/.github/scripts/compile-drivers.sh
@@ -17,6 +17,7 @@ build_xf86drv_ac    input-keyboard          2.1.0.2
 build_xf86drv_ac    input-libinput          1.5.1.0
 build_xf86drv_ac    input-mouse             1.9.6
 build_xf86drv_ac    input-synaptics         1.10.0.2
+build_xf86drv_ac    input-vmmouse           13.2.0.4
 
 build_xf86drv_ac    video-amdgpu            23.0.0.5
 build_xf86drv_ac    video-apm               1.3.0.3


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
