### PR TITLE
glamor/glamor_egl.c: try more egl platforms

### DIFF
--- a/glamor/glamor_egl.h
+++ b/glamor/glamor_egl.h
@@ -60,7 +60,7 @@
  * like mesa will be able to adverise these (even though it can do EGL 1.5).
  */
 static inline EGLDisplay
-glamor_egl_get_display(EGLint type, void *native)
+glamor_egl_get_display2(EGLint type, void *native, Bool platform_fallback)
 {
     /* In practise any EGL 1.5 implementation would support the EXT extension */
     if (epoxy_has_egl_extension(NULL, "EGL_EXT_platform_base")) {
@@ -71,7 +71,14 @@ glamor_egl_get_display(EGLint type, void *native)
     }
 
     /* Welp, everything is awful. */
-    return eglGetDisplay(native);
+    return platform_fallback ? eglGetDisplay(native) : NULL;
+}
+
+/* Used by Xephyr */
+static inline EGLDisplay
+glamor_egl_get_display(EGLint type, void *native)
+{
+    return glamor_egl_get_display2(type, native, TRUE);
 }
 
 #endif


### PR DESCRIPTION
Just a dump of some code I'm playing around with.
If anyone finds this useful, good for them.

This code uses [my dumb gbm backend](https://github.com/stefan11111/dumb_gbm) to create a gbm device that only creates linear gbm buffers, and tries to do egl with them.

Nvidia [doesn't allow creating `GL_TEXTURE_2D` textures with `glEGLImageTargetTexture2DOES`](https://github.com/elFarto/nvidia-vaapi-driver/issues/15#issuecomment-1015827050), so I had to get creative.

The non `#if 0`-ed code maps a gbm bo and uses that map to create a texture.
The `#if 0`-ed code tells egl that our linear buffer is actually blocklinear, and creates an EGLImage from it.
Nvidia then happily creates a `GL_TEXTURE_2D` texture from it using the regular glEGLImageTargetTexture2DOES` call.
The `if 0`-ed magic constant is taken from my machine and is not at all correct on other machines.
It should be queried, but I left it as is in cases anyone wants to play around with this.
The constant should be replaced with another format the card supports.

There is some other code to initially paint the buffer.

The problem with this is that it doesn't quite work.

When the gpu using this is not the primary gpu, then everything works.
We get glx working on it, and we don't care if we can actually see the contents of the buffers, only that the gpu can draw into it.

This code breaks for some reason when it's driving the primary gpu.
Nothing that is drawn appears on the screen.

I can populate the buffer for the root pixmap, which I do inside the `if 1`-ed code, and I can see what I draw there, but nothing else gets drawn.

Switching to another tty, I can see that glx is fully initialized and working, but there is no image on the screen:
```
$ DISPLAY=:1 glxinfo -B
name of display: :1
display: :1  screen: 0
direct rendering: Yes
Memory info (GL_NVX_gpu_memory_info):
    Dedicated video memory: 2048 MB
    Total available memory: 2048 MB
    Currently available dedicated video memory: 1915 MB
OpenGL vendor string: NVIDIA Corporation
OpenGL renderer string: NVIDIA GeForce GTX 1050/PCIe/SSE2
OpenGL core profile version string: 4.6.0 NVIDIA 470.256.02
OpenGL core profile shading language version string: 4.60 NVIDIA
OpenGL core profile context flags: (none)
OpenGL core profile profile mask: core profile

OpenGL version string: 4.6.0 NVIDIA 470.256.02
OpenGL shading language version string: 4.60 NVIDIA
OpenGL context flags: (none)
OpenGL profile mask: (none)

OpenGL ES profile version string: OpenGL ES 3.2 NVIDIA 470.256.02
OpenGL ES profile shading language version string: OpenGL ES GLSL ES 3.20
```
@ONykyf @cepelinas9000 @notbabaisyou @metux Any idea how to fix this code, or it it even can be fixed?
The point of this is to get old nvidia cards working with the modesetting driver, with full hw accel,
and without needing to use EGLStreams or vulkan.

We don't really care all that much that the gbm bo's are linear, as graphical intensive applications are usually written in vulkan, which is unaffected by this.