### PR TITLE
.github: compile-drivers.sh: add xf86-video-mga driver

### DIFF
--- a/.github/scripts/compile-drivers.sh
+++ b/.github/scripts/compile-drivers.sh
@@ -32,6 +32,7 @@ build_xf86drv_ac    video-i128              1.4.1.2
 build_xf86drv_ac    video-i740              1.4.0.2
 build_xf86drv_ac    video-intel             3.0.0.3
 build_xf86drv_ac    video-mach64            6.10.0.3
+build_xf86drv_ac    video-mga               2.1.0.2
 build_xf86drv_ac    video-nouveau           1.0.18.3
 build_xf86drv_ac    video-omap              0.4.5.2
 build_xf86drv_ac    video-qxl               0.1.6.2


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
