### PR TITLE
.github: compile-drivers: compile the xf86-input-wacom driver

### DIFF
--- a/.github/scripts/compile-drivers.sh
+++ b/.github/scripts/compile-drivers.sh
@@ -19,6 +19,7 @@ build_xf86drv_ac    input-mouse             1.9.6
 build_xf86drv_ac    input-synaptics         1.10.0.2
 build_xf86drv_ac    input-vmmouse           13.2.0.4
 build_xf86drv_ac    input-void              1.4.2.3
+build_xf86drv_ac    input-wacom             1.2.3.3
 
 build_xf86drv_ac    video-amdgpu            23.0.0.5
 build_xf86drv_ac    video-apm               1.3.0.3

--- a/.github/scripts/ubuntu/install-pkg.sh
+++ b/.github/scripts/ubuntu/install-pkg.sh
@@ -74,6 +74,7 @@ apt-get install -y \
 	libxmu-dev \
 	libxmuu-dev \
 	libxpm-dev \
+	libxrandr-dev \
 	libxrender-dev \
 	libxres-dev \
 	libxshmfence-dev \


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
