### PR TITLE
os: avoid closing null fd at Fopen

### DIFF
--- a/os/utils.c
+++ b/os/utils.c
@@ -1122,7 +1122,9 @@ Fopen(const char *file, const char *type)
     iop = fopen(file, type);
 
     if (seteuid(euid) == -1) {
-        fclose(iop);
+        if (iop) {
+            fclose(iop);
+        }
         return NULL;
     }
     return iop;


### PR DESCRIPTION
In `Fopen` function variable `iop` may store NULL as a result of `fopen` call. In this case, if later privileges couldn't be restored (`seteuid` call fails), further `fclose(iop)` call will cause runtime error.

This commit adds check `iop` for NULL before calling `fclose` to prevent potential NULL pointer dereference.

Found by Linux Verification Center (linuxtesting.org) with SVACE.


Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2115>

Backport from Xorg