### PR TITLE
.github: fix NetBSD and DragflyBSD build

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -258,7 +258,7 @@ jobs:
                   envs: 'MESON_ARGS'
                   usesh: true
                   release: "6.4.2"
-                  run:     ./.github/scripts/DragonFlyBSD/run-xserver-build.sh
+                  run:     cd "${{ github.workspace }}" && ./.github/scripts/DragonFlyBSD/run-xserver-build.sh
 
     xserver-build-netbsd:
         runs-on: ubuntu-latest
@@ -272,7 +272,8 @@ jobs:
                   envs: 'MESON_ARGS'
                   usesh: true
                   release: '10.1'
-                  run:     ./.github/scripts/netbsd/run-xserver-build.sh
+                  run:     cd "${{ github.workspace }}" && ./.github/scripts/netbsd/run-xserver-build.sh
+
     xserver-build-cygwin:
         runs-on: windows-latest
         steps:


### PR DESCRIPTION
For some strange reason, vm-actions on these two targets suddenly doesn't
chdir into our source tree anymore (while still doing so on others),
so we're ending up in /root instead, thus can't call our script.

We need to explicitly chdir into /home/runner/work/xserver/xserver before
calling our actual build script.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
