### PR TITLE
fb: reexport fbGetGCPrivateKey and add its wrapped version

### DIFF
--- a/fb/fb.h
+++ b/fb/fb.h
@@ -254,8 +254,8 @@ fbGetScreenPrivateKey(void);
 /* private field of a screen */
 typedef struct {
 #ifdef FB_ACCESS_WRAPPER
-    SetupWrapProcPtr setupWrap; /* driver hook to set pixmap access wrapping */
-    FinishWrapProcPtr finishWrap;       /* driver hook to clean up pixmap access wrapping */
+    SetupWrapProcPtr setupWrap;   /* driver hook to set pixmap access wrapping */
+    FinishWrapProcPtr finishWrap; /* driver hook to clean up pixmap access wrapping */
 #endif
     DevPrivateKeyRec    gcPrivateKeyRec;
     DevPrivateKeyRec    winPrivateKeyRec;

--- a/fb/fb_priv.h
+++ b/fb/fb_priv.h
@@ -12,7 +12,10 @@
 
 #define FbBitsStrideToStipStride(s) (((s) << (FB_SHIFT - FB_STIP_SHIFT)))
 
-#define fbGetGCPrivateKey(pGC) (&fbGetScreenPrivate((pGC)->pScreen)->gcPrivateKeyRec)
+/* NVidia v.340 legacy driver needs this symbol */
+extern _X_EXPORT DevPrivateKey
+fbGetGCPrivateKey(GCPtr pGC);
+
 #define fbGetGCPrivate(pGC) ((FbGCPrivPtr)dixLookupPrivate(&(pGC)->devPrivates, fbGetGCPrivateKey(pGC)))
 
 #define fbGetScreenPixmap(s)    ((PixmapPtr) (s)->devPrivate)

--- a/fb/fballpriv.c
+++ b/fb/fballpriv.c
@@ -25,10 +25,17 @@
 #include "fb/fb_priv.h"
 
 static DevPrivateKeyRec fbScreenPrivateKeyRec;
+
 DevPrivateKey
 fbGetScreenPrivateKey(void)
 {
     return &fbScreenPrivateKeyRec;
+}
+
+DevPrivateKey
+fbGetGCPrivateKey(GCPtr pGC)
+{
+    return &fbGetScreenPrivate((pGC)->pScreen)->gcPrivateKeyRec;
 }
 
 Bool

--- a/fb/wfbrename.h
+++ b/fb/wfbrename.h
@@ -54,6 +54,7 @@
 #define fbFixCoordModePrevious wfbFixCoordModePrevious
 #define fbGCFuncs wfbGCFuncs
 #define fbGCOps wfbGCOps
+#define fbGetGCPrivateKey wfbGetGCPrivateKey
 #define fbGetImage wfbGetImage
 #define fbGetScreenPrivateKey wfbGetScreenPrivateKey
 #define fbGetSpans wfbGetSpans


### PR DESCRIPTION
This patch reexports a symbol needed by NVidia 340 driver and adds its "wrapped" version for libwfb to prevent XServer crashes.

Fixes https://github.com/X11Libre/xserver/issues/1715