### PR TITLE
arm_video.c: Fixed xf86_os_support.h's #include.

### DIFF
--- a/hw/xfree86/os-support/bsd/arm_video.c
+++ b/hw/xfree86/os-support/bsd/arm_video.c
@@ -65,7 +65,7 @@
 #include <X11/X.h>
 
 #include "xf86.h"
-#include "xf86_os_support."
+#include "xf86_os_support.h"
 #include "xf86Priv.h"
 #include "xf86_OSlib.h"
 #include "compiler.h"


### PR DESCRIPTION
The 'h' in the file suffixed was mistakenly removed, fixed it.