### PR TITLE
seatd-libseat.c: fix compilation when XSERVER_PLATFORM_BUS is disabled

### DIFF
--- a/hw/xfree86/os-support/shared/seatd-libseat.c
+++ b/hw/xfree86/os-support/shared/seatd-libseat.c
@@ -38,14 +38,16 @@
 #include "os.h"
 #include "xf86.h"
 #include "xf86_priv.h"
+#ifdef XSERVER_PLATFORM_BUS
+#include "xf86platformBus_priv.h"
 #include "xf86platformBus.h"
+#endif
 #include "xf86Xinput.h"
 #include "xf86Xinput_priv.h"
 #include "xf86Priv.h"
 #include "globals.h"
 
 #include "config/hotplug_priv.h"
-#include "xf86platformBus_priv.h"
 
 #include "seatd-libseat.h"
 
@@ -89,7 +91,9 @@ enable_seat(struct libseat *seat, void *userdata)
             }
         }
     xf86InputEnableVTProbe(); /* Add any paused input devices */
+    #ifdef XSERVER_PLATFORM_BUS
     xf86platformVTProbe(); /* Probe for outputs */
+    #endif
 }
 
 /*


### PR DESCRIPTION
As seatd support has finally been added to Xlibre, I decided to test it on my system without udev, after reading the compilation error and understanding XSERVER_PLATFORM_BUS, I found https://github.com/X11Libre/xserver/commit/9878e097a7de2f86eff0dcfd9fe5d83b162197ec, this same fix applies here and successfully compiles and runs the X server rootless.