### PR TITLE
xfree86/common: hide a variable behind XSERVER_LIBPCIACESS

### DIFF
--- a/hw/xfree86/common/xf86Bus.c
+++ b/hw/xfree86/common/xf86Bus.c
@@ -821,10 +821,12 @@ xf86CheckSlot(const void *ptr, BusType type)
             if (!strcasecmp(pent->driver->driverName, "modesetting")) {
                 /* Examine the first device only */
                 msOther = xf86FindOptionValue(pent->devices[0]->options, "kmsdev");
-                if ((msOther == NULL) && (pci_other == NULL)) {
+                if (msOther == NULL)
+#ifdef XSERVER_LIBPCIACCESS
+                    if (pci_other == NULL)
+#endif
                     /* Autoconfigured */
                     msOther = "/dev/dri/card0";
-                }
             }
         }
 


### PR DESCRIPTION
A variable pci_other is declared and can be used only on libpciacceess builds.

Fixes: https://github.com/X11Libre/xserver/issues/1713