### PR TITLE
xfree86: loader: add subdirs for input and video drivers

### DIFF
--- a/hw/xfree86/loader/loadmod.c
+++ b/hw/xfree86/loader/loadmod.c
@@ -177,10 +177,13 @@ LoaderSetPath(const char *path)
 static const char *stdSubdirs[] = {
     // first try loading from per-ABI subdir
     XORG_MODULE_ABI_TAG "/",
-    XORG_MODULE_ABI_TAG "/input/",
+    XORG_MODULE_ABI_TAG "/input/",                   // deprecated -- dropped in ABI 26
     XORG_MODULE_ABI_TAG "/drivers/",
+    XORG_MODULE_ABI_TAG "/drivers/input/",
+    XORG_MODULE_ABI_TAG "/drivers/video/",
     XORG_MODULE_ABI_TAG "/extensions/",
     // now try loading from legacy / unversioned directories
+    // will be dropped in ABI 26 -- proprietary drivers need some symlink logic
     "",
     "input/",
     "drivers/",


### PR DESCRIPTION
in the future, input and video drivers should reside in separate
sub-directories. still supporting the old dirs until ABI 26.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
