### PR TITLE
xfree86: move the xf86-input-mouse driver in-tree

### DIFF
--- a/.github/scripts/compile-drivers.sh
+++ b/.github/scripts/compile-drivers.sh
@@ -15,7 +15,6 @@ build_xf86drv_ac    input-evdev             25.0.0
 build_xf86drv_ac    input-joystick          25.0.0
 build_xf86drv_ac    input-keyboard          25.0.0
 build_xf86drv_ac    input-libinput          25.0.0
-build_xf86drv_ac    input-mouse             25.0.0
 build_xf86drv_ac    input-synaptics         25.0.0
 build_xf86drv_ac    input-vmmouse           25.0.0
 build_xf86drv_ac    input-void              25.0.0

--- a/hw/xfree86/drivers/input/meson.build
+++ b/hw/xfree86/drivers/input/meson.build
@@ -1,3 +1,7 @@
 if get_option('xf86-input-inputtest')
     subdir('inputtest')
 endif
+
+if get_option('xf86-input-mouse')
+    subdir('mouse')
+endif

--- a/hw/xfree86/drivers/input/mouse/COPYING
+++ b/hw/xfree86/drivers/input/mouse/COPYING
@@ -1,0 +1,132 @@
+Copyright (c) 2004, 2022, Oracle and/or its affiliates.
+Copyright 2012 Red Hat, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next
+paragraph) shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+Copyright 1990,91 by Thomas Roell, Dinkelscherben, Germany.
+Copyright 1993 by David Dawes <dawes@xfree86.org>
+Copyright 2002 by SuSE Linux AG, Author: Egbert Eich
+Copyright 1994-2002 by The XFree86 Project, Inc.
+Copyright 2002 by Paul Elliott
+
+Permission to use, copy, modify, distribute, and sell this software and its
+documentation for any purpose is hereby granted without fee, provided that
+the above copyright notice appear in all copies and that both that
+copyright notice and this permission notice appear in supporting
+documentation, and that the names of copyright holders not be
+used in advertising or publicity pertaining to distribution of the
+software without specific, written prior permission.  The copyright holders
+make no representations about the suitability of this
+software for any purpose.  It is provided "as is" without express or
+implied warranty.
+
+THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+Copyright 1998 by Kazutaka YOKOTA <yokota@zodiac.mech.utsunomiya-u.ac.jp>
+
+Permission to use, copy, modify, distribute, and sell this software and its
+documentation for any purpose is hereby granted without fee, provided that
+the above copyright notice appear in all copies and that both that
+copyright notice and this permission notice appear in supporting
+documentation, and that the name of Kazutaka YOKOTA not be used in
+advertising or publicity pertaining to distribution of the software without
+specific, written prior permission.  Kazutaka YOKOTA makes no representations
+about the suitability of this software for any purpose.  It is provided
+"as is" without express or implied warranty.
+
+KAZUTAKA YOKOTA DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+EVENT SHALL KAZUTAKA YOKOTA BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+Copyright (c) 1999-2003 by The XFree86 Project, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of the copyright holder(s)
+and author(s) shall not be used in advertising or otherwise to promote
+the sale, use or other dealings in this Software without prior written
+authorization from the copyright holder(s) and author(s).
+
+Copyright 1997,1998 by UCHIYAMA Yasushi
+
+Permission to use, copy, modify, distribute, and sell this software and its
+documentation for any purpose is hereby granted without fee, provided that
+the above copyright notice appear in all copies and that both that
+copyright notice and this permission notice appear in supporting
+documentation, and that the name of UCHIYAMA Yasushi not be used in
+advertising or publicity pertaining to distribution of the software without
+specific, written prior permission.  UCHIYAMA Yasushi makes no representations
+about the suitability of this software for any purpose.  It is provided
+"as is" without express or implied warranty.
+
+UCHIYAMA YASUSHI DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+EVENT SHALL UCHIYAMA YASUSHI BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+Copyright 2001 by J. Kean Johnston <jkj@sco.com>
+
+Permission to use, copy, modify, distribute, and sell this software and its
+documentation for any purpose is hereby granted without fee, provided that
+the above copyright notice appear in all copies and that both that
+copyright notice and this permission notice appear in supporting
+documentation, and that the name J. Kean Johnston not be used in
+advertising or publicity pertaining to distribution of the software without
+specific, written prior permission.  J. Kean Johnston makes no
+representations about the suitability of this software for any purpose.
+It is provided "as is" without express or implied warranty.
+
+J. KEAN JOHNSTON DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+EVENT SHALL J. KEAN JOHNSTON BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.

--- a/hw/xfree86/drivers/input/mouse/README
+++ b/hw/xfree86/drivers/input/mouse/README
@@ -1,0 +1,1214 @@
+  Mouse Support in xf86-input-mouse
+  Original version written by Kazutaka Yokota for XFree86 on 17 December 2002
+  Updated by Alan Coopersmith for X.Org releases
+  ____________________________________________________________
+
+  Table of Contents
+
+
+  1. Introduction
+  2. Supported Hardware
+  3. OS Support for Mice
+     3.1 Summary of Supported Mouse Protocol Types
+     3.2 FreeBSD
+     3.3 FreeBSD(98)
+     3.4 NetBSD
+     3.5 NetBSD/pc98
+     3.6 OpenBSD
+     3.7 Solaris & illumos
+     3.8 Linux
+     3.9 Linux/98
+
+  4. Configuring Your Mouse
+  5. xorg.conf Options
+     5.1 Buttons
+     5.2 ZAxisMapping
+     5.3 Resolution
+     5.4 Drag Lock Buttons
+
+  6. Mouse Gallery
+     6.1 MS IntelliMouse (serial, PS/2)
+     6.2 MS IntelliMouse Explorer (PS/2, USB)
+     6.3 Kensington Thinking Mouse and Kensington Expert Mouse (serial,
+         PS/2)
+     6.4 Genius NetScroll (PS/2)
+     6.5 Genius NetMouse and NetMouse Pro (serial, PS/2)
+     6.6 Genius NetScroll Optical (PS/2, USB)
+     6.7 ALPS GlidePoint (serial, PS/2)
+     6.8 ASCII MieMouse (serial, PS/2)
+     6.9 Logitech MouseMan+ and FirstMouse+ (serial, PS/2)
+     6.10 IBM ScrollPoint (PS/2)
+     6.11 8D ScrollMouse (serial, PS/2)
+     6.12 A4 Tech 4D mice (serial, PS/2, USB)
+
+  7. Configuration Examples
+
+
+  ______________________________________________________________________
+
+  1.  Introduction
+
+
+  This document describes mouse support in the xf86-input-mouse driver
+  for the XLibre X server.   This driver is mainly used on non-Linux
+  operating systems such as BSD & Solaris, as modern Linux systems use
+  the xf86-input-evdev or xf86-input-libinput drivers instead.
+
+
+  Mouse configuration has often been mysterious task for novice users.
+  However, once you learn several basics, it is straightforward to write
+  the mouse "InputDevice" section in the xorg.conf file by hand.
+
+
+  2.  Supported Hardware
+
+
+  The xf86-input-mouse driver supports four classes of mice: serial,
+  bus and PS/2 mice, and additional mouse types supported by specific
+  operating systems, such as USB mice.
+
+
+     Serial mouse
+        The serial mouse was once the most popular pointing device for
+        PCs.  There have been numerous serial mouse models from a number
+        of manufacturers.  Despite the wide range of variations, there
+        have been relatively few protocols (data format) with which the
+        serial mouse talks to the host computer.
+
+        The modern serial mouse conforms to the PnP COM device
+        specification so that the host computer can automatically detect
+        the mouse and load an appropriate driver.  The X server supports
+        this specification and can detect popular PnP serial mouse
+        models on most platforms.
+
+
+     Bus mouse
+        The bus mouse connects to a dedicated interface card in an
+        expansion slot.  Some video cards, notably those from ATI, and
+        integrated I/O cards may also have a bus mouse connector.  Some
+        bus mice are known as `InPort mouse'.
+
+        Note that some mouse manufacturers have sold a package including
+        a serial mouse and a serial interface card.  Don't confuse this
+        type of products with the genuine bus mouse.
+
+
+     PS/2 mouse
+        They are sometimes called `Mouse-port mouse'.  The PS/2 mouse was
+        common for a generation after serial mice, and most laptops still
+        use the PS/2 protocol for built-in pointer devices.
+
+        The PS/2 mouse is an intelligent device and may have more than
+        three buttons and a wheel or a roller.  The PS/2 mouse is
+        usually compatible with the original PS/2 mouse from IBM
+        immediately after power up.  The PS/2 mouse with additional
+        features requires a specialized initialization procedure to
+        enable these features.  Without proper initialization, it
+        behaves as though it were an ordinary two or three button mouse.
+
+
+     USB mouse
+        USB (Universal Serial Bus) ports are present on most modern
+        computers. Several devices can be plugged into this bus,
+        including mice and keyboards.
+
+        This driver includes support for USB mice on some systems.
+
+  Many mice nowadays can be used both as a serial mouse and as a PS/2
+  mouse, or as both a PS/2 and a USB mouse.  They have logic to distinguish
+  which interface it is connected to.  However, a mouse which is not
+  marketed as compatible with both mouse interfaces lacks this logic and
+  cannot be used in such a way, even if you can find an appropriate adapter
+  with which you can connect the mouse to a different format port.
+
+  This driver supports a mouse with a wheel, a roller or a knob.  Its
+  action is detected as the Z (third) axis motion of the mouse.  As the
+  X server or clients normally do not use the Z axis movement of the
+  pointing device, a configuration option, "ZAxisMapping", is provided
+  to assign the Z axis movement to another axis or a pair of buttons
+  (see below).
+
+
+  3.  OS Support for Mice
+
+
+
+  3.1.  Summary of Supported Mouse Protocol Types
+
+
+                                  Protocol Types
+                  serial     PnP     BusMouse    PS/2   Extended PS/2
+  OS platforms   protocols  serial   protocol  protocol  protocols
+                            "Auto"  "BusMouse"  "PS/2"   "xxxPS/2"    USB
+  -------------------------------------------------------------------------
+  FreeBSD           Ok        Ok        Ok        Ok        SP*1       SP*1
+  FreeBSD(98)       Ok        ?         Ok        NA        NA         ?
+  NetBSD            Ok        Ok        Ok        SP*1      SP*1       SP*1
+  NetBSD/pc98       Ok        ?         Ok        NA        NA         NA
+  OpenBSD           Ok        Ok        Ok        Ok*1      Ok*1       Ok*1
+  Solaris           Ok        NA*1      ?*1       Ok        Ok         SP*1
+  Linux             Ok        Ok        Ok        Ok        Ok         ?
+  Linux/98          Ok        ?         Ok        NA        NA         ?
+
+
+  Ok: support is available,  NA: not available, ?: untested or unknown.
+  SP: support is available in a different form
+
+  *1 Refer to the following sections for details.
+
+
+
+  3.2.  FreeBSD
+
+  FreeBSD supports the "SysMouse" protocol which must be specified when
+  the moused daemon is running in versions 2.2.1 or later.
+
+  When running the mouseddaemon, you must always specify the
+  /dev/sysmouse device and the "SysMouse" protocol to the X server,
+  regardless of the actual type of your mouse.
+
+  FreeBSD versions 2.2.6 or later include the kernel-level support for
+  extended PS/2 mouse protocols and there is no need to specify the
+  exact protocol name to the X server.  Instead specify the "PS/2" or
+  "Auto" protocol and the X server will automatically make use of the
+  kernel-level support.
+
+  In fact, "Auto" protocol support is really efficient in these
+  versions.  You may always specify "Auto" to any mouse, serial, bus or
+  PS/2, unless the mouse is an old serial model which doesn't support
+  PnP.
+
+  FreeBSD versions 2.2.5 or earlier do not support extended PS/2 mouse
+  protocols ("xxxPS/2").  Always specify the "PS/2" protocol for any
+  PS/2 mouse in these versions regardless of the brand of the mouse.
+
+  FreeBSD versions 3.1 or later have support for USB mice.  Specify the
+  "Auto" protocol for the /dev/ums0 device.  (If the moused daemon is
+  running for the USB mouse, you must use /dev/sysmouse instead of
+  /dev/ums0 as explained above.) See the ums(4) manual page for details.
+
+
+  3.3.  FreeBSD(98)
+
+  The PS/2 mouse is not supported.
+
+
+  3.4.  NetBSD
+
+  NetBSD 1.3.x and former does not support extended PS/2 mouse protocols
+  ("xxxPS/2").  The PS/2 mouse device driver /dev/pms emulates the bus
+  mouse.  Therefore, you should always specify the "BusMouse" protocol
+  for any PS/2 mouse regardless of the brand of the mouse.
+
+  The "wsmouse" protocol introduced in NetBSD 1.4 along with the wscons
+  console driver is supported. You need to run binaries compiled on
+  NetBSD 1.4 to have support for it though. Use "/dev/wsmouse0" for the
+  device. Refer to the wsmouse(4) manual page for kernel configuration
+  information.
+
+  This driver also provides support for USB mice. See the ums(4) manual
+  page for details.
+
+
+  3.5.  NetBSD/pc98
+
+  The PS/2 mouse is not supported.
+
+
+
+  3.6.  OpenBSD
+
+  The raw PS/2 mouse device driver /dev/psm0 uses the raw PS/2 mouse
+  protocol.
+
+  OpenBSD 2.2 and earlier does not support extended PS/2 mouse protocols
+  ("xxxPS/2") . Therefore, you should specify the "PS/2" protocol for
+  any PS/2 mouse regardless of the brand of the mouse.
+
+  OpenBSD 2.3 and later support all extended PS/2 mouse protocols.  You
+  can select the "Auto" protocol for PnP PS/2 mice or any specific
+  extended ("xxxPS/2") protocol for non PnP mice.
+
+  There is also a cooked PS/2 mouse device driver /dev/pms0 which
+  emulates the bus mouse. Specify the "BusMouse" protocol for any PS/2
+  mouse regardless of the brand of the mouse when using this device.
+
+  XFree86 3.3.6 support USB mice on OpenBSD 2.6 and later though the
+  generic Human Interface Device (hid) /dev/uhid*. Select the "usb"
+  protocol and the /dev/uhid* instance corresponding to your mouse as
+  the device name.
+
+
+  3.7.  Solaris & illumos
+
+  Testing has been done with Solaris 10 and 11.
+
+  On Solaris 10 1/06 and later versions with "virtual mouse" support,
+  all PS/2 and USB mice connected to the system can be accessed via the
+  /dev/mouse device using the VUID protocol, including USB mice plugged
+  in after the X server is started. On older releases or to address mice
+  individually, specific devices and protocols may be used.
+
+  Logitech and Microsoft bus mice have not been tested, but might work
+  with the /dev/logi and /dev/msm devices.  Standard 2 and 3 button PS/2
+  mice work with the "PS/2" protocol type and the /dev/kdmouse device.
+  USB mice work with the "VUID" protocol type and the /dev/mouse device.
+  The PnP serial mouse support via the "Auto" protocol has been tested
+  and does not work. The "Auto" protocol can however detect PS/2 and USB
+  mice correctly.
+
+  Additional USB mice can be connected using the "VUID" protocol type
+  and the appropriate "/dev/usb/hid" device with the
+       Option "StreamsModule" "usbms"
+  line included in the associated "InputDevice" section.
+
+
+  3.8.  Linux
+
+  All protocol types should work.
+
+
+  3.9.  Linux/98
+
+  The PS/2 mouse is not supported.
+
+
+
+  4.  Configuring Your Mouse
+
+
+  Before editing the xorg.conf file to set up mouse configuration, you
+  must identify the interface type, the device name and the protocol
+  type of your mouse.  Blindly trying every possible combination of
+  mouse settings will lead you nowhere.
+
+  The first thing you need to know is the interface type of the mouse
+  you are going to use.  It can be determined by looking at the
+  connector of the mouse.  The serial mouse has a D-Sub female 9- or
+  25-pin connector.  The bus mice have either a D-Sub male 9-pin
+  connector or a round DIN 9-pin connector.  The PS/2 mouse is equipped
+  with a small, round DIN 6-pin connector.  USB mice have a thin
+  rectangular connector.  Some mice come with adapters with which the
+  connector can be converted to another. If you are to use such an
+  adapter, remember that the connector at the very end of the
+  mouse/adapter pair is what matters.
+
+  The next thing to decide is a device node to use for the given
+  interface.  For the bus and PS/2 mice, there is little choice; your OS
+  most possibly offers just one device node each for the bus mouse and
+  PS/2 mouse.  There may be more than one serial port to which the
+  serial mouse can be attached.
+
+  The next step is to guess the appropriate protocol type for the mouse.
+  The X server may be able to select a protocol type for the given mouse
+  automatically in some cases.  Otherwise, the user has to choose one
+  manually.  Follow the guidelines below.
+
+
+     Bus mouse
+        The bus and InPort mice always use "BusMouse" protocol
+        regardless of the brand of the mouse.
+
+        Some OSs may allow you to specify "Auto" as the protocol type
+        for the bus mouse.
+
+
+     PS/2 mouse
+        The "PS/2" protocol should always be tried first for the PS/2
+        mouse regardless of the brand of the mouse.  Any PS/2 mouse
+        should work with this protocol type, although wheels and other
+        additional features are unavailable in the X server.
+
+        After verifying the mouse works with this protocol, you may
+        choose to specify one of "xxxPS/2" protocols so that extra
+        features are made available in the X server.  However, support
+        for these PS/2 mice assumes certain behavior of the underlying
+        OS and may not always work as expected.  Support for some PS/2
+        mouse models may be disabled all together for some OS platforms
+        for this reason.
+
+        Some OSs may allow you to specify "Auto" as the protocol type
+        for the PS/2 mouse and the X server will automatically adjust
+        itself.
+
+
+     Serial mouse
+        The server supports a wide range of mice, both old and new.  If
+        your mouse is of a relatively new model, it may conform to the
+        PnP COM device specification and the X server may be able to
+        detect an appropriate protocol type for the mouse automatically.
+
+        Specify "Auto" as the protocol type and start the X server.  If
+        the mouse is not a PnP mouse, or the X server cannot determine a
+        suitable protocol type, the server will print the following
+        error message and abort.
+
+
+        <mousename>: cannot determine the mouse protocol
+
+
+
+     If the X server generates the above error message, you need to
+     manually specify a protocol type for your mouse.  Choose one from
+     the following list:
+
+
+        o  GlidePoint
+
+        o  IntelliMouse
+
+        o  Logitech
+
+        o  Microsoft
+
+        o  MMHittab
+
+        o  MMSeries
+
+        o  MouseMan
+
+        o  MouseSystems
+
+        o  ThinkingMouse
+
+     When you choose, keep in mind the following rule of thumb:
+
+
+        1. "Logitech" protocol is for old serial mouse models from
+           Logitech.  Modern Logitech mice use either "MouseMan" or
+           "Microsoft" protocol.
+
+        2. Most 2-button serial mice support the "Microsoft" protocol.
+
+        3. 3-button serial mice may work with the "Mousesystems"
+           protocol. If it doesn't, it may work instead with the
+           "Microsoft" protocol although the third (middle) button won't
+           function.  3-button serial mice may also work with the
+           "Mouseman" protocol under which the third button may function
+           as expected.
+
+        4. 3-button serial mice may have a small switch at the bottom of
+           the mouse to choose between ``MS'' and ``PC'', or ``2'' and
+           ``3''.  ``MS'' or ``2'' usually mean the "Microsoft"
+           protocol.  ``PC'' or ``3'' will choose the "MouseSystems"
+           protocol.
+
+        5. If the serial mouse has a roller or a wheel, it may be
+           compatible with the "IntelliMouse" protocol.
+
+        6. If the serial mouse has a roller or a wheel and it doesn't
+           work with the "IntelliMouse" protocol, you have to use it as
+           a regular 2- or 3-button serial mouse.
+
+     If the "Auto" protocol is specified and the mouse seems to be
+     working, but you find that not all features of the mouse are
+     available, that is because the X server does not have native
+     support for that model of mouse and is using a ``compatible''
+     protocol according to PnP information.
+
+
+     USB mouse
+        If your mouse is connected to the USB port, it can either be
+        supported by the "Auto" protocol, or by an OS-specific protocol
+        (see below), or as a generic Human Interface Device by the "usb"
+        protocol.
+
+
+     Standardized protocols
+        Mouse device drivers in your OS may use the standardized
+        protocol regardless of the model or the class of the mouse.  For
+        example, Solaris systems support "VUID" protocol.  In FreeBSD
+        the system mouse device /dev/sysmouse uses the "SysMouse"
+        protocol.  Please refer to the OS support section of this file
+        for more information.
+
+
+
+  5.  xorg.conf Options
+
+
+  The old Pointer section has been replaced by a more general
+  InputDevice section. The following is a minimal example of an
+  InputDevice section for a mouse:
+
+
+  Section "InputDevice"
+          Identifier      "Mouse 1"
+          Driver          "mouse"
+          Option          "Device"    "/dev/mouse"
+          Option          "Protocol"  "Auto"
+  EndSection
+
+
+
+  The mouse driver supports the following config file options:
+
+
+  5.1.  Buttons
+
+  This option tells the X server the number of buttons on the mouse.
+  Currently there is no reliable way to automatically detect the correct
+  number.  This option is the only means for the X server to obtain it.
+  The default value is three.
+
+
+  Note that if you intend to assign Z axis movement to button events
+  using the ZAxisMapping option below, you need to take account of those
+  buttons into N too.
+
+
+          Option  "Buttons"   "N"
+
+
+
+  5.2.  ZAxisMapping
+
+  This option maps the Z axis (wheel) motion to buttons or to another
+  axis.
+
+
+          Option  "ZAxisMapping"      "X"
+          Option  "ZAxisMapping"      "Y"
+          Option  "ZAxisMapping"      "N1 N2"
+          Option  "ZAxisMapping"      "N1 N2 N3 N4"
+
+
+
+  The first example will map the Z axis motion to the X axis motion.
+  Whenever the user moves the wheel/roller, its movement is reported as
+  the X axis motion. When the wheel/roller stays still, the real X axis
+  motion is reported as is. The third example will map negative Z axis
+  motion to the button N1 and positive Z axis motion to the button N2.
+  If this option is used and the buttons N1 or N2 actually exists in the
+  mouse, their actions won't be detected by the X server.
+
+  The last example is useful for the mouse with two wheels of which the
+  second wheel is used to generate horizontal scroll action, and the
+  mouse which has a knob or a stick which can detect the horizontal
+  force applied by the user.  The motion of the second wheel will be
+  mapped to the buttons N3, for the negative direction, and N4, for the
+  positive direction.  If the buttons N3 and N4 actually exist in this
+  mouse, their actions won't be detected by the X server.
+
+  NOTE #1: horizontal movement may not always be detected by the current
+  version of the X11R7.5 X servers, because there appears to be no
+  accepted standard as to how the horizontal direction is encoded in
+  mouse data.
+
+  NOTE #2: Some mice think left is the negative horizontal direction,
+  others may think otherwise.  Moreover, there are some mice whose two
+  wheels are both mounted vertically, and the direction of the second
+  vertical wheel does not match the first one's.
+
+  You need to edit the xorg.conf file by hand to change this option if
+  the default value of "4 5 6 7" does not match the needs of your
+  configuration.
+
+
+  5.3.  Resolution
+
+  The following option will set the mouse device resolution to N counts
+  per inch, if possible:
+
+
+          Option  "Resolution"        "N"
+
+
+
+  Not all mice and OSs can support this option.
+
+  5.4.  Drag Lock Buttons
+
+  Some people find it difficult or inconvenient to hold a trackball
+  button down, while at the same time moving the ball. Drag lock buttons
+  simulate the holding down of another button. When a drag lock button
+  is first pressed, its target buttons is "locked" down until the second
+  time the lock button is released, or until the button itself is
+  pressed and released. This allows the starting of a drag, the movement
+  of the trackball, and the ending of the drag to be separate
+  operations.
+
+
+          Option  "DragLockButtons"   "W X Y Z"
+
+
+
+  This option consists of pairs of buttons. Each lock button number is
+  followed by the number of the button that it locks. In the above,
+  button number "W" is a drag lock button for button "X" and button
+  number "Y" is a drag lock button for button "Z".
+
+  It may not be desirable to use multiple buttons as drag locks.
+  Instead, a "master drag lock button" may be defined. A master drag
+  lock button acts as a "META" key. After a master lock button is
+  released, the next button pressed is "locked" and not released until
+  the second time the real button is released.
+
+
+          Option  "DragLockButtons"   "M"
+
+
+
+  Since button "M" is unpaired it is a master drag lock button.
+
+
+  6.  Mouse Gallery
+
+
+  In all of the examples below, it is assumed that /dev/mouse is a link
+  to the appropriate serial port or PS/2 mouse device.
+
+
+  6.1.  MS IntelliMouse (serial, PS/2)
+
+  This mouse has a wheel which also acts as the button 2 (middle
+  button).  The wheel movement is recognized as the Z axis motion.  This
+  behavior is not compatible with XFree86 versions prior to 3.3.2, but
+  is more consistent with the support for other mice with wheels or
+  rollers.  If you want to make the wheel behave like before, you can
+  use the "ZAxisMapping" option as described above.
+
+  IntelliMouse supports the PnP COM device specification.
+
+  To use this mouse as a serial device:
+
+          Option  "Protocol"  "Auto"
+
+
+  or:
+
+          Option  "Protocol"  "IntelliMouse"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports PS/2 mouse
+  initialization:
+          Option  "Protocol"  "IMPS/2"
+
+
+
+  To use this mouse as the PS/2 device but the OS does not support PS/2
+  mouse initialization (the wheel won't work in this case):
+
+          Option  "Protocol"  "PS/2"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports automatic
+  PS/2 mouse detection:
+
+          Option  "Protocol"  "Auto"
+
+
+
+  6.2.  MS IntelliMouse Explorer (PS/2, USB)
+
+  This mouse has a wheel which also acts as the button 2 (middle
+  button).  There are two side buttons; they are recognized as the
+  buttons 4 and 5.  The wheel movement is recognized as the Z axis
+  motion.
+
+  To use this mouse as the PS/2 device and the OS supports PS/2 mouse
+  initialization:
+
+          Option  "Protocol"  "ExplorerPS/2"
+
+
+
+  To use this mouse as the PS/2 device but the OS does not support PS/2
+  mouse initialization (the wheel and the side buttons won't work in
+  this case):
+
+          Option  "Protocol"  "PS/2"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports automatic
+  PS/2 mouse detection:
+
+          Option  "Protocol"  "Auto"
+
+
+
+  To use this mouse as the USB device and the OS supports the generic
+  HID protocol:
+
+          Option  "Protocol"  "usb"
+
+
+
+  To use this mouse as the USB device and the OS supports automatic
+  mouse detection:
+
+          Option  "Protocol"  "Auto"
+
+
+
+  6.3.  Kensington Thinking Mouse and Kensington Expert Mouse (serial,
+  PS/2)
+
+  These mice have four buttons.  The Kensington Expert Mouse is really a
+  trackball.  Both Thinking mice support the PnP COM device
+  specification.
+
+  To use this mouse as a serial device:
+
+          Option  "Protocol"  "Auto"
+
+
+  or:
+
+          Option  "Protocol"  "ThinkingMouse"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports PS/2 mouse
+  initialization:
+
+          Option  "Protocol"  "ThinkingMousePS/2"
+
+
+
+  To use this mouse as the PS/2 device but the OS does not support PS/2
+  mouse initialization (the third and the fourth buttons act as though
+  they were the first and the second buttons):
+
+          Option  "Protocol"  "PS/2"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports automatic
+  PS/2 mouse detection:
+
+          Option  "Protocol"  "Auto"
+
+
+
+  6.4.  Genius NetScroll (PS/2)
+
+  This mouse has four buttons and a roller. The roller movement is
+  recognized as the Z axis motion.
+
+  To use this mouse as the PS/2 device and the OS supports PS/2 mouse
+  initialization:
+
+          Option  "Protocol"  "NetScrollPS/2"
+
+
+
+  To use this mouse as the PS/2 device but the OS does not support PS/2
+  mouse initialization (the roller and the fourth button won't work):
+
+          Option  "Protocol"  "PS/2"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports automatic
+  PS/2 mouse detection:
+
+          Option  "Protocol"  "Auto"
+
+
+  6.5.  Genius NetMouse and NetMouse Pro (serial, PS/2)
+
+  These mice have a "magic button" which is used like a wheel or a
+  roller. The "magic button" action is recognized as the Z axis motion.
+  NetMouse Pro is identical to NetMouse except that it has the third
+  button on the left hand side.
+
+  NetMouse and NetMouse Pro support the PnP COM device specification.
+  When used as a serial mouse, they are compatible with MS IntelliMouse.
+
+  To use these mice as a serial device:
+
+          Option  "Protocol"  "Auto"
+
+
+  or:
+
+          Option  "Protocol"  "IntelliMouse"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports PS/2 mouse
+  initialization:
+
+          Option  "Protocol"  "NetMousePS/2"
+
+
+
+  To use this mouse as the PS/2 device but the OS does not support PS/2
+  mouse initialization (the "magic button" and the third button won't
+  work):
+
+          Option  "Protocol"  "PS/2"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports automatic
+  PS/2 mouse detection:
+
+          Option  "Protocol"  "Auto"
+
+
+
+  6.6.  Genius NetScroll Optical (PS/2, USB)
+
+  This mouse has a wheel which also acts as the button 2 (middle
+  button), and two side buttons which are recognized as the buttons 4
+  and 5.  It is compatible with NetMouse and NetMouse Pro.
+
+  To use this mouse as the PS/2 device and the OS supports PS/2 mouse
+  initialization:
+
+          Option  "Protocol"  "NetMousePS/2"
+
+
+
+  To use this mouse as the PS/2 device but the OS does not support PS/2
+  mouse initialization (the wheel and the side buttons won't work):
+
+          Option  "Protocol"  "PS/2"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports automatic
+  PS/2 mouse detection:
+          Option  "Protocol"  "Auto"
+
+
+
+  To use this mouse as the USB device and the OS supports the generic
+  HID protocol:
+
+          Option  "Protocol"  "usb"
+
+
+
+  To use this mouse as the USB device and the OS supports automatic
+  mouse detection:
+
+          Option  "Protocol"  "Auto"
+
+
+
+  6.7.  ALPS GlidePoint (serial, PS/2)
+
+  The serial version of this pad device has been supported since XFree86
+  3.2. `Tapping' action is interpreted as the fourth button press.
+  (IMHO, the fourth button of GlidePoint should always be mapped to the
+  first button in order to make this pad behave like the other pad
+  products.)
+
+  To use this pad as a serial device:
+
+          Option  "Protocol"  "GlidePoint"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports PS/2 mouse
+  initialization:
+
+          Option  "Protocol"  "GlidePointPS/2"
+
+
+
+  To use this mouse as the PS/2 device but the OS does not support PS/2
+  mouse initialization:
+
+          Option  "Protocol"  "PS/2"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports automatic
+  PS/2 mouse detection:
+
+          Option  "Protocol"  "Auto"
+
+
+
+  6.8.  ASCII MieMouse (serial, PS/2)
+
+  This mouse appears to be OEM from Genius. Although its shape is quite
+  different, it works like Genius NetMouse Pro. This mouse has a "knob"
+  which is used like a wheel or a roller. The "knob" action is
+  recognized as the Z axis motion.
+
+  MieMouse supports the PnP COM device specification. When used as a
+  serial mouse, it is compatible with MS IntelliMouse.
+
+
+  To use this mouse as a serial device:
+
+          Option  "Protocol"  "Auto"
+
+
+  or:
+
+          Option  "Protocol"  "IntelliMouse"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports PS/2 mouse
+  initialization:
+
+          Option  "Protocol"  "NetMousePS/2"
+
+
+
+  To use this mouse as the PS/2 device but the OS does not support PS/2
+  mouse initialization (the knob and the third button won't work):
+
+          Option  "Protocol"  "PS/2"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports automatic
+  PS/2 mouse detection:
+
+          Option  "Protocol"  "Auto"
+
+
+
+  6.9.  Logitech MouseMan+ and FirstMouse+ (serial, PS/2)
+
+  MouseMan+ has two buttons on top, one side button and a roller.
+  FirstMouse+ has two buttons and a roller. The roller movement is
+  recognized as the Z axis motion. The roller also acts as the third
+  button. The side button is recognized as the fourth button.
+
+  MouseMan+ and FirstMouse+ support the PnP COM device specification.
+  They have MS IntelliMouse compatible mode when used as a serial mouse.
+
+  To use these mice as a serial device:
+
+          Option  "Protocol"  "Auto"
+
+
+  or:
+
+          Option  "Protocol"  "IntelliMouse"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports PS/2 mouse
+  initialization:
+
+          Option  "Protocol"  "MouseManPlusPS/2"
+
+
+
+  To use this mouse as the PS/2 device but the OS does not support PS/2
+  mouse initialization (the wheel and the fourth button won't work):
+
+          Option  "Protocol"  "PS/2"
+
+  To use this mouse as the PS/2 device and the OS supports automatic
+  PS/2 mouse detection:
+
+          Option  "Protocol"  "Auto"
+
+
+
+  6.10.  IBM ScrollPoint (PS/2)
+
+  ScrollPoint has a "stick" in between the two buttons.  This "stick" is
+  the same as the stick-shaped pointing device often found on notebook
+  computers, on which you move the mouse cursor by pushing the stick.
+  The stick movement is recognized as the Z axis motion.  You can push
+  the stick to right and left, as well as forward and backward. Give
+  four numbers to ZAxisMapping option to map movement along all these
+  four directions to button actions.
+
+  This mouse is compatible with Logitech MouseMan+.  To use this mouse
+  as the PS/2 device and the OS supports PS/2 mouse initialization:
+
+          Option  "Protocol"  "MouseManPlusPS/2"
+
+
+
+  To use this mouse as the PS/2 device but the OS does not support PS/2
+  mouse initialization (the stick won't work):
+
+          Option  "Protocol"  "PS/2"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports automatic
+  PS/2 mouse detection:
+
+          Option  "Protocol"  "Auto"
+
+
+
+  6.11.  8D ScrollMouse (serial, PS/2)
+
+  ScrollMouse, also known as GyroMouse, has a "stick" similar to IBM
+  ScrollPoint.  The stick movement is recognized as the Z axis motion.
+  You can push the stick to right and left, as well as forward and
+  backward. Give four numbers to ZAxisMapping option to map movement
+  along all these four directions to button actions.
+
+  ScrollMouse supports the PnP COM device specification. When used as a
+  serial mouse, it is compatible with MS IntelliMouse.
+
+  To use this mouse as a serial device:
+
+          Option  "Protocol"  "Auto"
+
+
+  or:
+
+          Option  "Protocol"  "IntelliMouse"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports PS/2 mouse
+  initialization:
+
+
+          Option  "Protocol"  "IMPS/2"
+
+
+
+  To use this mouse as the PS/2 device but the OS does not support PS/2
+  mouse initialization (the stick won't work):
+
+          Option  "Protocol"  "PS/2"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports automatic
+  PS/2 mouse detection:
+
+          Option  "Protocol"  "Auto"
+
+
+
+  6.12.  A4 Tech 4D mice (serial, PS/2, USB)
+
+  A4 Tech produces quit a number of mice with one or two wheels.  Their
+  mice may have 2, 3, or 4 buttons.  The wheels movement is recognized
+  as the Z axis motion.  Give four numbers to ZAxisMapping option to map
+  movement of both wheels to button actions.
+
+  4D mice support the PnP COM device specification. When used as a
+  serial mouse, it is compatible with MS IntelliMouse.
+
+  To use this mouse as a serial device:
+
+          Option  "Protocol"  "Auto"
+
+
+  or:
+
+          Option  "Protocol"  "IntelliMouse"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports PS/2 mouse
+  initialization:
+
+          Option  "Protocol"  "IMPS/2"
+
+
+
+  To use this mouse as the PS/2 device but the OS does not support PS/2
+  mouse initialization (the wheels won't work):
+
+          Option  "Protocol"  "PS/2"
+
+
+
+  To use this mouse as the PS/2 device and the OS supports automatic
+  PS/2 mouse detection:
+
+          Option  "Protocol"  "Auto"
+
+
+
+  To use this mouse as the USB device and the OS supports the generic
+  HID protocol:
+
+          Option  "Protocol"  "usb"
+
+  To use this mouse as the USB device and the OS supports automatic
+  mouse detection:
+
+          Option  "Protocol"  "Auto"
+
+
+
+  7.  Configuration Examples
+
+
+  This section shows some example InputDevice section for popular mice.
+  All the examples assume that the mouse is connected to the PS/2 mouse
+  port, and the OS supports the PS/2 mouse initialization.  It is also
+  assumed that /dev/mouse is a link to the PS/2 mouse port.
+
+  Logitech MouseMan+ has 4 buttons and a wheel. The following example
+  makes the wheel movement available as the button 5 and 6.
+
+
+  Section "InputDevice"
+          Identifier      "MouseMan+"
+          Driver          "mouse"
+          Option          "Device"    "/dev/mouse"
+          Option          "Protocol"  "MouseManPlusPS/2"
+          Option          "Buttons"   "6"
+          Option          "ZAxisMapping"      "5 6"
+  EndSection
+
+
+
+  You can change button number assignment using the xmodmap command
+  AFTER you start the X server with the above configuration.  You may
+  not like to use the wheel as the button 2 and rather want the side
+  button (button 4) act like the button 2. You may also want to map the
+  wheel movement to the button 4 and 5.  This can be done by the
+  following command:
+
+
+          xmodmap -e "pointer = 1 6 3 2 4 5"
+
+
+
+  After this command is run, the correspondence between the buttons and
+  button numbers will be as shown in the following table.
+
+
+  Physical Buttons        Reported as:
+  ------------------------------------
+  1 Left Button             Button 1
+  2 Wheel Button            Button 6
+  3 Right Button            Button 3
+  4 Side Button             Button 2
+  5 Wheel Negative Move     Button 4
+  6 Wheel Positive Move     Button 5
+
+
+
+  Starting in the Xorg 6.9 release, you can also achieve this in your
+  configuration file by adding this to the "InputDevice" section in
+  xorg.conf:
+
+          Option "ButtonMapping" "1 6 3 2 4 5"
+
+
+
+  For the MS IntelliMouse Explorer which as a wheel and 5 buttons, you
+  may have the following InputDevice section.
+
+
+  Section "InputDevice"
+          Identifier      "IntelliMouse Explorer"
+          Driver          "mouse"
+          Option          "Device"    "/dev/mouse"
+          Option          "Protocol"  "ExplorerPS/2"
+          Option          "Buttons"   "7"
+          Option          "ZAxisMapping"      "6 7"
+  EndSection
+
+
+
+  The IntelliMouse Explorer has 5 buttons, thus, you should give "7" to
+  the Buttons option if you want to map the wheel movement to buttons (6
+  and 7).  With this configuration, the correspondence between the
+  buttons and button numbers will be as follows:
+
+
+  Physical Buttons        Reported as:
+  ------------------------------------
+  1 Left Button             Button 1
+  2 Wheel Button            Button 2
+  3 Right Button            Button 3
+  4 Side Button 1           Button 4
+  5 Side Button 2           Button 5
+  6 Wheel Negative Move     Button 6
+  7 Wheel Positive Move     Button 7
+
+
+
+  You can change button number assignment using xmodmap AFTER you
+  started the X server with the above configuration.
+
+
+          xmodmap -e "pointer = 1 2 3 4 7 5 6"
+
+
+
+  The above command will moves the side button 2 to the button 7 and
+  make the wheel movement reported as the button 5 and 6. See the table
+  below.
+
+
+  Physical Buttons        Reported as:
+  ------------------------------------
+  1 Left Button             Button 1
+  2 Wheel Button            Button 2
+  3 Right Button            Button 3
+  4 Side Button 1           Button 4
+  5 Side Button 2           Button 7
+  6 Wheel Negative Move     Button 5
+  7 Wheel Positive Move     Button 6
+
+
+
+  For the A4 Tech WinEasy mouse which has two wheels and 3 buttons, you
+  may have the following InputDevice section.
+
+
+
+  Section "InputDevice"
+          Identifier      "WinEasy"
+          Driver          "mouse"
+          Option          "Device"    "/dev/mouse"
+          Option          "Protocol"  "IMPS/2"
+          Option          "Buttons"   "7"
+          Option          "ZAxisMapping"      "4 5 6 7"
+  EndSection
+
+
+
+  The movement of the first wheel is mapped to the button 4 and 5. The
+  second wheel's movement will be reported as the buttons 6 and 7.
+
+  The Kensington Expert mouse is really a trackball. It has 4 buttons
+  arranged in a rectangle around the ball.
+
+
+  Section "InputDevice"
+          Identifier  "DLB"
+          Driver      "mouse"
+          Option      "Protocol" "ThinkingMousePS/2"
+          Option      "Buttons" "3"
+          Option      "Emulate3Buttons"
+          Option      "Device" "/dev/mouse"
+          Option      "DragLockButtons" "2 1 4 3"
+  EndSection
+
+
+  In this example, button 2 is a drag lock button for button number 1,
+  and button 4 is a drag lock button for button 3.  Since button 2 is
+  above button 1 and button 4 is above button 3 in the layout of this
+  trackball, this is reasonable.
+
+  Because button 2 is being used as a drag lock, it can not be used as
+  an ordinary button. However, it can be activated by using the
+  "Emulate3Buttons" feature. However, some people my be unable to press
+  two buttons at the same time. They may prefer the following
+  InputDevice section which defines button 4 as a master drag lock
+  button, and leaves button 2 free for ordinary use.
+
+  Section "InputDevice"
+          Identifier  "MasterDLB"
+          Driver      "mouse"
+          Option      "Protocol" "ThinkingMousePS/2"
+          Option      "Buttons" "3"
+          Option      "Device" "/dev/mouse"
+          Option      "DragLockButtons" "4"
+  EndSection
+
+
+

--- a/hw/xfree86/drivers/input/mouse/include/xf86-mouse-properties.h
+++ b/hw/xfree86/drivers/input/mouse/include/xf86-mouse-properties.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2012, Oracle and/or its affiliates.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef _XF86_MOUSE_PROPERTIES_H_
+#define _XF86_MOUSE_PROPERTIES_H_
+
+/* Middle mouse button emulation */
+/* BOOL */
+#define MOUSE_PROP_MIDBUTTON "Mouse Middle Button Emulation"
+/* CARD32 */
+#define MOUSE_PROP_MIDBUTTON_TIMEOUT "Mouse Middle Button Timeout"
+
+#endif /* _XF86_MOUSE_PROPERTIES_H_ */

--- a/hw/xfree86/drivers/input/mouse/man/mousedrv.man
+++ b/hw/xfree86/drivers/input/mouse/man/mousedrv.man
@@ -1,0 +1,347 @@
+.\" shorthand for double quote that works everywhere.
+.ds q \N'34'
+.TH MOUSE __drivermansuffix__ 2025-04-22 __vendorversion__
+.SH NAME
+mouse \- XLibre mouse input driver
+.SH SYNOPSIS
+.nf
+.B "Section \*qInputDevice\*q"
+.BI "  Identifier \*q" idevname \*q
+.B  "  Driver \*qmouse\*q"
+.BI "  Option \*qProtocol\*q \*q" protoname \*q
+.BI "  Option \*qDevice\*q   \*q" devpath \*q
+\ \ ...
+.B EndSection
+.fi
+.SH DESCRIPTION
+.B mouse
+is an
+.B XLibre
+input driver for mice.
+The driver supports most available mouse types and interfaces,
+though the level of support for types of mice depends on the OS.
+.PP
+The
+.B mouse
+driver functions as a pointer input device.
+Multiple mice are supported by multiple instances of this driver.
+.SH SUPPORTED HARDWARE
+.TP
+USB mouse
+USB (Universal Serial Bus) ports are present on most modern computers.
+Several devices can be plugged into this bus, including mice and keyboards.
+Support for USB mice is platform specific.
+.TP
+PS/2 mouse
+The PS/2 mouse is an intelligent device and may have more than
+three buttons and a wheel or a roller.
+The PS/2 mouse is usually compatible with the original PS/2 mouse from IBM
+immediately after power up.
+The PS/2 mouse with additional features requires a specialized
+initialization procedure to enable these features.
+Without proper initialization, it behaves as though it were an ordinary
+two or three button mouse.
+.TP
+Serial mouse
+There have been numerous serial mouse models from a number of
+manufacturers.
+Despite the wide range of variations, there have been relatively
+few protocols (data format) with which the serial mouse talks
+to the host computer.
+.IP
+The modern serial mouse conforms to the PnP COM device specification
+so that the host computer can automatically detect the mouse
+and load an appropriate driver.
+This driver supports this specification and can detect
+popular PnP serial mouse models on most platforms.
+.TP
+Bus mouse
+The bus mouse connects to a dedicated interface card in an expansion slot.
+Some older video cards, notably those from ATI,
+and integrated I/O cards may also have a bus mouse connector.
+.PP
+The interface type of the mouse can be determined by looking at the connector
+of the mouse.
+USB mice have a thin rectangular connector, which may have rounded corners.
+PS/2 mice are equipped with a small, round DIN 6-pin connector.
+Serial mouse have a D-Sub female 9- or 25-pin connector.
+Bus mice have either a D-Sub male 9-pin connector
+or a round DIN 9-pin connector.
+Some mice come with adapters with which the connector can
+be converted to another.
+If you are to use such an adapter,
+remember that the connector at the very end of the mouse/adapter pair is
+what matters.
+.SH CONFIGURATION DETAILS
+Depending on the X server version in use, input device options may be set
+in either a xorg.conf file, an xorg.conf.d snippet,
+or in the configuration files read by the Hardware Abstraction Layer (HAL)
+daemon,
+.BR hald (1).
+.PP
+Please refer to
+.BR xorg.conf (__filemansuffix__)
+for general configuration details
+and for options that can be used with all input drivers.
+This section only covers configuration details specific to this driver.
+.PP
+The driver can auto-detect the mouse type on some platforms.
+On some platforms this is limited to plug and play serial mice, and on some the
+auto-detection works for any mouse that the OS's kernel driver supports.
+On others, it is always necessary to specify the mouse protocol in the
+config file.
+The
+.I README
+document provided with this driver contains some detailed information about
+this.
+.PP
+The following driver
+.B Options
+are supported:
+.TP 7
+.BI "Option \*qProtocol\*q \*q" string \*q
+Specify the mouse protocol.
+Valid protocol types include:
+.PP
+.RS 12
+Auto, Microsoft, MouseSystems, MMSeries, Logitech, MouseMan, MMHitTab,
+GlidePoint, IntelliMouse, ThinkingMouse, ValuMouseScroll, AceCad, PS/2, ImPS/2,
+ExplorerPS/2, ThinkingMousePS/2, MouseManPlusPS/2, GlidePointPS/2,
+NetMousePS/2, NetScrollPS/2, BusMouse, SysMouse, WSMouse, VUID.
+.RE
+.PP
+.RS 7
+Not all protocols are supported on all platforms.
+The "Auto" protocol specifies that protocol auto-detection should be attempted.
+The default protocol setting is platform-specific.
+.RE
+.TP 7
+.BI "Option \*qDevice\*q \*q" string \*q
+Specifies the device through which the mouse can be accessed.
+A common setting is "/dev/mouse",
+which is often a symbolic link to the real device.
+This option is mandatory, and there is no default setting.
+The driver may however attempt to probe some default devices
+if this option is missing.
+Property: "Device Node" (read-only).
+.TP 7
+.BI "Option \*qButtons\*q \*q" integer \*q
+Specifies the number of mouse buttons.
+In cases where the number of buttons cannot be auto-detected,
+the default value is 3.
+The maximum number is 24.
+.TP 7
+.BI "Option \*qEmulate3Buttons\*q \*q" boolean \*q
+Enable/disable the emulation of the third (middle) mouse button for mice
+which only have two physical buttons.
+The third button is emulated by pressing both buttons simultaneously.
+Default: on, until a press of a physical button 3 is detected.
+Property: "Mouse Middle Button Emulation"
+.TP 7
+.BI "Option \*qEmulate3Timeout\*q \*q" integer \*q
+Sets the timeout (in milliseconds) that the driver waits before deciding
+if two buttons where pressed "simultaneously" when 3 button emulation is
+enabled.
+Default: 50.
+Property: "Mouse Middle Button Timeout"
+.TP 7
+.BI "Option \*qChordMiddle\*q \*q" boolean \*q
+Enable/disable handling of mice that send left+right events when the middle
+button is used.
+Default: off.
+.TP 7
+.BI "Option \*qEmulateWheel\*q \*q" boolean \*q
+Enable/disable "wheel" emulation.
+Wheel emulation means emulating button press/release events
+when the mouse is moved while a specific real button is pressed.
+Wheel button events (typically buttons 4 and 5) are usually used for scrolling.
+Wheel emulation is useful for getting wheel-like behaviour with trackballs.
+It can also be useful for mice with 4 or more buttons but no wheel.
+See the description of the
+.BR EmulateWheelButton ,
+.BR EmulateWheelInertia ,
+.BR XAxisMapping ,
+and
+.B YAxisMapping
+options below.  Default: off.
+.TP 7
+.BI "Option \*qEmulateWheelButton\*q \*q" integer \*q
+Specifies which button must be held down to enable wheel emulation mode.
+While this button is down, X and/or Y pointer movement will generate button
+press/release events as specified for the
+.B XAxisMapping
+and
+.B YAxisMapping
+settings.
+If set to 0, no button is required and
+any motion of the device is converted into wheel events.
+Default: 4.
+.TP 7
+.BI "Option \*qEmulateWheelInertia\*q \*q" integer \*q
+Specifies how far (in pixels) the pointer must move to generate button
+press/release events in wheel emulation mode.
+Default: 10.
+.TP 7
+.BI "Option \*qEmulateWheelTimeout\*q \*q" integer \*q
+Specifies the time in milliseconds the
+.B EmulateWheelButton
+must be pressed before wheel emulation is started.
+If the
+.B EmulateWheelButton
+is released before this timeout,
+the original button press/release event is sent.
+Default: 200.
+.TP 7
+.BI "Option \*qXAxisMapping\*q \*q" "N1 N2" \*q
+Specifies which buttons are mapped to motion in the X direction in wheel
+emulation mode.
+Button number
+.I N1
+is mapped to the negative X axis motion and button number
+.I N2
+is mapped to the positive X axis motion.
+Default: no mapping.
+.TP 7
+.BI "Option \*qYAxisMapping\*q \*q" "N1 N2" \*q
+Specifies which buttons are mapped to motion in the Y direction in wheel
+emulation mode.
+Button number
+.I N1
+is mapped to the negative Y axis motion and button number
+.I N2
+is mapped to the positive Y axis motion.
+Default: no mapping.
+.TP 7
+.B "Option \*qZAxisMapping\*q \*qX\*q"
+.TP 7
+.B "Option \*qZAxisMapping\*q \*qY\*q"
+.TP 7
+.BI "Option \*qZAxisMapping\*q \*q" "N1 N2" \*q
+.TP 7
+.BI "Option \*qZAxisMapping\*q \*q" "N1 N2 N3 N4" \*q
+Set the mapping for the Z axis (wheel) motion to buttons or another axis
+.RB ( X
+or
+.BR Y ).
+Button number
+.I N1
+is mapped to the negative Z axis motion and button number
+.I N2
+is mapped to the positive Z axis motion.
+For mice with two wheels, four button numbers can be specified,
+with the negative and positive motion of the second wheel
+mapped respectively to buttons number
+.I N3
+and
+.IR N4 .
+Note that the protocols for mice with one and two wheels can be different
+and the driver may not be able to autodetect it.
+Default: "4 5".
+.TP 7
+.BI "Option \*qButtonMapping\*q \*q" "N1 N2 [...]" \*q
+Specifies how physical mouse buttons are mapped to logical buttons.
+Physical button 1 is mapped to logical button
+.IR N1 ,
+physical button 2 to
+.IR N2 ,
+and so forth.
+This enables the use of physical buttons that are obscured by
+.IR ZAxisMapping .
+Default:\ "1\ 2\ 3\ 8\ 9\ 10\ ...".
+.TP 7
+.BI "Option \*qFlipXY\*q \*q" boolean \*q
+Enable/disable swapping the X and Y axes.
+This transformation is applied after the
+.BR InvX ,
+.BR InvY ,
+and
+.B AngleOffset
+transformations.
+Default: off.
+.TP 7
+.BI "Option \*qInvX\*q \*q" boolean \*q
+Invert the X axis.
+Default: off.
+.TP 7
+.BI "Option \*qInvY\*q \*q" boolean \*q
+Invert the Y axis.
+Default: off.
+.TP 7
+.BI "Option \*qAngleOffset\*q \*q" integer \*q
+Specify a clockwise angular offset (in degrees) to apply to the pointer motion.
+This transformation is applied before the
+.BR FlipXY ,
+.BR InvX ,
+and
+.B InvY
+transformations.  Default: 0.
+.TP 7
+.BI "Option \*qSampleRate\*q \*q" integer \*q
+Sets the number of motion/button events the mouse sends per second.
+Setting this is only supported for some mice,
+including some Logitech mice and some PS/2 mice on some platforms.
+Default: whatever the mouse is already set to.
+.TP 7
+.BI "Option \*qResolution\*q \*q" integer \*q
+Sets the resolution of the device in counts per inch.
+Setting this is only supported for some mice,
+including some PS/2 mice on some platforms.
+Default: whatever the mouse is already set to.
+.TP 7
+.BI "Option \*qSensitivity\*q \*q" float \*q
+Mouse movements are multiplied by this float before being processed.
+Use this mechanism to slow down high resolution mice.
+Because values bigger than 1.0
+will result in not all pixels on the screen being accessible,
+you should instead use mouse acceleration (see
+.BR "man xset" )
+for speeding up low resolution mice.
+Default: 1.0
+.TP 7
+.BI "Option \*qDragLockButtons\*q \*q" "L1 B2 L3 B4" \*q
+Sets \*qdrag lock buttons\*q that simulate holding a button down,
+so that low dexterity people do not have to hold a button down at the
+same time they move a mouse cursor.
+Button numbers occur in pairs,
+with the lock button number occurring first,
+followed by the button number that is the target of the lock button.
+.TP 7
+.BI "Option \*qDragLockButtons\*q \*q" "M1" \*q
+Sets a \*qmaster drag lock button\*q that acts as a \*qMeta Key\*q
+indicating that the next button pressed is to be
+\*qdrag locked\*q.
+.TP 7
+.BI "Option \*qClearDTR\*q \*q" boolean \*q
+Enable/disable clearing the DTR line on the serial port used by the mouse.
+Some dual-protocol mice require the DTR line to be cleared to operate
+in the non-default protocol.
+This option is for serial mice only and is handled by the X server.
+Default: off.
+.TP 7
+.BI "Option \*qClearRTS\*q \*q" boolean \*q
+Enable/disable clearing the RTS line on the serial port used by the mouse.
+Some dual-protocol mice require the RTS line to be cleared to operate
+in the non-default protocol.
+This option is for serial mice only and is handled by the X server.
+Default: off.
+.TP 7
+.BI "Option \*qBaudRate\*q \*q" integer \*q
+Set the baud rate to use for communicating with a serial mouse.
+This option should rarely be required because the default is correct for almost
+all situations.
+Valid values include: 300, 1200, 2400, 4800, 9600, 19200.
+Default: 1200.
+.PP
+There are some other options that may be used to control various parameters
+for serial port communication, but they are not documented here because
+the driver sets them correctly for each mouse protocol type.
+.SH "SEE ALSO"
+.BR XLibre (__appmansuffix__),
+.BR xorg.conf (__filemansuffix__),
+.BR Xserver (__appmansuffix__),
+.BR X (__miscmansuffix__),
+.BR README.mouse .
+.sp
+.BR hal (__miscmansuffix__),
+.BR hald (__adminmansuffix__),
+.BR fdi (__filemansuffix__).

--- a/hw/xfree86/drivers/input/mouse/meson.build
+++ b/hw/xfree86/drivers/input/mouse/meson.build
@@ -1,0 +1,37 @@
+mouse_drv_srcs = [
+    'src/mouse.c',
+    'src/pnp.c'
+]
+
+if host_machine.system() in [ 'netbsd', 'dragonfly', 'freebsd', 'openbsd' ]
+    mouse_drv_srcs += [ 'src/bsd_mouse.c' ]
+elif host_machine.system() in [ 'linux' ]
+    mouse_drv_srcs += [ 'src/lnx_mouse.c' ]
+elif host_machine.system() in [ 'sunos' ]
+    mouse_drv_srcs += [ 'src/sun_mouse.c' ]
+elif host_machine.system() in [ 'hurd' ]
+    mouse_drv_srcs += [ 'src/hurd_mouse.c' ]
+else
+    error('unsupported OS: '+host_machine.system())
+endif
+
+shared_module(
+    'mouse_drv',
+    mouse_drv_srcs,
+    name_prefix: '',
+
+    include_directories: [inc, xorg_inc, 'include'],
+    c_args: xorg_c_args,
+    dependencies: [common_dep],
+
+    install: true,
+    install_dir: join_paths(module_abi_dir, 'input'),
+
+    link_with: xserver_exec,
+)
+
+install_man(configure_file(
+    input: 'man/mousedrv.man',
+    output: 'mousedrv.4',
+    configuration: manpage_config,
+))

--- a/hw/xfree86/drivers/input/mouse/src/bsd_mouse.c
+++ b/hw/xfree86/drivers/input/mouse/src/bsd_mouse.c
@@ -1,0 +1,801 @@
+
+/*
+ * Copyright (c) 1999-2003 by The XFree86 Project, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of the copyright holder(s)
+ * and author(s) shall not be used in advertising or otherwise to promote
+ * the sale, use or other dealings in this Software without prior written
+ * authorization from the copyright holder(s) and author(s).
+ */
+
+#include <xorg-server.h>
+
+#include <errno.h>
+#include <sys/stat.h>
+#include <X11/X.h>
+
+#include "xf86.h"
+#include "xf86Priv.h"
+#include "xf86_OSlib.h"
+#include "xf86Xinput.h"
+#include "mouse.h"
+#include "xisb.h"
+#include "mipointer.h"
+#ifdef WSCONS_SUPPORT
+#include <dev/wscons/wsconsio.h>
+#endif
+#ifdef USBMOUSE_SUPPORT
+#ifdef HAS_LIB_USB_HID
+#include <usbhid.h>
+#else
+#include "usb.h"
+#endif
+
+#ifdef __DragonFly__
+# include <bus/u4b/usb.h>
+#else
+# include <dev/usb/usb.h>
+#endif
+#ifdef USB_GET_REPORT_ID
+#define USB_NEW_HID
+#endif
+
+#define HUP_GENERIC_DESKTOP     0x0001
+#define HUP_BUTTON              0x0009
+
+#define HUG_X                   0x0030
+#define HUG_Y                   0x0031
+#define HUG_Z                   0x0032
+#define HUG_WHEEL               0x0038
+
+#define HID_USAGE2(p,u) (((p) << 16) | u)
+
+/* The UMS mice have middle button as number 3 */
+#define UMS_BUT(i) ((i) == 0 ? 2 : (i) == 1 ? 0 : (i) == 2 ? 1 : (i))
+#endif /* USBMOUSE_SUPPORT */
+
+#ifdef USBMOUSE_SUPPORT
+static void usbSigioReadInput (int fd, void *closure);
+#endif
+static const char *FindDevice(InputInfoPtr, const char *, int);
+
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__)
+/* These are for FreeBSD and DragonFly */
+#define DEFAULT_MOUSE_DEV               "/dev/mouse"
+#define DEFAULT_SYSMOUSE_DEV            "/dev/sysmouse"
+#define DEFAULT_PS2_DEV                 "/dev/psm0"
+
+static const char *mouseDevs[] = {
+        DEFAULT_MOUSE_DEV,
+        DEFAULT_SYSMOUSE_DEV,
+        DEFAULT_PS2_DEV,
+        NULL
+};
+#elif (defined(__OpenBSD__) || defined(__NetBSD__)) && defined(WSCONS_SUPPORT)
+/* Only wsmouse mice are autoconfigured for now on OpenBSD */
+#define DEFAULT_WSMOUSE_DEV             "/dev/wsmouse"
+#define DEFAULT_WSMOUSE0_DEV            "/dev/wsmouse0"
+
+static const char *mouseDevs[] = {
+        DEFAULT_WSMOUSE_DEV,
+        DEFAULT_WSMOUSE0_DEV,
+        NULL
+};
+#endif
+
+static int
+SupportedInterfaces(void)
+{
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__) || defined(__NetBSD__)
+    return MSE_SERIAL | MSE_BUS | MSE_PS2 | MSE_AUTO | MSE_MISC;
+#else
+    return MSE_SERIAL | MSE_BUS | MSE_PS2 | MSE_XPS2 | MSE_AUTO | MSE_MISC;
+#endif
+}
+
+/* Names of protocols that are handled internally here. */
+static const char *internalNames[] = {
+#if defined(WSCONS_SUPPORT)
+        "WSMouse",
+#endif
+#if defined(USBMOUSE_SUPPORT)
+        "usb",
+#endif
+        NULL
+};
+
+/*
+ * Names of MSC_MISC protocols that the OS supports.  These are decoded by
+ * main "mouse" driver.
+ */
+static const char *miscNames[] = {
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__)
+        "SysMouse",
+#endif
+        NULL
+};
+
+static const char **
+BuiltinNames(void)
+{
+    return internalNames;
+}
+
+static Bool
+CheckProtocol(const char *protocol)
+{
+    int i;
+
+    for (i = 0; internalNames[i]; i++)
+        if (xf86NameCmp(protocol, internalNames[i]) == 0)
+            return TRUE;
+    for (i = 0; miscNames[i]; i++)
+        if (xf86NameCmp(protocol, miscNames[i]) == 0)
+            return TRUE;
+    return FALSE;
+}
+
+static const char *
+DefaultProtocol(void)
+{
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__)
+    return "Auto";
+#elif (defined(__OpenBSD__) || defined(__NetBSD__)) && defined(WSCONS_SUPPORT)
+    return "WSMouse";
+#else
+    return NULL;
+#endif
+}
+
+#if (defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__)) && defined(MOUSE_PROTO_SYSMOUSE)
+static struct {
+        int dproto;
+        const char *name;
+} devproto[] = {
+        { MOUSE_PROTO_MS,               "Microsoft" },
+        { MOUSE_PROTO_MSC,              "MouseSystems" },
+        { MOUSE_PROTO_LOGI,             "Logitech" },
+        { MOUSE_PROTO_MM,               "MMSeries" },
+        { MOUSE_PROTO_LOGIMOUSEMAN,     "MouseMan" },
+        { MOUSE_PROTO_BUS,              "BusMouse" },
+        { MOUSE_PROTO_INPORT,           "BusMouse" },
+        { MOUSE_PROTO_PS2,              "PS/2" },
+        { MOUSE_PROTO_HITTAB,           "MMHitTab" },
+        { MOUSE_PROTO_GLIDEPOINT,       "GlidePoint" },
+        { MOUSE_PROTO_INTELLI,          "Intellimouse" },
+        { MOUSE_PROTO_THINK,            "ThinkingMouse" },
+        { MOUSE_PROTO_SYSMOUSE,         "SysMouse" }
+};
+
+static const char *
+SetupAuto(InputInfoPtr pInfo, int *protoPara)
+{
+    int i;
+    mousehw_t hw;
+    mousemode_t mode;
+
+    if (pInfo->fd == -1)
+        return NULL;
+
+    /* set the driver operation level, if applicable */
+    i = 1;
+    ioctl(pInfo->fd, MOUSE_SETLEVEL, &i);
+
+    /* interrogate the driver and get some intelligence on the device. */
+    hw.iftype = MOUSE_IF_UNKNOWN;
+    hw.model = MOUSE_MODEL_GENERIC;
+    ioctl(pInfo->fd, MOUSE_GETHWINFO, &hw);
+    xf86MsgVerb(X_INFO, 3, "%s: SetupAuto: hw.iftype is %d, hw.model is %d\n",
+                pInfo->name, hw.iftype, hw.model);
+    if (ioctl(pInfo->fd, MOUSE_GETMODE, &mode) == 0) {
+        for (i = 0; i < sizeof(devproto)/sizeof(devproto[0]); ++i) {
+            if (mode.protocol == devproto[i].dproto) {
+                /* override some parameters */
+                if (protoPara) {
+                    protoPara[4] = mode.packetsize;
+                    protoPara[0] = mode.syncmask[0];
+                    protoPara[1] = mode.syncmask[1];
+                }
+                xf86MsgVerb(X_INFO, 3, "%s: SetupAuto: protocol is %s\n",
+                            pInfo->name, devproto[i].name);
+                return devproto[i].name;
+            }
+        }
+    }
+    return NULL;
+}
+
+static void
+SetSysMouseRes(InputInfoPtr pInfo, const char *protocol, int rate, int res)
+{
+    mousemode_t mode;
+    MouseDevPtr pMse;
+
+    pMse = pInfo->private;
+
+    mode.rate = rate > 0 ? rate : -1;
+    mode.resolution = res > 0 ? res : -1;
+    mode.accelfactor = -1;
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__)
+    if (pMse->autoProbe ||
+        (protocol && xf86NameCmp(protocol, "SysMouse") == 0)) {
+        /*
+         * As the FreeBSD sysmouse driver defaults to protocol level 0
+         * every time it is opened we enforce protocol level 1 again at
+         * this point.
+         */
+        mode.level = 1;
+    } else
+        mode.level = -1;
+#else
+    mode.level = -1;
+#endif
+    ioctl(pInfo->fd, MOUSE_SETMODE, &mode);
+}
+#endif
+
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__)
+
+#define MOUSED_PID_FILE "/var/run/moused.pid"
+
+/*
+ * Try to check if moused is running.  DEFAULT_SYSMOUSE_DEV is useless without
+ * it.  There doesn't seem to be a better way of checking.
+ */
+static Bool
+MousedRunning(void)
+{
+    FILE *f = NULL;
+    unsigned int pid;
+
+    if ((f = fopen(MOUSED_PID_FILE, "r")) != NULL) {
+        if (fscanf(f, "%u", &pid) == 1 && pid > 0) {
+            if (kill(pid, 0) == 0) {
+                fclose(f);
+                return TRUE;
+            }
+        }
+        fclose(f);
+    }
+    return FALSE;
+}
+
+static const char *
+FindDevice(InputInfoPtr pInfo, const char *protocol, int flags)
+{
+    int fd = -1;
+    const char **pdev, *dev = NULL;
+    Bool devMouse = FALSE;
+    struct stat devMouseStat;
+    struct stat sb;
+
+    for (pdev = mouseDevs; *pdev; pdev++) {
+        SYSCALL (fd = open(*pdev, O_RDWR | O_NONBLOCK));
+        if (fd == -1) {
+#ifdef DEBUG
+            ErrorF("Cannot open %s (%s)\n", *pdev, strerror(errno));
+#endif
+        } else {
+            /*
+             * /dev/mouse is held until checks for matches with other devices
+             * are done.  This is so that when it points to /dev/sysmouse,
+             * the test for whether /dev/sysmouse is usable can be made.
+             */
+            if (!strcmp(*pdev, DEFAULT_MOUSE_DEV)) {
+                if (fstat(fd, &devMouseStat) == 0)
+                    devMouse = TRUE;
+                close(fd);
+                continue;
+            } else if (!strcmp(*pdev, DEFAULT_SYSMOUSE_DEV)) {
+                /* Check if /dev/mouse is the same as /dev/sysmouse. */
+                if (devMouse && fstat(fd, &sb) == 0 &&
+                    devMouseStat.st_dev == sb.st_dev &&
+                    devMouseStat.st_ino == sb.st_ino) {
+                    /* If the same, use /dev/sysmouse. */
+                    devMouse = FALSE;
+                }
+                close(fd);
+                if (MousedRunning())
+                    break;
+                else {
+#ifdef DEBUG
+                    ErrorF("moused isn't running\n");
+#endif
+                }
+            } else {
+                close(fd);
+                break;
+            }
+        }
+    }
+
+    if (*pdev)
+        dev = *pdev;
+    else if (devMouse)
+        dev = DEFAULT_MOUSE_DEV;
+
+    if (dev) {
+        /* Set the Device option. */
+        pInfo->options =
+            xf86AddNewOption(pInfo->options, "Device", dev);
+        xf86Msg(X_INFO, "%s: Setting Device option to \"%s\"\n",
+                pInfo->name, dev);
+    }
+
+    return *pdev;
+}
+#endif
+
+#if (defined(__OpenBSD__) || defined(__NetBSD__)) && defined(WSCONS_SUPPORT)
+
+/* Only support wsmouse configuration for now */
+static const char *
+SetupAuto(InputInfoPtr pInfo, int *protoPara)
+{
+
+    xf86MsgVerb(X_INFO, 3, "%s: SetupAuto: protocol is %s\n",
+                pInfo->name, "wsmouse");
+    return "wsmouse";
+}
+
+static void
+SetMouseRes(InputInfoPtr pInfo, const char *protocol, int rate, int res)
+{
+
+    xf86MsgVerb(X_INFO, 3, "%s: SetMouseRes: protocol %s rate %d res %d\n",
+            pInfo->name, protocol, rate, res);
+}
+
+static const char *
+FindDevice(InputInfoPtr pInfo, const char *protocol, int flags)
+{
+    int fd = -1;
+    const char **pdev;
+
+    for (pdev = mouseDevs; *pdev; pdev++) {
+        SYSCALL(fd = open(*pdev, O_RDWR | O_NONBLOCK));
+        if (fd != -1) {
+            /* Set the Device option. */
+            pInfo->options =
+                xf86AddNewOption(pInfo->options,
+                                 "Device", *pdev);
+            xf86Msg(X_INFO, "%s: found Device \"%s\"\n",
+                    pInfo->name, *pdev);
+            close(fd);
+            break;
+        }
+    }
+    return *pdev;
+}
+#endif /* __OpenBSD__ || __NetBSD__ && WSCONS_SUPPORT */
+
+#ifdef WSCONS_SUPPORT
+#define NUMEVENTS 64
+
+static void
+wsconsReadInput(InputInfoPtr pInfo)
+{
+    MouseDevPtr pMse;
+    static struct wscons_event eventList[NUMEVENTS];
+    int n, c;
+    struct wscons_event *event = eventList;
+    unsigned char *pBuf;
+
+    pMse = pInfo->private;
+
+    XisbBlockDuration(pMse->buffer, -1);
+    pBuf = (unsigned char *)eventList;
+    n = 0;
+    while (n < sizeof(eventList) && (c = XisbRead(pMse->buffer)) >= 0) {
+        pBuf[n++] = (unsigned char)c;
+    }
+
+    if (n == 0)
+        return;
+
+    n /= sizeof(struct wscons_event);
+    while( n-- ) {
+        int buttons = pMse->lastButtons;
+        int dx = 0, dy = 0, dz = 0, dw = 0, x, y;
+        switch (event->type) {
+        case WSCONS_EVENT_MOUSE_UP:
+#define BUTBIT (1 << (event->value <= 2 ? 2 - event->value : event->value))
+            buttons &= ~BUTBIT;
+            break;
+        case WSCONS_EVENT_MOUSE_DOWN:
+            buttons |= BUTBIT;
+            break;
+        case WSCONS_EVENT_MOUSE_DELTA_X:
+            dx = event->value;
+            break;
+        case WSCONS_EVENT_MOUSE_DELTA_Y:
+            dy = -event->value;
+            break;
+#ifdef WSCONS_EVENT_MOUSE_DELTA_Z
+        case WSCONS_EVENT_MOUSE_DELTA_Z:
+            dz = event->value;
+            break;
+#endif
+#ifdef WSCONS_EVENT_MOUSE_DELTA_W
+        case WSCONS_EVENT_MOUSE_DELTA_W:
+            dw = event->value;
+            break;
+#endif
+	case WSCONS_EVENT_MOUSE_ABSOLUTE_X:
+	    x = event->value;
+	    xf86PostMotionEvent(pInfo->dev, TRUE, 0, 1, x);
+	    ++event;
+	    continue;
+	case WSCONS_EVENT_MOUSE_ABSOLUTE_Y:
+	    y = event->value;
+	    xf86PostMotionEvent(pInfo->dev, TRUE, 1, 1, y);
+	    ++event;
+	    continue;
+#ifdef WSCONS_EVENT_MOUSE_ABSOLUTE_Z
+	case WSCONS_EVENT_MOUSE_ABSOLUTE_Z:
+	    ++event;
+	    continue;
+#endif
+#ifdef WSCONS_EVENT_MOUSE_ABSOLUTE_W
+	case WSCONS_EVENT_MOUSE_ABSOLUTE_W:
+	    ++event;
+	    continue;
+#endif
+        default:
+            LogMessageVerbSigSafe(X_WARNING, -1,
+                                  "%s: bad wsmouse event type=%d\n", pInfo->name,
+                                  event->type);
+            ++event;
+            continue;
+        }
+
+        pMse->PostEvent(pInfo, buttons, dx, dy, dz, dw);
+        ++event;
+    }
+    return;
+}
+
+
+/* This function is called when the protocol is "wsmouse". */
+static Bool
+wsconsPreInit(InputInfoPtr pInfo, const char *protocol, int flags)
+{
+    MouseDevPtr pMse = pInfo->private;
+
+    /* Setup the local input proc. */
+    pInfo->read_input = wsconsReadInput;
+    pMse->xisbscale = sizeof(struct wscons_event);
+
+    return TRUE;
+}
+#endif
+
+#if defined(USBMOUSE_SUPPORT)
+
+typedef struct _UsbMseRec {
+    int packetSize;
+    int iid;
+    hid_item_t loc_x;           /* x locator item */
+    hid_item_t loc_y;           /* y locator item */
+    hid_item_t loc_z;           /* z (wheel) locator item */
+    hid_item_t loc_w;           /* z (wheel) locator item */
+    hid_item_t loc_btn[MSE_MAXBUTTONS]; /* buttons locator items */
+   unsigned char *buffer;
+} UsbMseRec, *UsbMsePtr;
+
+static int
+usbMouseProc(DeviceIntPtr pPointer, int what)
+{
+    InputInfoPtr pInfo;
+    MouseDevPtr pMse;
+    UsbMsePtr pUsbMse;
+    unsigned char map[MSE_MAXBUTTONS + 1];
+    int nbuttons;
+
+    pInfo = pPointer->public.devicePrivate;
+    pMse = pInfo->private;
+    pMse->device = pPointer;
+    pUsbMse = pMse->mousePriv;
+
+    switch (what) {
+    case DEVICE_INIT:
+        pPointer->public.on = FALSE;
+
+        for (nbuttons = 0; nbuttons < MSE_MAXBUTTONS; ++nbuttons)
+            map[nbuttons + 1] = nbuttons + 1;
+
+        InitPointerDeviceStruct((DevicePtr)pPointer,
+                                map,
+                                min(pMse->buttons, MSE_MAXBUTTONS),
+                                miPointerGetMotionEvents,
+                                pMse->Ctrl,
+                                miPointerGetMotionBufferSize());
+
+        /* X valuator */
+        xf86InitValuatorAxisStruct(pPointer, 0, 0, -1, 1, 0, 1);
+        xf86InitValuatorDefaults(pPointer, 0);
+        /* Y valuator */
+        xf86InitValuatorAxisStruct(pPointer, 1, 0, -1, 1, 0, 1);
+        xf86InitValuatorDefaults(pPointer, 1);
+        xf86MotionHistoryAllocate(pInfo);
+        break;
+
+    case DEVICE_ON:
+        pInfo->fd = xf86OpenSerial(pInfo->options);
+        if (pInfo->fd == -1)
+            xf86Msg(X_WARNING, "%s: cannot open input device\n", pInfo->name);
+        else {
+            pMse->buffer = XisbNew(pInfo->fd, pUsbMse->packetSize);
+            if (!pMse->buffer) {
+                free(pMse);
+                xf86CloseSerial(pInfo->fd);
+                pInfo->fd = -1;
+            } else {
+                xf86FlushInput(pInfo->fd);
+                if (!xf86InstallSIGIOHandler (pInfo->fd, usbSigioReadInput,
+                                              pInfo))
+                    AddEnabledDevice(pInfo->fd);
+            }
+        }
+        pMse->lastButtons = 0;
+        pMse->lastMappedButtons = 0;
+        pMse->emulateState = 0;
+        pPointer->public.on = TRUE;
+        break;
+
+    case DEVICE_OFF:
+    case DEVICE_CLOSE:
+        if (pInfo->fd != -1) {
+            RemoveEnabledDevice(pInfo->fd);
+            if (pUsbMse->packetSize > 8 && pUsbMse->buffer) {
+                free(pUsbMse->buffer);
+            }
+            if (pMse->buffer) {
+                XisbFree(pMse->buffer);
+                pMse->buffer = NULL;
+            }
+            xf86CloseSerial(pInfo->fd);
+            pInfo->fd = -1;
+        }
+        pPointer->public.on = FALSE;
+        usleep(300000);
+        break;
+
+    default:
+        return BadValue;
+    }
+    return Success;
+}
+
+static void
+usbReadInput(InputInfoPtr pInfo)
+{
+    MouseDevPtr pMse;
+    UsbMsePtr pUsbMse;
+    int buttons = pMse->lastButtons;
+    int dx = 0, dy = 0, dz = 0, dw = 0;
+    int n, c;
+    unsigned char *pBuf;
+
+    pMse = pInfo->private;
+    pUsbMse = pMse->mousePriv;
+
+    XisbBlockDuration(pMse->buffer, -1);
+    pBuf = pUsbMse->buffer;
+    n = 0;
+    while ((c = XisbRead(pMse->buffer)) >= 0 && n < pUsbMse->packetSize) {
+        pBuf[n++] = (unsigned char)c;
+    }
+    if (n == 0)
+        return;
+    if (n != pUsbMse->packetSize) {
+        LogMessageVerbSigSafe(X_WARNING, -1,
+                              "%s: incomplete packet, size %d\n",
+                              pInfo->name, n);
+    }
+    /* discard packets with an id that don't match the mouse */
+    /* XXX this is probably not the right thing */
+    if (pUsbMse->iid != 0) {
+        if (*pBuf++ != pUsbMse->iid)
+            return;
+    }
+    dx = hid_get_data(pBuf, &pUsbMse->loc_x);
+    dy = hid_get_data(pBuf, &pUsbMse->loc_y);
+    dz = hid_get_data(pBuf, &pUsbMse->loc_z);
+    dw = hid_get_data(pBuf, &pUsbMse->loc_w);
+
+    buttons = 0;
+    for (n = 0; n < pMse->buttons; n++) {
+        if (hid_get_data(pBuf, &pUsbMse->loc_btn[n]))
+            buttons |= (1 << UMS_BUT(n));
+    }
+    pMse->PostEvent(pInfo, buttons, dx, dy, dz, dw);
+    return;
+}
+
+static void
+usbSigioReadInput (int fd, void *closure)
+{
+    usbReadInput ((InputInfoPtr) closure);
+}
+
+/* This function is called when the protocol is "usb". */
+static Bool
+usbPreInit(InputInfoPtr pInfo, const char *protocol, int flags)
+{
+    MouseDevPtr pMse = pInfo->private;
+    UsbMsePtr pUsbMse;
+    report_desc_t reportDesc;
+    int i;
+
+    pUsbMse = malloc(sizeof(UsbMseRec));
+    if (pUsbMse == NULL) {
+        xf86Msg(X_ERROR, "%s: cannot allocate UsbMouseRec\n", pInfo->name);
+        free(pMse);
+        return FALSE;
+    }
+
+    pMse->protocol = protocol;
+    xf86Msg(X_CONFIG, "%s: Protocol: %s\n", pInfo->name, protocol);
+
+    /* Collect the options, and process the common options. */
+    xf86CollectInputOptions(pInfo, NULL);
+    xf86ProcessCommonOptions(pInfo, pInfo->options);
+
+    /* Check if the device can be opened. */
+    pInfo->fd = xf86OpenSerial(pInfo->options);
+    if (pInfo->fd == -1) {
+        if (xf86GetAllowMouseOpenFail())
+            xf86Msg(X_WARNING, "%s: cannot open input device\n", pInfo->name);
+        else {
+            xf86Msg(X_ERROR, "%s: cannot open input device\n", pInfo->name);
+            free(pUsbMse);
+            free(pMse);
+            return FALSE;
+        }
+    }
+    /* Get USB information */
+    reportDesc = hid_get_report_desc(pInfo->fd);
+    /* Get packet size & iid */
+#ifdef USB_NEW_HID
+    if (ioctl(pInfo->fd, USB_GET_REPORT_ID, &pUsbMse->iid) == -1) {
+            xf86Msg(X_ERROR, "Error ioctl USB_GET_REPORT_ID on %s : %s\n",
+                    pInfo->name, strerror(errno));
+            return FALSE;
+    }
+    pUsbMse->packetSize = hid_report_size(reportDesc, hid_input,
+                                              pUsbMse->iid);
+#else
+    pUsbMse->packetSize = hid_report_size(reportDesc, hid_input,
+                                              &pUsbMse->iid);
+#endif
+    /* Allocate buffer */
+    if (pUsbMse->packetSize <= 8) {
+        pUsbMse->buffer = pMse->protoBuf;
+    } else {
+        pUsbMse->buffer = malloc(pUsbMse->packetSize);
+    }
+    if (pUsbMse->buffer == NULL) {
+        xf86Msg(X_ERROR, "%s: cannot allocate buffer\n", pInfo->name);
+        free(pUsbMse);
+        free(pMse);
+        xf86CloseSerial(pInfo->fd);
+        return FALSE;
+    }
+#ifdef USB_NEW_HID
+    if (hid_locate(reportDesc, HID_USAGE2(HUP_GENERIC_DESKTOP, HUG_X),
+                   hid_input, &pUsbMse->loc_x, pUsbMse->iid) < 0) {
+        xf86Msg(X_WARNING, "%s: no x locator\n", pInfo->name);
+    }
+    if (hid_locate(reportDesc, HID_USAGE2(HUP_GENERIC_DESKTOP, HUG_Y),
+                   hid_input, &pUsbMse->loc_y, pUsbMse->iid) < 0) {
+        xf86Msg(X_WARNING, "%s: no y locator\n", pInfo->name);
+    }
+    if (hid_locate(reportDesc, HID_USAGE2(HUP_GENERIC_DESKTOP, HUG_WHEEL),
+                   hid_input, &pUsbMse->loc_z, pUsbMse->iid) < 0) {
+    }
+#else
+    if (hid_locate(reportDesc, HID_USAGE2(HUP_GENERIC_DESKTOP, HUG_X),
+                   hid_input, &pUsbMse->loc_x) < 0) {
+        xf86Msg(X_WARNING, "%s: no x locator\n", pInfo->name);
+    }
+    if (hid_locate(reportDesc, HID_USAGE2(HUP_GENERIC_DESKTOP, HUG_Y),
+                   hid_input, &pUsbMse->loc_y) < 0) {
+        xf86Msg(X_WARNING, "%s: no y locator\n", pInfo->name);
+    }
+    if (hid_locate(reportDesc, HID_USAGE2(HUP_GENERIC_DESKTOP, HUG_WHEEL),
+                   hid_input, &pUsbMse->loc_z) < 0) {
+    }
+#endif
+    /* Probe for number of buttons */
+    for (i = 1; i <= MSE_MAXBUTTONS; i++) {
+        if (!hid_locate(reportDesc, HID_USAGE2(HUP_BUTTON, i),
+                        hid_input, &pUsbMse->loc_btn[i-1]
+#ifdef USB_NEW_HID
+                        , pUsbMse->iid
+#endif
+                        ))
+            break;
+    }
+    pMse->buttons = i-1;
+
+    xf86CloseSerial(pInfo->fd);
+    pInfo->fd = -1;
+
+    /* Private structure */
+    pMse->mousePriv = pUsbMse;
+
+    /* Process common mouse options (like Emulate3Buttons, etc). */
+    pMse->CommonOptions(pInfo);
+
+    /* Setup the local procs. */
+    pInfo->device_control = usbMouseProc;
+    pInfo->read_input = usbReadInput;
+
+    return TRUE;
+}
+#endif /* USBMOUSE */
+
+static Bool
+bsdMousePreInit(InputInfoPtr pInfo, const char *protocol, int flags)
+{
+    /* The protocol is guaranteed to be one of the internalNames[] */
+#ifdef WSCONS_SUPPORT
+    if (xf86NameCmp(protocol, "WSMouse") == 0) {
+        return wsconsPreInit(pInfo, protocol, flags);
+    }
+#endif
+#ifdef USBMOUSE_SUPPORT
+    if (xf86NameCmp(protocol, "usb") == 0) {
+        return usbPreInit(pInfo, protocol, flags);
+    }
+#endif
+    return TRUE;
+}
+
+OSMouseInfoPtr
+OSMouseInit(int flags)
+{
+    OSMouseInfoPtr p;
+
+    p = calloc(1, sizeof(OSMouseInfoRec));
+    if (!p)
+        return NULL;
+    p->SupportedInterfaces = SupportedInterfaces;
+    p->BuiltinNames = BuiltinNames;
+    p->DefaultProtocol = DefaultProtocol;
+    p->CheckProtocol = CheckProtocol;
+#if (defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__)) && defined(MOUSE_PROTO_SYSMOUSE)
+    p->SetupAuto = SetupAuto;
+    p->SetPS2Res = SetSysMouseRes;
+    p->SetBMRes = SetSysMouseRes;
+    p->SetMiscRes = SetSysMouseRes;
+#endif
+#if (defined(__OpenBSD__) || defined(__NetBSD__)) && defined(WSCONS_SUPPORT)
+    p->SetupAuto = SetupAuto;
+    p->SetMiscRes = SetMouseRes;
+#endif
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__NetBSD__)
+    p->FindDevice = FindDevice;
+#endif
+    p->PreInit = bsdMousePreInit;
+    return p;
+}

--- a/hw/xfree86/drivers/input/mouse/src/bsd_mouse.c
+++ b/hw/xfree86/drivers/input/mouse/src/bsd_mouse.c
@@ -26,7 +26,7 @@
  * authorization from the copyright holder(s) and author(s).
  */
 
-#include <xorg-server.h>
+#include <xorg-config.h>
 
 #include <errno.h>
 #include <sys/stat.h>

--- a/hw/xfree86/drivers/input/mouse/src/compat-api.h
+++ b/hw/xfree86/drivers/input/mouse/src/compat-api.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Author: Dave Airlie <airlied@redhat.com>
+ */
+
+/* this file provides API compat between server post 1.13 and pre it,
+   it should be reused inside as many drivers as possible */
+#ifndef COMPAT_API_H
+#define COMPAT_API_H
+
+#endif

--- a/hw/xfree86/drivers/input/mouse/src/hurd_mouse.c
+++ b/hw/xfree86/drivers/input/mouse/src/hurd_mouse.c
@@ -1,0 +1,244 @@
+/*
+ * Copyright 1997,1998 by UCHIYAMA Yasushi
+ *
+ * Permission to use, copy, modify, distribute, and sell this software and its
+ * documentation for any purpose is hereby granted without fee, provided that
+ * the above copyright notice appear in all copies and that both that
+ * copyright notice and this permission notice appear in supporting
+ * documentation, and that the name of UCHIYAMA Yasushi not be used in
+ * advertising or publicity pertaining to distribution of the software without
+ * specific, written prior permission.  UCHIYAMA Yasushi makes no representations
+ * about the suitability of this software for any purpose.  It is provided
+ * "as is" without express or implied warranty.
+ *
+ * UCHIYAMA YASUSHI DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+ * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+ * EVENT SHALL UCHIYAMA YASUSHI BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+ * DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+ * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#ifdef HAVE_XORG_CONFIG_H
+#include <xorg-config.h>
+#endif
+
+#include <xorg-server.h>
+#include <X11/X.h>
+#include <X11/Xproto.h>
+#include "inputstr.h"
+#include "scrnintstr.h"
+#include "mipointer.h"
+
+#include "xf86.h"
+#include "xf86Xinput.h"
+#include "mouse.h"
+#include "xf86_OSlib.h"
+#include "xisb.h"
+
+#include <stdio.h>
+#include <errno.h>
+#include <sys/time.h>
+#include <sys/file.h>
+#include <assert.h>
+#include <mach.h>
+#include <sys/ioctl.h>
+
+#define DEFAULT_MOUSE_DEV       "/dev/mouse"
+
+typedef unsigned short kev_type;                /* kd event type */
+typedef unsigned char Scancode;
+
+struct mouse_motion {
+    short mm_deltaX;            /* units? */
+    short mm_deltaY;
+};
+
+typedef struct {
+    kev_type type;                      /* see below */
+    struct timeval time;                /* timestamp */
+    union {                             /* value associated with event */
+        boolean_t up;           /* MOUSE_LEFT .. MOUSE_RIGHT */
+        Scancode sc;            /* KEYBD_EVENT */
+        struct mouse_motion mmotion;    /* MOUSE_MOTION */
+    } value;
+} kd_event;
+
+/*
+ * kd_event ID's.
+ */
+#define MOUSE_LEFT      1               /* mouse left button up/down */
+#define MOUSE_MIDDLE    2
+#define MOUSE_RIGHT     3
+#define MOUSE_MOTION    4               /* mouse motion */
+#define KEYBD_EVENT     5               /* key up/down */
+
+#define NUMEVENTS       64
+
+/*
+ * OsMouseReadInput --
+ *      Get some events from our queue.  Process all outstanding events now.
+ */
+static void
+OsMouseReadInput(InputInfoPtr pInfo)
+{
+    MouseDevPtr pMse;
+    static kd_event eventList[NUMEVENTS];
+    static int remainder = 0;
+    int n, c;
+    kd_event *event = eventList;
+    unsigned char *pBuf;
+
+    pMse = pInfo->private;
+
+    XisbBlockDuration(pMse->buffer, -1);
+    pBuf = (unsigned char *)eventList;
+    n = remainder;
+    while (n < sizeof(eventList) && (c = XisbRead(pMse->buffer)) >= 0)
+        pBuf[n++] = (unsigned char)c;
+
+    if (n == remainder)
+        return;
+
+    remainder = n % sizeof(kd_event);
+    n /= sizeof(kd_event);
+    while( n-- ) {
+        int buttons = pMse->lastButtons;
+        int dx = 0, dy = 0;
+        switch (event->type) {
+        case MOUSE_RIGHT:
+            buttons  = (buttons & 6) |(event->value.up ? 0 : 1);
+            break;
+        case MOUSE_MIDDLE:
+            buttons  = (buttons & 5) |(event->value.up ? 0 : 2);
+            break;
+        case MOUSE_LEFT:
+            buttons  = (buttons & 3) |(event->value.up ? 0 : 4) ;
+            break;
+        case MOUSE_MOTION:
+            dx = event->value.mmotion.mm_deltaX;
+            dy = - event->value.mmotion.mm_deltaY;
+            break;
+        default:
+            LogMessageVerbSigSafe(X_ERROR, -1, "Bad mouse event (%d)\n",event->type);
+            continue;
+        }
+        pMse->PostEvent(pInfo, buttons, dx, dy, 0, 0);
+        ++event;
+    }
+    memcpy(eventList, event, remainder);
+    return;
+}
+
+static Bool
+OsMousePreInit(InputInfoPtr pInfo, const char *protocol, int flags)
+{
+    MouseDevPtr pMse;
+
+    /* This is called when the protocol is "OSMouse". */
+
+    pMse = pInfo->private;
+    pMse->protocol = protocol;
+    xf86Msg(X_CONFIG, "%s: Protocol: %s\n", pInfo->name, protocol);
+
+    /* Collect the options, and process the common options. */
+    xf86CollectInputOptions(pInfo, NULL);
+    xf86ProcessCommonOptions(pInfo, pInfo->options);
+
+    /* Check if the device can be opened. */
+    pInfo->fd = xf86OpenSerial(pInfo->options);
+    if (pInfo->fd == -1) {
+        if (xf86GetAllowMouseOpenFail())
+            xf86Msg(X_WARNING, "%s: cannot open input device\n", pInfo->name);
+        else {
+            xf86Msg(X_ERROR, "%s: cannot open input device\n", pInfo->name);
+            free(pMse);
+            return FALSE;
+        }
+    }
+    xf86CloseSerial(pInfo->fd);
+    pInfo->fd = -1;
+
+    /* Process common mouse options (like Emulate3Buttons, etc). */
+    pMse->CommonOptions(pInfo);
+
+    /* Setup the local procs. */
+    pInfo->read_input = OsMouseReadInput;
+
+    return TRUE;
+}
+
+static const char *
+FindDevice(InputInfoPtr pInfo, const char *protocol, int flags)
+{
+    static const char path[] = DEFAULT_MOUSE_DEV;
+    int fd;
+
+    SYSCALL (fd = open(path, O_RDWR | O_NONBLOCK | O_EXCL));
+
+    if (fd == -1)
+        return NULL;
+
+    close(fd);
+    pInfo->options =
+        xf86AddNewOption(pInfo->options, "Device", path);
+    xf86Msg(X_INFO, "%s: Setting Device option to \"%s\"\n", pInfo->name,
+            path);
+
+    return path;
+}
+
+static int
+SupportedInterfaces(void)
+{
+    /* XXX Need to check this. */
+    return MSE_SERIAL | MSE_BUS | MSE_PS2 | MSE_XPS2 | MSE_AUTO;
+}
+
+static const char *internalNames[] = {
+        "OSMouse",
+        NULL
+};
+
+static const char **
+BuiltinNames(void)
+{
+    return internalNames;
+}
+
+static Bool
+CheckProtocol(const char *protocol)
+{
+    int i;
+
+    for (i = 0; internalNames[i]; i++)
+        if (xf86NameCmp(protocol, internalNames[i]) == 0)
+            return TRUE;
+    return FALSE;
+}
+
+static const char *
+DefaultProtocol(void)
+{
+    return "OSMouse";
+}
+
+OSMouseInfoPtr
+OSMouseInit(int flags)
+{
+    OSMouseInfoPtr p;
+
+    p = calloc(1, sizeof(OSMouseInfoRec));
+    if (!p)
+        return NULL;
+    p->SupportedInterfaces = SupportedInterfaces;
+    p->BuiltinNames = BuiltinNames;
+    p->FindDevice = FindDevice;
+    p->DefaultProtocol = DefaultProtocol;
+    p->CheckProtocol = CheckProtocol;
+    p->PreInit = OsMousePreInit;
+    return p;
+}
+

--- a/hw/xfree86/drivers/input/mouse/src/hurd_mouse.c
+++ b/hw/xfree86/drivers/input/mouse/src/hurd_mouse.c
@@ -21,11 +21,8 @@
  *
  */
 
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
-#include <xorg-server.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>
 #include "inputstr.h"

--- a/hw/xfree86/drivers/input/mouse/src/lnx_mouse.c
+++ b/hw/xfree86/drivers/input/mouse/src/lnx_mouse.c
@@ -3,11 +3,8 @@
  * Copyright 1999 by The XFree86 Project, Inc.
  */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+#include <xorg-config.h>
 
-#include <xorg-server.h>
 #include <X11/X.h>
 #include "xf86.h"
 #include "xf86Xinput.h"

--- a/hw/xfree86/drivers/input/mouse/src/lnx_mouse.c
+++ b/hw/xfree86/drivers/input/mouse/src/lnx_mouse.c
@@ -1,0 +1,222 @@
+
+/*
+ * Copyright 1999 by The XFree86 Project, Inc.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <xorg-server.h>
+#include <X11/X.h>
+#include "xf86.h"
+#include "xf86Xinput.h"
+#include "mouse.h"
+#include "xf86_OSlib.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static int
+SupportedInterfaces(void)
+{
+    return MSE_SERIAL | MSE_BUS | MSE_PS2 | MSE_XPS2 | MSE_AUTO;
+}
+
+static const char *
+DefaultProtocol(void)
+{
+    return "Auto";
+}
+
+#define DEFAULT_MOUSE_DEV               "/dev/input/mice"
+#define DEFAULT_PS2_DEV                 "/dev/psaux"
+#define DEFAULT_GPM_DATA_DEV            "/dev/gpmdata"
+#define DEFAULT_GPM_CTL_DEV             "/dev/gpmdata"
+
+static const char *mouseDevs[] = {
+        DEFAULT_MOUSE_DEV,
+        DEFAULT_PS2_DEV,
+        DEFAULT_GPM_DATA_DEV,
+        NULL
+};
+
+typedef enum {
+        MOUSE_PROTO_UNKNOWN = 0,
+        MOUSE_PROTO_SERIAL,
+        MOUSE_PROTO_PS2,
+        MOUSE_PROTO_MSC,
+        MOUSE_PROTO_GPM,
+        MOUSE_PROTO_EXPPS2,
+} protocolTypes;
+
+static struct {
+        protocolTypes proto;
+        const char *name;
+} devproto[] = {
+        { MOUSE_PROTO_UNKNOWN,  NULL },
+        { MOUSE_PROTO_PS2,      "PS/2" },
+        { MOUSE_PROTO_MSC,      "MouseSystems" },
+        { MOUSE_PROTO_GPM,      "GPM" },
+        { MOUSE_PROTO_EXPPS2,   "ExplorerPS/2" },
+};
+
+static const char *
+FindDevice(InputInfoPtr pInfo, const char *protocol, int flags)
+{
+    int fd = -1;
+    const char **pdev;
+
+    for (pdev = mouseDevs; *pdev; pdev++) {
+        SYSCALL (fd = open(*pdev, O_RDWR | O_NONBLOCK | O_EXCL));
+        if (fd == -1) {
+#ifdef DEBUG
+            ErrorF("Cannot open %s (%s)\n", *pdev, strerror(errno));
+#endif
+        } else
+            break;
+    }
+
+    if (*pdev) {
+        close(fd);
+        /* Set the Device option. */
+        pInfo->options =
+            xf86AddNewOption(pInfo->options, "Device", *pdev);
+        xf86Msg(X_INFO, "%s: Setting Device option to \"%s\"\n",
+                pInfo->name, *pdev);
+    }
+
+    return *pdev;
+}
+
+static const char *
+lnxMouseMagic(InputInfoPtr pInfo)
+{
+    int fd = -1;
+    const char *dev;
+    char *realdev;
+    struct stat sbuf;
+    int i;
+    int proto = MOUSE_PROTO_UNKNOWN;
+
+    dev = xf86SetStrOption(pInfo->options, "Device", NULL);
+    if (!dev) {
+#ifdef DEBUG
+        ErrorF("xf86SetStrOption failed to return the device name\n");
+#endif
+        return NULL;
+    }
+    /* Look at the device name to guess the protocol. */
+    realdev = NULL;
+    if (strcmp(dev, DEFAULT_MOUSE_DEV) == 0) {
+        if (lstat(dev, &sbuf) != 0) {
+#ifdef DEBUG
+            ErrorF("lstat failed for %s (%s)\n", dev, strerror(errno));
+#endif
+            return NULL;
+        }
+        if (S_ISLNK(sbuf.st_mode)) {
+            realdev = xnfalloc(PATH_MAX + 1);
+            i = readlink(dev, realdev, PATH_MAX);
+            if (i <= 0) {
+#ifdef DEBUG
+                ErrorF("readlink failed for %s (%s)\n", dev, strerror(errno));
+#endif
+                free(realdev);
+                return NULL;
+            }
+            realdev[i] = '\0';
+        }
+    }
+    if (!realdev)
+        realdev = xnfstrdup(dev);
+    else {
+        /* If realdev doesn't contain a '/' then prepend "/dev/" */
+        if (!strchr(realdev, '/')) {
+            char *tmp = xnfalloc(strlen(realdev) + 5 + 1);
+            sprintf(tmp, "/dev/%s", realdev);
+            free(realdev);
+            realdev = tmp;
+        }
+    }
+
+    if (strcmp(realdev, DEFAULT_MOUSE_DEV) == 0)
+        proto = MOUSE_PROTO_EXPPS2;
+    else if (strcmp(realdev, DEFAULT_PS2_DEV) == 0)
+        proto = MOUSE_PROTO_EXPPS2;
+    else if (strcmp(realdev, DEFAULT_GPM_DATA_DEV) == 0)
+        proto = MOUSE_PROTO_MSC;
+    else if (strcmp(realdev, DEFAULT_GPM_CTL_DEV) == 0)
+        proto = MOUSE_PROTO_GPM;
+    free(realdev);
+    /*
+     * If the protocol can't be guessed from the device name,
+     * try to characterise it.
+     */
+    if (proto == MOUSE_PROTO_UNKNOWN) {
+        SYSCALL (fd = open(dev, O_RDWR | O_NONBLOCK | O_EXCL));
+        if (isatty(fd)) {
+            /* Serial PnP has already failed, so give up. */
+        } else {
+            if (fstat(fd, &sbuf) != 0) {
+#ifdef DEBUG
+                ErrorF("fstat failed for %s (%s)\n", dev, strerror(errno));
+#endif
+                close(fd);
+                return NULL;
+            }
+            if (S_ISFIFO(sbuf.st_mode)) {
+                /* Assume GPM data in MSC format. */
+                proto = MOUSE_PROTO_MSC;
+            } else {
+                /* Default to PS/2 */
+                proto = MOUSE_PROTO_PS2;
+            }
+        }
+        close(fd);
+    }
+    if (proto == MOUSE_PROTO_UNKNOWN) {
+        xf86Msg(X_ERROR, "%s: Cannot find mouse protocol.\n",
+                pInfo->name);
+        return NULL;
+    } else {
+        for (i = 0; i < sizeof(devproto)/sizeof(devproto[0]); i++) {
+            if (devproto[i].proto == proto) {
+                xf86Msg(X_INFO,
+                        "%s: Setting mouse protocol to \"%s\"\n",
+                        pInfo->name, devproto[i].name);
+                return devproto[i].name;
+            }
+        }
+    }
+    return NULL;
+}
+
+static const char *
+GuessProtocol(InputInfoPtr pInfo, int flags)
+{
+    return lnxMouseMagic(pInfo);
+}
+
+static const char *
+SetupAuto(InputInfoPtr pInfo, int *protoPara)
+{
+    return lnxMouseMagic(pInfo);
+}
+
+OSMouseInfoPtr
+OSMouseInit(int flags)
+{
+    OSMouseInfoPtr p;
+
+    p = calloc(sizeof(OSMouseInfoRec), 1);
+    if (!p)
+        return NULL;
+    p->SupportedInterfaces = SupportedInterfaces;
+    p->DefaultProtocol = DefaultProtocol;
+    p->FindDevice = FindDevice;
+    p->GuessProtocol = GuessProtocol;
+    p->SetupAuto = SetupAuto;
+    return p;
+}
+

--- a/hw/xfree86/drivers/input/mouse/src/mouse.c
+++ b/hw/xfree86/drivers/input/mouse/src/mouse.c
@@ -70,6 +70,8 @@
 #include <sys/ioctl.h>
 #endif
 
+#include "xorgVersion.h"
+
 #include "compiler.h"
 
 #include "xisb.h"
@@ -3731,7 +3733,9 @@ static XF86ModuleVersionInfo xf86MouseVersionRec =
     MODINFOSTRING1,
     MODINFOSTRING2,
     XORG_VERSION_CURRENT,
-    PACKAGE_VERSION_MAJOR, PACKAGE_VERSION_MINOR, PACKAGE_VERSION_PATCHLEVEL,
+    XORG_VERSION_MAJOR,
+    XORG_VERSION_MINOR,
+    XORG_VERSION_PATCH,
     ABI_CLASS_XINPUT,
     ABI_XINPUT_VERSION,
     MOD_CLASS_XINPUT,

--- a/hw/xfree86/drivers/input/mouse/src/mouse.c
+++ b/hw/xfree86/drivers/input/mouse/src/mouse.c
@@ -43,11 +43,8 @@
  * and to help limited dexterity persons
  */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+#include <xorg-config.h>
 
-#include <xorg-server.h>
 #include <math.h>
 #include <string.h>
 #include <stdio.h>

--- a/hw/xfree86/drivers/input/mouse/src/mouse.c
+++ b/hw/xfree86/drivers/input/mouse/src/mouse.c
@@ -1,0 +1,3753 @@
+/*
+ *
+ * Copyright 1990,91 by Thomas Roell, Dinkelscherben, Germany.
+ * Copyright 1993 by David Dawes <dawes@xfree86.org>
+ * Copyright 2002 by SuSE Linux AG, Author: Egbert Eich
+ * Copyright 1994-2002 by The XFree86 Project, Inc.
+ * Copyright 2002 by Paul Elliott
+ *
+ * Permission to use, copy, modify, distribute, and sell this software and its
+ * documentation for any purpose is hereby granted without fee, provided that
+ * the above copyright notice appear in all copies and that both that
+ * copyright notice and this permission notice appear in supporting
+ * documentation, and that the names of copyright holders not be
+ * used in advertising or publicity pertaining to distribution of the
+ * software without specific, written prior permission.  The copyright holders
+ * make no representations about the suitability of this
+ * software for any purpose.  It is provided "as is" without express or
+ * implied warranty.
+ *
+ * THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+ * SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+/* Patch for PS/2 Intellimouse - Tim Goodwin 1997-11-06. */
+
+/*
+ * [JCH-96/01/21] Added fourth button support for PROT_GLIDEPOINT mouse
+ * protocol.
+ */
+
+/*
+ * [TVO-97/03/05] Added microsoft IntelliMouse support
+ */
+
+/*
+ * [PME-02/08/11] Added support for drag lock buttons
+ * for use with 4 button trackballs for convenience
+ * and to help limited dexterity persons
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <xorg-server.h>
+#include <math.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <X11/X.h>
+
+#include "xf86.h"
+
+#include <X11/extensions/XI.h>
+#include "extnsionst.h"
+#include "extinit.h"
+
+#include "xf86Xinput.h"
+#include "xf86_OSproc.h"
+#include "exevents.h"
+#include <X11/Xatom.h>
+#include "xserver-properties.h"
+#include "xf86-mouse-properties.h"
+
+#ifdef __NetBSD__
+#include <time.h>
+#include <dev/wscons/wsconsio.h>
+#include <sys/ioctl.h>
+#endif
+
+#include "compiler.h"
+
+#include "xisb.h"
+#include "mouse.h"
+#include "mousePriv.h"
+#include "mipointer.h"
+
+#ifndef sign
+#define sign(x) ((x) < 0 ? -1 : ((x) > 0 ? 1 : 0))
+#endif
+
+enum {
+    /* number of bits in mapped nibble */
+    NIB_BITS=4,
+    /* size of map of nibbles to bitmask */
+    NIB_SIZE= (1 << NIB_BITS),
+    /* mask for map */
+    NIB_MASK= (NIB_SIZE -1),
+    /* number of maps to map all the buttons */
+    NIB_COUNT = ((MSE_MAXBUTTONS+NIB_BITS-1)/NIB_BITS)
+};
+
+/*data to be used in implementing trackball drag locks.*/
+typedef struct _DragLockRec {
+
+    /* Fields used to implement trackball drag locks. */
+    /* mask for those buttons that are ordinary drag lock buttons */
+    int lockButtonsM;
+
+    /* mask for the master drag lock button if any */
+    int masterLockM;
+
+    /* button state up/down from last time adjusted for drag locks */
+    int lockLastButtons;
+
+    /*
+     * true if master lock state i.e. master drag lock
+     * button has just been pressed
+     */
+    int masterTS;
+
+    /* simulate these buttons being down although they are not */
+    int simulatedDown;
+
+    /*
+     * data to map bits for drag lock buttons to corresponding
+     * bits for the target buttons
+     */
+    int nib_table[NIB_COUNT][NIB_SIZE];
+
+} DragLockRec, *DragLockPtr;
+
+
+static int MousePreInit(InputDriverPtr drv, InputInfoPtr pInfo, int flags);
+static int MouseProc(DeviceIntPtr device, int what);
+static void MouseCtrl(DeviceIntPtr device, PtrCtrl *ctrl);
+static void MousePostEvent(InputInfoPtr pInfo, int buttons,
+                           int dx, int dy, int dz, int dw);
+static void MouseReadInput(InputInfoPtr pInfo);
+static void MouseBlockHandler(void *data, void *waitTime);
+static void MouseWakeupHandler(void *data, int i);
+static void FlushButtons(MouseDevPtr pMse);
+
+static Bool SetupMouse(InputInfoPtr pInfo);
+static Bool initMouseHW(InputInfoPtr pInfo);
+#ifdef SUPPORT_MOUSE_RESET
+static Bool mouseReset(InputInfoPtr pInfo, unsigned char val);
+static void ps2WakeupHandler(void *data, int i, void *LastSelectMask);
+static void ps2BlockHandler(void *data, struct timeval **waitTime,
+                            void *LastSelectMask);
+#endif
+static void Emulate3ButtonsSetEnabled(InputInfoPtr pInfo, Bool enable);
+
+/* mouse autoprobe stuff */
+static const char *autoOSProtocol(InputInfoPtr pInfo, int *protoPara);
+static void autoProbeMouse(InputInfoPtr pInfo, Bool inSync, Bool lostSync);
+static void checkForErraticMovements(InputInfoPtr pInfo, int dx, int dy);
+static Bool collectData(MouseDevPtr pMse, unsigned char u);
+static void SetMouseProto(MouseDevPtr pMse, MouseProtocolID protocolID);
+static Bool autoGood(MouseDevPtr pMse);
+
+#undef MOUSE
+_X_EXPORT InputDriverRec MOUSE = {
+	.driverVersion		= 1,
+	.driverName		= "mouse",
+	.Identify		= NULL,
+	.PreInit		= MousePreInit,
+	.UnInit			= NULL,
+	.module			= NULL,
+	.default_options	= NULL,
+	.capabilities		= 0
+};
+
+#define RETRY_COUNT 4
+
+/* Properties that can be set at runtime via xinput */
+static Atom prop_mbemu     = 0; /* Middle button emulation on/off property */
+static Atom prop_mbtimeout = 0; /* Middle button timeout property */
+
+/*
+ * Microsoft (all serial models), Logitech MouseMan, First Mouse, etc,
+ * ALPS GlidePoint, Thinking Mouse.
+ */
+static const char *msDefaults[] = {
+        "BaudRate",     "1200",
+        "DataBits",     "7",
+        "StopBits",     "1",
+        "Parity",       "None",
+        "FlowControl",  "None",
+        "VTime",        "0",
+        "VMin",         "1",
+        NULL
+};
+/* MouseSystems */
+static const char *mlDefaults[] = {
+        "BaudRate",     "1200",
+        "DataBits",     "8",
+        "StopBits",     "2",
+        "Parity",       "None",
+        "FlowControl",  "None",
+        "VTime",        "0",
+        "VMin",         "1",
+        NULL
+};
+/* MMSeries */
+static const char *mmDefaults[] = {
+        "BaudRate",     "1200",
+        "DataBits",     "8",
+        "StopBits",     "1",
+        "Parity",       "Odd",
+        "FlowControl",  "None",
+        "VTime",        "0",
+        "VMin",         "1",
+        NULL
+};
+/* Hitachi Tablet */
+static const char *mmhitDefaults[] = {
+        "BaudRate",     "1200",
+        "DataBits",     "8",
+        "StopBits",     "1",
+        "Parity",       "None",
+        "FlowControl",  "None",
+        "VTime",        "0",
+        "VMin",         "1",
+        NULL
+};
+/* AceCad Tablet */
+static const char *acecadDefaults[] = {
+        "BaudRate",     "9600",
+        "DataBits",     "8",
+        "StopBits",     "1",
+        "Parity",       "Odd",
+        "FlowControl",  "None",
+        "VTime",        "0",
+        "VMin",         "1",
+        NULL
+};
+
+static MouseProtocolRec mouseProtocols[] = {
+
+    /* Serial protocols */
+    { "Microsoft",              MSE_SERIAL,     msDefaults,     PROT_MS },
+    { "MouseSystems",           MSE_SERIAL,     mlDefaults,     PROT_MSC },
+    { "MMSeries",               MSE_SERIAL,     mmDefaults,     PROT_MM },
+    { "Logitech",               MSE_SERIAL,     mlDefaults,     PROT_LOGI },
+    { "MouseMan",               MSE_SERIAL,     msDefaults,     PROT_LOGIMAN },
+    { "MMHitTab",               MSE_SERIAL,     mmhitDefaults,  PROT_MMHIT },
+    { "GlidePoint",             MSE_SERIAL,     msDefaults,     PROT_GLIDE },
+    { "IntelliMouse",           MSE_SERIAL,     msDefaults,     PROT_IMSERIAL },
+    { "ThinkingMouse",          MSE_SERIAL,     msDefaults,     PROT_THINKING },
+    { "AceCad",                 MSE_SERIAL,     acecadDefaults, PROT_ACECAD },
+    { "ValuMouseScroll",        MSE_SERIAL,     msDefaults,     PROT_VALUMOUSESCROLL },
+
+    /* Standard PS/2 */
+    { "PS/2",                   MSE_PS2,        NULL,           PROT_PS2 },
+    { "GenericPS/2",            MSE_PS2,        NULL,           PROT_GENPS2 },
+
+    /* Extended PS/2 */
+    { "ImPS/2",                 MSE_XPS2,       NULL,           PROT_IMPS2 },
+    { "ExplorerPS/2",           MSE_XPS2,       NULL,           PROT_EXPPS2 },
+    { "ThinkingMousePS/2",      MSE_XPS2,       NULL,           PROT_THINKPS2 },
+    { "MouseManPlusPS/2",       MSE_XPS2,       NULL,           PROT_MMPS2 },
+    { "GlidePointPS/2",         MSE_XPS2,       NULL,           PROT_GLIDEPS2 },
+    { "NetMousePS/2",           MSE_XPS2,       NULL,           PROT_NETPS2 },
+    { "NetScrollPS/2",          MSE_XPS2,       NULL,           PROT_NETSCPS2 },
+
+    /* Bus Mouse */
+    { "BusMouse",               MSE_BUS,        NULL,           PROT_BM },
+
+    /* Auto-detect (PnP) */
+    { "Auto",                   MSE_AUTO,       NULL,           PROT_AUTO },
+
+    /* Misc (usually OS-specific) */
+    { "SysMouse",               MSE_MISC,       mlDefaults,     PROT_SYSMOUSE },
+    { "WSMouse",                MSE_MISC,       NULL,           PROT_WSMOUSE },
+    { "VUID",                   MSE_MISC,       NULL,           PROT_VUID },
+
+    /* end of list */
+    { NULL,                     MSE_NONE,       NULL,           PROT_UNKNOWN }
+};
+
+/* Process options common to all mouse types. */
+static void
+MouseCommonOptions(InputInfoPtr pInfo)
+{
+    MouseDevPtr pMse;
+    MessageType buttons_from = X_CONFIG;
+    char *s;
+    int origButtons;
+    int i;
+
+    pMse = pInfo->private;
+
+    pMse->buttons = xf86SetIntOption(pInfo->options, "Buttons", 0);
+    if (!pMse->buttons) {
+        pMse->buttons = MSE_DFLTBUTTONS;
+        buttons_from = X_DEFAULT;
+    }
+    origButtons = pMse->buttons;
+
+    pMse->emulate3Buttons = xf86SetBoolOption(pInfo->options,
+                                              "Emulate3Buttons", FALSE);
+    if (!xf86FindOptionValue(pInfo->options,"Emulate3Buttons")) {
+        pMse->emulate3ButtonsSoft = TRUE;
+        pMse->emulate3Buttons = TRUE;
+    }
+
+    pMse->emulate3Timeout = xf86SetIntOption(pInfo->options,
+                                             "Emulate3Timeout", 50);
+    if (pMse->emulate3Buttons || pMse->emulate3ButtonsSoft) {
+        MessageType from = X_CONFIG;
+        if (pMse->emulate3ButtonsSoft)
+            from = X_DEFAULT;
+        xf86Msg(from, "%s: Emulate3Buttons, Emulate3Timeout: %d\n",
+                pInfo->name, pMse->emulate3Timeout);
+    }
+
+    pMse->chordMiddle = xf86SetBoolOption(pInfo->options, "ChordMiddle", FALSE);
+    pMse->flipXY = xf86SetBoolOption(pInfo->options, "FlipXY", FALSE);
+    if (xf86SetBoolOption(pInfo->options, "InvX", FALSE)) {
+        pMse->invX = -1;
+    } else
+        pMse->invX = 1;
+    if (xf86SetBoolOption(pInfo->options, "InvY", FALSE)) {
+        pMse->invY = -1;
+    } else
+        pMse->invY = 1;
+    pMse->angleOffset = xf86SetIntOption(pInfo->options, "AngleOffset", 0);
+
+
+    if (pMse->pDragLock)
+        free(pMse->pDragLock);
+    pMse->pDragLock = NULL;
+
+    s = xf86SetStrOption(pInfo->options, "DragLockButtons", NULL);
+
+    if (s) {
+        int lock;             /* lock button */
+        int target;           /* target button */
+        int lockM,targetM;    /* bitmasks for drag lock, target */
+        int j;                /* indexes */
+        char *s1;             /* parse input string */
+        DragLockPtr pLock;
+
+        pLock = pMse->pDragLock = calloc(1, sizeof(DragLockRec));
+        /* init code */
+
+        /* initial string to be taken apart */
+        s1 = s;
+
+        /* keep getting numbers which are buttons */
+        while ((s1 != NULL) && (lock = strtol(s1, &s1, 10)) != 0) {
+
+            /* check sanity for a button */
+            if ((lock < 0) || (lock > MSE_MAXBUTTONS)) {
+                xf86Msg(X_WARNING, "DragLock: Invalid button number = %d\n",
+                        lock);
+                break;
+            }
+            /* turn into a button mask */
+            lockM = 1 << (lock - 1);
+
+            /* try to get drag lock button */
+            if ((s1 == NULL) || ((target=strtol(s1, &s1, 10)) == 0)) {
+                /*if no target, must be a master drag lock button */
+                /* save master drag lock mask */
+                pLock->masterLockM = lockM;
+                xf86Msg(X_CONFIG,
+                        "DragLock button %d is master drag lock",
+                        lock);
+            } else {
+                /* have target button number*/
+                /* check target button number for sanity */
+                if ((target < 0) || (target > MSE_MAXBUTTONS)) {
+                    xf86Msg(X_WARNING,
+                            "DragLock: Invalid button number for target=%d\n",
+                            target);
+                    break;
+                }
+
+                /* target button mask */
+                targetM = 1 << (target - 1);
+
+                xf86Msg(X_CONFIG,
+                        "DragLock: button %d is drag lock for button %d\n",
+                        lock,target);
+                lock--;
+
+                /* initialize table that maps drag lock mask to target mask */
+                pLock->nib_table[lock / NIB_BITS][1 << (lock % NIB_BITS)] =
+                        targetM;
+
+                /* add new drag lock to mask of drag locks */
+                pLock->lockButtonsM |= lockM;
+            }
+
+        }
+
+        /*
+         * fill out rest of map that maps sets of drag lock buttons
+         * to sets of target buttons, in the form of masks
+         */
+
+        /* for each nibble */
+        for (i = 0; i < NIB_COUNT; i++) {
+            /* for each possible set of bits for that nibble */
+            for (j = 0; j < NIB_SIZE; j++) {
+                int ff, fM, otherbits;
+
+                /* get first bit set in j*/
+                ff = ffs(j) - 1;
+                /* if 0 bits set nothing to do */
+                if (ff >= 0) {
+                    /* form mask for fist bit set */
+                    fM = 1 << ff;
+                    /* mask off first bit set to get remaining bits set*/
+                    otherbits = j & ~fM;
+                    /*
+                     * if otherbits =0 then only 1 bit set
+                     * so j=fM
+                     * nib_table[i][fM] already calculated if fM has
+                     * only 1 bit set.
+                     * nib_table[i][j] has already been filled in
+                     * by previous loop. otherwise
+                     * otherbits < j so nibtable[i][otherbits]
+                     * has already been calculated.
+                     */
+                    if (otherbits)
+                        pLock->nib_table[i][j] =
+                                     pLock->nib_table[i][fM] |
+                                     pLock->nib_table[i][otherbits];
+
+                }
+            }
+        }
+        free(s);
+    }
+
+    s = xf86SetStrOption(pInfo->options, "ZAxisMapping", "4 5");
+    if (s) {
+        int b1 = 0, b2 = 0, b3 = 0, b4 = 0;
+        char *msg = NULL;
+
+        pMse->negativeZ = pMse->positiveZ = MSE_NOAXISMAP;
+        pMse->negativeW = pMse->positiveW = MSE_NOAXISMAP;
+        if (!xf86NameCmp(s, "x")) {
+            pMse->negativeZ = pMse->positiveZ = MSE_MAPTOX;
+            msg = strdup("X axis");
+        } else if (!xf86NameCmp(s, "y")) {
+            pMse->negativeZ = pMse->positiveZ = MSE_MAPTOY;
+            msg = strdup("Y axis");
+        } else if (sscanf(s, "%d %d %d %d", &b1, &b2, &b3, &b4) >= 2 &&
+                 b1 > 0 && b1 <= MSE_MAXBUTTONS &&
+                 b2 > 0 && b2 <= MSE_MAXBUTTONS) {
+            pMse->negativeZ = 1 << (b1-1);
+            pMse->positiveZ = 1 << (b2-1);
+            if (b3 > 0 && b3 <= MSE_MAXBUTTONS &&
+                b4 > 0 && b4 <= MSE_MAXBUTTONS) {
+                pMse->negativeW = 1 << (b3-1);
+                pMse->positiveW = 1 << (b4-1);
+                if (asprintf(&msg, "buttons %d, %d, %d and %d",
+                             b1, b2, b3, b4) == -1)
+                    msg = NULL;
+            }
+            else {
+                if (asprintf(&msg, "buttons %d and %d", b1, b2) == -1)
+                    msg = NULL;
+            }
+            if (b1 > pMse->buttons) pMse->buttons = b1;
+            if (b2 > pMse->buttons) pMse->buttons = b2;
+            if (b3 > pMse->buttons) pMse->buttons = b3;
+            if (b4 > pMse->buttons) pMse->buttons = b4;
+        }
+        if (msg) {
+            xf86Msg(X_CONFIG, "%s: ZAxisMapping: %s\n", pInfo->name, msg);
+            free(msg);
+        } else {
+            xf86Msg(X_WARNING, "%s: Invalid ZAxisMapping value: \"%s\"\n",
+                    pInfo->name, s);
+        }
+        free(s);
+    }
+    if (xf86SetBoolOption(pInfo->options, "EmulateWheel", FALSE)) {
+        Bool yFromConfig = FALSE;
+        int wheelButton;
+
+        pMse->emulateWheel = TRUE;
+        wheelButton = xf86SetIntOption(pInfo->options,
+                                        "EmulateWheelButton", 4);
+        if (wheelButton < 0 || wheelButton > MSE_MAXBUTTONS) {
+            xf86Msg(X_WARNING, "%s: Invalid EmulateWheelButton value: %d\n",
+                        pInfo->name, wheelButton);
+            wheelButton = 4;
+        }
+        pMse->wheelButton = wheelButton;
+
+        pMse->wheelInertia = xf86SetIntOption(pInfo->options,
+                                        "EmulateWheelInertia", 10);
+        if (pMse->wheelInertia <= 0) {
+            xf86Msg(X_WARNING, "%s: Invalid EmulateWheelInertia value: %d\n",
+                        pInfo->name, pMse->wheelInertia);
+            pMse->wheelInertia = 10;
+        }
+        pMse->wheelButtonTimeout = xf86SetIntOption(pInfo->options,
+                                        "EmulateWheelTimeout", 200);
+        if (pMse->wheelButtonTimeout <= 0) {
+            xf86Msg(X_WARNING, "%s: Invalid EmulateWheelTimeout value: %d\n",
+                        pInfo->name, pMse->wheelButtonTimeout);
+            pMse->wheelButtonTimeout = 200;
+        }
+
+        pMse->negativeX = MSE_NOAXISMAP;
+        pMse->positiveX = MSE_NOAXISMAP;
+        s = xf86SetStrOption(pInfo->options, "XAxisMapping", NULL);
+        if (s) {
+            int b1 = 0, b2 = 0;
+            char *msg = NULL;
+
+            if ((sscanf(s, "%d %d", &b1, &b2) == 2) &&
+                 b1 > 0 && b1 <= MSE_MAXBUTTONS &&
+                 b2 > 0 && b2 <= MSE_MAXBUTTONS) {
+                if (asprintf(&msg, "buttons %d and %d", b1, b2) == -1)
+                    msg = NULL;
+                pMse->negativeX = b1;
+                pMse->positiveX = b2;
+                if (b1 > pMse->buttons) pMse->buttons = b1;
+                if (b2 > pMse->buttons) pMse->buttons = b2;
+            } else {
+                xf86Msg(X_WARNING, "%s: Invalid XAxisMapping value: \"%s\"\n",
+                        pInfo->name, s);
+            }
+            if (msg) {
+                xf86Msg(X_CONFIG, "%s: XAxisMapping: %s\n", pInfo->name, msg);
+                free(msg);
+            }
+            free(s);
+        }
+        s = xf86SetStrOption(pInfo->options, "YAxisMapping", NULL);
+        if (s) {
+            int b1 = 0, b2 = 0;
+            char *msg = NULL;
+
+            if ((sscanf(s, "%d %d", &b1, &b2) == 2) &&
+                 b1 > 0 && b1 <= MSE_MAXBUTTONS &&
+                 b2 > 0 && b2 <= MSE_MAXBUTTONS) {
+                if (asprintf(&msg, "buttons %d and %d", b1, b2) == -1)
+                    msg = NULL;
+                pMse->negativeY = b1;
+                pMse->positiveY = b2;
+                if (b1 > pMse->buttons) pMse->buttons = b1;
+                if (b2 > pMse->buttons) pMse->buttons = b2;
+                yFromConfig = TRUE;
+            } else {
+                xf86Msg(X_WARNING, "%s: Invalid YAxisMapping value: \"%s\"\n",
+                        pInfo->name, s);
+            }
+            if (msg) {
+                xf86Msg(X_CONFIG, "%s: YAxisMapping: %s\n", pInfo->name, msg);
+                free(msg);
+            }
+            free(s);
+        }
+        if (!yFromConfig) {
+            pMse->negativeY = 4;
+            pMse->positiveY = 5;
+            if (pMse->negativeY > pMse->buttons)
+                pMse->buttons = pMse->negativeY;
+            if (pMse->positiveY > pMse->buttons)
+                pMse->buttons = pMse->positiveY;
+            xf86Msg(X_DEFAULT, "%s: YAxisMapping: buttons %d and %d\n",
+                    pInfo->name, pMse->negativeY, pMse->positiveY);
+        }
+        xf86Msg(X_CONFIG, "%s: EmulateWheel, EmulateWheelButton: %d, "
+                          "EmulateWheelInertia: %d, "
+                          "EmulateWheelTimeout: %d\n",
+                pInfo->name, wheelButton, pMse->wheelInertia,
+                pMse->wheelButtonTimeout);
+    }
+    s = xf86SetStrOption(pInfo->options, "ButtonMapping", NULL);
+    if (s) {
+       int b, n = 0;
+       char *s1 = s;
+       /* keep getting numbers which are buttons */
+       while (s1 && n < MSE_MAXBUTTONS && (b = strtol(s1, &s1, 10)) != 0) {
+           /* check sanity for a button */
+           if (b < 0 || b > MSE_MAXBUTTONS) {
+               xf86Msg(X_WARNING,
+                       "ButtonMapping: Invalid button number = %d\n", b);
+               break;
+           }
+           pMse->buttonMap[n++] = 1 << (b-1);
+           if (b > pMse->buttons) pMse->buttons = b;
+       }
+       free(s);
+    }
+    /* get maximum of mapped buttons */
+    for (i = pMse->buttons-1; i >= 0; i--) {
+        int f = ffs (pMse->buttonMap[i]);
+        if (f > pMse->buttons)
+            pMse->buttons = f;
+    }
+    if (origButtons != pMse->buttons)
+        buttons_from = X_CONFIG;
+    xf86Msg(buttons_from, "%s: Buttons: %d\n", pInfo->name, pMse->buttons);
+
+    pMse->doubleClickSourceButtonMask = 0;
+    pMse->doubleClickTargetButtonMask = 0;
+    pMse->doubleClickTargetButton = 0;
+    s = xf86SetStrOption(pInfo->options, "DoubleClickButtons", NULL);
+    if (s) {
+        int b1 = 0, b2 = 0;
+        char *msg = NULL;
+
+        if ((sscanf(s, "%d %d", &b1, &b2) == 2) &&
+            (b1 > 0) && (b1 <= MSE_MAXBUTTONS) &&
+            (b2 > 0) && (b2 <= MSE_MAXBUTTONS)) {
+            if (asprintf(&msg, "buttons %d and %d", b1, b2) == -1)
+                msg = NULL;
+            pMse->doubleClickTargetButton = b1;
+            pMse->doubleClickTargetButtonMask = 1 << (b1 - 1);
+            pMse->doubleClickSourceButtonMask = 1 << (b2 - 1);
+            if (b1 > pMse->buttons) pMse->buttons = b1;
+            if (b2 > pMse->buttons) pMse->buttons = b2;
+        } else {
+            xf86Msg(X_WARNING, "%s: Invalid DoubleClickButtons value: \"%s\"\n",
+                    pInfo->name, s);
+        }
+        if (msg) {
+            xf86Msg(X_CONFIG, "%s: DoubleClickButtons: %s\n", pInfo->name, msg);
+            free(msg);
+        }
+        free(s);
+    }
+}
+/*
+ * map bits corresponding to lock buttons.
+ * for each bit for a lock button,
+ * turn on bit corresponding to button button that the lock
+ * button services.
+ */
+
+static int
+lock2targetMap(DragLockPtr pLock, int lockMask)
+{
+    int result,i;
+    result = 0;
+
+    /*
+     * for each nibble group of bits, use
+     * map for that group to get corresponding
+     * bits, turn them on.
+     * if 4 or less buttons only first map will
+     * need to be used.
+     */
+    for (i = 0; (i < NIB_COUNT) && lockMask; i++) {
+        result |= pLock->nib_table[i][lockMask& NIB_MASK];
+
+        lockMask &= ~NIB_MASK;
+        lockMask >>= NIB_BITS;
+    }
+    return result;
+}
+
+static void
+MouseHWOptions(InputInfoPtr pInfo)
+{
+    MouseDevPtr  pMse = pInfo->private;
+    mousePrivPtr mPriv = (mousePrivPtr)pMse->mousePriv;
+
+    if (mPriv == NULL)
+            return;
+
+    if ((mPriv->soft
+         = xf86SetBoolOption(pInfo->options, "AutoSoft", FALSE))) {
+        xf86Msg(X_CONFIG, "Don't initialize mouse when auto-probing\n");
+    }
+    pMse->sampleRate = xf86SetIntOption(pInfo->options, "SampleRate", 0);
+    pMse->resolution = xf86SetIntOption(pInfo->options, "Resolution", 0);
+    mPriv->sensitivity = xf86SetRealOption(pInfo->options, "Sensitivity", 1.0);
+}
+
+static void
+MouseSerialOptions(InputInfoPtr pInfo)
+{
+    MouseDevPtr  pMse = pInfo->private;
+
+    pMse->baudRate = xf86SetIntOption(pInfo->options, "BaudRate", 0);
+}
+
+static MouseProtocolID
+ProtocolNameToID(const char *name)
+{
+    int i;
+
+    for (i = 0; mouseProtocols[i].name; i++)
+        if (xf86NameCmp(name, mouseProtocols[i].name) == 0)
+            return mouseProtocols[i].id;
+    return PROT_UNKNOWN;
+}
+
+static const char *
+ProtocolIDToName(MouseProtocolID id)
+{
+    int i;
+
+    switch (id) {
+    case PROT_UNKNOWN:
+        return "Unknown";
+
+    case PROT_UNSUP:
+        return "Unsupported";
+
+    default:
+        for (i = 0; mouseProtocols[i].name; i++)
+            if (id == mouseProtocols[i].id)
+                return mouseProtocols[i].name;
+        return "Invalid";
+    }
+}
+
+static int
+ProtocolIDToClass(MouseProtocolID id)
+{
+    int i;
+
+    switch (id) {
+    case PROT_UNKNOWN:
+    case PROT_UNSUP:
+        return MSE_NONE;
+
+    default:
+        for (i = 0; mouseProtocols[i].name; i++)
+            if (id == mouseProtocols[i].id)
+                return mouseProtocols[i].class;
+        return MSE_NONE;
+    }
+}
+
+static MouseProtocolPtr
+GetProtocol(MouseProtocolID id) {
+    int i;
+
+    switch (id) {
+    case PROT_UNKNOWN:
+    case PROT_UNSUP:
+        return NULL;
+
+    default:
+        for (i = 0; mouseProtocols[i].name; i++)
+            if (id == mouseProtocols[i].id) {
+                return &mouseProtocols[i];
+            }
+        return NULL;
+    }
+}
+
+static OSMouseInfoPtr osInfo = NULL;
+
+static Bool
+InitProtocols(void)
+{
+    int classes;
+    int i;
+
+    if (osInfo)
+        return TRUE;
+
+    osInfo = OSMouseInit(0);
+    if (!osInfo)
+        return FALSE;
+    if (!osInfo->SupportedInterfaces)
+        return FALSE;
+
+    classes = osInfo->SupportedInterfaces();
+    if (!classes)
+        return FALSE;
+
+    /* Mark unsupported interface classes. */
+    for (i = 0; mouseProtocols[i].name; i++)
+        if (!(mouseProtocols[i].class & classes))
+            mouseProtocols[i].id = PROT_UNSUP;
+
+    for (i = 0; mouseProtocols[i].name; i++)
+        if (mouseProtocols[i].class & MSE_MISC)
+            if (!osInfo->CheckProtocol ||
+                !osInfo->CheckProtocol(mouseProtocols[i].name))
+                mouseProtocols[i].id = PROT_UNSUP;
+
+    /* NetBSD uses PROT_BM for "PS/2". */
+#if defined(__NetBSD__)
+    for (i = 0; mouseProtocols[i].name; i++)
+        if (mouseProtocols[i].id == PROT_PS2)
+            mouseProtocols[i].id = PROT_BM;
+#endif
+
+    return TRUE;
+}
+
+static const char*
+MouseFindDevice(InputInfoPtr pInfo, const char* protocol)
+{
+    const char *device;
+
+    if (!osInfo->FindDevice)
+        return NULL;
+
+    xf86Msg(X_WARNING, "%s: No Device specified, looking for one...\n", pInfo->name);
+    device = osInfo->FindDevice(pInfo, protocol, 0);
+    if (!device)
+        xf86Msg(X_ERROR, "%s: Cannot find which device to use.\n", pInfo->name);
+    else
+        xf86Msg(X_PROBED, "%s: Device: \"%s\"\n", pInfo->name, device);
+
+    return device;
+}
+
+static const char*
+MousePickProtocol(InputInfoPtr pInfo, const char* device,
+                  const char *protocol, MouseProtocolID *protocolID_out)
+{
+    MouseProtocolID protocolID = *protocolID_out;
+
+    protocolID = ProtocolNameToID(protocol);
+
+    if (protocolID == PROT_AUTO)
+    {
+        const char *osProt;
+        if (osInfo->SetupAuto && (osProt = osInfo->SetupAuto(pInfo,NULL))) {
+            protocolID = ProtocolNameToID(osProt);
+            protocol = osProt;
+        }
+    }
+
+    switch (protocolID) {
+        case PROT_WSMOUSE:
+        case PROT_VUID:
+            if (osInfo->PreInit)
+                osInfo->PreInit(pInfo, protocol, 0);
+            break;
+        case PROT_UNKNOWN:
+            /* Check for a builtin OS-specific protocol,
+             * and call its PreInit. */
+            if (osInfo->CheckProtocol
+                    && osInfo->CheckProtocol(protocol)) {
+                if (!device)
+                    MouseFindDevice(pInfo, protocol);
+                if (osInfo->PreInit) {
+                    osInfo->PreInit(pInfo, protocol, 0);
+                }
+                break;
+            }
+            xf86Msg(X_ERROR, "%s: Unknown protocol \"%s\"\n",
+                    pInfo->name, protocol);
+            break;
+        case PROT_UNSUP:
+            xf86Msg(X_ERROR,
+                    "%s: Protocol \"%s\" is not supported on this "
+                    "platform\n", pInfo->name, protocol);
+            break;
+        default:
+            break;
+    }
+
+    *protocolID_out = protocolID;
+
+    return protocol;
+}
+
+static int
+MousePreInit(InputDriverPtr drv, InputInfoPtr pInfo, int flags)
+{
+    MouseDevPtr pMse;
+    mousePrivPtr mPriv;
+    MessageType protocolFrom = X_DEFAULT;
+    const char *protocol;
+    const char *device;
+    MouseProtocolID protocolID;
+    MouseProtocolPtr pProto;
+    int i;
+    int rc = Success;
+
+    if (!InitProtocols())
+        return BadAlloc;
+
+    /* Initialise the InputInfoRec. */
+    pInfo->type_name = XI_MOUSE;
+    pInfo->device_control = MouseProc;
+    pInfo->read_input = MouseReadInput;
+    pInfo->control_proc = NULL;
+    pInfo->switch_mode = NULL;
+    pInfo->fd = -1;
+    pInfo->dev = NULL;
+
+    /* Allocate the MouseDevRec and initialise it. */
+    if (!(pMse = calloc(1, sizeof(MouseDevRec))))
+    {
+        rc = BadAlloc;
+        goto out;
+    }
+
+    pInfo->private = pMse;
+    pMse->Ctrl = MouseCtrl;
+    pMse->PostEvent = MousePostEvent;
+    pMse->CommonOptions = MouseCommonOptions;
+
+    /* Find the protocol type. */
+    protocol = xf86SetStrOption(pInfo->options, "Protocol", NULL);
+    if (protocol) {
+        protocolFrom = X_CONFIG;
+    } else if (osInfo->DefaultProtocol) {
+        protocol = osInfo->DefaultProtocol();
+        protocolFrom = X_DEFAULT;
+    }
+    if (!protocol) {
+        xf86Msg(X_ERROR, "%s: No Protocol specified\n", pInfo->name);
+        rc = BadValue;
+        goto out;
+    }
+
+    device = xf86SetStrOption(pInfo->options, "Device", NULL);
+
+    /* Default Mapping: 1 2 3 8 9 10 11 ... */
+    for (i = 0; i < MSE_MAXBUTTONS; i++)
+        pMse->buttonMap[i] = 1 << (i > 2 && i < MSE_MAXBUTTONS-4 ? i+4 : i);
+
+    protocol = MousePickProtocol(pInfo, device, protocol, &protocolID);
+
+    if (!device)
+        MouseFindDevice(pInfo, protocol);
+
+    xf86Msg(protocolFrom, "%s: Protocol: \"%s\"\n", pInfo->name, protocol);
+    if (protocolID == PROT_UNKNOWN)
+        goto out;
+    if (!(pProto = GetProtocol(protocolID)))
+    {
+        rc = BadValue;
+        goto out;
+    }
+
+    pMse->protocolID = protocolID;
+    pMse->oldProtocolID = protocolID;  /* hack */
+
+    pMse->autoProbe = FALSE;
+    /* Collect the options, and process the common options. */
+    xf86CollectInputOptions(pInfo, pProto->defaults);
+    xf86ProcessCommonOptions(pInfo, pInfo->options);
+
+    /* Check if the device can be opened. */
+    pInfo->fd = xf86OpenSerial(pInfo->options);
+    if (pInfo->fd == -1) {
+        if (xf86GetAllowMouseOpenFail())
+            xf86Msg(X_WARNING, "%s: cannot open input device\n", pInfo->name);
+        else {
+            xf86Msg(X_ERROR, "%s: cannot open input device\n", pInfo->name);
+            if (pMse->mousePriv)
+                free(pMse->mousePriv);
+            free(pMse);
+            pInfo->private = NULL;
+            rc = BadValue;
+            goto out;
+        }
+    }
+    xf86CloseSerial(pInfo->fd);
+    pInfo->fd = -1;
+
+    if (!(mPriv = calloc(1, sizeof(mousePrivRec))))
+    {
+        rc = BadAlloc;
+        goto out;
+    }
+
+    pMse->mousePriv = mPriv;
+    pMse->CommonOptions(pInfo);
+    pMse->checkMovements = checkForErraticMovements;
+    pMse->autoProbeMouse = autoProbeMouse;
+    pMse->collectData = collectData;
+    pMse->dataGood = autoGood;
+
+    MouseHWOptions(pInfo);
+    MouseSerialOptions(pInfo);
+
+out:
+    return rc;
+}
+
+static void MouseInitButtonLabels(Atom *btn_labels)
+{
+    int i;
+    Atom unknown_btn;
+
+    btn_labels[0] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_LEFT);
+    btn_labels[1] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_MIDDLE);
+    btn_labels[2] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_RIGHT);
+    btn_labels[3] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_WHEEL_UP);
+    btn_labels[4] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_WHEEL_DOWN);
+    btn_labels[5] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_HWHEEL_LEFT);
+    btn_labels[6] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_HWHEEL_RIGHT);
+
+    unknown_btn = XIGetKnownProperty(BTN_LABEL_PROP_BTN_UNKNOWN);
+    for (i = 7; i < MSE_MAXBUTTONS; i++)
+        btn_labels[i] = unknown_btn;
+}
+
+static int
+MouseSetProperty(DeviceIntPtr device, Atom atom,
+                                XIPropertyValuePtr val, BOOL checkonly)
+{
+    InputInfoPtr pInfo = device->public.devicePrivate;
+    MouseDevPtr pMse = pInfo->private;
+
+    if (atom == prop_mbemu)
+    {
+        if (val->format != 8 || val->size != 1 || val->type != XA_INTEGER)
+            return BadMatch;
+
+        if (!checkonly)
+            Emulate3ButtonsSetEnabled(pInfo, *((BOOL*)val->data));
+    }
+    else if (atom == prop_mbtimeout)
+    {
+        if (val->format != 32 || val->size != 1 || val->type != XA_INTEGER)
+            return BadMatch;
+
+        if (!checkonly)
+            pMse->emulate3Timeout = *((CARD32*)val->data);
+    }
+
+    return Success;
+}
+
+static void
+MouseInitProperties(DeviceIntPtr device)
+{
+    InputInfoPtr pInfo = device->public.devicePrivate;
+    MouseDevPtr pMse = pInfo->private;
+    int rc;
+
+#ifdef XI_PROP_DEVICE_NODE
+    const char *device_node =
+        xf86CheckStrOption(pInfo->options, "Device", NULL);
+
+    if (device_node)
+    {
+        Atom prop_device = MakeAtom(XI_PROP_DEVICE_NODE,
+                                    strlen(XI_PROP_DEVICE_NODE), TRUE);
+        XIChangeDeviceProperty(device, prop_device, XA_STRING, 8,
+                               PropModeReplace,
+                               strlen(device_node), device_node, FALSE);
+    }
+#endif /* XI_PROP_DEVICE_NODE */
+
+    /* Button labels */
+    if (pMse->buttons > 0)
+    {
+        Atom prop_btn_label = XIGetKnownProperty(BTN_LABEL_PROP);
+
+        if (prop_btn_label)
+        {
+            Atom btn_labels[MSE_MAXBUTTONS];
+            MouseInitButtonLabels(btn_labels);
+
+            XIChangeDeviceProperty(device, prop_btn_label, XA_ATOM, 32,
+                                   PropModeReplace, pMse->buttons,
+                                   btn_labels, FALSE);
+            XISetDevicePropertyDeletable(device, prop_btn_label, FALSE);
+        }
+    }
+
+    /* Middle button emulation - which this driver calls 3rd button emulation,
+     * but evdev's properties considers that to be simulating right button
+     * clicks from a one button mouse, which this driver does not currently
+     * support, so we use this name for better consistency.
+     */
+    prop_mbemu = MakeAtom(MOUSE_PROP_MIDBUTTON, strlen(MOUSE_PROP_MIDBUTTON),
+                          TRUE);
+    rc = XIChangeDeviceProperty(device, prop_mbemu, XA_INTEGER, 8,
+                                PropModeReplace, 1,
+                                &pMse->emulate3Buttons, FALSE);
+    if (rc != Success)
+        return;
+    XISetDevicePropertyDeletable(device, prop_mbemu, FALSE);
+
+    prop_mbtimeout = MakeAtom(MOUSE_PROP_MIDBUTTON_TIMEOUT,
+                              strlen(MOUSE_PROP_MIDBUTTON_TIMEOUT), TRUE);
+    rc = XIChangeDeviceProperty(device, prop_mbtimeout, XA_INTEGER, 32,
+                                PropModeReplace, 1,
+                                &pMse->emulate3Timeout, FALSE);
+
+    if (rc != Success)
+        return;
+    XISetDevicePropertyDeletable(device, prop_mbtimeout, FALSE);
+
+    XIRegisterPropertyHandler(device, MouseSetProperty, NULL, NULL);
+}
+
+static void
+MouseReadInput(InputInfoPtr pInfo)
+{
+    MouseDevPtr pMse;
+    int j, buttons, dx, dy, dz, dw, baddata;
+    int pBufP;
+    int c;
+    unsigned char *pBuf, u;
+
+
+    pMse = pInfo->private;
+    pBufP = pMse->protoBufTail;
+    pBuf = pMse->protoBuf;
+
+    if (pInfo->fd == -1)
+        return;
+
+    /*
+     * Set blocking to -1 on the first call because we know there is data to
+     * read. Xisb automatically clears it after one successful read so that
+     * succeeding reads are preceded by a select with a 0 timeout to prevent
+     * read from blocking indefinitely.
+     */
+    XisbBlockDuration(pMse->buffer, -1);
+
+    while ((c = XisbRead(pMse->buffer)) >= 0) {
+        u = (unsigned char)c;
+
+#if defined (EXTMOUSEDEBUG) || defined (MOUSEDATADEBUG)
+        LogMessageVerbSigSafe(X_INFO, -1, "mouse byte: %x\n",u);
+#endif
+
+        /* if we do autoprobing collect the data */
+        if (pMse->collectData && pMse->autoProbe)
+            if (pMse->collectData(pMse,u))
+                continue;
+
+#ifdef SUPPORT_MOUSE_RESET
+        if (mouseReset(pInfo,u)) {
+            pBufP = 0;
+            continue;
+        }
+#endif
+        if (pBufP >= pMse->protoPara[4]) {
+            /*
+             * Buffer contains a full packet, which has already been processed:
+             * Empty the buffer and check for optional 4th byte, which will be
+             * processed directly, without being put into the buffer first.
+             */
+            pBufP = 0;
+            if ((u & pMse->protoPara[0]) != pMse->protoPara[1] &&
+                (u & pMse->protoPara[5]) == pMse->protoPara[6]) {
+                /*
+                 * Hack for Logitech MouseMan Mouse - Middle button
+                 *
+                 * Unfortunately this mouse has variable length packets: the
+                 * standard Microsoft 3 byte packet plus an optional 4th byte
+                 * whenever the middle button status changes.
+                 *
+                 * We have already processed the standard packet with the
+                 * movement and button info.  Now post an event message with
+                 * the old status of the left and right buttons and the
+                 * updated middle button.
+                 */
+                /*
+                 * Even worse, different MouseMen and TrackMen differ in the
+                 * 4th byte: some will send 0x00/0x20, others 0x01/0x21, or
+                 * even 0x02/0x22, so I have to strip off the lower bits.
+                 * [CHRIS-211092]
+                 *
+                 * [JCH-96/01/21]
+                 * HACK for ALPS "fourth button".  (It's bit 0x10 of the
+                 * "fourth byte" and it is activated by tapping the glidepad
+                 * with the finger! 8^) We map it to bit bit3, and the
+                 * reverse map in xf86Events just has to be extended so that
+                 * it is identified as Button 4.  The lower half of the
+                 * reverse-map may remain unchanged.
+                 */
+                /*
+                 * [KAZU-030897]
+                 * Receive the fourth byte only when preceding three bytes
+                 * have been detected (pBufP >= pMse->protoPara[4]).  In the
+                 * previous versions, the test was pBufP == 0; we may have
+                 * mistakingly received a byte even if we didn't see anything
+                 * preceding the byte.
+                 */
+#ifdef EXTMOUSEDEBUG
+                LogMessageVerbSigSafe(X_INFO, -1, "mouse 4th byte %x\n",u);
+#endif
+                dx = dy = dz = dw = 0;
+                buttons = 0;
+                switch (pMse->protocolID) {
+
+                /*
+                 * [KAZU-221197]
+                 * IntelliMouse, NetMouse (including NetMouse Pro) and Mie
+                 * Mouse always send the fourth byte, whereas the fourth byte
+                 * is optional for GlidePoint and ThinkingMouse.  The fourth
+                 * byte is also optional for MouseMan+ and FirstMouse+ in
+                 * their native mode.  It is always sent if they are in the
+                 * IntelliMouse compatible mode.
+                 */
+                case PROT_IMSERIAL:     /* IntelliMouse, NetMouse, Mie Mouse,
+                                           MouseMan+ */
+                    dz = (u & 0x08) ?
+                                (u & 0x0f) - 16 : (u & 0x0f);
+                    if ((dz >= 7) || (dz <= -7))
+                        dz = 0;
+                    buttons |=  ((int)(u & 0x10) >> 3)
+                              | ((int)(u & 0x20) >> 2)
+                              | (pMse->lastButtons & 0x05);
+                    break;
+
+                case PROT_GLIDE:
+                case PROT_THINKING:
+                    buttons |= ((int)(u & 0x10) >> 1);
+                    _X_FALLTHROUGH; /* fall through */
+
+                default:
+                    buttons |= ((int)(u & 0x20) >> 4) |
+                               (pMse->lastButtons & 0x05);
+                    break;
+                }
+                goto post_event;
+            }
+        }
+        /* End of packet buffer flush and 4th byte hack. */
+
+        /*
+         * Append next byte to buffer (which is empty or contains an
+         * incomplete packet); iterate if packet (still) not complete.
+         */
+        pBuf[pBufP++] = u;
+        if (pBufP != pMse->protoPara[4]) continue;
+#ifdef EXTMOUSEDEBUG2
+        {
+            int i;
+            LogMessageVerbSigSafe(X_INFO, -1, "received %d bytes",pBufP);
+            for ( i=0; i < pBufP; i++)
+                LogMessageVerbSigSafe(X_INFO, -1, " %x",pBuf[i]);
+            LogMessageVerbSigSafe(X_INFO, -1, "\n");
+        }
+#endif
+
+        /*
+         * Hack for resyncing: We check here for a package that is:
+         *  a) illegal (detected by wrong data-package header)
+         *  b) invalid (0x80 == -128 and that might be wrong for MouseSystems)
+         *  c) bad header-package
+         *
+         * NOTE: b) is a violation of the MouseSystems-Protocol, since values
+         *       of -128 are allowed, but since they are very seldom we can
+         *       easily  use them as package-header with no button pressed.
+         * NOTE/2: On a PS/2 mouse any byte is valid as a data byte.
+         *       Furthermore, 0x80 is not valid as a header byte. For a PS/2
+         *       mouse we skip checking data bytes.  For resyncing a PS/2
+         *       mouse we require the two most significant bits in the header
+         *       byte to be 0. These are the overflow bits, and in case of
+         *       an overflow we actually lose sync. Overflows are very rare,
+         *       however, and we quickly gain sync again after an overflow
+         *       condition. This is the best we can do. (Actually, we could
+         *       use bit 0x08 in the header byte for resyncing, since that
+         *       bit is supposed to be always on, but nobody told Microsoft...)
+         */
+
+        /*
+         * [KAZU,OYVIND-120398]
+         * The above hack is wrong!  Because of b) above, we shall see
+         * erroneous mouse events so often when the MouseSystem mouse is
+         * moved quickly.  As for the PS/2 and its variants, we don't need
+         * to treat them as special cases, because protoPara[2] and
+         * protoPara[3] are both 0x00 for them, thus, any data bytes will
+         * never be discarded.  0x80 is rejected for MMSeries, Logitech
+         * and MMHittab protocols, because protoPara[2] and protoPara[3]
+         * are 0x80 and 0x00 respectively.  The other protocols are 7-bit
+         * protocols; there is no use checking 0x80.
+         *
+         * All in all we should check the condition a) only.
+         */
+
+        /*
+         * [OYVIND-120498]
+         * Check packet for valid data:
+         * If driver is in sync with datastream, the packet is considered
+         * bad if any byte (header and/or data) contains an invalid value.
+         *
+         * If packet is bad, we discard the first byte and shift the buffer.
+         * Next iteration will then check the new situation for validity.
+         *
+         * If flag MF_SAFE is set in proto[7] and the driver
+         * is out of sync, the packet is also considered bad if
+         * any of the data bytes contains a valid header byte value.
+         * This situation could occur if the buffer contains
+         * the tail of one packet and the header of the next.
+         *
+         * Note: The driver starts in out-of-sync mode (pMse->inSync = 0).
+         */
+
+        baddata = 0;
+
+        /* All databytes must be valid. */
+        for (j = 1; j < pBufP; j++ )
+            if ((pBuf[j] & pMse->protoPara[2]) != pMse->protoPara[3])
+                baddata = 1;
+
+        /* If out of sync, don't mistake a header byte for data. */
+        if ((pMse->protoPara[7] & MPF_SAFE) && !pMse->inSync)
+            for (j = 1; j < pBufP; j++ )
+                if ((pBuf[j] & pMse->protoPara[0]) == pMse->protoPara[1])
+                    baddata = 1;
+
+        /* Accept or reject the packet ? */
+        if ((pBuf[0] & pMse->protoPara[0]) != pMse->protoPara[1] || baddata) {
+            if (pMse->inSync) {
+#ifdef EXTMOUSEDEBUG
+                LogMessageVerbSigSafe(X_INFO, -1, "mouse driver lost sync\n");
+#endif
+            }
+#ifdef EXTMOUSEDEBUG
+            LogMessageVerbSigSafe(X_INFO, -1, "skipping byte %x\n",*pBuf);
+#endif
+            /* Tell auto probe that we are out of sync */
+            if (pMse->autoProbeMouse && pMse->autoProbe)
+                pMse->autoProbeMouse(pInfo, FALSE, pMse->inSync);
+            pMse->protoBufTail = --pBufP;
+            for (j = 0; j < pBufP; j++)
+                pBuf[j] = pBuf[j+1];
+            pMse->inSync = 0;
+            continue;
+        }
+        /* Tell auto probe that we were successful */
+        if (pMse->autoProbeMouse && pMse->autoProbe)
+            pMse->autoProbeMouse(pInfo, TRUE, FALSE);
+
+        if (!pMse->inSync) {
+#ifdef EXTMOUSEDEBUG
+            LogMessageVerbSigSafe(X_INFO, -1, "mouse driver back in sync\n");
+#endif
+            pMse->inSync = 1;
+        }
+
+        if (!pMse->dataGood(pMse))
+            continue;
+
+        /*
+         * Packet complete and verified, now process it ...
+         */
+    REDO_INTERPRET:
+        dz = dw = 0;
+        switch (pMse->protocolID) {
+        case PROT_LOGIMAN:      /* MouseMan / TrackMan   [CHRIS-211092] */
+        case PROT_MS:           /* Microsoft */
+            if (pMse->chordMiddle)
+                buttons = (((int) pBuf[0] & 0x30) == 0x30) ? 2 :
+                                  ((int)(pBuf[0] & 0x20) >> 3)
+                                | ((int)(pBuf[0] & 0x10) >> 4);
+            else
+                buttons = (pMse->lastButtons & 2)
+                        | ((int)(pBuf[0] & 0x20) >> 3)
+                        | ((int)(pBuf[0] & 0x10) >> 4);
+            dx = (signed char)(((pBuf[0] & 0x03) << 6) | (pBuf[1] & 0x3F));
+            dy = (signed char)(((pBuf[0] & 0x0C) << 4) | (pBuf[2] & 0x3F));
+            break;
+
+        case PROT_GLIDE:        /* ALPS GlidePoint */
+        case PROT_THINKING:     /* ThinkingMouse */
+        case PROT_IMSERIAL:     /* IntelliMouse, NetMouse, Mie Mouse, MouseMan+ */
+            buttons =  (pMse->lastButtons & (8 + 2))
+                     | ((int)(pBuf[0] & 0x20) >> 3)
+                     | ((int)(pBuf[0] & 0x10) >> 4);
+            dx = (signed char)(((pBuf[0] & 0x03) << 6) | (pBuf[1] & 0x3F));
+            dy = (signed char)(((pBuf[0] & 0x0C) << 4) | (pBuf[2] & 0x3F));
+            break;
+
+        case PROT_MSC:          /* Mouse Systems Corp */
+            buttons = (~pBuf[0]) & 0x07;
+            dx =    (signed char)(pBuf[1]) + (char)(pBuf[3]);
+            dy = - ((signed char)(pBuf[2]) + (char)(pBuf[4]));
+            break;
+
+        case PROT_MMHIT:        /* MM_HitTablet */
+            buttons = pBuf[0] & 0x07;
+            if (buttons != 0)
+                buttons = 1 << (buttons - 1);
+            dx = (pBuf[0] & 0x10) ?   pBuf[1] : - pBuf[1];
+            dy = (pBuf[0] & 0x08) ? - pBuf[2] :   pBuf[2];
+            break;
+
+        case PROT_ACECAD:       /* ACECAD */
+            /* ACECAD is almost exactly like MM but the buttons are different */
+            buttons = (pBuf[0] & 0x02) | ((pBuf[0] & 0x04) >> 2) |
+                      ((pBuf[0] & 1) << 2);
+            dx = (pBuf[0] & 0x10) ?   pBuf[1] : - pBuf[1];
+            dy = (pBuf[0] & 0x08) ? - pBuf[2] :   pBuf[2];
+            break;
+
+        case PROT_MM:           /* MM Series */
+        case PROT_LOGI:         /* Logitech Mice */
+            buttons = pBuf[0] & 0x07;
+            dx = (pBuf[0] & 0x10) ?   pBuf[1] : - pBuf[1];
+            dy = (pBuf[0] & 0x08) ? - pBuf[2] :   pBuf[2];
+            break;
+
+        case PROT_BM:           /* BusMouse */
+            buttons = (~pBuf[0]) & 0x07;
+            dx =   (signed char)pBuf[1];
+            dy = - (signed char)pBuf[2];
+            break;
+
+        case PROT_PS2:          /* PS/2 mouse */
+        case PROT_GENPS2:       /* generic PS/2 mouse */
+            buttons = (pBuf[0] & 0x04) >> 1 |       /* Middle */
+                      (pBuf[0] & 0x02) >> 1 |       /* Right */
+                      (pBuf[0] & 0x01) << 2;        /* Left */
+            dx = (pBuf[0] & 0x10) ?    (int)pBuf[1]-256  :  (int)pBuf[1];
+            dy = (pBuf[0] & 0x20) ?  -((int)pBuf[2]-256) : -(int)pBuf[2];
+            break;
+
+        /* PS/2 mouse variants */
+        case PROT_IMPS2:        /* IntelliMouse PS/2 */
+        case PROT_NETPS2:       /* NetMouse PS/2 */
+            buttons = (pBuf[0] & 0x04) >> 1 |       /* Middle */
+                      (pBuf[0] & 0x02) >> 1 |       /* Right */
+                      (pBuf[0] & 0x01) << 2 |       /* Left */
+                      (pBuf[0] & 0x40) >> 3 |       /* button 4 */
+                      (pBuf[0] & 0x80) >> 3;        /* button 5 */
+            dx = (pBuf[0] & 0x10) ?    pBuf[1]-256  :  pBuf[1];
+            dy = (pBuf[0] & 0x20) ?  -(pBuf[2]-256) : -pBuf[2];
+            /*
+             * The next cast must be 'signed char' for platforms (like PPC)
+             * where char defaults to unsigned.
+             */
+            dz = (signed char)(pBuf[3] | ((pBuf[3] & 0x08) ? 0xf8 : 0));
+            if ((pBuf[3] & 0xf8) && ((pBuf[3] & 0xf8) != 0xf8)) {
+                if (pMse->autoProbe) {
+                    SetMouseProto(pMse, PROT_EXPPS2);
+                    xf86Msg(X_INFO,
+                            "Mouse autoprobe: Changing protocol to %s\n",
+                            pMse->protocol);
+
+                    goto REDO_INTERPRET;
+                } else
+                    dz = 0;
+            }
+            break;
+
+        case PROT_EXPPS2:       /* IntelliMouse Explorer PS/2 */
+            if (pMse->autoProbe && (pBuf[3] & 0xC0)) {
+                SetMouseProto(pMse, PROT_IMPS2);
+                xf86Msg(X_INFO,"Mouse autoprobe: Changing protocol to %s\n",
+                        pMse->protocol);
+                goto REDO_INTERPRET;
+            }
+            buttons = (pBuf[0] & 0x04) >> 1 |       /* Middle */
+                      (pBuf[0] & 0x02) >> 1 |       /* Right */
+                      (pBuf[0] & 0x01) << 2 |       /* Left */
+                      (pBuf[3] & 0x10) >> 1 |       /* button 4 */
+                      (pBuf[3] & 0x20) >> 1;        /* button 5 */
+            dx = (pBuf[0] & 0x10) ?    pBuf[1]-256  :  pBuf[1];
+            dy = (pBuf[0] & 0x20) ?  -(pBuf[2]-256) : -pBuf[2];
+            if (pMse->negativeW != MSE_NOAXISMAP) {
+                switch (pBuf[3] & 0x0f) {
+                case 0x00:          break;
+                case 0x01: dz =  1; break;
+                case 0x02: dw =  1; break;
+                case 0x0e: dw = -1; break;
+                case 0x0f: dz = -1; break;
+                default:
+                    xf86Msg(X_INFO,
+                            "Mouse autoprobe: Disabling secondary wheel\n");
+                    pMse->negativeW = pMse->positiveW = MSE_NOAXISMAP;
+                }
+            }
+            if (pMse->negativeW == MSE_NOAXISMAP)
+                dz = (pBuf[3]&0x08) ? (pBuf[3]&0x0f) - 16 : (pBuf[3]&0x0f);
+            break;
+
+        case PROT_MMPS2:        /* MouseMan+ PS/2 */
+            buttons = (pBuf[0] & 0x04) >> 1 |       /* Middle */
+                      (pBuf[0] & 0x02) >> 1 |       /* Right */
+                      (pBuf[0] & 0x01) << 2;        /* Left */
+            dx = (pBuf[0] & 0x10) ? pBuf[1] - 256 : pBuf[1];
+            if (((pBuf[0] & 0x48) == 0x48) &&
+                (abs(dx) > 191) &&
+                ((((pBuf[2] & 0x03) << 2) | 0x02) == (pBuf[1] & 0x0f))) {
+                /* extended data packet */
+                switch ((((pBuf[0] & 0x30) >> 2) | ((pBuf[1] & 0x30) >> 4))) {
+                case 1:         /* wheel data packet */
+                    buttons |= ((pBuf[2] & 0x10) ? 0x08 : 0) | /* 4th button */
+                               ((pBuf[2] & 0x20) ? 0x10 : 0);  /* 5th button */
+                    dx = dy = 0;
+                    dz = (pBuf[2] & 0x08) ? (pBuf[2] & 0x0f) - 16 :
+                                            (pBuf[2] & 0x0f);
+                    break;
+                case 2:         /* Logitech reserves this packet type */
+                    /*
+                     * IBM ScrollPoint uses this packet to encode its
+                     * stick movement.
+                     */
+                    buttons |= (pMse->lastButtons & ~0x07);
+                    dx = dy = 0;
+                    dz = (pBuf[2] & 0x80) ? ((pBuf[2] >> 4) & 0x0f) - 16 :
+                                            ((pBuf[2] >> 4) & 0x0f);
+                    dw = (pBuf[2] & 0x08) ? (pBuf[2] & 0x0f) - 16 :
+                                            (pBuf[2] & 0x0f);
+                    break;
+                case 0:         /* device type packet - shouldn't happen */
+                default:
+                    buttons |= (pMse->lastButtons & ~0x07);
+                    dx = dy = 0;
+                    dz = 0;
+                    break;
+                }
+            } else {
+                buttons |= (pMse->lastButtons & ~0x07);
+                dx = (pBuf[0] & 0x10) ?    pBuf[1]-256  :  pBuf[1];
+                dy = (pBuf[0] & 0x20) ?  -(pBuf[2]-256) : -pBuf[2];
+            }
+            break;
+
+        case PROT_GLIDEPS2:     /* GlidePoint PS/2 */
+            buttons = (pBuf[0] & 0x04) >> 1 |       /* Middle */
+                      (pBuf[0] & 0x02) >> 1 |       /* Right */
+                      (pBuf[0] & 0x01) << 2 |       /* Left */
+                      ((pBuf[0] & 0x08) ? 0 : 0x08);/* fourth button */
+            dx = (pBuf[0] & 0x10) ?    pBuf[1]-256  :  pBuf[1];
+            dy = (pBuf[0] & 0x20) ?  -(pBuf[2]-256) : -pBuf[2];
+            break;
+
+        case PROT_NETSCPS2:     /* NetScroll PS/2 */
+            buttons = (pBuf[0] & 0x04) >> 1 |       /* Middle */
+                      (pBuf[0] & 0x02) >> 1 |       /* Right */
+                      (pBuf[0] & 0x01) << 2 |       /* Left */
+                      ((pBuf[3] & 0x02) ? 0x08 : 0) | /* button 4 */
+                      ((pBuf[3] & 0x01) ? 0x10 : 0);  /* button 5 */
+            dx = (pBuf[0] & 0x10) ?    pBuf[1]-256  :  pBuf[1];
+            dy = (pBuf[0] & 0x20) ?  -(pBuf[2]-256) : -pBuf[2];
+            dz = (pBuf[3] & 0x10) ? pBuf[4] - 256 : pBuf[4];
+            break;
+
+        case PROT_THINKPS2:     /* ThinkingMouse PS/2 */
+            buttons = (pBuf[0] & 0x04) >> 1 |       /* Middle */
+                      (pBuf[0] & 0x02) >> 1 |       /* Right */
+                      (pBuf[0] & 0x01) << 2 |       /* Left */
+                      ((pBuf[0] & 0x08) ? 0x08 : 0);/* fourth button */
+            pBuf[1] |= (pBuf[0] & 0x40) ? 0x80 : 0x00;
+            dx = (pBuf[0] & 0x10) ?    pBuf[1]-256  :  pBuf[1];
+            dy = (pBuf[0] & 0x20) ?  -(pBuf[2]-256) : -pBuf[2];
+            break;
+
+        case PROT_SYSMOUSE:     /* sysmouse */
+            buttons = (~pBuf[0]) & 0x07;
+            dx =    (signed char)(pBuf[1]) + (signed char)(pBuf[3]);
+            dy = - ((signed char)(pBuf[2]) + (signed char)(pBuf[4]));
+            /* FreeBSD sysmouse sends additional data bytes */
+            if (pMse->protoPara[4] >= 8) {
+                /*
+                 * These casts must be 'signed char' for platforms (like PPC)
+                 * where char defaults to unsigned.
+                 */
+                dz = ((signed char)(pBuf[5] << 1) +
+                      (signed char)(pBuf[6] << 1)) >> 1;
+                buttons |= (int)(~pBuf[7] & 0x7f) << 3;
+            }
+            break;
+
+        case PROT_VALUMOUSESCROLL:      /* Kensington ValuMouseScroll */
+            buttons = ((int)(pBuf[0] & 0x20) >> 3)
+                      | ((int)(pBuf[0] & 0x10) >> 4)
+                      | ((int)(pBuf[3] & 0x10) >> 3);
+            dx = (signed char)(((pBuf[0] & 0x03) << 6) | (pBuf[1] &  0x3F));
+            dy = (signed char)(((pBuf[0] & 0x0C) << 4) | (pBuf[2] &  0x3F));
+            dz = (pBuf[3] & 0x08) ? ((int)(pBuf[3] & 0x0F) - 0x10) :
+                                    ((int)(pBuf[3] & 0x0F));
+            break;
+
+        default: /* There's a table error */
+#ifdef EXTMOUSEDEBUG
+            LogMessageVerbSigSafe(X_INFO, -1, "mouse table error\n");
+#endif
+            continue;
+        }
+#ifdef EXTMOUSEDEBUG
+        LogMessageVerbSigSafe(X_INFO, -1, "packet");
+        for ( j=0; j < pBufP; j++)
+            LogMessageVerbSigSafe(X_INFO, -1, " %x",pBuf[j]);
+        LogMessageVerbSigSafe(X_INFO, -1, "\n");
+#endif
+
+post_event:
+#ifdef EXTMOUSEDEBUG
+        LogMessageVerbSigSafe(X_INFO, -1, "dx=%i dy=%i dz=%i dw=%i buttons=%x\n",dx,dy,dz,dw,buttons);
+#endif
+        /* When auto-probing check if data makes sense */
+        if (pMse->checkMovements && pMse->autoProbe)
+            pMse->checkMovements(pInfo,dx,dy);
+        /* post an event */
+        pMse->PostEvent(pInfo, buttons, dx, dy, dz, dw);
+
+        /*
+         * We don't reset pBufP here yet, as there may be an additional data
+         * byte in some protocols. See above.
+         */
+    }
+    pMse->protoBufTail = pBufP;
+}
+
+/*
+ * MouseCtrl --
+ *      Alter the control parameters for the mouse. Note that all
+ *      settings are now handled by dix.
+ */
+
+static void
+MouseCtrl(DeviceIntPtr device, PtrCtrl *ctrl)
+{
+    /* This function intentionally left blank */
+}
+
+/*
+ ***************************************************************************
+ *
+ * MouseProc --
+ *
+ ***************************************************************************
+ */
+
+static int
+MouseProc(DeviceIntPtr device, int what)
+{
+    InputInfoPtr pInfo;
+    MouseDevPtr pMse;
+    mousePrivPtr mPriv;
+    unsigned char map[MSE_MAXBUTTONS + 1];
+    int i;
+    Atom btn_labels[MSE_MAXBUTTONS] = {0};
+    Atom axes_labels[2] = { 0, 0 };
+
+    pInfo = device->public.devicePrivate;
+    pMse = pInfo->private;
+    pMse->device = device;
+
+    switch (what)
+    {
+    case DEVICE_INIT:
+        device->public.on = FALSE;
+        /*
+         * [KAZU-241097] We don't know exactly how many buttons the
+         * device has, so setup the map with the maximum number.
+         */
+        for (i = 0; i < MSE_MAXBUTTONS; i++)
+            map[i + 1] = i + 1;
+
+        MouseInitButtonLabels(btn_labels);
+        axes_labels[0] = XIGetKnownProperty(AXIS_LABEL_PROP_REL_X);
+        axes_labels[1] = XIGetKnownProperty(AXIS_LABEL_PROP_REL_Y);
+
+        InitPointerDeviceStruct((DevicePtr)device, map,
+                                min(pMse->buttons, MSE_MAXBUTTONS),
+                                btn_labels,
+                                pMse->Ctrl,
+                                GetMotionHistorySize(), 2,
+                                axes_labels
+                                );
+
+        /* X valuator */
+        xf86InitValuatorAxisStruct(device, 0,
+                axes_labels[0],
+                -1, -1, 1, 0, 1, Relative);
+        xf86InitValuatorDefaults(device, 0);
+        /* Y valuator */
+        xf86InitValuatorAxisStruct(device, 1,
+                axes_labels[1],
+                -1, -1, 1, 0, 1, Relative);
+        xf86InitValuatorDefaults(device, 1);
+
+#ifdef EXTMOUSEDEBUG
+        ErrorF("assigning %p name=%s\n", device, pInfo->name);
+#endif
+        MouseInitProperties(device);
+        break;
+
+    case DEVICE_ON:
+        pInfo->fd = xf86OpenSerial(pInfo->options);
+        if (pInfo->fd == -1)
+            xf86Msg(X_WARNING, "%s: cannot open input device\n", pInfo->name);
+        else {
+#if defined(__NetBSD__) && defined(WSCONS_SUPPORT) && defined(WSMOUSEIO_SETVERSION)
+            int version = WSMOUSE_EVENT_VERSION;
+            if (ioctl(pInfo->fd, WSMOUSEIO_SETVERSION, &version) == -1)
+                xf86Msg(X_WARNING, "%s: cannot set version\n", pInfo->name);
+#endif
+            if (pMse->xisbscale)
+                pMse->buffer = XisbNew(pInfo->fd, pMse->xisbscale * 4);
+            else
+                pMse->buffer = XisbNew(pInfo->fd, 64);
+            if (!pMse->buffer) {
+                xf86CloseSerial(pInfo->fd);
+                pInfo->fd = -1;
+            } else {
+                if (!SetupMouse(pInfo)) {
+                    xf86CloseSerial(pInfo->fd);
+                    pInfo->fd = -1;
+                    XisbFree(pMse->buffer);
+                    pMse->buffer = NULL;
+                } else {
+                    mPriv = (mousePrivPtr)pMse->mousePriv;
+                    if (mPriv != NULL) {
+                        if ( pMse->protocolID != PROT_AUTO) {
+                            pMse->inSync = TRUE; /* @@@ */
+                            if (mPriv->soft)
+                                mPriv->autoState = AUTOPROBE_GOOD;
+                            else
+                                mPriv->autoState = AUTOPROBE_H_GOOD;
+                        } else {
+                            if (mPriv->soft)
+                                mPriv->autoState = AUTOPROBE_NOPROTO;
+                            else
+                                mPriv->autoState = AUTOPROBE_H_NOPROTO;
+                        }
+                    }
+                    xf86FlushInput(pInfo->fd);
+                    xf86AddEnabledDevice(pInfo);
+                    if (pMse->emulate3Buttons || pMse->emulate3ButtonsSoft) {
+                        RegisterBlockAndWakeupHandlers (MouseBlockHandler,
+                                                        MouseWakeupHandler,
+                                                        (void*) pInfo);
+                    }
+                }
+            }
+        }
+        pMse->lastButtons = 0;
+        pMse->lastMappedButtons = 0;
+        pMse->emulateState = 0;
+        pMse->emulate3Pending = FALSE;
+        pMse->wheelButtonExpires = GetTimeInMillis ();
+        device->public.on = TRUE;
+        FlushButtons(pMse);
+        break;
+
+    case DEVICE_OFF:
+        if (pInfo->fd != -1) {
+            xf86RemoveEnabledDevice(pInfo);
+            if (pMse->buffer) {
+                XisbFree(pMse->buffer);
+                pMse->buffer = NULL;
+            }
+            xf86CloseSerial(pInfo->fd);
+            pInfo->fd = -1;
+            if (pMse->emulate3Buttons || pMse->emulate3ButtonsSoft)
+            {
+                RemoveBlockAndWakeupHandlers (MouseBlockHandler,
+                                              MouseWakeupHandler,
+                                              (void*) pInfo);
+            }
+        }
+        device->public.on = FALSE;
+        break;
+    case DEVICE_CLOSE:
+        free(pMse->mousePriv);
+        pMse->mousePriv = NULL;
+        break;
+
+    default:
+        return BadValue;
+    }
+    return Success;
+}
+
+/**********************************************************************
+ *
+ * FlushButtons -- reset button states.
+ *
+ **********************************************************************/
+
+static void
+FlushButtons(MouseDevPtr pMse)
+{
+    pMse->lastButtons = 0;
+    pMse->lastMappedButtons = 0;
+}
+
+/**********************************************************************
+ *
+ *  Emulate3Button support code
+ *
+ **********************************************************************/
+
+
+/*
+ * Lets create a simple finite-state machine for 3 button emulation:
+ *
+ * We track buttons 1 and 3 (left and right).  There are 11 states:
+ *   0 ground           - initial state
+ *   1 delayed left     - left pressed, waiting for right
+ *   2 delayed right    - right pressed, waiting for left
+ *   3 pressed middle   - right and left pressed, emulated middle sent
+ *   4 pressed left     - left pressed and sent
+ *   5 pressed right    - right pressed and sent
+ *   6 released left    - left released after emulated middle
+ *   7 released right   - right released after emulated middle
+ *   8 repressed left   - left pressed after released left
+ *   9 repressed right  - right pressed after released right
+ *  10 pressed both     - both pressed, not emulating middle
+ *
+ * At each state, we need handlers for the following events
+ *   0: no buttons down
+ *   1: left button down
+ *   2: right button down
+ *   3: both buttons down
+ *   4: emulate3Timeout passed without a button change
+ * Note that button events are not deltas, they are the set of buttons being
+ * pressed now.  It's possible (ie, mouse hardware does it) to go from (eg)
+ * left down to right down without anything in between, so all cases must be
+ * handled.
+ *
+ * a handler consists of three values:
+ *   0: action1
+ *   1: action2
+ *   2: new emulation state
+ *
+ * action > 0: ButtonPress
+ * action = 0: nothing
+ * action < 0: ButtonRelease
+ *
+ * The comment preceding each section is the current emulation state.
+ * The comments to the right are of the form
+ *      <button state> (<events>) -> <new emulation state>
+ * which should be read as
+ *      If the buttons are in <button state>, generate <events> then go to
+ *      <new emulation state>.
+ */
+static signed char stateTab[11][5][3] = {
+/* 0 ground */
+  {
+    {  0,  0,  0 },   /* nothing -> ground (no change) */
+    {  0,  0,  1 },   /* left -> delayed left */
+    {  0,  0,  2 },   /* right -> delayed right */
+    {  2,  0,  3 },   /* left & right (middle press) -> pressed middle */
+    {  0,  0, -1 }    /* timeout N/A */
+  },
+/* 1 delayed left */
+  {
+    {  1, -1,  0 },   /* nothing (left event) -> ground */
+    {  0,  0,  1 },   /* left -> delayed left (no change) */
+    {  1, -1,  2 },   /* right (left event) -> delayed right */
+    {  2,  0,  3 },   /* left & right (middle press) -> pressed middle */
+    {  1,  0,  4 },   /* timeout (left press) -> pressed left */
+  },
+/* 2 delayed right */
+  {
+    {  3, -3,  0 },   /* nothing (right event) -> ground */
+    {  3, -3,  1 },   /* left (right event) -> delayed left (no change) */
+    {  0,  0,  2 },   /* right -> delayed right (no change) */
+    {  2,  0,  3 },   /* left & right (middle press) -> pressed middle */
+    {  3,  0,  5 },   /* timeout (right press) -> pressed right */
+  },
+/* 3 pressed middle */
+  {
+    { -2,  0,  0 },   /* nothing (middle release) -> ground */
+    {  0,  0,  7 },   /* left -> released right */
+    {  0,  0,  6 },   /* right -> released left */
+    {  0,  0,  3 },   /* left & right -> pressed middle (no change) */
+    {  0,  0, -1 },   /* timeout N/A */
+  },
+/* 4 pressed left */
+  {
+    { -1,  0,  0 },   /* nothing (left release) -> ground */
+    {  0,  0,  4 },   /* left -> pressed left (no change) */
+    { -1,  0,  2 },   /* right (left release) -> delayed right */
+    {  3,  0, 10 },   /* left & right (right press) -> pressed both */
+    {  0,  0, -1 },   /* timeout N/A */
+  },
+/* 5 pressed right */
+  {
+    { -3,  0,  0 },   /* nothing (right release) -> ground */
+    { -3,  0,  1 },   /* left (right release) -> delayed left */
+    {  0,  0,  5 },   /* right -> pressed right (no change) */
+    {  1,  0, 10 },   /* left & right (left press) -> pressed both */
+    {  0,  0, -1 },   /* timeout N/A */
+  },
+/* 6 released left */
+  {
+    { -2,  0,  0 },   /* nothing (middle release) -> ground */
+    { -2,  0,  1 },   /* left (middle release) -> delayed left */
+    {  0,  0,  6 },   /* right -> released left (no change) */
+    {  1,  0,  8 },   /* left & right (left press) -> repressed left */
+    {  0,  0, -1 },   /* timeout N/A */
+  },
+/* 7 released right */
+  {
+    { -2,  0,  0 },   /* nothing (middle release) -> ground */
+    {  0,  0,  7 },   /* left -> released right (no change) */
+    { -2,  0,  2 },   /* right (middle release) -> delayed right */
+    {  3,  0,  9 },   /* left & right (right press) -> repressed right */
+    {  0,  0, -1 },   /* timeout N/A */
+  },
+/* 8 repressed left */
+  {
+    { -2, -1,  0 },   /* nothing (middle release, left release) -> ground */
+    { -2,  0,  4 },   /* left (middle release) -> pressed left */
+    { -1,  0,  6 },   /* right (left release) -> released left */
+    {  0,  0,  8 },   /* left & right -> repressed left (no change) */
+    {  0,  0, -1 },   /* timeout N/A */
+  },
+/* 9 repressed right */
+  {
+    { -2, -3,  0 },   /* nothing (middle release, right release) -> ground */
+    { -3,  0,  7 },   /* left (right release) -> released right */
+    { -2,  0,  5 },   /* right (middle release) -> pressed right */
+    {  0,  0,  9 },   /* left & right -> repressed right (no change) */
+    {  0,  0, -1 },   /* timeout N/A */
+  },
+/* 10 pressed both */
+  {
+    { -1, -3,  0 },   /* nothing (left release, right release) -> ground */
+    { -3,  0,  4 },   /* left (right release) -> pressed left */
+    { -1,  0,  5 },   /* right (left release) -> pressed right */
+    {  0,  0, 10 },   /* left & right -> pressed both (no change) */
+    {  0,  0, -1 },   /* timeout N/A */
+  },
+};
+
+/*
+ * Table to allow quick reversal of natural button mapping to correct mapping
+ */
+
+/*
+ * [JCH-96/01/21] The ALPS GlidePoint pad extends the MS protocol
+ * with a fourth button activated by tapping the PAD.
+ * The 2nd line corresponds to 4th button on; the drv sends
+ * the buttons in the following map (MSBit described first) :
+ * 0 | 4th | 1st | 2nd | 3rd
+ * And we remap them (MSBit described first) :
+ * 0 | 4th | 3rd | 2nd | 1st
+ */
+static char reverseMap[16] = { 0,  4,  2,  6,
+                               1,  5,  3,  7,
+                               8, 12, 10, 14,
+                               9, 13, 11, 15 };
+
+static char hitachMap[16] = {  0,  2,  1,  3,
+                               8, 10,  9, 11,
+                               4,  6,  5,  7,
+                              12, 14, 13, 15 };
+
+#define reverseBits(map, b)     (((b) & ~0x0f) | map[(b) & 0x0f])
+
+static CARD32
+buttonTimer(InputInfoPtr pInfo)
+{
+    MouseDevPtr pMse;
+    int id;
+
+    pMse = pInfo->private;
+
+    input_lock();
+
+    pMse->emulate3Pending = FALSE;
+    if ((id = stateTab[pMse->emulateState][4][0]) != 0) {
+        xf86PostButtonEvent(pInfo->dev, 0, abs(id), (id >= 0), 0, 0);
+        pMse->emulateState = stateTab[pMse->emulateState][4][2];
+    } else {
+        LogMessageVerbSigSafe(X_WARNING, -1,
+            "Got unexpected buttonTimer in state %d\n", pMse->emulateState);
+    }
+
+    input_unlock();
+    return 0;
+}
+
+static void
+Emulate3ButtonsSetEnabled(InputInfoPtr pInfo, Bool enable)
+{
+    MouseDevPtr pMse = pInfo->private;
+
+    if (pMse->emulate3Buttons == enable)
+        return;
+
+    pMse->emulate3Buttons = enable;
+
+    if (enable) {
+        pMse->emulateState = 0;
+        pMse->emulate3Pending = FALSE;
+        pMse->emulate3ButtonsSoft = FALSE; /* specifically requested now */
+
+        RegisterBlockAndWakeupHandlers (MouseBlockHandler, MouseWakeupHandler,
+                                        (void*) pInfo);
+    } else {
+        if (pMse->emulate3Pending)
+            buttonTimer(pInfo);
+
+        RemoveBlockAndWakeupHandlers (MouseBlockHandler, MouseWakeupHandler,
+                                      (void*) pInfo);
+    }
+}
+
+static Bool
+Emulate3ButtonsSoft(InputInfoPtr pInfo)
+{
+    MouseDevPtr pMse = pInfo->private;
+
+    if (!pMse->emulate3ButtonsSoft)
+        return TRUE;
+
+#if defined(__NetBSD__) && defined(WSCONS_SUPPORT)
+    /*
+     * On NetBSD a wsmouse is a multiplexed device. Imagine a notebook
+     * with two-button mousepad, and an external USB mouse plugged in
+     * temporarily. After using button 3 on the external mouse and
+     * unplugging it again, the mousepad will still need to emulate
+     * 3 buttons.
+     */
+    return TRUE;
+#else
+    LogMessageVerbSigSafe(X_INFO, 4,
+        "mouse: 3rd Button detected: disabling emulate3Button\n");
+
+    Emulate3ButtonsSetEnabled(pInfo, FALSE);
+
+    return FALSE;
+#endif
+}
+
+static void MouseBlockHandler(void *data, void *waitTime)
+{
+    InputInfoPtr    pInfo = (InputInfoPtr) data;
+    MouseDevPtr     pMse = (MouseDevPtr) pInfo->private;
+    int             ms;
+
+    if (pMse->emulate3Pending)
+    {
+        ms = pMse->emulate3Expires - GetTimeInMillis ();
+        if (ms <= 0)
+            ms = 0;
+        AdjustWaitForDelay (waitTime, ms);
+    }
+}
+
+static void MouseWakeupHandler(void *data, int i)
+{
+    InputInfoPtr    pInfo = (InputInfoPtr) data;
+    MouseDevPtr     pMse = (MouseDevPtr) pInfo->private;
+    int             ms;
+
+    if (pMse->emulate3Pending)
+    {
+        ms = pMse->emulate3Expires - GetTimeInMillis ();
+        if (ms <= 0)
+            buttonTimer (pInfo);
+    }
+}
+
+/*******************************************************************
+ *
+ * Post mouse events
+ *
+ *******************************************************************/
+
+static void
+MouseDoPostEvent(InputInfoPtr pInfo, int buttons, int dx, int dy)
+{
+    MouseDevPtr pMse;
+    int emulateButtons;
+    int id, change;
+    int emuWheelDelta, emuWheelButton, emuWheelButtonMask;
+    int wheelButtonMask;
+    int ms;
+
+    pMse = pInfo->private;
+
+    change = buttons ^ pMse->lastMappedButtons;
+    pMse->lastMappedButtons = buttons;
+
+    /* Do single button double click */
+    if (pMse->doubleClickSourceButtonMask) {
+        if (buttons & pMse->doubleClickSourceButtonMask) {
+            if (!(pMse->doubleClickOldSourceState)) {
+                /* double-click button has just been pressed.
+                 * Ignore it if target button is already down.
+                 */
+                if (!(buttons & pMse->doubleClickTargetButtonMask)) {
+                    /* Target button isn't down, so send a double-click */
+                    xf86PostButtonEvent(pInfo->dev, 0, pMse->doubleClickTargetButton, 1, 0, 0);
+                    xf86PostButtonEvent(pInfo->dev, 0, pMse->doubleClickTargetButton, 0, 0, 0);
+                    xf86PostButtonEvent(pInfo->dev, 0, pMse->doubleClickTargetButton, 1, 0, 0);
+                    xf86PostButtonEvent(pInfo->dev, 0, pMse->doubleClickTargetButton, 0, 0, 0);
+                }
+            }
+            pMse->doubleClickOldSourceState = 1;
+        }
+        else
+            pMse->doubleClickOldSourceState = 0;
+
+        /* Whatever happened, mask the double-click button so it doesn't get
+         * processed as a normal button as well.
+         */
+        buttons &= ~(pMse->doubleClickSourceButtonMask);
+        change  &= ~(pMse->doubleClickSourceButtonMask);
+    }
+
+    if (pMse->emulateWheel) {
+        /* Emulate wheel button handling */
+        if(pMse->wheelButton == 0)
+            wheelButtonMask = 0;
+        else
+            wheelButtonMask = 1 << (pMse->wheelButton - 1);
+
+        if (change & wheelButtonMask) {
+            if (buttons & wheelButtonMask) {
+                /* Start timeout handling */
+                pMse->wheelButtonExpires = GetTimeInMillis () + pMse->wheelButtonTimeout;
+                ms = - pMse->wheelButtonTimeout;
+            } else {
+                ms = pMse->wheelButtonExpires - GetTimeInMillis ();
+
+                if (0 < ms) {
+                    /*
+                     * If the button is released early enough emit the button
+                     * press/release events
+                     */
+                    xf86PostButtonEvent(pInfo->dev, 0, pMse->wheelButton,
+                                        1, 0, 0);
+                    xf86PostButtonEvent(pInfo->dev, 0, pMse->wheelButton,
+                                        0, 0, 0);
+                }
+            }
+        } else
+            ms = pMse->wheelButtonExpires - GetTimeInMillis ();
+
+        /* Intercept wheel emulation if the necessary button is depressed or
+           if no button is necessary */
+        if ((buttons & wheelButtonMask) || wheelButtonMask==0) {
+            if (ms <= 0 || wheelButtonMask==0) {
+                /* Y axis movement */
+                if (pMse->negativeY != MSE_NOAXISMAP) {
+                    pMse->wheelYDistance += dy;
+                    if (pMse->wheelYDistance < 0) {
+                        emuWheelDelta = -pMse->wheelInertia;
+                        emuWheelButton = pMse->negativeY;
+                    } else {
+                        emuWheelDelta = pMse->wheelInertia;
+                        emuWheelButton = pMse->positiveY;
+                    }
+                    emuWheelButtonMask = 1 << (emuWheelButton - 1);
+                    while (abs(pMse->wheelYDistance) > pMse->wheelInertia) {
+                        pMse->wheelYDistance -= emuWheelDelta;
+
+                        pMse->wheelXDistance = 0;
+                        /*
+                         * Synthesize the press and release, but not when
+                         * the button to be synthesized is already pressed
+                         * "for real".
+                         */
+                        if (!(emuWheelButtonMask & buttons) ||
+                            (emuWheelButtonMask & wheelButtonMask)) {
+                            xf86PostButtonEvent(pInfo->dev, 0, emuWheelButton,
+                                                1, 0, 0);
+                            xf86PostButtonEvent(pInfo->dev, 0, emuWheelButton,
+                                                0, 0, 0);
+                        }
+                    }
+                }
+
+                /* X axis movement */
+                if (pMse->negativeX != MSE_NOAXISMAP) {
+                    pMse->wheelXDistance += dx;
+                    if (pMse->wheelXDistance < 0) {
+                        emuWheelDelta = -pMse->wheelInertia;
+                        emuWheelButton = pMse->negativeX;
+                    } else {
+                        emuWheelDelta = pMse->wheelInertia;
+                        emuWheelButton = pMse->positiveX;
+                    }
+                    emuWheelButtonMask = 1 << (emuWheelButton - 1);
+                    while (abs(pMse->wheelXDistance) > pMse->wheelInertia) {
+                        pMse->wheelXDistance -= emuWheelDelta;
+
+                        pMse->wheelYDistance = 0;
+                        /*
+                         * Synthesize the press and release, but not when
+                         * the button to be synthesized is already pressed
+                         * "for real".
+                         */
+                        if (!(emuWheelButtonMask & buttons) ||
+                            (emuWheelButtonMask & wheelButtonMask)) {
+                            xf86PostButtonEvent(pInfo->dev, 0, emuWheelButton,
+                                                1, 0, 0);
+                            xf86PostButtonEvent(pInfo->dev, 0, emuWheelButton,
+                                                0, 0, 0);
+                        }
+                    }
+                }
+            }
+
+            /* Absorb the mouse movement while the wheel button is pressed. */
+            dx = 0;
+            dy = 0;
+        }
+        /*
+         * Button events for the wheel button are only emitted through
+         * the timeout code.
+         */
+        buttons &= ~wheelButtonMask;
+        change  &= ~wheelButtonMask;
+    }
+
+    if (pMse->emulate3ButtonsSoft && pMse->emulate3Pending && (dx || dy))
+        buttonTimer(pInfo);
+
+    if (dx || dy)
+        xf86PostMotionEvent(pInfo->dev, 0, 0, 2, dx, dy);
+
+    if (change) {
+
+        /*
+         * adjust buttons state for drag locks!
+         * if there is drag locks
+         */
+        if (pMse->pDragLock) {
+            DragLockPtr   pLock;
+            int tarOfGoingDown, tarOfDown;
+            int realbuttons;
+
+            /* get drag lock block */
+            pLock = pMse->pDragLock;
+            /* save real buttons */
+            realbuttons = buttons;
+
+            /* if drag lock used */
+
+            /* state of drag lock buttons not seen always up */
+
+            buttons &= ~pLock->lockButtonsM;
+
+            /*
+             * if lock buttons being depressed changes state of
+             * targets simulatedDown.
+             */
+            tarOfGoingDown = lock2targetMap(pLock,
+                                realbuttons & change & pLock->lockButtonsM);
+            pLock->simulatedDown ^= tarOfGoingDown;
+
+            /* targets of drag locks down */
+            tarOfDown = lock2targetMap(pLock,
+                                realbuttons & pLock->lockButtonsM);
+
+            /*
+             * when simulatedDown set and target pressed,
+             * simulatedDown goes false
+             */
+            pLock->simulatedDown &= ~(realbuttons & change);
+
+            /*
+             * if master drag lock released
+             * then master drag lock state on
+             */
+            pLock->masterTS |= (~realbuttons & change) & pLock->masterLockM;
+
+            /* if master state, buttons going down are simulatedDown */
+            if (pLock->masterTS)
+                pLock->simulatedDown |= (realbuttons & change);
+
+            /* if any button pressed, no longer in master drag lock state */
+            if (realbuttons & change)
+                pLock->masterTS = 0;
+
+            /* if simulatedDown or drag lock down, simulate down */
+            buttons |= (pLock->simulatedDown | tarOfDown);
+
+            /* master button not seen */
+            buttons &= ~(pLock->masterLockM);
+
+            /* buttons changed since last time */
+            change = buttons ^ pLock->lockLastButtons;
+
+            /* save this time for next last time. */
+            pLock->lockLastButtons = buttons;
+        }
+
+        if (pMse->emulate3Buttons
+            && (!(buttons & 0x02) || Emulate3ButtonsSoft(pInfo))) {
+
+            /* handle all but buttons 1 & 3 normally */
+
+            change &= ~05;
+
+            /* emulate the third button by the other two */
+
+            emulateButtons = (buttons & 01) | ((buttons &04) >> 1);
+
+            if ((id = stateTab[pMse->emulateState][emulateButtons][0]) != 0)
+                xf86PostButtonEvent(pInfo->dev, 0, abs(id), (id >= 0), 0, 0);
+            if ((id = stateTab[pMse->emulateState][emulateButtons][1]) != 0)
+                xf86PostButtonEvent(pInfo->dev, 0, abs(id), (id >= 0), 0, 0);
+
+            pMse->emulateState =
+                stateTab[pMse->emulateState][emulateButtons][2];
+
+            if (stateTab[pMse->emulateState][4][0] != 0) {
+                pMse->emulate3Expires =
+                    GetTimeInMillis() + pMse->emulate3Timeout;
+                pMse->emulate3Pending = TRUE;
+            } else {
+                pMse->emulate3Pending = FALSE;
+            }
+        }
+
+        while (change) {
+            id = ffs(change);
+            change &= ~(1 << (id - 1));
+            xf86PostButtonEvent(pInfo->dev, 0, id,
+                                (buttons & (1 << (id - 1))), 0, 0);
+        }
+
+    }
+}
+
+static void
+MousePostEvent(InputInfoPtr pInfo, int truebuttons,
+               int dx, int dy, int dz, int dw)
+{
+    MouseDevPtr pMse;
+    mousePrivPtr mousepriv;
+    int zbutton = 0, wbutton = 0, zbuttoncount = 0, wbuttoncount = 0;
+    int i, b, buttons = 0;
+
+    pMse = pInfo->private;
+    mousepriv = (mousePrivPtr)pMse->mousePriv;
+
+    if (pMse->protocolID == PROT_MMHIT)
+        b = reverseBits(hitachMap, truebuttons);
+    else
+        b = reverseBits(reverseMap, truebuttons);
+
+    /* Remap mouse buttons */
+    b &= (1<<MSE_MAXBUTTONS)-1;
+    for (i = 0; b; i++) {
+       if (b & 1)
+           buttons |= pMse->buttonMap[i];
+       b >>= 1;
+    }
+
+    /* Map the Z axis movement. */
+    /* XXX Could this go in the conversion_proc? */
+    switch (pMse->negativeZ) {
+    case MSE_NOZMAP:    /* do nothing */
+        dz = 0;
+        break;
+    case MSE_MAPTOX:
+        if (dz != 0) {
+            dx = dz;
+            dz = 0;
+        }
+        break;
+    case MSE_MAPTOY:
+        if (dz != 0) {
+            dy = dz;
+            dz = 0;
+        }
+        break;
+    default:    /* buttons */
+        buttons &= ~(pMse->negativeZ | pMse->positiveZ);
+        if (dz < 0) {
+            zbutton = pMse->negativeZ;
+            zbuttoncount = -dz;
+        } else if (dz > 0) {
+            zbutton = pMse->positiveZ;
+            zbuttoncount = dz;
+        }
+        dz = 0;
+        break;
+    }
+    switch (pMse->negativeW) {
+    case MSE_NOZMAP:    /* do nothing */
+        dw = 0;
+        break;
+    case MSE_MAPTOX:
+        if (dw != 0) {
+            dx = dw;
+            dw = 0;
+        }
+        break;
+    case MSE_MAPTOY:
+        if (dw != 0) {
+            dy = dw;
+            dw = 0;
+        }
+        break;
+    default:    /* buttons */
+        buttons &= ~(pMse->negativeW | pMse->positiveW);
+        if (dw < 0) {
+            wbutton = pMse->negativeW;
+            wbuttoncount = -dw;
+        } else if (dw > 0) {
+            wbutton = pMse->positiveW;
+            wbuttoncount = dw;
+        }
+        dw = 0;
+        break;
+    }
+
+
+    /* Apply angle offset */
+    if (pMse->angleOffset != 0) {
+        double rad = 3.141592653 * pMse->angleOffset / 180.0;
+        int ndx = dx;
+        dx = (int)((dx * cos(rad)) + (dy * sin(rad)) + 0.5);
+        dy = (int)((dy * cos(rad)) - (ndx * sin(rad)) + 0.5);
+    }
+
+    dx = pMse->invX * dx;
+    dy = pMse->invY * dy;
+    if (pMse->flipXY) {
+        int tmp = dx;
+        dx = dy;
+        dy = tmp;
+    }
+
+    /* Accumulate the scaled dx, dy in the private variables
+       fracdx,fracdy and return the integer number part */
+    if (mousepriv) {
+        mousepriv->fracdx += mousepriv->sensitivity*dx;
+        mousepriv->fracdy += mousepriv->sensitivity*dy;
+        mousepriv->fracdx -= ( dx=(int)(mousepriv->fracdx) );
+        mousepriv->fracdy -= ( dy=(int)(mousepriv->fracdy) );
+    }
+
+    /* If mouse wheel movement has to be mapped on a button, we need to
+     * loop for button press and release events. */
+    do {
+        MouseDoPostEvent(pInfo, buttons | zbutton | wbutton, dx, dy);
+        dx = dy = 0;
+        if (zbutton || wbutton)
+            MouseDoPostEvent(pInfo, buttons, 0, 0);
+        if (--zbuttoncount <= 0)
+            zbutton = 0;
+        if (--wbuttoncount <= 0)
+            wbutton = 0;
+    } while (zbutton || wbutton);
+
+    pMse->lastButtons = truebuttons;
+}
+/******************************************************************
+ *
+ * Mouse Setup Code
+ *
+ ******************************************************************/
+/*
+ * This array is indexed by the MouseProtocolID values, so the order of the
+ * entries must match that of the MouseProtocolID enum in mouse.h.
+ */
+static unsigned char proto[PROT_NUMPROTOS][8] = {
+  /* --header--  ---data--- packet -4th-byte-  mouse   */
+  /* mask   id   mask   id  bytes  mask   id   flags   */
+                                                            /* Serial mice */
+  {  0x40, 0x40, 0x40, 0x00,  3,  ~0x23, 0x00, MPF_NONE },  /* MicroSoft */
+  {  0xf8, 0x80, 0x00, 0x00,  5,   0x00, 0xff, MPF_SAFE },  /* MouseSystems */
+  {  0xe0, 0x80, 0x80, 0x00,  3,   0x00, 0xff, MPF_NONE },  /* MMSeries */
+  {  0xe0, 0x80, 0x80, 0x00,  3,   0x00, 0xff, MPF_NONE },  /* Logitech */
+  {  0x40, 0x40, 0x40, 0x00,  3,  ~0x23, 0x00, MPF_NONE },  /* MouseMan */
+  {  0xe0, 0x80, 0x80, 0x00,  3,   0x00, 0xff, MPF_NONE },  /* MM_HitTablet */
+  {  0x40, 0x40, 0x40, 0x00,  3,  ~0x33, 0x00, MPF_NONE },  /* GlidePoint */
+  {  0x40, 0x40, 0x40, 0x00,  3,  ~0x3f, 0x00, MPF_NONE },  /* IntelliMouse */
+  {  0x40, 0x40, 0x40, 0x00,  3,  ~0x33, 0x00, MPF_NONE },  /* ThinkingMouse */
+  {  0x80, 0x80, 0x80, 0x00,  3,   0x00, 0xff, MPF_NONE },  /* ACECAD */
+  {  0x40, 0x40, 0x40, 0x00,  4,   0x00, 0xff, MPF_NONE },  /* ValuMouseScroll */
+                                                            /* PS/2 variants */
+  {  0xc0, 0x00, 0x00, 0x00,  3,   0x00, 0xff, MPF_NONE },  /* PS/2 mouse */
+  {  0xc8, 0x08, 0x00, 0x00,  3,   0x00, 0x00, MPF_NONE },  /* genericPS/2 mouse*/
+  {  0x08, 0x08, 0x00, 0x00,  4,   0x00, 0xff, MPF_NONE },  /* IntelliMouse */
+  {  0x08, 0x08, 0x00, 0x00,  4,   0x00, 0xff, MPF_NONE },  /* Explorer */
+  {  0x80, 0x80, 0x00, 0x00,  3,   0x00, 0xff, MPF_NONE },  /* ThinkingMouse */
+  {  0x08, 0x08, 0x00, 0x00,  3,   0x00, 0xff, MPF_NONE },  /* MouseMan+ */
+  {  0xc0, 0x00, 0x00, 0x00,  3,   0x00, 0xff, MPF_NONE },  /* GlidePoint */
+  {  0x08, 0x08, 0x00, 0x00,  4,   0x00, 0xff, MPF_NONE },  /* NetMouse */
+  {  0xc0, 0x00, 0x00, 0x00,  6,   0x00, 0xff, MPF_NONE },  /* NetScroll */
+                                                            /* Bus Mouse */
+  {  0xf8, 0x80, 0x00, 0x00,  5,   0x00, 0xff, MPF_NONE },  /* BusMouse */
+  {  0xf8, 0x80, 0x00, 0x00,  5,   0x00, 0xff, MPF_NONE },  /* Auto (dummy) */
+  {  0xf8, 0x80, 0x00, 0x00,  8,   0x00, 0xff, MPF_NONE },  /* SysMouse */
+};
+
+
+/*
+ * SetupMouse --
+ *      Sets up the mouse parameters
+ */
+static Bool
+SetupMouse(InputInfoPtr pInfo)
+{
+    MouseDevPtr pMse;
+    int protoPara[8] = {-1, -1, -1, -1, -1, -1, -1, -1};
+    const char *name = NULL;
+    Bool automatic = FALSE;
+
+    pMse = pInfo->private;
+
+    /* Handle the "Auto" protocol. */
+    if (pMse->protocolID == PROT_AUTO) {
+        /*
+         * We come here when user specifies protocol "auto" in
+         * the configuration file or through the xf86misc extensions.
+         * So we initialize autoprobing here.
+         * Probe for PnP/OS mouse first. If unsuccessful
+         * try to guess protocol from incoming data.
+         */
+        automatic = TRUE;
+        pMse->autoProbe = TRUE;
+        name = autoOSProtocol(pInfo,protoPara);
+        if (name)  {
+#ifdef EXTMOUSEDEBUG
+            ErrorF("PnP/OS Mouse detected: %s\n",name);
+#endif
+        }
+    }
+
+    SetMouseProto(pMse, pMse->protocolID);
+
+    if (automatic) {
+        if (name) {
+            /* Possible protoPara overrides from SetupAuto. */
+            for (size_t i = 0; i < sizeof(pMse->protoPara); i++)
+                if (protoPara[i] != -1)
+                    pMse->protoPara[i] = protoPara[i];
+            /* if we come here PnP/OS mouse probing was successful */
+        } else {
+            /* PnP/OS mouse probing wasn't successful; we look at data */
+        }
+    }
+
+    /*
+     * If protocol has changed fetch the default options
+     * for the new protocol.
+     */
+    if (pMse->oldProtocolID != pMse->protocolID) {
+        if ((pMse->protocolID >= 0)
+            && (pMse->protocolID < PROT_NUMPROTOS)
+            && mouseProtocols[pMse->protocolID].defaults) {
+            void *tmp = xf86OptionListCreate(
+                mouseProtocols[pMse->protocolID].defaults, -1, 0);
+            pInfo->options = xf86OptionListMerge(pInfo->options, tmp);
+        }
+        /*
+         * If baudrate is set write it back to the option
+         * list so that the serial interface code can access
+         * the new value. Not set means default.
+         */
+        if (pMse->baudRate)
+            xf86ReplaceIntOption(pInfo->options, "BaudRate", pMse->baudRate);
+        pMse->oldProtocolID = pMse->protocolID; /* hack */
+    }
+
+
+    /* Set the port parameters. */
+    if (!automatic)
+        xf86SetSerial(pInfo->fd, pInfo->options);
+
+    if (!initMouseHW(pInfo))
+        return FALSE;
+
+    pMse->protoBufTail = 0;
+    pMse->inSync = 0;
+
+    return TRUE;
+}
+
+/********************************************************************
+ *
+ * Mouse HW setup code
+ *
+ ********************************************************************/
+
+/*
+** The following lines take care of the Logitech MouseMan protocols.
+** The "Logitech" protocol is for the old "series 9" Logitech products.
+** All products since then use the "MouseMan" protocol.  Some models
+** were programmable, but most (all?) of the current models are not.
+**
+** NOTE: There are different versions of both MouseMan and TrackMan!
+**       Hence I add another protocol PROT_LOGIMAN, which the user can
+**       specify as MouseMan in an xorg.conf file. This entry was
+**       formerly handled as a special case of PROT_MS. However, people
+**       who don't have the middle button problem, can still specify
+**       Microsoft and use PROT_MS.
+**
+** By default, these mice should use a 3 byte Microsoft protocol
+** plus a 4th byte for the middle button. However, the mouse might
+** have switched to a different protocol before we use it, so I send
+** the proper sequence just in case.
+**
+** NOTE: - all commands to (at least the European) MouseMan have to
+**         be sent at 1200 Baud.
+**       - each command starts with a '*'.
+**       - whenever the MouseMan receives a '*', it will switch back
+**       to 1200 Baud. Hence I have to select the desired protocol
+**       first, then select the baud rate.
+**
+** The protocols supported by the (European) MouseMan are:
+**   -  5 byte packed binary protocol, as with the Mouse Systems
+**      mouse. Selected by sequence "*U".
+**   -  2 button 3 byte MicroSoft compatible protocol. Selected
+**      by sequence "*V".
+**   -  3 button 3+1 byte MicroSoft compatible protocol (default).
+**      Selected by sequence "*X".
+**
+** The following baud rates are supported:
+**   -  1200 Baud (default). Selected by sequence "*n".
+**   -  9600 Baud. Selected by sequence "*q".
+**
+** Selecting a sample rate is no longer supported with the MouseMan!
+**               [CHRIS-211092]
+*/
+
+/*
+ * Do a reset wrap mode before reset.
+ */
+#define do_ps2Reset(x)  do { \
+    int i = RETRY_COUNT;\
+     while (i-- > 0) { \
+       xf86FlushInput(x->fd); \
+       if (ps2Reset(x)) break; \
+    } \
+  } while (0)
+
+
+static Bool
+initMouseHW(InputInfoPtr pInfo)
+{
+    MouseDevPtr pMse = pInfo->private;
+    const char *s;
+    unsigned char c;
+    int speed;
+    void *options;
+    unsigned char *param = NULL;
+    int paramlen = 0;
+    int count = RETRY_COUNT;
+    Bool ps2Init = TRUE;
+
+    switch (pMse->protocolID) {
+        case PROT_LOGI:         /* Logitech Mice */
+            /*
+             * The baud rate selection command must be sent at the current
+             * baud rate; try all likely settings.
+             */
+            speed = pMse->baudRate;
+            switch (speed) {
+                case 9600:
+                    s = "*q";
+                    break;
+                case 4800:
+                    s = "*p";
+                    break;
+                case 2400:
+                    s = "*o";
+                    break;
+                case 1200:
+                    s = "*n";
+                    break;
+                default:
+                    /* Fallback value */
+                    speed = 1200;
+                    s = "*n";
+            }
+            xf86SetSerialSpeed(pInfo->fd, 9600);
+            xf86WriteSerial(pInfo->fd, s, 2);
+            usleep(100000);
+            xf86SetSerialSpeed(pInfo->fd, 4800);
+            xf86WriteSerial(pInfo->fd, s, 2);
+            usleep(100000);
+            xf86SetSerialSpeed(pInfo->fd, 2400);
+            xf86WriteSerial(pInfo->fd, s, 2);
+            usleep(100000);
+            xf86SetSerialSpeed(pInfo->fd, 1200);
+            xf86WriteSerial(pInfo->fd, s, 2);
+            usleep(100000);
+            xf86SetSerialSpeed(pInfo->fd, speed);
+
+            /* Select MM series data format. */
+            xf86WriteSerial(pInfo->fd, "S", 1);
+            usleep(100000);
+            /* Set the parameters up for the MM series protocol. */
+            options = pInfo->options;
+            xf86CollectInputOptions(pInfo, mmDefaults);
+            xf86SetSerial(pInfo->fd, pInfo->options);
+            pInfo->options = options;
+
+            /* Select report rate/frequency. */
+            if      (pMse->sampleRate <=   0)  c = 'O';  /* 100 */
+            else if (pMse->sampleRate <=  15)  c = 'J';  /*  10 */
+            else if (pMse->sampleRate <=  27)  c = 'K';  /*  20 */
+            else if (pMse->sampleRate <=  42)  c = 'L';  /*  35 */
+            else if (pMse->sampleRate <=  60)  c = 'R';  /*  50 */
+            else if (pMse->sampleRate <=  85)  c = 'M';  /*  67 */
+            else if (pMse->sampleRate <= 125)  c = 'Q';  /* 100 */
+            else                               c = 'N';  /* 150 */
+            xf86WriteSerial(pInfo->fd, &c, 1);
+            break;
+
+        case PROT_LOGIMAN:
+            speed = pMse->baudRate;
+            switch (speed) {
+                case 9600:
+                    s = "*q";
+                    break;
+                case 1200:
+                    s = "*n";
+                    break;
+                default:
+                    /* Fallback value */
+                    speed = 1200;
+                    s = "*n";
+            }
+            xf86SetSerialSpeed(pInfo->fd, 1200);
+            xf86WriteSerial(pInfo->fd, "*n", 2);
+            xf86WriteSerial(pInfo->fd, "*X", 2);
+            xf86WriteSerial(pInfo->fd, s, 2);
+            usleep(100000);
+            xf86SetSerialSpeed(pInfo->fd, speed);
+            break;
+
+        case PROT_MMHIT:                /* MM_HitTablet */
+            /*
+             * Initialize Hitachi PUMA Plus - Model 1212E to desired settings.
+             * The tablet must be configured to be in MM mode, NO parity,
+             * Binary Format.  pMse->sampleRate controls the sensitivity
+             * of the tablet.  We only use this tablet for it's 4-button puck
+             * so we don't run in "Absolute Mode".
+             */
+            xf86WriteSerial(pInfo->fd, "z8", 2);        /* Set Parity = "NONE" */
+            usleep(50000);
+            xf86WriteSerial(pInfo->fd, "zb", 2);        /* Set Format = "Binary" */
+            usleep(50000);
+            xf86WriteSerial(pInfo->fd, "@", 1); /* Set Report Mode = "Stream" */
+            usleep(50000);
+            xf86WriteSerial(pInfo->fd, "R", 1); /* Set Output Rate = "45 rps" */
+            usleep(50000);
+            xf86WriteSerial(pInfo->fd, "I\x20", 2);     /* Set Incrememtal Mode "20" */
+            usleep(50000);
+            xf86WriteSerial(pInfo->fd, "E", 1); /* Set Data Type = "Relative */
+            usleep(50000);
+            /*
+             * These sample rates translate to 'lines per inch' on the Hitachi
+             * tablet.
+             */
+            if      (pMse->sampleRate <=   40) c = 'g';
+            else if (pMse->sampleRate <=  100) c = 'd';
+            else if (pMse->sampleRate <=  200) c = 'e';
+            else if (pMse->sampleRate <=  500) c = 'h';
+            else if (pMse->sampleRate <= 1000) c = 'j';
+            else                               c = 'd';
+            xf86WriteSerial(pInfo->fd, &c, 1);
+            usleep(50000);
+            xf86WriteSerial(pInfo->fd, "\021", 1);      /* Resume DATA output */
+            break;
+
+        case PROT_THINKING:             /* ThinkingMouse */
+            /* This mouse may send a PnP ID string, ignore it. */
+            usleep(200000);
+            xf86FlushInput(pInfo->fd);
+            /* Send the command to initialize the beast. */
+            for (s = "E5E5"; *s; ++s) {
+                xf86WriteSerial(pInfo->fd, s, 1);
+                if ((xf86WaitForInput(pInfo->fd, 1000000) <= 0))
+                    break;
+                xf86ReadSerial(pInfo->fd, &c, 1);
+                if (c != *s)
+                    break;
+            }
+            break;
+
+        case PROT_MSC:          /* MouseSystems Corp */
+            usleep(100000);
+            xf86FlushInput(pInfo->fd);
+            break;
+
+        case PROT_ACECAD:
+            /* initialize */
+            /* A nul character resets. */
+            xf86WriteSerial(pInfo->fd, "", 1);
+            usleep(50000);
+            /* Stream out relative mode high resolution increments of 1. */
+            xf86WriteSerial(pInfo->fd, "@EeI!", 5);
+            break;
+
+        case PROT_BM:           /* bus/InPort mouse */
+            if (osInfo->SetBMRes)
+                osInfo->SetBMRes(pInfo, pMse->protocol, pMse->sampleRate,
+                                 pMse->resolution);
+            break;
+
+        case PROT_GENPS2:
+            ps2Init = FALSE;
+            break;
+
+        case PROT_PS2:
+        case PROT_GLIDEPS2:
+            break;
+
+        case PROT_IMPS2:                /* IntelliMouse */
+        {
+            static unsigned char seq[] = { 243, 200, 243, 100, 243, 80 };
+            param = seq;
+            paramlen = sizeof(seq);
+        }
+        break;
+
+        case PROT_EXPPS2:               /* IntelliMouse Explorer */
+        {
+            static unsigned char seq[] = { 243, 200, 243, 100, 243, 80,
+                                           243, 200, 243, 200, 243, 80 };
+
+            param = seq;
+            paramlen = sizeof(seq);
+        }
+        break;
+
+        case PROT_NETPS2:               /* NetMouse, NetMouse Pro, Mie Mouse */
+        case PROT_NETSCPS2:             /* NetScroll */
+        {
+            static unsigned char seq[] = { 232, 3, 230, 230, 230, 233 };
+
+            param = seq;
+            paramlen = sizeof(seq);
+        }
+        break;
+
+        case PROT_MMPS2:                /* MouseMan+, FirstMouse+ */
+        {
+            static unsigned char seq[] = { 230, 232, 0, 232, 3, 232, 2, 232, 1,
+                                           230, 232, 3, 232, 1, 232, 2, 232, 3 };
+            param = seq;
+            paramlen = sizeof(seq);
+        }
+        break;
+
+        case PROT_THINKPS2:             /* ThinkingMouse */
+        {
+            static unsigned char seq[] = { 243, 10, 232,  0, 243, 20, 243, 60,
+                                           243, 40, 243, 20, 243, 20, 243, 60,
+                                           243, 40, 243, 20, 243, 20 };
+            param = seq;
+            paramlen = sizeof(seq);
+        }
+        break;
+        case PROT_SYSMOUSE:
+            if (osInfo->SetMiscRes)
+                osInfo->SetMiscRes(pInfo, pMse->protocol, pMse->sampleRate,
+                                   pMse->resolution);
+            break;
+
+        default:
+            /* Nothing to do. */
+            break;
+    }
+
+    if (pMse->class & (MSE_PS2 | MSE_XPS2)) {
+        /*
+         * If one part of the PS/2 mouse initialization fails
+         * redo complete initialization. There are mice which
+         * have occasional problems with initialization and
+         * are in an unknown state.
+         */
+        if (ps2Init) {
+        REDO:
+            do_ps2Reset(pInfo);
+            if (paramlen > 0) {
+                if (!ps2SendPacket(pInfo,param,paramlen)) {
+                    usleep(30000);
+                    xf86FlushInput(pInfo->fd);
+                    if (!count--)
+                        return TRUE;
+                    goto REDO;
+                }
+                ps2GetDeviceID(pInfo);
+                usleep(30000);
+                xf86FlushInput(pInfo->fd);
+            }
+
+            if (osInfo->SetPS2Res) {
+                osInfo->SetPS2Res(pInfo, pMse->protocol, pMse->sampleRate,
+                                  pMse->resolution);
+            } else {
+                unsigned char c2[2];
+
+                c = 0xE6;       /*230*/ /* 1:1 scaling */
+                if (!ps2SendPacket(pInfo,&c,1)) {
+                    if (!count--)
+                        return TRUE;
+                    goto REDO;
+                }
+                c2[0] = 0xF3; /*243*/ /* set sampling rate */
+                if (pMse->sampleRate > 0) {
+                    if (pMse->sampleRate >= 200)
+                        c2[1] = 200;
+                    else if (pMse->sampleRate >= 100)
+                        c2[1] = 100;
+                    else if (pMse->sampleRate >= 80)
+                        c2[1] = 80;
+                    else if (pMse->sampleRate >= 60)
+                        c2[1] = 60;
+                    else if (pMse->sampleRate >= 40)
+                        c2[1] = 40;
+                    else
+                        c2[1] = 20;
+                } else {
+                    c2[1] = 100;
+                }
+                if (!ps2SendPacket(pInfo,c2,2)) {
+                    if (!count--)
+                        return TRUE;
+                    goto REDO;
+                }
+                c2[0] = 0xE8; /*232*/   /* set device resolution */
+                if (pMse->resolution > 0) {
+                    if (pMse->resolution >= 200)
+                        c2[1] = 3;
+                    else if (pMse->resolution >= 100)
+                        c2[1] = 2;
+                    else if (pMse->resolution >= 50)
+                        c2[1] = 1;
+                    else
+                        c2[1] = 0;
+                } else {
+                    c2[1] = 3; /* used to be 2, W. uses 3 */
+                }
+                if (!ps2SendPacket(pInfo,c2,2)) {
+                    if (!count--)
+                        return TRUE;
+                    goto REDO;
+                }
+                usleep(30000);
+                xf86FlushInput(pInfo->fd);
+                if (!ps2EnableDataReporting(pInfo)) {
+                    xf86Msg(X_INFO, "%s: ps2EnableDataReporting: failed\n",
+                            pInfo->name);
+                    xf86FlushInput(pInfo->fd);
+                    if (!count--)
+                        return TRUE;
+                    goto REDO;
+                } else {
+                    xf86Msg(X_INFO, "%s: ps2EnableDataReporting: succeeded\n",
+                            pInfo->name);
+                }
+            }
+            /*
+             * The PS/2 reset handling needs to be rechecked.
+             * We need to wait until after the 4.3 release.
+             */
+        }
+    } else {
+        if (paramlen > 0) {
+            if (xf86WriteSerial(pInfo->fd, param, paramlen) != paramlen)
+                xf86Msg(X_ERROR, "%s: Mouse initialization failed\n",
+                        pInfo->name);
+            usleep(30000);
+            xf86FlushInput(pInfo->fd);
+        }
+    }
+
+    return TRUE;
+}
+
+#ifdef SUPPORT_MOUSE_RESET
+static Bool
+mouseReset(InputInfoPtr pInfo, unsigned char val)
+{
+    MouseDevPtr pMse = pInfo->private;
+    mousePrivPtr mousepriv = (mousePrivPtr)pMse->mousePriv;
+    CARD32 prevEvent = mousepriv->lastEvent;
+    Bool expectReset = FALSE;
+    Bool ret = FALSE;
+
+    mousepriv->lastEvent = GetTimeInMillis();
+
+#ifdef EXTMOUSEDEBUG
+    LogMessageVerbSigSafe(X_INFO, -1, "byte: 0x%x time: %li\n",val,mousepriv->lastEvent);
+#endif
+    /*
+     * We believe that the following is true:
+     * When the mouse is replugged it will send a reset package
+     * It takes several seconds to replug a mouse: We don't see
+     * events for several seconds before we see the replug event package.
+     * There is no significant delay between consecutive bytes
+     * of a replug event package.
+     * There are no bytes sent after the replug event package until
+     * the mouse is reset.
+     */
+
+    if (mousepriv->current == 0
+        && (mousepriv->lastEvent - prevEvent) < 4000)
+        return FALSE;
+
+    if (mousepriv->current > 0
+        && (mousepriv->lastEvent - prevEvent) >= 1000) {
+        mousepriv->inReset = FALSE;
+        mousepriv->current = 0;
+        return FALSE;
+    }
+
+    if (mousepriv->inReset)
+        mousepriv->inReset = FALSE;
+
+#ifdef EXTMOUSEDEBUG
+    LogMessageVerbSigSafe(X_INFO, -1, "Mouse Current: %i 0x%x\n",mousepriv->current, val);
+#endif
+
+    /* here we put the mouse specific reset detection */
+    /* They need to do three things:                 */
+    /*  Check if byte may be a reset byte            */
+    /*  If so: Set expectReset TRUE                  */
+    /*  If convinced: Set inReset TRUE               */
+    /*                Register BlockAndWakeupHandler */
+
+    /* PS/2 */
+    {
+        unsigned char seq[] = { 0xaa, 0x00 };
+        int len = sizeof(seq);
+
+        if (seq[mousepriv->current] == val)
+            expectReset = TRUE;
+
+        if (len == mousepriv->current + 1) {
+            mousepriv->inReset = TRUE;
+            mousepriv->expires = GetTimeInMillis() + 1000;
+
+#ifdef EXTMOUSEDEBUG
+            LogMessageVerbSigSafe(X_INFO, -1, "Found PS/2 Reset string\n");
+#endif
+            RegisterBlockAndWakeupHandlers (ps2BlockHandler,
+                                            ps2WakeupHandler, (void*) pInfo);
+            ret = TRUE;
+        }
+    }
+
+        if (!expectReset)
+            mousepriv->current = 0;
+        else
+            mousepriv->current++;
+        return ret;
+}
+
+static void
+ps2BlockHandler(void *data, struct timeval **waitTime,
+                void *LastSelectMask)
+{
+    InputInfoPtr    pInfo = (InputInfoPtr) data;
+    MouseDevPtr     pMse = (MouseDevPtr) pInfo->private;
+    mousePrivPtr    mousepriv = (mousePrivPtr)pMse->mousePriv;
+    int             ms;
+
+    if (mousepriv->inReset) {
+        ms = mousepriv->expires - GetTimeInMillis ();
+        if (ms <= 0)
+            ms = 0;
+        AdjustWaitForDelay (waitTime, ms);
+    } else
+        RemoveBlockAndWakeupHandlers (ps2BlockHandler, ps2WakeupHandler,
+                                      (void*) pInfo);
+}
+
+static void
+ps2WakeupHandler(void *data, int i, void *LastSelectMask)
+{
+    InputInfoPtr    pInfo = (InputInfoPtr) data;
+    MouseDevPtr     pMse = (MouseDevPtr) pInfo->private;
+    mousePrivPtr mousepriv = (mousePrivPtr)pMse->mousePriv;
+    int             ms;
+
+    if (mousepriv->inReset) {
+        unsigned char val;
+        int blocked;
+
+        ms = mousepriv->expires - GetTimeInMillis();
+        if (ms > 0)
+            return;
+
+        blocked = xf86BlockSIGIO ();
+
+        xf86MsgVerb(X_INFO,3,
+                    "Got reinsert event: reinitializing PS/2 mouse\n");
+        val = 0xf4;
+        if (xf86WriteSerial(pInfo->fd, &val, 1) != 1)
+            xf86Msg(X_ERROR, "%s: Write to mouse failed\n",
+                    pInfo->name);
+        xf86UnblockSIGIO(blocked);
+    }
+    RemoveBlockAndWakeupHandlers (ps2BlockHandler, ps2WakeupHandler,
+                                  (void*) pInfo);
+}
+#endif /* SUPPORT_MOUSE_RESET */
+
+/************************************************************
+ *
+ * Autoprobe stuff
+ *
+ ************************************************************/
+#ifdef EXTMOUSEDEBUG
+#  define AP_DBG(x) { ErrorF("Autoprobe: "); ErrorF x; }
+#  define AP_DBGC(x) ErrorF x ;
+# else
+#  define AP_DBG(x)
+#  define AP_DBGC(x)
+#endif
+
+static
+MouseProtocolID hardProtocolList[] = {  PROT_MSC, PROT_MM, PROT_LOGI,
+                                        PROT_LOGIMAN, PROT_MMHIT,
+                                        PROT_GLIDE, PROT_IMSERIAL,
+                                        PROT_THINKING, PROT_ACECAD,
+                                        PROT_THINKPS2, PROT_MMPS2,
+                                        PROT_GLIDEPS2,
+                                        PROT_NETSCPS2, PROT_EXPPS2,PROT_IMPS2,
+                                        PROT_GENPS2, PROT_NETPS2,
+                                        PROT_MS,
+                                        PROT_UNKNOWN
+};
+
+static
+MouseProtocolID softProtocolList[] = {  PROT_MSC, PROT_MM, PROT_LOGI,
+                                        PROT_LOGIMAN, PROT_MMHIT,
+                                        PROT_GLIDE, PROT_IMSERIAL,
+                                        PROT_THINKING, PROT_ACECAD,
+                                        PROT_THINKPS2, PROT_MMPS2,
+                                        PROT_GLIDEPS2,
+                                        PROT_NETSCPS2 ,PROT_IMPS2,
+                                        PROT_GENPS2,
+                                        PROT_MS,
+                                        PROT_UNKNOWN
+};
+
+static const char *
+autoOSProtocol(InputInfoPtr pInfo, int *protoPara)
+{
+    MouseDevPtr pMse = pInfo->private;
+    const char *name = NULL;
+    MouseProtocolID protocolID = PROT_UNKNOWN;
+
+    /* Check if the OS has a detection mechanism. */
+    if (osInfo->SetupAuto) {
+        name = osInfo->SetupAuto(pInfo, protoPara);
+        if (name) {
+            protocolID = ProtocolNameToID(name);
+            switch (protocolID) {
+                case PROT_UNKNOWN:
+                    /* Check for a builtin OS-specific protocol. */
+                    if (osInfo->CheckProtocol && osInfo->CheckProtocol(name)) {
+                        /* We can only come here if the protocol has been
+                         * changed to auto through the xf86misc extension
+                         * and we have detected an OS specific builtin
+                         * protocol. Currently we cannot handle this */
+                        name = NULL;
+                    } else
+                        name = NULL;
+                    break;
+                case PROT_UNSUP:
+                    name = NULL;
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+    if (!name) {
+        /* A PnP serial mouse? */
+        protocolID = MouseGetPnpProtocol(pInfo);
+        if (protocolID >= 0 && protocolID < PROT_NUMPROTOS) {
+            name = ProtocolIDToName(protocolID);
+            xf86Msg(X_PROBED, "%s: PnP-detected protocol: \"%s\"\n",
+                    pInfo->name, name);
+        }
+    }
+    if (!name && osInfo->GuessProtocol) {
+        name = osInfo->GuessProtocol(pInfo, 0);
+        if (name)
+            protocolID = ProtocolNameToID(name);
+    }
+
+    if (name) {
+        pMse->protocolID = protocolID;
+    }
+
+    return name;
+}
+
+/*
+ * createProtocolList() -- create a list of protocols which may
+ * match on the incoming data stream.
+ */
+static void
+createProtoList(MouseDevPtr pMse, MouseProtocolID *protoList)
+{
+    int i, j, k  = 0;
+    MouseProtocolID prot;
+    unsigned char *para;
+    mousePrivPtr mPriv = (mousePrivPtr)pMse->mousePriv;
+    MouseProtocolID *tmplist = NULL;
+
+    AP_DBGC(("Autoprobe: "));
+    for (i = 0; i < mPriv->count; i++)
+        AP_DBGC(("%2.2x ", (unsigned char) mPriv->data[i]));
+    AP_DBGC(("\n"));
+
+    if (protoList == NULL) {
+        AP_DBG(("Skipping probe, protoList is NULL"));
+        return;
+    }
+
+    input_lock();
+
+    /* create a private copy first so we can write in the old list */
+    if ((tmplist = malloc(sizeof(MouseProtocolID) * NUM_AUTOPROBE_PROTOS))){
+        for (i = 0; protoList[i] != PROT_UNKNOWN; i++) {
+            tmplist[i] = protoList[i];
+        }
+        tmplist[i] = PROT_UNKNOWN;
+        protoList = tmplist;
+    } else
+        return;
+
+    for (i = 0; ((prot = protoList[i]) != PROT_UNKNOWN
+                 && (k < NUM_AUTOPROBE_PROTOS - 1)) ; i++) {
+        Bool bad = TRUE;
+        unsigned char byte = 0;
+        int count = 0;
+        int next_header_candidate = 0;
+        int header_count = 0;
+
+        if (!GetProtocol(prot))
+            continue;
+        para = proto[prot];
+
+        AP_DBG(("Protocol: %s ", ProtocolIDToName(prot)));
+
+#ifdef EXTMOUSEDEBUG
+        for (j = 0; j < 7; j++)
+            AP_DBGC(("%2.2x ", (unsigned char) para[j]));
+        AP_DBGC(("\n"));
+#endif
+        j = 0;
+        while (1) {
+            /* look for header */
+            while (j < mPriv->count) {
+                if (((byte = mPriv->data[j++]) & para[0]) == para[1]){
+                    AP_DBG(("found header %2.2x\n",byte));
+                    next_header_candidate = j;
+                    count = 1;
+                    break;
+                } else {
+                    /*
+                     * Bail out if number of bytes per package have
+                     * been tested for header.
+                     * Take bytes per package of leading garbage into
+                     * account.
+                     */
+                    if (j > para[4] && ++header_count > para[4]) {
+                        j = mPriv->count;
+                        break;
+                    }
+                }
+            }
+            /* check if remaining data matches protocol */
+            while (j < mPriv->count) {
+                byte = mPriv->data[j++];
+                if (count == para[4]) {
+                    count = 0;
+                    /* check and eat excess byte */
+                    if (((byte & para[0]) != para[1])
+                        && ((byte & para[5]) == para[6])) {
+                        AP_DBG(("excess byte found\n"));
+                        continue;
+                    }
+                }
+                if (count == 0) {
+                    /* validate next header */
+                    bad = FALSE;
+                    AP_DBG(("Complete set found\n"));
+                    if ((byte & para[0]) != para[1]) {
+                        AP_DBG(("Autoprobe: header bad\n"));
+                        bad = TRUE;
+                        break;
+                    } else {
+                        count++;
+                        continue;
+                    }
+                }
+                /* validate data */
+                else if (((byte & para[2]) != para[3])
+                         || ((para[7] & MPF_SAFE)
+                             && ((byte & para[0]) == para[1]))) {
+                    AP_DBG(("data bad\n"));
+                    bad = TRUE;
+                    break;
+                } else {
+                    count ++;
+                    continue;
+                }
+            }
+            if (!bad) {
+                /* this is a matching protocol */
+                mPriv->protoList[k++] = prot;
+                AP_DBG(("Autoprobe: Adding protocol %s to list (entry %i)\n",
+                        ProtocolIDToName(prot),k-1));
+                break;
+            }
+            j = next_header_candidate;
+            next_header_candidate = 0;
+            /* we have tested number of bytes per package for header */
+            if (j > para[4] && ++header_count > para[4])
+                break;
+            /* we have not found anything that looks like a header */
+            if (!next_header_candidate)
+                break;
+            AP_DBG(("Looking for new header\n"));
+        }
+    }
+
+    input_unlock();
+
+    mPriv->protoList[k] = PROT_UNKNOWN;
+
+    free(tmplist);
+}
+
+
+/* This only needs to be done once */
+static void **serialDefaultsList = NULL;
+
+/*
+ * createSerialDefaultsLists() - create a list of the different default
+ * settings for the serial interface of the known protocols.
+ */
+static void
+createSerialDefaultsList(void)
+{
+    int i = 0, j, k;
+
+    serialDefaultsList = (void **)XNFalloc(sizeof(void*));
+    serialDefaultsList[0] = NULL;
+
+    for (j = 0; mouseProtocols[j].name; j++) {
+        if (!mouseProtocols[j].defaults)
+            continue;
+        for (k = 0; k < i; k++)
+            if (mouseProtocols[j].defaults == serialDefaultsList[k])
+                continue;
+        i++;
+        serialDefaultsList = (void**)XNFrealloc(serialDefaultsList,
+                                                sizeof(void*)*(i+1));
+        serialDefaultsList[i-1] = mouseProtocols[j].defaults;
+        serialDefaultsList[i] = NULL;
+    }
+}
+
+typedef enum {
+    STATE_INVALID,
+    STATE_UNCERTAIN,
+    STATE_VALID
+} validState;
+
+/* Probing threshold values */
+#define PROBE_UNCERTAINTY 50
+#define BAD_CERTAINTY 6
+#define BAD_INC_CERTAINTY 1
+#define BAD_INC_CERTAINTY_WHEN_SYNC_LOST 2
+
+static validState
+validCount(mousePrivPtr mPriv, Bool inSync, Bool lostSync)
+{
+    if (inSync) {
+        if (!--mPriv->goodCount) {
+            /* we are sure to have found the correct protocol */
+            mPriv->badCount = 0;
+            return STATE_VALID;
+        }
+        AP_DBG(("%i successful rounds to go\n",
+                mPriv->goodCount));
+        return STATE_UNCERTAIN;
+    }
+
+
+    /* We are out of sync again */
+    mPriv->goodCount = PROBE_UNCERTAINTY;
+    /* We increase uncertainty of having the correct protocol */
+    mPriv->badCount+= lostSync ? BAD_INC_CERTAINTY_WHEN_SYNC_LOST
+        : BAD_INC_CERTAINTY;
+
+    if (mPriv->badCount < BAD_CERTAINTY) {
+        /* We are not convinced yet to have the wrong protocol */
+        AP_DBG(("Changing protocol after: %i rounds\n",
+                BAD_CERTAINTY - mPriv->badCount));
+        return STATE_UNCERTAIN;
+    }
+    return STATE_INVALID;
+}
+
+#define RESET_VALIDATION   do { mPriv->goodCount = PROBE_UNCERTAINTY; \
+                                mPriv->badCount = 0;\
+                                mPriv->prevDx = 0;\
+                                mPriv->prevDy = 0;\
+                                mPriv->accDx = 0;\
+                                mPriv->accDy = 0;\
+                                mPriv->acc = 0; } while (0)
+
+static void
+autoProbeMouse(InputInfoPtr pInfo, Bool inSync, Bool lostSync)
+{
+    MouseDevPtr pMse = pInfo->private;
+    mousePrivPtr mPriv = (mousePrivPtr)pMse->mousePriv;
+
+    MouseProtocolID *protocolList = NULL;
+
+    while (1) {
+        switch (mPriv->autoState) {
+        case AUTOPROBE_GOOD:
+            if (inSync)
+                return;
+            AP_DBG(("State GOOD\n"));
+            RESET_VALIDATION;
+            mPriv->autoState = AUTOPROBE_VALIDATE1;
+            return;
+        case AUTOPROBE_H_GOOD:
+            if (inSync)
+                return;
+            AP_DBG(("State H_GOOD\n"));
+            RESET_VALIDATION;
+            mPriv->autoState = AUTOPROBE_H_VALIDATE2;
+            return;
+        case AUTOPROBE_H_NOPROTO:
+            AP_DBG(("State H_NOPROTO\n"));
+            mPriv->protocolID = 0;
+            mPriv->autoState = AUTOPROBE_H_SETPROTO;
+            break;
+        case AUTOPROBE_H_SETPROTO:
+            AP_DBG(("State H_SETPROTO\n"));
+            if ((pMse->protocolID = hardProtocolList[mPriv->protocolID++])
+                == PROT_UNKNOWN) {
+                mPriv->protocolID = 0;
+                break;
+            } else if (GetProtocol(pMse->protocolID) &&  SetupMouse(pInfo)) {
+                FlushButtons(pMse);
+                RESET_VALIDATION;
+                AP_DBG(("Autoprobe: Trying Protocol: %s\n",
+                        ProtocolIDToName(pMse->protocolID)));
+                mPriv->autoState = AUTOPROBE_H_VALIDATE1;
+                return;
+            }
+            break;
+        case AUTOPROBE_H_VALIDATE1:
+            AP_DBG(("State H_VALIDATE1\n"));
+            switch (validCount(mPriv,inSync,lostSync)) {
+            case STATE_INVALID:
+                mPriv->autoState = AUTOPROBE_H_SETPROTO;
+                break;
+            case STATE_VALID:
+                    xf86Msg(X_INFO,"Mouse autoprobe: selecting %s protocol\n",
+                            ProtocolIDToName(pMse->protocolID));
+                    mPriv->autoState = AUTOPROBE_H_GOOD;
+                    return;
+            case STATE_UNCERTAIN:
+                return;
+            default:
+                break;
+            }
+            break;
+        case AUTOPROBE_H_VALIDATE2:
+            AP_DBG(("State H_VALIDATE2\n"));
+            switch (validCount(mPriv,inSync,lostSync)) {
+            case STATE_INVALID:
+                mPriv->autoState = AUTOPROBE_H_AUTODETECT;
+                break;
+            case STATE_VALID:
+                xf86Msg(X_INFO,"Mouse autoprobe: selecting %s protocol\n",
+                        ProtocolIDToName(pMse->protocolID));
+                mPriv->autoState = AUTOPROBE_H_GOOD;
+                return;
+            case STATE_UNCERTAIN:
+                return;
+            }
+            break;
+        case AUTOPROBE_H_AUTODETECT:
+            AP_DBG(("State H_AUTODETECT\n"));
+            pMse->protocolID = PROT_AUTO;
+            AP_DBG(("Looking for PnP/OS mouse\n"));
+            mPriv->count = 0;
+            SetupMouse(pInfo);
+            if (pMse->protocolID != PROT_AUTO)
+                mPriv->autoState = AUTOPROBE_H_GOOD;
+            else
+                mPriv->autoState = AUTOPROBE_H_NOPROTO;
+            break;
+        case AUTOPROBE_NOPROTO:
+            AP_DBG(("State NOPROTO\n"));
+            mPriv->count = 0;
+            mPriv->serialDefaultsNum = -1;
+            mPriv->autoState = AUTOPROBE_COLLECT;
+            break;
+        case AUTOPROBE_COLLECT:
+            AP_DBG(("State COLLECT\n"));
+            if (mPriv->count <= NUM_MSE_AUTOPROBE_BYTES)
+                return;
+            protocolList = softProtocolList;
+            mPriv->autoState = AUTOPROBE_CREATE_PROTOLIST;
+            break;
+        case AUTOPROBE_CREATE_PROTOLIST:
+            AP_DBG(("State CREATE_PROTOLIST\n"));
+            createProtoList(pMse, protocolList);
+            mPriv->protocolID = 0;
+            mPriv->autoState = AUTOPROBE_SWITCH_PROTOCOL;
+            break;
+        case AUTOPROBE_AUTODETECT:
+            AP_DBG(("State AUTODETECT\n"));
+            pMse->protocolID = PROT_AUTO;
+            AP_DBG(("Looking for PnP/OS mouse\n"));
+            mPriv->count = 0;
+            SetupMouse(pInfo);
+            if (pMse->protocolID != PROT_AUTO)
+                mPriv->autoState = AUTOPROBE_GOOD;
+            else
+                mPriv->autoState = AUTOPROBE_NOPROTO;
+            break;
+        case AUTOPROBE_VALIDATE1:
+            AP_DBG(("State VALIDATE1\n"));
+            switch (validCount(mPriv,inSync,lostSync)) {
+            case STATE_INVALID:
+                mPriv->autoState = AUTOPROBE_AUTODETECT;
+                break;
+            case STATE_VALID:
+                xf86Msg(X_INFO,"Mouse autoprobe: selecting %s protocol\n",
+                        ProtocolIDToName(pMse->protocolID));
+                mPriv->autoState = AUTOPROBE_GOOD;
+                break;
+            case STATE_UNCERTAIN:
+                return;
+            }
+            break;
+        case AUTOPROBE_VALIDATE2:
+            AP_DBG(("State VALIDATE2\n"));
+            switch (validCount(mPriv,inSync,lostSync)) {
+            case STATE_INVALID:
+                protocolList = &mPriv->protoList[mPriv->protocolID];
+                mPriv->autoState = AUTOPROBE_CREATE_PROTOLIST;
+                break;
+            case STATE_VALID:
+                xf86Msg(X_INFO,"Mouse autoprobe: selecting %s protocol\n",
+                        ProtocolIDToName(pMse->protocolID));
+                mPriv->autoState = AUTOPROBE_GOOD;
+                break;
+            case STATE_UNCERTAIN:
+                return;
+            }
+            break;
+        case AUTOPROBE_SWITCHSERIAL:
+        {
+            void *serialDefaults;
+            AP_DBG(("State SWITCHSERIAL\n"));
+
+            if (!serialDefaultsList)
+                createSerialDefaultsList();
+
+            AP_DBG(("Switching serial params\n"));
+            if ((serialDefaults =
+                 serialDefaultsList[++mPriv->serialDefaultsNum]) == NULL) {
+                mPriv->serialDefaultsNum = 0;
+            } else {
+                void *tmp = xf86OptionListCreate(serialDefaults, -1, 0);
+                xf86SetSerial(pInfo->fd, tmp);
+                xf86OptionListFree(tmp);
+                mPriv->count = 0;
+                mPriv->autoState = AUTOPROBE_COLLECT;
+            }
+            break;
+        }
+        case AUTOPROBE_SWITCH_PROTOCOL:
+        {
+            MouseProtocolID prot;
+            MouseProtocolPtr pProto;
+            void *defaults;
+            AP_DBG(("State SWITCH_PROTOCOL\n"));
+            prot = mPriv->protoList[mPriv->protocolID++];
+            if (prot == PROT_UNKNOWN)
+                mPriv->autoState = AUTOPROBE_SWITCHSERIAL;
+            else if (!((pProto = GetProtocol(prot)) &&
+                       ((defaults = pProto->defaults)))
+                       || (mPriv->serialDefaultsNum == -1
+                           && (defaults == msDefaults))
+                       || (mPriv->serialDefaultsNum != -1
+                           && serialDefaultsList[mPriv->serialDefaultsNum]
+                           == defaults)) {
+                AP_DBG(("Changing Protocol to %s\n",
+                        ProtocolIDToName(prot)));
+                SetMouseProto(pMse,prot);
+                FlushButtons(pMse);
+                RESET_VALIDATION;
+                mPriv->autoState = AUTOPROBE_VALIDATE2;
+                return;
+            }
+            break;
+        }
+        }
+    }
+}
+
+static Bool
+autoGood(MouseDevPtr pMse)
+{
+    mousePrivPtr mPriv = (mousePrivPtr)pMse->mousePriv;
+
+    if (!pMse->autoProbe)
+        return TRUE;
+
+    switch (mPriv->autoState) {
+    case AUTOPROBE_GOOD:
+    case AUTOPROBE_H_GOOD:
+        return TRUE;
+    case AUTOPROBE_VALIDATE1: /* @@@ */
+    case AUTOPROBE_H_VALIDATE1: /* @@@ */
+    case AUTOPROBE_VALIDATE2:
+    case AUTOPROBE_H_VALIDATE2:
+        if (mPriv->goodCount < PROBE_UNCERTAINTY/2)
+            return TRUE;
+        _X_FALLTHROUGH; /* FALLTHROUGH */
+    default:
+        return FALSE;
+    }
+}
+
+
+#define TOT_THRESHOLD 3000
+#define VAL_THRESHOLD 40
+
+/*
+ * checkForErraticMovements() -- check if mouse 'jumps around'.
+ */
+static void
+checkForErraticMovements(InputInfoPtr pInfo, int dx, int dy)
+{
+    MouseDevPtr pMse = pInfo->private;
+    mousePrivPtr mPriv = (mousePrivPtr)pMse->mousePriv;
+
+    if (!mPriv->goodCount)
+        return;
+
+#if 0
+    if (abs(dx - mPriv->prevDx) > 300
+        || abs(dy - mPriv->prevDy) > 300)
+        AP_DBG(("erratic1 behaviour\n"));
+#endif
+    if (abs(dx) > VAL_THRESHOLD) {
+        if (sign(dx) == sign(mPriv->prevDx)) {
+            mPriv->accDx += dx;
+            if (abs(mPriv->accDx) > mPriv->acc) {
+                mPriv->acc = abs(mPriv->accDx);
+                AP_DBG(("acc=%i\n",mPriv->acc));
+            }
+            else {
+                AP_DBG(("accDx=%i\n",mPriv->accDx));
+            }
+        } else {
+            mPriv->accDx = 0;
+        }
+    }
+
+    if (abs(dy) > VAL_THRESHOLD) {
+        if (sign(dy) == sign(mPriv->prevDy)) {
+            mPriv->accDy += dy;
+            if (abs(mPriv->accDy) > mPriv->acc) {
+                mPriv->acc = abs(mPriv->accDy);
+                AP_DBG(("acc: %i\n",mPriv->acc));
+            } else {
+                AP_DBG(("accDy=%i\n",mPriv->accDy));
+            }
+        } else {
+            mPriv->accDy = 0;
+        }
+    }
+    mPriv->prevDx = dx;
+    mPriv->prevDy = dy;
+    if (mPriv->acc > TOT_THRESHOLD) {
+        mPriv->goodCount = PROBE_UNCERTAINTY;
+        mPriv->prevDx = 0;
+        mPriv->prevDy = 0;
+        mPriv->accDx = 0;
+        mPriv->accDy = 0;
+        mPriv->acc = 0;
+        AP_DBG(("erratic2 behaviour\n"));
+        autoProbeMouse(pInfo, FALSE,TRUE);
+    }
+}
+
+static void
+SetMouseProto(MouseDevPtr pMse, MouseProtocolID protocolID)
+{
+    pMse->protocolID = protocolID;
+    pMse->protocol = ProtocolIDToName(pMse->protocolID);
+    pMse->class = ProtocolIDToClass(pMse->protocolID);
+    if ((pMse->protocolID >= 0) && (pMse->protocolID < PROT_NUMPROTOS))
+        memcpy(pMse->protoPara, proto[pMse->protocolID],
+               sizeof(pMse->protoPara));
+
+    if (pMse->emulate3ButtonsSoft)
+        pMse->emulate3Buttons = TRUE;
+}
+
+/*
+ * collectData() -- collect data bytes sent by mouse.
+ */
+static Bool
+collectData(MouseDevPtr pMse, unsigned char u)
+{
+    mousePrivPtr mPriv = (mousePrivPtr)pMse->mousePriv;
+    if (mPriv->count < NUM_MSE_AUTOPROBE_TOTAL) {
+        mPriv->data[mPriv->count++] = u;
+        if (mPriv->count <= NUM_MSE_AUTOPROBE_BYTES) {
+                return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+/**************** end of autoprobe stuff *****************/
+
+
+static void xf86MouseUnplug(void *p)
+{
+}
+
+static void *xf86MousePlug(void *module, void *options, int *errmaj, int *errmin)
+{
+    static Bool Initialised = FALSE;
+
+    if (!Initialised)
+        Initialised = TRUE;
+
+    xf86AddInputDriver(&MOUSE, module, 0);
+
+    return module;
+}
+
+static XF86ModuleVersionInfo xf86MouseVersionRec =
+{
+    "mouse",
+    MODULEVENDORSTRING,
+    MODINFOSTRING1,
+    MODINFOSTRING2,
+    XORG_VERSION_CURRENT,
+    PACKAGE_VERSION_MAJOR, PACKAGE_VERSION_MINOR, PACKAGE_VERSION_PATCHLEVEL,
+    ABI_CLASS_XINPUT,
+    ABI_XINPUT_VERSION,
+    MOD_CLASS_XINPUT,
+    {0, 0, 0, 0}                /* signature, to be patched into the file by */
+                                /* a tool */
+};
+
+_X_EXPORT XF86ModuleData mouseModuleData = {
+    &xf86MouseVersionRec,
+    xf86MousePlug,
+    xf86MouseUnplug
+};
+
+/*
+  Look at hitachi device stuff.
+*/

--- a/hw/xfree86/drivers/input/mouse/src/mouse.h
+++ b/hw/xfree86/drivers/input/mouse/src/mouse.h
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 1999-2003 by The XFree86 Project, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of the copyright holder(s)
+ * and author(s) shall not be used in advertising or otherwise to promote
+ * the sale, use or other dealings in this Software without prior written
+ * authorization from the copyright holder(s) and author(s).
+ */
+
+/* Public interface to OS-specific mouse support. */
+
+#ifndef _XF86OSMOUSE_H_
+#define _XF86OSMOUSE_H_
+
+#include <X11/Xfuncproto.h>
+
+#ifndef _X_FALLTHROUGH /* xproto < 7.0.34 */
+# if  __has_attribute(fallthrough)
+#  define _X_FALLTHROUGH __attribute__((fallthrough))
+# else
+#  define _X_FALLTHROUGH (void)0
+# endif
+#endif
+
+#include "xf86Xinput.h"
+
+/* Mouse interface classes */
+#define MSE_NONE        0x00
+#define MSE_SERIAL      0x01            /* serial port */
+#define MSE_BUS         0x02            /* old bus mouse */
+#define MSE_PS2         0x04            /* standard read-only PS/2 */
+#define MSE_XPS2        0x08            /* extended PS/2 */
+#define MSE_AUTO        0x10            /* auto-detect (PnP) */
+#define MSE_MISC        0x20            /* The OS layer will identify the
+                                         * specific protocol names that are
+                                         * supported for this class. */
+
+/* Mouse Protocol IDs. */
+typedef enum {
+    PROT_UNKNOWN = -2,
+    PROT_UNSUP = -1,            /* protocol is not supported */
+    PROT_MS = 0,
+    PROT_MSC,
+    PROT_MM,
+    PROT_LOGI,
+    PROT_LOGIMAN,
+    PROT_MMHIT,
+    PROT_GLIDE,
+    PROT_IMSERIAL,
+    PROT_THINKING,
+    PROT_ACECAD,
+    PROT_VALUMOUSESCROLL,
+    PROT_PS2,
+    PROT_GENPS2,
+    PROT_IMPS2,
+    PROT_EXPPS2,
+    PROT_THINKPS2,
+    PROT_MMPS2,
+    PROT_GLIDEPS2,
+    PROT_NETPS2,
+    PROT_NETSCPS2,
+    PROT_BM,
+    PROT_AUTO,
+    PROT_SYSMOUSE,
+    PROT_WSMOUSE,
+    PROT_VUID,
+    PROT_NUMPROTOS      /* This must always be last. */
+} MouseProtocolID;
+
+struct _MouseDevRec;
+
+typedef int (*GetInterfaceTypesProc)(void);
+typedef const char **(*BuiltinNamesProc)(void);
+typedef Bool (*CheckProtocolProc)(const char *protocol);
+typedef Bool (*BuiltinPreInitProc)(InputInfoPtr pInfo, const char *protocol,
+                                   int flags);
+typedef const char *(*DefaultProtocolProc)(void);
+typedef const char *(*SetupAutoProc)(InputInfoPtr pInfo, int *protoPara);
+typedef void (*SetResProc)(InputInfoPtr pInfo, const char* protocol, int rate,
+                           int res);
+typedef const char *(*FindDeviceProc)(InputInfoPtr pInfo, const char *protocol,
+                                      int flags);
+typedef const char *(*GuessProtocolProc)(InputInfoPtr pInfo, int flags);
+
+/*
+ * OSMouseInfoRec is used to pass information from the OSMouse layer to the
+ * OS-independent mouse driver.
+ */
+typedef struct {
+        GetInterfaceTypesProc   SupportedInterfaces;
+        BuiltinNamesProc        BuiltinNames;
+        CheckProtocolProc       CheckProtocol;
+        BuiltinPreInitProc      PreInit;
+        DefaultProtocolProc     DefaultProtocol;
+        SetupAutoProc           SetupAuto;
+        SetResProc              SetPS2Res;
+        SetResProc              SetBMRes;
+        SetResProc              SetMiscRes;
+        FindDeviceProc          FindDevice;
+        GuessProtocolProc       GuessProtocol;
+} OSMouseInfoRec, *OSMouseInfoPtr;
+
+/*
+ * SupportedInterfaces: Returns the mouse interface types that the OS support.
+ *              If MSE_MISC is returned, then the BuiltinNames and
+ *              CheckProtocol should be set.
+ *
+ * BuiltinNames: Returns the names of the protocols that are fully handled
+ *              in the OS-specific code.  These are names that don't appear
+ *              directly in the main "mouse" driver.
+ *
+ * CheckProtocol: Checks if the protocol name given is supported by the
+ *              OS.  It should return TRUE for both "builtin" protocols and
+ *              protocols of type MSE_MISC that are supported by the OS.
+ *
+ * PreInit:     The PreInit function for protocols that are builtin.  This
+ *              function is passed the protocol name.
+ *
+ * DefaultProtocol: Returns the name of a default protocol that should be used
+ *              for the OS when none has been supplied in the config file.
+ *              This should only be set when there is a reasonable default.
+ *
+ * SetupAuto:   This function can be used to do OS-specific protocol
+ *              auto-detection.  It returns the name of the detected protocol,
+ *              or NULL when detection fails.  It may also adjust one or more
+ *              of the "protoPara" values for the detected protocol by setting
+ *              then to something other than -1.  SetupAuto gets called in two
+ *              ways.  The first is before any devices have been opened.  This
+ *              can be used when the protocol "Auto" always maps to a single
+ *              protocol type.  The second is with the device open, allowing
+ *              OS-specific probing to be done.
+ *
+ * SetPS2Res:   Set the resolution and sample rate for MSE_PS2 and MSE_XPS2
+ *              protocol types.
+ *
+ * SetBMRes:    Set the resolution and sample rate for MSE_BM protocol types.
+ *
+ * SetMiscRes:  Set the resolution and sample rate for MSE_MISC protocol types.
+ *
+ * FindDevice:  This function gets called when no Device has been specified
+ *              in the config file.  OS-specific methods may be used to guess
+ *              which input device to use.  This function is called after the
+ *              pre-open attempts at protocol discovery are done, but before
+ *              the device is open.  I.e., after the first SetupAuto() call,
+ *              after the DefaultProtocol() call, but before the PreInit()
+ *              call.  Available protocol information may be used in locating
+ *              the default input device.
+ *
+ * GuessProtocol: A last resort attempt at guessing the mouse protocol by
+ *              whatever OS-specific means might be available.  OS-independent
+ *              things should be in the mouse driver.  This function gets
+ *              called after the mouse driver's OS-independent methods have
+ *              failed.
+ */
+
+extern OSMouseInfoPtr OSMouseInit(int flags);
+
+/* Z axis mapping */
+#define MSE_NOZMAP      0
+#define MSE_MAPTOX      -1
+#define MSE_MAPTOY      -2
+#define MSE_MAPTOZ      -3
+#define MSE_MAPTOW      -4
+
+/* Generalize for other axes. */
+#define MSE_NOAXISMAP   MSE_NOZMAP
+
+#define MSE_MAXBUTTONS  24
+#define MSE_DFLTBUTTONS  3
+
+/*
+ * Mouse device record.  This is shared by the mouse driver and the OSMouse
+ * layer.
+ */
+
+typedef void (*checkMovementsProc)(InputInfoPtr,int, int);
+typedef void (*autoProbeProc)(InputInfoPtr, Bool, Bool);
+typedef Bool (*collectDataProc)(struct _MouseDevRec *, unsigned char);
+typedef Bool (*dataGoodProc)(struct _MouseDevRec *);
+
+typedef void (*PostMseEventProc)(InputInfoPtr pInfo, int buttons,
+                              int dx, int dy, int dz, int dw);
+typedef void (*MouseCommonOptProc)(InputInfoPtr pInfo);
+
+typedef struct _MouseDevRec {
+    PtrCtrlProcPtr      Ctrl;
+    PostMseEventProc    PostEvent;
+    MouseCommonOptProc  CommonOptions;
+    DeviceIntPtr        device;
+    const char *        protocol;
+    MouseProtocolID     protocolID;
+    MouseProtocolID     oldProtocolID; /* hack */
+    int                 class;
+    int                 mseModel;
+    int                 baudRate;
+    int                 oldBaudRate;
+    int                 sampleRate;
+    int                 lastButtons;
+    int                 buttons;        /* # of buttons */
+    int                 emulateState;   /* automata state for 2 button mode */
+    Bool                emulate3Buttons;
+    Bool                emulate3ButtonsSoft;
+    int                 emulate3Timeout;/* Timeout for 3 button emulation */
+    Bool                chordMiddle;
+    Bool                flipXY;
+    int                 invX;
+    int                 invY;
+    int                 resolution;
+    int                 negativeZ;      /* button mask */
+    int                 positiveZ;      /* button mask */
+    int                 negativeW;      /* button mask */
+    int                 positiveW;      /* button mask */
+    void               *buffer;         /* usually an XISBuffer* */
+    int                 protoBufTail;
+    unsigned char       protoBuf[8];
+    unsigned char       protoPara[8];
+    unsigned char       inSync;         /* driver in sync with datastream */
+    void               *mousePriv;      /* private area */
+    InputInfoPtr        pInfo;
+    Bool                emulate3Pending;/* timer waiting */
+    CARD32              emulate3Expires;/* time to fire emulation code */
+    Bool                emulateWheel;
+    int                 wheelInertia;
+    int                 wheelButton;
+    int                 negativeX;      /* Button values.  Unlike the Z and */
+    int                 positiveX;      /* W equivalents, these are button  */
+    int                 negativeY;      /* values rather than button masks. */
+    int                 positiveY;
+    int                 wheelYDistance;
+    int                 wheelXDistance;
+    Bool                autoProbe;
+    checkMovementsProc  checkMovements;
+    autoProbeProc       autoProbeMouse;
+    collectDataProc     collectData;
+    dataGoodProc        dataGood;
+    int                 angleOffset;
+    void               *pDragLock;      /* drag lock area */
+    int                 xisbscale;      /* buffer size for 1 event */
+    int                 wheelButtonTimeout;/* Timeout for the wheel button emulation */
+    CARD32              wheelButtonExpires;
+    int                 doubleClickSourceButtonMask;
+    int                 doubleClickTargetButton;
+    int                 doubleClickTargetButtonMask;
+    int                 doubleClickOldSourceState;
+    int                 lastMappedButtons;
+    int                 buttonMap[MSE_MAXBUTTONS];
+} MouseDevRec, *MouseDevPtr;
+
+#endif /* _XF86OSMOUSE_H_ */

--- a/hw/xfree86/drivers/input/mouse/src/mousePriv.h
+++ b/hw/xfree86/drivers/input/mouse/src/mousePriv.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 1997-1999 by The XFree86 Project, Inc.
+ */
+
+#ifndef _X_MOUSEPRIV_H
+#define _X_MOUSEPRIV_H
+
+#if 0
+# define MOUSEINITDEBUG
+# define MOUSEDATADEBUG
+#endif
+
+#include "mouse.h"
+#include "xf86Xinput.h"
+/* Private interface for the mouse driver. */
+
+typedef enum  {
+    AUTOPROBE_H_NOPROTO,
+    AUTOPROBE_H_GOOD,
+    AUTOPROBE_H_AUTODETECT,
+    AUTOPROBE_H_VALIDATE1,
+    AUTOPROBE_H_VALIDATE2,
+    AUTOPROBE_H_SETPROTO,
+    AUTOPROBE_NOPROTO,
+    AUTOPROBE_COLLECT,
+    AUTOPROBE_CREATE_PROTOLIST,
+    AUTOPROBE_GOOD,
+    AUTOPROBE_AUTODETECT,
+    AUTOPROBE_VALIDATE1,
+    AUTOPROBE_VALIDATE2,
+    AUTOPROBE_SWITCHSERIAL,
+    AUTOPROBE_SWITCH_PROTOCOL
+} mseAutoProbeStates;
+
+typedef struct {
+    const char *        name;
+    int                 class;
+    const char **       defaults;
+    MouseProtocolID     id;
+} MouseProtocolRec, *MouseProtocolPtr;
+
+#define NUM_MSE_AUTOPROBE_BYTES 24  /* multiple of 3,4 and 6 byte packages */
+#define NUM_MSE_AUTOPROBE_TOTAL 64
+#define NUM_AUTOPROBE_PROTOS 17
+
+
+typedef struct {
+    int         current;
+    Bool        inReset;
+    CARD32      lastEvent;
+    CARD32      expires;
+    Bool        soft;
+    int         goodCount;
+    int         badCount;
+    int         protocolID;
+    int         count;
+    char        data[NUM_MSE_AUTOPROBE_TOTAL];
+    mseAutoProbeStates autoState;
+    MouseProtocolID protoList[NUM_AUTOPROBE_PROTOS];
+    int         serialDefaultsNum;
+    int         prevDx, prevDy;
+    int         accDx, accDy;
+    int         acc;
+    CARD32      pnpLast;
+    Bool        disablePnPauto;
+    float       fracdx,fracdy;
+    float       sensitivity;
+} mousePrivRec, *mousePrivPtr;
+
+/* mouse proto flags */
+#define MPF_NONE                0x00
+#define MPF_SAFE                0x01
+
+/* pnp.c */
+MouseProtocolID MouseGetPnpProtocol(InputInfoPtr pInfo);
+Bool ps2Reset(InputInfoPtr pInfo);
+Bool ps2EnableDataReporting(InputInfoPtr pInfo);
+Bool ps2SendPacket(InputInfoPtr pInfo, unsigned char *bytes, int len);
+int ps2GetDeviceID(InputInfoPtr pInfo);
+
+#endif /* _X_MOUSE_H */

--- a/hw/xfree86/drivers/input/mouse/src/pnp.c
+++ b/hw/xfree86/drivers/input/mouse/src/pnp.c
@@ -1,0 +1,784 @@
+/*
+ * Copyright 1998 by Kazutaka YOKOTA <yokota@zodiac.mech.utsunomiya-u.ac.jp>
+ *
+ * Permission to use, copy, modify, distribute, and sell this software and its
+ * documentation for any purpose is hereby granted without fee, provided that
+ * the above copyright notice appear in all copies and that both that
+ * copyright notice and this permission notice appear in supporting
+ * documentation, and that the name of Kazutaka YOKOTA not be used in
+ * advertising or publicity pertaining to distribution of the software without
+ * specific, written prior permission.  Kazutaka YOKOTA makes no representations
+ * about the suitability of this software for any purpose.  It is provided
+ * "as is" without express or implied warranty.
+ *
+ * KAZUTAKA YOKOTA DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+ * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+ * EVENT SHALL KAZUTAKA YOKOTA BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+ * DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+ * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <xorg-server.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <X11/X.h>
+#include <X11/Xproto.h>
+#include "inputstr.h"
+#include "scrnintstr.h"
+#include "xf86.h"
+#include "xf86Priv.h"
+#include "xf86Xinput.h"
+#include "xf86_OSproc.h"
+#include "mouse.h"
+#include "mousePriv.h"
+
+#ifdef MOUSEINITDEBUG
+# define DEBUG
+# define EXTMOUSEDEBUG
+#endif
+
+/* serial PnP ID string */
+typedef struct {
+    int revision;       /* PnP revision, 100 for 1.00 */
+    char *eisaid;       /* EISA ID including mfr ID and product ID */
+    char *serial;       /* serial No, optional */
+    char *class;        /* device class, optional */
+    char *compat;       /* list of compatible drivers, optional */
+    char *description;  /* product description, optional */
+    int neisaid;        /* length of the above fields... */
+    int nserial;
+    int nclass;
+    int ncompat;
+    int ndescription;
+} pnpid_t;
+
+/* symbol table entry */
+typedef struct {
+    const char *name;
+    MouseProtocolID val;
+} symtab_t;
+
+/* PnP EISA/product IDs */
+static symtab_t pnpprod[] = {
+    { "KML0001",  PROT_THINKING },      /* Kensington ThinkingMouse */
+    { "MSH0001",  PROT_IMSERIAL },      /* MS IntelliMouse */
+    { "MSH0004",  PROT_IMSERIAL },      /* MS IntelliMouse TrackBall */
+    { "KYEEZ00",  PROT_MS },            /* Genius EZScroll */
+    { "KYE0001",  PROT_MS },            /* Genius PnP Mouse */
+    { "KYE0002",  PROT_MS },            /* MouseSystem (Genius?) SmartScroll */
+    { "KYE0003",  PROT_IMSERIAL },      /* Genius NetMouse */
+    { "KYE0004",  PROT_IMSERIAL },      /* Genius NetScroll+ (serial) */
+    { "LGI800C",  PROT_IMSERIAL },      /* Logitech MouseMan (4 button model) */
+    { "LGI8033",  PROT_IMSERIAL },      /* Logitech Cordless MouseMan Wheel */
+    { "LGI8050",  PROT_IMSERIAL },      /* Logitech MouseMan+ */
+    { "LGI8051",  PROT_IMSERIAL },      /* Logitech FirstMouse+ */
+    { "LGI8001",  PROT_LOGIMAN },       /* Logitech serial */
+    { "A4W0005",  PROT_IMSERIAL },      /* A4 Tech 4D/4D+ Mouse */
+    { "PEC9802",  PROT_IMSERIAL },      /* 8D Scroll Mouse */
+
+    { "PNP0F00",  PROT_BM },            /* MS bus */
+    { "PNP0F01",  PROT_MS },            /* MS serial */
+    { "PNP0F02",  PROT_BM },            /* MS InPort */
+    { "PNP0F03",  PROT_PS2 },           /* MS PS/2 */
+    /*
+     * EzScroll returns PNP0F04 in the compatible device field; but it
+     * doesn't look compatible... XXX
+     */
+    { "PNP0F04",  PROT_MSC },           /* MouseSystems */
+    { "PNP0F05",  PROT_MSC },           /* MouseSystems */
+#ifdef notyet
+    { "PNP0F06",  PROT_??? },           /* Genius Mouse */
+    { "PNP0F07",  PROT_??? },           /* Genius Mouse */
+#endif
+    { "PNP0F08",  PROT_LOGIMAN },       /* Logitech serial */
+    { "PNP0F09",  PROT_MS },            /* MS BallPoint serial */
+    { "PNP0F0A",  PROT_MS },            /* MS PnP serial */
+    { "PNP0F0B",  PROT_MS },            /* MS PnP BallPoint serial */
+    { "PNP0F0C",  PROT_MS },            /* MS serial compatible */
+    { "PNP0F0D",  PROT_BM },            /* MS InPort compatible */
+    { "PNP0F0E",  PROT_PS2 },           /* MS PS/2 compatible */
+    { "PNP0F0F",  PROT_MS },            /* MS BallPoint compatible */
+#ifdef notyet
+    { "PNP0F10",  PROT_??? },           /* TI QuickPort */
+#endif
+    { "PNP0F11",  PROT_BM },            /* MS bus compatible */
+    { "PNP0F12",  PROT_PS2 },           /* Logitech PS/2 */
+    { "PNP0F13",  PROT_PS2 },           /* PS/2 */
+#ifdef notyet
+    { "PNP0F14",  PROT_??? },           /* MS Kids Mouse */
+#endif
+    { "PNP0F15",  PROT_BM },            /* Logitech bus */
+#ifdef notyet
+    { "PNP0F16",  PROT_??? },           /* Logitech SWIFT */
+#endif
+    { "PNP0F17",  PROT_LOGIMAN },       /* Logitech serial compat */
+    { "PNP0F18",  PROT_BM },            /* Logitech bus compatible */
+    { "PNP0F19",  PROT_PS2 },           /* Logitech PS/2 compatible */
+#ifdef notyet
+    { "PNP0F1A",  PROT_??? },           /* Logitech SWIFT compatible */
+    { "PNP0F1B",  PROT_??? },           /* HP Omnibook */
+    { "PNP0F1C",  PROT_??? },           /* Compaq LTE TrackBall PS/2 */
+    { "PNP0F1D",  PROT_??? },           /* Compaq LTE TrackBall serial */
+    { "PNP0F1E",  PROT_??? },           /* MS Kids Trackball */
+#endif
+    { NULL,       PROT_UNKNOWN },
+};
+
+static const char *pnpSerial[] = {
+        "BaudRate",     "1200",
+        "DataBits",     "7",
+        "StopBits",     "1",
+        "Parity",       "None",
+        "FlowControl",  "None",
+        "VTime",        "0",
+        "VMin",         "1",
+        NULL
+};
+
+static int pnpgets(InputInfoPtr, char *, Bool *prePNP);
+static int pnpparse(InputInfoPtr, pnpid_t *, char *, int);
+static MouseProtocolID prepnpparse(InputInfoPtr pInfo, char *buf);
+static symtab_t *pnpproto(pnpid_t *);
+static symtab_t *gettoken(symtab_t *, char *, int);
+static MouseProtocolID getPs2ProtocolPnP(InputInfoPtr pInfo);
+static MouseProtocolID probePs2ProtocolPnP(InputInfoPtr pInfo);
+
+static MouseProtocolID
+MouseGetSerialPnpProtocol(InputInfoPtr pInfo)
+{
+    char buf[256];      /* PnP ID string may be up to 256 bytes long */
+    pnpid_t pnpid;
+    symtab_t *t;
+    int len;
+    Bool prePNP;
+
+    if ((len = pnpgets(pInfo, buf, &prePNP)) > 0)
+    {
+        if (!prePNP) {
+            if (pnpparse(pInfo, &pnpid, buf, len) &&
+                (t = pnpproto(&pnpid)) != NULL) {
+                xf86MsgVerb(X_INFO, 2, "%s: PnP-detected protocol ID: %d\n",
+                            pInfo->name, t->val);
+                return (t->val);
+            }
+        } else
+            return prepnpparse(pInfo,buf);
+    }
+    return PROT_UNKNOWN;
+}
+
+MouseProtocolID
+MouseGetPnpProtocol(InputInfoPtr pInfo)
+{
+    MouseDevPtr  pMse = pInfo->private;
+    mousePrivPtr mPriv = (mousePrivPtr)pMse->mousePriv;
+    MouseProtocolID val;
+    CARD32 last;
+
+    if ((val = MouseGetSerialPnpProtocol(pInfo)) != PROT_UNKNOWN) {
+        if (val == MouseGetSerialPnpProtocol(pInfo))
+            return val;
+    }
+
+    last = mPriv->pnpLast;
+    mPriv->pnpLast = currentTime.milliseconds;
+
+    if (last) {
+        if (last - currentTime.milliseconds < 100
+            || (mPriv->disablePnPauto
+                && (last - currentTime.milliseconds < 10000))) {
+#ifdef EXTMOUSEDEBUG
+            xf86ErrorF("Mouse: Disabling PnP\n");
+#endif
+            mPriv->disablePnPauto = TRUE;
+            return PROT_UNKNOWN;
+        }
+    }
+
+#ifdef EXTMOUSEDEBUG
+    if (mPriv->disablePnPauto)
+        xf86ErrorF("Mouse: Enabling PnP\n");
+#endif
+    mPriv->disablePnPauto = FALSE;
+
+    if (mPriv->soft)
+        return getPs2ProtocolPnP(pInfo);
+    else
+        return probePs2ProtocolPnP(pInfo);
+}
+
+/*
+ * Try to elicit a PnP ID as described in
+ * Microsoft, Hayes: "Plug and Play External COM Device Specification,
+ * rev 1.00", 1995.
+ *
+ * The routine does not fully implement the COM Enumerator as per Section
+ * 2.1 of the document.  In particular, we don't have idle state in which
+ * the driver software monitors the com port for dynamic connection or
+ * removal of a device at the port, because `moused' simply quits if no
+ * device is found.
+ *
+ * In addition, as PnP COM device enumeration procedure slightly has
+ * changed since its first publication, devices which follow earlier
+ * revisions of the above spec. may fail to respond if the rev 1.0
+ * procedure is used. XXX
+ */
+static int
+pnpgets(InputInfoPtr pInfo, char *buf, Bool *prePNP)
+{
+    int i;
+    char c;
+    void *pnpOpts;
+
+#if 0
+    /*
+     * This is the procedure described in rev 1.0 of PnP COM device spec.
+     * Unfortunately, some devices which conform to earlier revisions of
+     * the spec gets confused and do not return the ID string...
+     */
+
+    /* port initialization (2.1.2) */
+    if ((i = xf86GetSerialModemState(pInfo->fd)) == -1)
+        return 0;
+    i |= XF86_M_DTR;            /* DTR = 1 */
+    i &= ~XF86_M_RTS;           /* RTS = 0 */
+    if (xf86SetSerialModemState(pInfo->fd, i) == -1)
+        goto disconnect_idle;
+    usleep(200000);
+    if ((i = xf86GetSerialModemState(pInfo->fd)) == -1 ||
+        (i & XF86_M_DSR) == 0)
+        goto disconnect_idle;
+
+    /* port setup, 1st phase (2.1.3) */
+    pnpOpts = xf86OptionListCreate(pnpSerial, -1, 1);
+    xf86SetSerial(pInfo->fd, pnpOpts);
+    i = TIOCM_DTR | TIOCM_RTS;  /* DTR = 0, RTS = 0 */
+    xf86SerialModemClearBits(pInfo->fd, i);
+    usleep(200000);
+    i = TIOCM_DTR;              /* DTR = 1, RTS = 0 */
+    xf86SerialModemSetBits(pInfo->fd, i);
+    usleep(200000);
+
+    /* wait for response, 1st phase (2.1.4) */
+    xf86FlushInput(pInfo->fd);
+    i = TIOCM_RTS;              /* DTR = 1, RTS = 1 */
+    xf86SerialModemSetBits(pInfo->fd, i);
+
+    /* try to read something */
+    if (xf86WaitForInput(pInfo->fd, 200000) <= 0) {
+
+        /* port setup, 2nd phase (2.1.5) */
+        i = TIOCM_DTR | TIOCM_RTS;      /* DTR = 0, RTS = 0 */
+        xf86SerialModemClearBits(pInfo->fd, i);
+        usleep(200000);
+
+        /* wait for response, 2nd phase (2.1.6) */
+        xf86FlushInput(pInfo->fd);
+        i = TIOCM_DTR | TIOCM_RTS;      /* DTR = 1, RTS = 1 */
+        xf86SerialModemSetBits(pInfo->fd, i);
+
+        /* try to read something */
+        if (xf86WaitForInput(pInfo->fd, 200000) <= 0)
+            goto connect_idle;
+    }
+#else
+    /*
+     * This is a simplified procedure; it simply toggles RTS.
+     */
+
+    if ((i = xf86GetSerialModemState(pInfo->fd)) == -1)
+        return 0;
+    i |= XF86_M_DTR;            /* DTR = 1 */
+    i &= ~XF86_M_RTS;           /* RTS = 0 */
+    if (xf86SetSerialModemState(pInfo->fd, i) == -1)
+        goto disconnect_idle;
+    usleep(200000);
+
+    pnpOpts = xf86OptionListCreate(pnpSerial, -1, 1);
+    xf86SetSerial(pInfo->fd, pnpOpts);
+
+    /* wait for response */
+    xf86FlushInput(pInfo->fd);
+    i = XF86_M_DTR | XF86_M_RTS;        /* DTR = 1, RTS = 1 */
+    xf86SerialModemSetBits(pInfo->fd, i);
+
+    /* try to read something */
+    if (xf86WaitForInput(pInfo->fd, 200000) <= 0)
+        goto connect_idle;
+#endif
+
+    /* collect PnP COM device ID (2.1.7) */
+    i = 0;
+    *prePNP = FALSE;
+
+    usleep(200000);     /* the mouse must send `Begin ID' within 200msec */
+    while (xf86ReadSerial(pInfo->fd, &c, 1) == 1) {
+        /* we may see "M", or "M3..." before `Begin ID' */
+        if (c == 'M')
+            *prePNP = TRUE;
+
+        if ((c == 0x08) || (c == 0x28)) {       /* Begin ID */
+            *prePNP = FALSE;
+            buf[0] = c;
+            i = 1;
+            break;
+        }
+        if (*prePNP)
+            buf[i++] = c;
+
+        if (xf86WaitForInput(pInfo->fd, 200000) <= 0)
+            break;
+    }
+    if (i <= 0) {
+        /* we haven't seen `Begin ID' in time... */
+        goto connect_idle;
+    }
+    if (*prePNP)
+        return i;
+
+    ++c;                        /* make it `End ID' */
+    for (;;) {
+        if (xf86WaitForInput(pInfo->fd, 200000) <= 0)
+            break;
+
+        xf86ReadSerial(pInfo->fd, &buf[i], 1);
+        if (buf[i++] == c)      /* End ID */
+            break;
+        if (i >= 256)
+            break;
+    }
+    if (buf[i - 1] != c)
+        goto connect_idle;
+    return i;
+
+    /*
+     * According to PnP spec, we should set DTR = 1 and RTS = 0 while
+     * in idle state.  But, `moused' shall set DTR = RTS = 1 and proceed,
+     * assuming there is something at the port even if it didn't
+     * respond to the PnP enumeration procedure.
+     */
+disconnect_idle:
+    i = XF86_M_DTR | XF86_M_RTS;                /* DTR = 1, RTS = 1 */
+    xf86SerialModemSetBits(pInfo->fd, i);
+connect_idle:
+    return 0;
+}
+
+static int
+pnpparse(InputInfoPtr pInfo, pnpid_t *id, char *buf, int len)
+{
+    char s[3];
+    int offset;
+    int sum = 0;
+    int i, j;
+
+    id->revision = 0;
+    id->eisaid = NULL;
+    id->serial = NULL;
+    id->class = NULL;
+    id->compat = NULL;
+    id->description = NULL;
+    id->neisaid = 0;
+    id->nserial = 0;
+    id->nclass = 0;
+    id->ncompat = 0;
+    id->ndescription = 0;
+
+    offset = 0x28 - buf[0];
+
+    /* calculate checksum */
+    for (i = 0; i < len - 3; ++i) {
+        sum += buf[i];
+        buf[i] += offset;
+    }
+    sum += buf[len - 1];
+    for (; i < len; ++i)
+        buf[i] += offset;
+    xf86MsgVerb(X_INFO, 2, "%s: PnP ID string: `%*.*s'\n", pInfo->name,
+                len, len, buf);
+
+    /* revision */
+    buf[1] -= offset;
+    buf[2] -= offset;
+    id->revision = ((buf[1] & 0x3f) << 6) | (buf[2] & 0x3f);
+    xf86MsgVerb(X_INFO, 2, "%s: PnP rev %d.%02d\n", pInfo->name,
+                id->revision / 100, id->revision % 100);
+
+    /* EISA vendor and product ID */
+    id->eisaid = &buf[3];
+    id->neisaid = 7;
+
+    /* option strings */
+    i = 10;
+    if (buf[i] == '\\') {
+        /* device serial # */
+        for (j = ++i; i < len; ++i) {
+            if (buf[i] == '\\')
+                break;
+        }
+        if (i >= len)
+            i -= 3;
+        if (i - j == 8) {
+            id->serial = &buf[j];
+            id->nserial = 8;
+        }
+    }
+    if (buf[i] == '\\') {
+        /* PnP class */
+        for (j = ++i; i < len; ++i) {
+            if (buf[i] == '\\')
+                break;
+        }
+        if (i >= len)
+            i -= 3;
+        if (i > j + 1) {
+            id->class = &buf[j];
+            id->nclass = i - j;
+        }
+    }
+    if (buf[i] == '\\') {
+        /* compatible driver */
+        for (j = ++i; i < len; ++i) {
+            if (buf[i] == '\\')
+                break;
+        }
+        /*
+         * PnP COM spec prior to v0.96 allowed '*' in this field,
+         * it's not allowed now; just ignore it.
+         */
+        if (buf[j] == '*')
+            ++j;
+        if (i >= len)
+            i -= 3;
+        if (i > j + 1) {
+            id->compat = &buf[j];
+            id->ncompat = i - j;
+        }
+    }
+    if (buf[i] == '\\') {
+        /* product description */
+        for (j = ++i; i < len; ++i) {
+            if (buf[i] == ';')
+                break;
+        }
+        if (i >= len)
+            i -= 3;
+        if (i > j + 1) {
+            id->description = &buf[j];
+            id->ndescription = i - j;
+        }
+    }
+
+    /* checksum exists if there are any optional fields */
+    if ((id->nserial > 0) || (id->nclass > 0)
+        || (id->ncompat > 0) || (id->ndescription > 0)) {
+        xf86MsgVerb(X_INFO, 4, "%s: PnP checksum: 0x%02X\n", pInfo->name, sum);
+        sprintf(s, "%02X", sum & 0x0ff);
+        if (strncmp(s, &buf[len - 3], 2) != 0) {
+#if 0
+            /*
+             * Checksum error!!
+             * I found some mice do not comply with the PnP COM device
+             * spec regarding checksum... XXX
+             */
+            return FALSE;
+#endif
+        }
+    }
+
+    return TRUE;
+}
+
+/* We can only identify MS at the moment */
+static MouseProtocolID
+prepnpparse(InputInfoPtr pInfo, char *buf)
+{
+    if (buf[0] == 'M' && buf[1] == '3')
+        return PROT_MS;
+    return PROT_UNKNOWN;
+}
+
+
+static symtab_t *
+pnpproto(pnpid_t *id)
+{
+    symtab_t *t;
+    int i, j;
+
+    if (id->nclass > 0)
+        if (strncmp(id->class, "MOUSE", id->nclass) != 0)
+            /* this is not a mouse! */
+            return NULL;
+
+    if (id->neisaid > 0) {
+        t = gettoken(pnpprod, id->eisaid, id->neisaid);
+        if (t->val != -1)
+            return t;
+    }
+
+    /*
+     * The 'Compatible drivers' field may contain more than one
+     * ID separated by ','.
+     */
+    if (id->ncompat <= 0)
+        return NULL;
+    for (i = 0; i < id->ncompat; ++i) {
+        for (j = i; id->compat[i] != ','; ++i)
+            if (i >= id->ncompat)
+                break;
+        if (i > j) {
+            t = gettoken(pnpprod, id->compat + j, i - j);
+            if (t->val != -1)
+                return t;
+        }
+    }
+
+    return NULL;
+}
+
+/* name/val mapping */
+
+static symtab_t *
+gettoken(symtab_t *tab, char *s, int len)
+{
+    int i;
+
+    for (i = 0; tab[i].name != NULL; ++i) {
+        if (strncmp(tab[i].name, s, len) == 0)
+            break;
+    }
+    return &tab[i];
+}
+
+/******************* PS/2 PnP probing ****************/
+
+static int
+readMouse(InputInfoPtr pInfo, unsigned char *u)
+{
+
+    if (xf86WaitForInput(pInfo->fd, 200000) <= 0)
+        return FALSE;
+
+    xf86ReadSerial(pInfo->fd, u, 1);
+    return TRUE;
+}
+
+static void
+ps2DisableWrapMode(InputInfoPtr pInfo)
+{
+    unsigned char reset_wrap_mode[] = { 0xEC };
+    ps2SendPacket(pInfo, reset_wrap_mode, sizeof(reset_wrap_mode));
+}
+
+Bool
+ps2SendPacket(InputInfoPtr pInfo, unsigned char *bytes, int len)
+{
+    unsigned char c;
+    int i,j;
+
+#ifdef DEBUG
+    xf86ErrorF("Ps/2 data package:");
+    for (i = 0; i < len; i++)
+        xf86ErrorF(" %x", *(bytes + i));
+    xf86ErrorF("\n");
+#endif
+
+    for (i = 0; i < len; i++) {
+        for (j = 0; j < 10; j++) {
+            xf86WriteSerial(pInfo->fd, bytes + i, 1);
+            usleep(10000);
+            if (!readMouse(pInfo,&c)) {
+#ifdef DEBUG
+                xf86ErrorF("sending 0x%x to PS/2 unsuccessful\n",*(bytes + i));
+#endif
+                return FALSE;
+            }
+#ifdef DEBUG
+            xf86ErrorF("Received: 0x%x\n",c);
+#endif
+            if (c == 0xFA) /* ACK */
+                break;
+
+            if (c == 0xFE) /* resend */
+                continue;
+
+
+            if (c == 0xFC) /* error */
+                return FALSE;
+
+            /* Some mice accidentally enter wrap mode during init */
+            if (c == *(bytes + i)    /* wrap mode */
+                && (*(bytes + i) != 0xEC)) /* avoid recursion */
+                ps2DisableWrapMode(pInfo);
+
+            return FALSE;
+        }
+        if (j == 10)
+            return FALSE;
+    }
+
+    return TRUE;
+}
+
+static Bool
+ps2DisableDataReporting(InputInfoPtr pInfo)
+{
+    unsigned char packet[] = { 0xF5 };
+    return ps2SendPacket(pInfo, packet, sizeof(packet));
+}
+
+Bool
+ps2EnableDataReporting(InputInfoPtr pInfo)
+{
+    unsigned char packet[] = { 0xF4 };
+    return ps2SendPacket(pInfo, packet, sizeof(packet));
+}
+
+int
+ps2GetDeviceID(InputInfoPtr pInfo)
+{
+    unsigned char u;
+    unsigned char packet[] = { 0xf2 };
+
+    usleep(30000);
+    xf86FlushInput(pInfo->fd);
+    if (!ps2SendPacket(pInfo, packet, sizeof(packet)))
+        return -1;
+    while (1) {
+        if (!readMouse(pInfo,&u))
+            return -1;
+        if (u != 0xFA)
+            break;
+    }
+#ifdef DEBUG
+    xf86ErrorF("Obtained Mouse Type: %x\n",u);
+#endif
+    return (int) u;
+}
+
+Bool
+ps2Reset(InputInfoPtr pInfo)
+{
+    unsigned char u;
+    unsigned char packet[] = { 0xff };
+    unsigned char reply[] = { 0xaa, 0x00 };
+    unsigned int i;
+#ifdef DEBUG
+   xf86ErrorF("PS/2 Mouse reset\n");
+#endif
+    if (!ps2SendPacket(pInfo, packet, sizeof(packet)))
+        return FALSE;
+    /* we need a little delay here */
+    xf86WaitForInput(pInfo->fd, 500000);
+    for (i = 0; i < sizeof(reply) ; i++) {
+        if (!readMouse(pInfo,&u)) {
+            goto EXIT;
+        }
+        if (u != reply[i])
+            goto EXIT;
+    }
+    return TRUE;
+
+ EXIT:
+    xf86FlushInput(pInfo->fd);
+    return FALSE;
+}
+
+static MouseProtocolID
+probePs2ProtocolPnP(InputInfoPtr pInfo)
+{
+    unsigned char u;
+    MouseProtocolID ret = PROT_UNKNOWN;
+
+    xf86FlushInput(pInfo->fd);
+
+    ps2DisableDataReporting(pInfo);
+
+    if (ps2Reset(pInfo)) { /* Reset PS2 device */
+        unsigned char seq[] = { 243, 200, 243, 100, 243, 80 };
+        /* Try to identify Intelli Mouse */
+        if (ps2SendPacket(pInfo, seq, sizeof(seq))) {
+            u = ps2GetDeviceID(pInfo);
+            if (u == 0x03) {
+                /* found IntelliMouse now try IntelliExplorer */
+                unsigned char im_seq[] = { 243, 200, 243, 200, 243, 80 };
+                if (ps2SendPacket(pInfo,im_seq,sizeof(im_seq))) {
+                    u = ps2GetDeviceID(pInfo);
+                    if (u == 0x04)
+                        ret =  PROT_EXPPS2;
+                    else
+                        ret = PROT_IMPS2;
+                }
+            } else if (ps2Reset(pInfo))  /* reset again to find sane state */
+                ret = PROT_PS2;
+        }
+
+        if (ret != PROT_UNKNOWN)
+            ps2EnableDataReporting(pInfo);
+    }
+    return ret;
+}
+
+static struct ps2protos {
+    int Id;
+    MouseProtocolID protoID;
+} ps2 [] = {
+    { 0x0, PROT_PS2 },
+    { 0x3, PROT_IMPS2 },
+    { 0x4, PROT_EXPPS2 },
+    { -1 , PROT_UNKNOWN }
+};
+
+
+static MouseProtocolID
+getPs2ProtocolPnP(InputInfoPtr pInfo)
+{
+    int Id;
+    int i;
+    MouseProtocolID proto;
+    int count = 4;
+
+    xf86FlushInput(pInfo->fd);
+
+    while (--count)
+        if (ps2DisableDataReporting(pInfo))
+            break;
+
+    if (!count) {
+        proto = PROT_UNKNOWN;
+        goto EXIT;
+    }
+
+    if ((Id = ps2GetDeviceID(pInfo)) == -1) {
+        proto = PROT_UNKNOWN;
+        goto EXIT;
+    }
+
+    if (-1 == ps2EnableDataReporting(pInfo)) {
+        proto = PROT_UNKNOWN;
+        goto EXIT;
+    }
+
+    for (i = 0; ps2[i].protoID != PROT_UNKNOWN; i++) {
+        if (ps2[i].Id == Id) {
+            xf86MsgVerb(X_PROBED,2,"Found PS/2 proto ID %x\n",Id);
+            proto =  ps2[i].protoID;
+            goto EXIT;
+        }
+    }
+
+    proto = PROT_UNKNOWN;
+    xf86Msg(X_ERROR,"Found unknown PS/2 proto ID %x\n",Id);
+
+ EXIT:
+    xf86FlushInput(pInfo->fd);
+    return proto;
+}
+

--- a/hw/xfree86/drivers/input/mouse/src/pnp.c
+++ b/hw/xfree86/drivers/input/mouse/src/pnp.c
@@ -20,11 +20,8 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+#include <xorg-config.h>
 
-#include <xorg-server.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>

--- a/hw/xfree86/drivers/input/mouse/src/sun_mouse.c
+++ b/hw/xfree86/drivers/input/mouse/src/sun_mouse.c
@@ -1,0 +1,936 @@
+/*
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+/*
+ * Copyright 1999-2001 The XFree86 Project, Inc.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * XFREE86 PROJECT BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of the XFree86 Project shall
+ * not be used in advertising or otherwise to promote the sale, use or other
+ * dealings in this Software without prior written authorization from the
+ * XFree86 Project.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifdef HAVE_XORG_CONFIG_H
+#include <xorg-config.h>
+#endif
+
+#include <unistd.h> /* for ioctl(2) */
+#include <sys/stropts.h>
+#include <sys/vuid_event.h>
+#include <sys/msio.h>
+#include <fcntl.h>
+#include <errno.h>
+#include "xorg-server.h"
+#include "xf86.h"
+#include "xf86_OSlib.h"
+#include "mouse.h"
+#include "xisb.h"
+#include "mipointer.h"
+#include "xf86Crtc.h"
+
+/* Wheel mouse support in VUID drivers in Solaris 9 updates & Solaris 10 */
+#ifdef WHEEL_DEVID /* Defined in vuid_event.h if VUID wheel support present */
+# define HAVE_VUID_WHEEL
+#endif
+#ifdef HAVE_VUID_WHEEL
+# include <sys/vuid_wheel.h>
+#endif
+
+#include <libdevinfo.h>
+
+/* Support for scaling absolute coordinates to screen size in
+ * Solaris 10 updates and beyond */
+#if !defined(HAVE_ABSOLUTE_MOUSE_SCALING)
+# ifdef MSIOSRESOLUTION /* Defined in msio.h if scaling support present */
+#  define HAVE_ABSOLUTE_MOUSE_SCALING
+# endif
+#endif
+
+/* Names of protocols that are handled internally here. */
+
+static const char *internalNames[] = {
+        "VUID",
+        NULL
+};
+
+static const char *solarisMouseDevs[] = {
+    /* Device file:     Protocol:                       */
+    "/dev/mouse",       "VUID",         /* USB or SPARC */
+#if defined(__i386) || defined(__x86)
+    "/dev/kdmouse",     "PS/2",         /* PS/2 */
+#endif
+    NULL
+};
+
+typedef struct _VuidMseRec {
+    struct _VuidMseRec *next;
+    InputInfoPtr        pInfo;
+    Firm_event          event;
+    unsigned char *     buffer;
+    char *              strmod;
+    Bool(*wrapped_device_control)(DeviceIntPtr device, int what);
+#ifdef HAVE_ABSOLUTE_MOUSE_SCALING
+    Ms_screen_resolution         absres;
+#endif
+    OsTimerPtr          remove_timer;   /* Callback for removal on ENODEV */
+    int                 relToAbs;
+    int                 absX;
+    int                 absY;
+} VuidMseRec, *VuidMsePtr;
+
+static VuidMsePtr       vuidMouseList = NULL;
+
+static int  vuidMouseProc(DeviceIntPtr pPointer, int what);
+static void vuidReadInput(InputInfoPtr pInfo);
+
+static int CheckRelToAbs(InputInfoPtr pInfo);
+static int CheckRelToAbsWalker(di_node_t node, void *arg);
+
+#ifdef HAVE_ABSOLUTE_MOUSE_SCALING
+
+static void vuidMouseSendScreenSize(ScreenPtr pScreen, VuidMsePtr pVuidMse);
+static void vuidMouseAdjustFrame(ScrnInfoPtr pScrn, int x, int y);
+
+static unsigned long vuidMouseGeneration = 0;
+
+static DevPrivateKeyRec vuidMouseScreenIndex;
+
+#define vuidMouseGetScreenPrivate(s) ( \
+    dixLookupPrivate(&(s)->devPrivates, &vuidMouseScreenIndex))
+#define vuidMouseSetScreenPrivate(s,p) \
+    dixSetPrivate(&(s)->devPrivates, &vuidMouseScreenIndex, (void *) p)
+#endif /* HAVE_ABSOLUTE_MOUSE_SCALING */
+
+static inline
+VuidMsePtr getVuidMsePriv(InputInfoPtr pInfo)
+{
+    VuidMsePtr m = vuidMouseList;
+
+    while ((m != NULL) && (m->pInfo != pInfo)) {
+        m = m->next;
+    }
+
+    return m;
+}
+
+/* Called from OsTimer callback, since removing a device from the device
+   list or changing pInfo->fd while xf86Wakeup is looping through the list
+   causes server crashes */
+static CARD32
+vuidRemoveMouse(OsTimerPtr timer, CARD32 now, void *arg)
+{
+    InputInfoPtr pInfo = (InputInfoPtr) arg;
+
+    xf86DisableDevice(pInfo->dev, TRUE);
+
+    return 0;  /* All done, don't set to run again */
+}
+
+/*
+ * Initialize and enable the mouse wheel, if present.
+ *
+ * Returns 1 if mouse wheel was successfully enabled.
+ * Returns 0 if an error occurred or if there is no mouse wheel.
+ */
+static int
+vuidMouseWheelInit(InputInfoPtr pInfo)
+{
+#ifdef HAVE_VUID_WHEEL
+    wheel_state wstate;
+    int nwheel = -1;
+    int i;
+
+    wstate.vers = VUID_WHEEL_STATE_VERS;
+    wstate.id = 0;
+    wstate.stateflags = (uint32_t) -1;
+
+    SYSCALL(i = ioctl(pInfo->fd, VUIDGWHEELCOUNT, &nwheel));
+    if (i != 0)
+        return (0);
+
+    SYSCALL(i = ioctl(pInfo->fd, VUIDGWHEELSTATE, &wstate));
+    if (i != 0) {
+        xf86Msg(X_WARNING, "%s: couldn't get wheel state\n", pInfo->name);
+        return (0);
+    }
+
+    wstate.stateflags |= VUID_WHEEL_STATE_ENABLED;
+
+    SYSCALL(i = ioctl(pInfo->fd, VUIDSWHEELSTATE, &wstate));
+    if (i != 0) {
+        xf86Msg(X_WARNING, "%s: couldn't enable wheel\n", pInfo->name);
+        return (0);
+    }
+
+    return (1);
+#else
+    return (0);
+#endif
+}
+
+
+/* This function is called when the protocol is "VUID". */
+static Bool
+vuidPreInit(InputInfoPtr pInfo, const char *protocol, int flags)
+{
+    MouseDevPtr pMse = pInfo->private;
+    VuidMsePtr pVuidMse;
+
+    /* Ensure we don't add the same device twice */
+    if (getVuidMsePriv(pInfo) != NULL)
+        return TRUE;
+
+    pVuidMse = calloc(1, sizeof(VuidMseRec));
+    if (pVuidMse == NULL) {
+        xf86Msg(X_ERROR, "%s: cannot allocate VuidMouseRec\n", pInfo->name);
+        free(pMse);
+        return FALSE;
+    }
+
+    pVuidMse->buffer = (unsigned char *)&pVuidMse->event;
+    pVuidMse->strmod = xf86SetStrOption(pInfo->options, "StreamsModule", NULL);
+    pVuidMse->relToAbs = xf86SetIntOption(pInfo->options, "RelToAbs", -1);
+    if (pVuidMse->relToAbs == -1)
+        pVuidMse->relToAbs = CheckRelToAbs(pInfo);
+    pVuidMse->absX = 0;
+    pVuidMse->absY = 0;
+
+    /* Setup the local procs. */
+    pVuidMse->wrapped_device_control = pInfo->device_control;
+    pInfo->device_control = vuidMouseProc;
+    pInfo->read_input = vuidReadInput;
+
+    pMse->xisbscale = sizeof(Firm_event);
+
+#ifdef HAVE_ABSOLUTE_MOUSE_SCALING
+    pVuidMse->absres.height = pVuidMse->absres.width = 0;
+#endif
+    pVuidMse->pInfo = pInfo;
+    pVuidMse->next = vuidMouseList;
+    vuidMouseList = pVuidMse;
+
+    return TRUE;
+}
+
+/*
+ * It seems that the mouse that is presented by the Emulex ILOM
+ * device (USB 0x430, 0xa101 and USB 0x430, 0xa102) sends relative
+ * mouse movements.  But relative mouse movements are subject to
+ * acceleration.  This causes the position indicated on the ILOM
+ * window to not match what the Xorg server actually has.  This
+ * makes the mouse in this environment rather unusable.  So, for the
+ * Emulex ILOM device, we will change all relative mouse movements
+ * into absolute mouse movements, making it appear more like a
+ * tablet.  This will not be subject to acceleration, and this
+ * should keep the ILOM window and Xorg server with the same values
+ * for the coordinates of the mouse.
+ */
+
+typedef struct reltoabs_match {
+	int matched;
+	char const *matchname;
+	} reltoabs_match_t;
+
+/* Sun Microsystems, keyboard / mouse */
+#define	RELTOABS_MATCH1	"usbif430,a101.config1.1"
+/* Sun Microsystems, keyboard / mouse / storage */
+#define	RELTOABS_MATCH2	"usbif430,a102.config1.1"
+
+static int
+CheckRelToAbsWalker(di_node_t node, void *arg)
+{
+	di_minor_t minor;
+	char *path;
+	int numvalues;
+	int valueon;
+	char const *stringptr;
+	int status;
+	reltoabs_match_t *const matchptr = (reltoabs_match_t *)arg;
+	char *stringvalues;
+
+	for (minor = di_minor_next(node, DI_MINOR_NIL);
+	  minor != DI_MINOR_NIL;
+	  minor = di_minor_next(node, minor)) {
+	    path = di_devfs_minor_path(minor);
+	    status = path != NULL && strcmp(path, matchptr -> matchname) == 0;
+	    di_devfs_path_free(path);
+	    if (status)
+		break;
+	    }
+
+	if (minor == DI_MINOR_NIL)
+	    return (DI_WALK_CONTINUE);
+
+	numvalues = di_prop_lookup_strings(DDI_DEV_T_ANY, node,
+	  "compatible", &stringvalues);
+	if (numvalues <= 0)
+	    return (DI_WALK_CONTINUE);
+
+	for (valueon = 0, stringptr = stringvalues; valueon < numvalues;
+	  valueon++, stringptr += strlen(stringptr) + 1) {
+	    if (strcmp(stringptr, RELTOABS_MATCH1) == 0) {
+		matchptr -> matched = 1;
+		return (DI_WALK_TERMINATE);
+	    }
+	    if (strcmp(stringptr, RELTOABS_MATCH2) == 0) {
+		matchptr -> matched = 2;
+		return (DI_WALK_TERMINATE);
+	    }
+	}
+	return (DI_WALK_CONTINUE);
+}
+
+static int
+CheckRelToAbs(InputInfoPtr pInfo)
+{
+	char const *device;
+	char const *matchname;
+	ssize_t readstatus;
+	di_node_t node;
+	struct stat statbuf;
+	char linkname[512];
+	reltoabs_match_t reltoabs_match;
+
+	device = xf86CheckStrOption(pInfo->options, "Device", NULL);
+	if (device == NULL)
+	    return (0);
+
+	matchname = device;
+
+	if (lstat(device, &statbuf) == 0 &&
+	  (statbuf.st_mode & S_IFMT) == S_IFLNK) {
+	    readstatus = readlink(device, linkname, sizeof(linkname));
+	    if (readstatus > 0 && readstatus < (ssize_t) sizeof(linkname)) {
+		linkname[readstatus] = 0;
+		matchname = linkname;
+		if (strncmp(matchname, "../..", sizeof("../..") - 1) == 0)
+		    matchname += sizeof("../..") - 1;
+	    }
+	}
+
+	if (strncmp(matchname, "/devices", sizeof("/devices") - 1) == 0)
+	    matchname += sizeof("/devices") - 1;
+
+	reltoabs_match.matched = 0;
+	reltoabs_match.matchname = matchname;
+
+	node = di_init("/", DINFOCPYALL);
+	if (node == DI_NODE_NIL)
+	    return (0);
+
+	di_walk_node(node, DI_WALK_CLDFIRST, (void *)&reltoabs_match,
+	  CheckRelToAbsWalker);
+
+	di_fini(node);
+
+	return (reltoabs_match.matched != 0);
+}
+
+static void
+vuidFlushAbsEvents(InputInfoPtr pInfo, int absX, int absY,
+                   Bool *absXset, Bool *absYset)
+{
+#ifdef DEBUG
+    ErrorF("vuidFlushAbsEvents: %d,%d (set: %d, %d)\n", absX, absY,
+           *absXset, *absYset);
+#endif
+    if ((*absXset) && (*absYset)) {
+        xf86PostMotionEvent(pInfo->dev,
+                            /* is_absolute: */    TRUE,
+                            /* first_valuator: */ 0,
+                            /* num_valuators: */  2,
+                            absX, absY);
+    } else if (*absXset) {
+        xf86PostMotionEvent(pInfo->dev,
+                            /* is_absolute: */    TRUE,
+                            /* first_valuator: */ 0,
+                            /* num_valuators: */  1,
+                            absX);
+    } else if (*absYset) {
+        xf86PostMotionEvent(pInfo->dev,
+                            /* is_absolute: */    TRUE,
+                            /* first_valuator: */ 1,
+                            /* num_valuators: */  1,
+                            absY);
+    }
+
+    *absXset = FALSE;
+    *absYset = FALSE;
+}
+
+static void
+vuidReadInput(InputInfoPtr pInfo)
+{
+    MouseDevPtr pMse;
+    VuidMsePtr pVuidMse;
+    int buttons;
+    int dx = 0, dy = 0, dz = 0, dw = 0;
+    ssize_t n;
+    unsigned char *pBuf;
+    int absX = 0, absY = 0;
+    int hdisplay = 0, vdisplay = 0;
+    Bool absXset = FALSE, absYset = FALSE;
+    int relToAbs;
+
+    pMse = pInfo->private;
+    buttons = pMse->lastButtons;
+    pVuidMse = getVuidMsePriv(pInfo);
+    if (pVuidMse == NULL) {
+        xf86Msg(X_ERROR, "%s: cannot locate VuidMsePtr\n", pInfo->name);
+        return;
+    }
+    pBuf = pVuidMse->buffer;
+    relToAbs = pVuidMse->relToAbs;
+    if (relToAbs) {
+	ScreenPtr   pScreen = miPointerGetScreen(pInfo->dev);
+	ScrnInfoPtr pScr = XF86SCRNINFO(pScreen);
+
+	if (pScr->currentMode) {
+	    hdisplay = pScr->currentMode->HDisplay;
+	    vdisplay = pScr->currentMode->VDisplay;
+	}
+	absX = pVuidMse->absX;
+	absY = pVuidMse->absY;
+    }
+
+    do {
+        n = read(pInfo->fd, pBuf, sizeof(Firm_event));
+
+        if (n == 0) {
+            break;
+        } else if (n == -1) {
+            switch (errno) {
+                case EAGAIN: /* Nothing to read now */
+                    n = 0;   /* End loop, go on to flush events & return */
+                    continue;
+                case EINTR:  /* Interrupted, try again */
+                    continue;
+                case ENODEV: /* May happen when USB mouse is unplugged */
+                    /* We use X_NONE here because it didn't alloc since we
+                       may be called from SIGIO handler. No longer true for
+                       sigsafe logging, but matters for older servers  */
+                    LogMessageVerbSigSafe(X_NONE, 0,
+                                          "%s: Device no longer present - removing.\n",
+                                          pInfo->name);
+                    xf86RemoveEnabledDevice(pInfo);
+                    pVuidMse->remove_timer =
+                        TimerSet(pVuidMse->remove_timer, 0, 1,
+                                 vuidRemoveMouse, pInfo);
+                    return;
+                default:     /* All other errors */
+                    /* We use X_NONE here because it didn't alloc since we
+                       may be called from SIGIO handler. No longer true for
+                       sigsafe logging, but matters for older servers  */
+                    LogMessageVerbSigSafe(X_NONE, 0, "%s: Read error: %s\n",
+                                          pInfo->name, strerror(errno));
+                    return;
+            }
+        } else if (n != sizeof(Firm_event)) {
+            xf86Msg(X_WARNING, "%s: incomplete packet, size %zd\n",
+                        pInfo->name, n);
+        }
+
+#ifdef DEBUG
+        LogMessageVerbSigSafe("vuidReadInput: event type: %d value: %d\n",
+                              pVuidMse->event.id, pVuidMse->event.value);
+#endif
+
+        if (pVuidMse->event.id >= BUT_FIRST && pVuidMse->event.id <= BUT_LAST) {
+            /* button */
+            int butnum = pVuidMse->event.id - BUT_FIRST;
+
+            if (butnum < 3)
+                butnum = 2 - butnum;
+            if (!pVuidMse->event.value)
+                buttons &= ~(1 << butnum);
+            else
+                buttons |= (1 << butnum);
+        } else if (pVuidMse->event.id >= VLOC_FIRST &&
+                   pVuidMse->event.id <= VLOC_LAST) {
+            /* axis */
+            int delta = pVuidMse->event.value;
+            switch(pVuidMse->event.id) {
+            case LOC_X_DELTA:
+                if (!relToAbs)
+                    dx += delta;
+                else {
+                    if (absXset)
+                        vuidFlushAbsEvents(pInfo, absX, absY, &absXset, &absYset);
+                    absX += delta;
+                    if (absX < 0)
+                        absX = 0;
+                    else if (absX >= hdisplay && hdisplay > 0)
+                        absX = hdisplay - 1;
+                    pVuidMse->absX = absX;
+                    absXset = TRUE;
+                }
+                break;
+            case LOC_Y_DELTA:
+                if (!relToAbs)
+                    dy -= delta;
+                else {
+                    if (absYset)
+                        vuidFlushAbsEvents(pInfo, absX, absY, &absXset, &absYset);
+                    absY -= delta;
+                    if (absY < 0)
+                        absY = 0;
+                    else if (absY >= vdisplay && vdisplay > 0)
+                        absY = vdisplay - 1;
+                    pVuidMse->absY = absY;
+                    absYset = TRUE;
+                }
+                break;
+            case LOC_X_ABSOLUTE:
+                if (absXset) {
+                    vuidFlushAbsEvents(pInfo, absX, absY, &absXset, &absYset);
+                }
+                absX = delta;
+                absXset = TRUE;
+                break;
+            case LOC_Y_ABSOLUTE:
+                if (absYset) {
+                    vuidFlushAbsEvents(pInfo, absX, absY, &absXset, &absYset);
+                }
+                absY = delta;
+                absYset = TRUE;
+                break;
+            }
+        }
+#ifdef HAVE_VUID_WHEEL
+        else if (vuid_in_range(VUID_WHEEL, pVuidMse->event.id)) {
+            if (vuid_id_offset(pVuidMse->event.id) == 0)
+                dz -= VUID_WHEEL_GETDELTA(pVuidMse->event.value);
+            else
+                dw -= VUID_WHEEL_GETDELTA(pVuidMse->event.value);
+        }
+#endif
+#ifdef HAVE_ABSOLUTE_MOUSE_SCALING
+        else if (pVuidMse->event.id == MOUSE_TYPE_ABSOLUTE) {
+            ScreenPtr   ptrCurScreen;
+
+            /* force sending absolute resolution scaling ioctl */
+            pVuidMse->absres.height = pVuidMse->absres.width = 0;
+            ptrCurScreen = miPointerGetScreen(pInfo->dev);
+            vuidMouseSendScreenSize(ptrCurScreen, pVuidMse);
+        }
+#endif
+
+    } while (n != 0);
+
+    if (absXset || absYset) {
+        vuidFlushAbsEvents(pInfo, absX, absY, &absXset, &absYset);
+    }
+
+    pMse->PostEvent(pInfo, buttons, dx, dy, dz, dw);
+    return;
+}
+
+#ifdef HAVE_ABSOLUTE_MOUSE_SCALING
+static void vuidMouseSendScreenSize(ScreenPtr pScreen, VuidMsePtr pVuidMse)
+{
+    InputInfoPtr pInfo = pVuidMse->pInfo;
+    ScrnInfoPtr pScr = XF86SCRNINFO(pScreen);
+    int result;
+
+    if ((pVuidMse->absres.width != pScr->virtualX) ||
+        (pVuidMse->absres.height != pScr->virtualY))
+    {
+        pVuidMse->absres.width = pScr->virtualX;
+        pVuidMse->absres.height = pScr->virtualY;
+
+        do {
+            result = ioctl(pInfo->fd, MSIOSRESOLUTION, &(pVuidMse->absres));
+        } while ( (result != 0) && (errno == EINTR) );
+
+        if (result != 0) {
+            LogMessageVerbSigSafe(X_WARNING, -1,
+                                  "%s: couldn't set absolute mouse scaling resolution: %s\n",
+                                  pInfo->name, strerror(errno));
+#ifdef DEBUG
+        } else {
+            LogMessageVerbSigSafe(X_INFO,
+                                  "%s: absolute mouse scaling resolution set to %d x %d\n",
+                                  pInfo->name,
+                                  pVuidMse->absres.width,
+                                  pVuidMse->absres.height);
+#endif
+        }
+    }
+}
+
+static void vuidMouseAdjustFrame(ScrnInfoPtr pScrn, int x, int y)
+{
+      ScreenPtr         pScreen = xf86ScrnToScreen(pScrn);
+      xf86AdjustFrameProc *wrappedAdjustFrame
+          = (xf86AdjustFrameProc *) vuidMouseGetScreenPrivate(pScreen);
+      VuidMsePtr        m;
+      ScreenPtr         ptrCurScreen;
+
+      if (wrappedAdjustFrame) {
+          pScrn->AdjustFrame = wrappedAdjustFrame;
+          (*pScrn->AdjustFrame)(pScrn, x, y);
+          pScrn->AdjustFrame = vuidMouseAdjustFrame;
+      }
+
+      for (m = vuidMouseList; m != NULL ; m = m->next) {
+          ptrCurScreen = miPointerGetScreen(m->pInfo->dev);
+          if (ptrCurScreen == pScreen)
+          {
+              vuidMouseSendScreenSize(pScreen, m);
+          }
+      }
+}
+
+static void vuidMouseCrtcNotify(ScreenPtr pScreen)
+{
+    xf86_crtc_notify_proc_ptr wrappedCrtcNotify
+        = (xf86_crtc_notify_proc_ptr) vuidMouseGetScreenPrivate(pScreen);
+    VuidMsePtr       m;
+    ScreenPtr        ptrCurScreen;
+
+    if (wrappedCrtcNotify)
+        wrappedCrtcNotify(pScreen);
+
+    for (m = vuidMouseList; m != NULL ; m = m->next) {
+        ptrCurScreen = miPointerGetScreen(m->pInfo->dev);
+        if (ptrCurScreen == pScreen) {
+            vuidMouseSendScreenSize(pScreen, m);
+        }
+    }
+}
+#endif /* HAVE_ABSOLUTE_MOUSE_SCALING */
+
+
+static int
+vuidMouseProc(DeviceIntPtr pPointer, int what)
+{
+    InputInfoPtr pInfo;
+    MouseDevPtr pMse;
+    VuidMsePtr pVuidMse;
+    int ret = Success;
+    int i;
+
+    pInfo = pPointer->public.devicePrivate;
+    pMse = pInfo->private;
+    pMse->device = pPointer;
+
+    pVuidMse = getVuidMsePriv(pInfo);
+    if (pVuidMse == NULL) {
+        return BadImplementation;
+    }
+
+    switch (what) {
+
+    case DEVICE_INIT:
+#ifdef HAVE_ABSOLUTE_MOUSE_SCALING
+
+        if (!dixRegisterPrivateKey(&vuidMouseScreenIndex, PRIVATE_SCREEN, 0))
+                return BadAlloc;
+
+        if (vuidMouseGeneration != serverGeneration) {
+                for (i = 0; i < screenInfo.numScreens; i++) {
+                    ScreenPtr pScreen = screenInfo.screens[i];
+                    ScrnInfoPtr pScrn = XF86SCRNINFO(pScreen);
+                    if (xf86CrtcConfigPrivateIndex != -1) {
+                        xf86_crtc_notify_proc_ptr pCrtcNotify
+                            = xf86_wrap_crtc_notify(pScreen,
+                                                    vuidMouseCrtcNotify);
+                        vuidMouseSetScreenPrivate(pScreen, pCrtcNotify);
+                    } else {
+                        vuidMouseSetScreenPrivate(pScreen,
+                                                  pScrn->AdjustFrame);
+                        pScrn->AdjustFrame = vuidMouseAdjustFrame;
+                    }
+                }
+            vuidMouseGeneration = serverGeneration;
+        }
+#endif
+        ret = pVuidMse->wrapped_device_control(pPointer, what);
+        break;
+
+    case DEVICE_ON:
+        ret = pVuidMse->wrapped_device_control(pPointer, DEVICE_ON);
+
+        if ((ret == Success) && (pInfo->fd != -1)) {
+            int fmt = VUID_FIRM_EVENT;
+
+            if (pVuidMse->strmod) {
+                /* Check to see if module is already pushed */
+                SYSCALL(i = ioctl(pInfo->fd, I_FIND, pVuidMse->strmod));
+
+                if (i == 0) { /* Not already pushed */
+                    SYSCALL(i = ioctl(pInfo->fd, I_PUSH, pVuidMse->strmod));
+                    if (i < 0) {
+                        xf86Msg(X_WARNING, "%s: cannot push module '%s' "
+                                "onto mouse device: %s\n", pInfo->name,
+                                pVuidMse->strmod, strerror(errno));
+                        free(pVuidMse->strmod);
+                        pVuidMse->strmod = NULL;
+                    }
+                }
+            }
+
+            SYSCALL(i = ioctl(pInfo->fd, VUIDSFORMAT, &fmt));
+            if (i < 0) {
+                xf86Msg(X_WARNING,
+                        "%s: cannot set mouse device to VUID mode: %s\n",
+                        pInfo->name, strerror(errno));
+            }
+            vuidMouseWheelInit(pInfo);
+#ifdef HAVE_ABSOLUTE_MOUSE_SCALING
+            vuidMouseSendScreenSize(screenInfo.screens[0], pVuidMse);
+#endif
+            xf86FlushInput(pInfo->fd);
+
+            /* Allocate here so we don't alloc in ReadInput which may be called
+               from SIGIO handler. */
+            if (pVuidMse->remove_timer == NULL) {
+                pVuidMse->remove_timer = TimerSet(pVuidMse->remove_timer,
+                                                  0, 0, NULL, NULL);
+            }
+        }
+        break;
+
+    case DEVICE_CLOSE:
+        if (vuidMouseList == pVuidMse)
+            vuidMouseList = vuidMouseList->next;
+        else {
+            VuidMsePtr m = vuidMouseList;
+
+            while ((m != NULL) && (m->next != pVuidMse)) {
+                m = m->next;
+            }
+
+            if (m != NULL)
+                m->next = pVuidMse->next;
+        }
+        _X_FALLTHROUGH; /* fallthrough */
+    case DEVICE_OFF:
+        if (pInfo->fd != -1) {
+            if (pVuidMse->strmod) {
+                SYSCALL(i = ioctl(pInfo->fd, I_POP, pVuidMse->strmod));
+                if (i == -1) {
+                    xf86Msg(X_WARNING,
+                      "%s: cannot pop module '%s' off mouse device: %s\n",
+                      pInfo->name, pVuidMse->strmod, strerror(errno));
+                }
+            }
+        }
+        if (pVuidMse->remove_timer) {
+            TimerFree(pVuidMse->remove_timer);
+            pVuidMse->remove_timer = NULL;
+        }
+        ret = pVuidMse->wrapped_device_control(pPointer, what);
+        break;
+
+    default: /* Should never be called, but just in case */
+        ret = pVuidMse->wrapped_device_control(pPointer, what);
+        break;
+    }
+    return ret;
+}
+
+static Bool
+sunMousePreInit(InputInfoPtr pInfo, const char *protocol, int flags)
+{
+    /* The protocol is guaranteed to be one of the internalNames[] */
+    if (xf86NameCmp(protocol, "VUID") == 0) {
+        return vuidPreInit(pInfo, protocol, flags);
+    }
+    return TRUE;
+}
+
+static const char **
+BuiltinNames(void)
+{
+    return internalNames;
+}
+
+static Bool
+CheckProtocol(const char *protocol)
+{
+    int i;
+
+    for (i = 0; internalNames[i]; i++)
+        if (xf86NameCmp(protocol, internalNames[i]) == 0)
+            return TRUE;
+
+    return FALSE;
+}
+
+static const char *
+DefaultProtocol(void)
+{
+    return "Auto";
+}
+
+static Bool
+solarisMouseAutoProbe(InputInfoPtr pInfo, const char **protocol,
+        const char **device)
+{
+    const char **pdev, **pproto;
+    int fd = -1;
+    Bool found;
+    char *strmod;
+
+    if (*device == NULL) {
+        /* Check to see if xorg.conf or HAL specified a device to use */
+        *device = xf86CheckStrOption(pInfo->options, "Device", NULL);
+    }
+
+    if (*device != NULL) {
+        strmod = xf86CheckStrOption(pInfo->options, "StreamsModule", NULL);
+        if (strmod) {
+            /* if a device name is already known, and a StreamsModule is
+               specified to convert events to VUID, then we don't need to
+               probe further */
+            *protocol = "VUID";
+            return TRUE;
+        }
+    }
+
+
+    for (pdev = solarisMouseDevs; *pdev; pdev += 2) {
+        pproto = pdev + 1;
+        if ((*protocol != NULL) && (strcmp(*protocol, "Auto") != 0) &&
+          (*pproto != NULL) && (strcmp(*pproto, *protocol) != 0)) {
+            continue;
+        }
+        if ((*device != NULL) && (strcmp(*device, *pdev) != 0)) {
+            continue;
+        }
+        SYSCALL (fd = open(*pdev, O_RDWR | O_NONBLOCK));
+        if (fd == -1) {
+#ifdef DEBUG
+            ErrorF("Cannot open %s (%s)\n", pdev, strerror(errno));
+#endif
+        } else {
+            found = TRUE;
+            if ((*pproto != NULL) && (strcmp(*pproto, "VUID") == 0)) {
+                int i, r;
+                SYSCALL(r = ioctl(fd, VUIDGFORMAT, &i));
+                if (r < 0) {
+                    found = FALSE;
+                }
+            }
+            close(fd);
+            if (found == TRUE) {
+                if (*pproto != NULL) {
+                    *protocol = *pproto;
+                }
+                *device = *pdev;
+                return TRUE;
+            }
+        }
+    }
+    return FALSE;
+}
+
+static const char *
+SetupAuto(InputInfoPtr pInfo, int *protoPara)
+{
+    const char *pdev = NULL;
+    const char *pproto = NULL;
+    MouseDevPtr pMse = pInfo->private;
+
+    if (pInfo->fd == -1) {
+        /* probe to find device/protocol to use */
+        if (solarisMouseAutoProbe(pInfo, &pproto, &pdev) != FALSE) {
+            /* Set the Device option. */
+            pInfo->options =
+             xf86AddNewOption(pInfo->options, "Device", pdev);
+            xf86Msg(X_INFO, "%s: Setting Device option to \"%s\"\n",
+              pInfo->name, pdev);
+        }
+    } else if (pMse->protocolID == PROT_AUTO) {
+        pdev = xf86CheckStrOption(pInfo->options,
+                "Device", NULL);
+        if ((solarisMouseAutoProbe(pInfo, &pproto, &pdev) != FALSE) &&
+            (pproto != NULL))
+            sunMousePreInit(pInfo, pproto, 0);
+    }
+    return pproto;
+}
+
+static const char *
+FindDevice(InputInfoPtr pInfo, const char *protocol, int flags)
+{
+    const char *pdev = NULL;
+    const char *pproto = protocol;
+
+    if (solarisMouseAutoProbe(pInfo, &pproto, &pdev) != FALSE) {
+        /* Set the Device option. */
+        pInfo->options =
+          xf86AddNewOption(pInfo->options, "Device", pdev);
+        xf86Msg(X_INFO, "%s: Setting Device option to \"%s\"\n",
+          pInfo->name, pdev);
+    }
+    return pdev;
+}
+
+static int
+SupportedInterfaces(void)
+{
+    /* XXX This needs to be checked. */
+    return MSE_SERIAL | MSE_BUS | MSE_PS2 | MSE_AUTO | MSE_XPS2 | MSE_MISC;
+}
+
+OSMouseInfoPtr
+OSMouseInit(int flags)
+{
+    OSMouseInfoPtr p;
+
+    p = calloc(1, sizeof(OSMouseInfoRec));
+    if (!p)
+        return NULL;
+    p->SupportedInterfaces = SupportedInterfaces;
+    p->BuiltinNames = BuiltinNames;
+    p->CheckProtocol = CheckProtocol;
+    p->PreInit = sunMousePreInit;
+    p->DefaultProtocol = DefaultProtocol;
+    p->SetupAuto = SetupAuto;
+    p->FindDevice = FindDevice;
+
+    return p;
+}
+

--- a/hw/xfree86/drivers/input/mouse/src/sun_mouse.c
+++ b/hw/xfree86/drivers/input/mouse/src/sun_mouse.c
@@ -45,14 +45,7 @@
  * dealings in this Software without prior written authorization from the
  * XFree86 Project.
  */
-
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include <unistd.h> /* for ioctl(2) */
 #include <sys/stropts.h>
@@ -60,7 +53,6 @@
 #include <sys/msio.h>
 #include <fcntl.h>
 #include <errno.h>
-#include "xorg-server.h"
 #include "xf86.h"
 #include "xf86_OSlib.h"
 #include "mouse.h"

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -170,3 +170,9 @@ option('test_rendercheck_triangles', type: 'boolean', value: false,
        description: 'testsuite: run rendercheck triangles tests (might fail on Xephyr)')
 option('test_xephyr_gles', type: 'boolean', value: true,
        description: 'testsuite: run gles2/gles3 tests on Xephyr (might fail w/o DRI)')
+
+# xfree86 drivers
+option('xf86-input-inputtest', type: 'boolean', value: true,
+       description: 'Test input driver support on Xorg')
+option('xf86-input-mouse', type: 'boolean', value: true,
+       description: 'Simple mouse driver')


### PR DESCRIPTION
The driver is relatively simple, unlikely that we're getting anything substantial from xorg, and it's much faster to build in-tree.

Thus dropping the hassle of maintaining it internally by just moving it in-tree.
It can be disabled at build time via meson.
