### PR TITLE
xorg-server.pc: add xserverconfigdir variable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -833,7 +833,7 @@ if build_xorg
     sdkconfig.set('datarootdir', join_paths('${prefix}', get_option('datadir')))
     sdkconfig.set('moduledir', join_paths(join_paths('${exec_prefix}', module_dir), module_abi_tag))
     sdkconfig.set('sdkdir', join_paths('${prefix}', get_option('includedir'), 'xorg'))
-    sdkconfig.set('sysconfigdir', join_paths('${datarootdir}', 'X11/xorg.conf.d'))
+    sdkconfig.set('xserverconfigdir', join_paths('${datarootdir}', 'X11/xorg.conf.d'))
 
     sdkconfig.set('abi_ansic',
         run_command(awk, '-F', '[(,)]',

--- a/xlibre-server.pc.in
+++ b/xlibre-server.pc.in
@@ -5,7 +5,8 @@ includedir=@includedir@
 datarootdir=@datarootdir@
 moduledir=@moduledir@
 sdkdir=@sdkdir@
-sysconfigdir=@sysconfigdir@
+sysconfigdir=@xserverconfigdir@
+xserverconfigdir=@xserverconfigdir@
 
 abi_ansic=@abi_ansic@
 abi_videodrv=@abi_videodrv@

--- a/xorg-server.pc.in
+++ b/xorg-server.pc.in
@@ -5,7 +5,8 @@ includedir=@includedir@
 datarootdir=@datarootdir@
 moduledir=@moduledir@
 sdkdir=@sdkdir@
-sysconfigdir=@sysconfigdir@
+sysconfigdir=@xserverconfigdir@
+xserverconfigdir=@xserverconfigdir@
 
 abi_ansic=@abi_ansic@
 abi_videodrv=@abi_videodrv@


### PR DESCRIPTION
That variable is supposed to be used by drivers to query the path to
the xserver config directory (eg /etc/X11/xorg.conf.d), if they have
to install config snippets. It's supposed to replace / phase-out the
sysconfigdir variable, which has a bit misleading name.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
