### PR TITLE
hw: xquartz: remove apple blocks entirely

### DIFF
--- a/hw/xquartz/X11Application.m
+++ b/hw/xquartz/X11Application.m
@@ -242,6 +242,14 @@ QuartzModeBundleInit(void);
     [self activateX:NO];
 }
 
+static void
+sendX11NSEvent_fptr(void *e_ptr)
+{
+    NSEvent *e = e_ptr;
+    [X11App sendX11NSEvent:e];
+    [e release];
+}
+
 - (void) sendEvent:(NSEvent *)e
 {
     /* Don't try sending to X if we haven't initialized.  This can happen if AppKit takes over
@@ -472,9 +480,8 @@ QuartzModeBundleInit(void);
     }
 
     if (for_x) {
-        dispatch_async(eventTranslationQueue, ^{
-            [self sendX11NSEvent:e];
-        });
+        NSEvent *event_copy = [e retain];
+        dispatch_async_f(eventTranslationQueue, event_copy, sendX11NSEvent_fptr);
     }
 }
 
@@ -561,81 +568,151 @@ QuartzModeBundleInit(void);
 
 @end
 
+/* Helper function for X11ApplicationSetWindowMenu */
+static void
+setWindowMenuOnMain_fptr(void *arg)
+{
+    NSArray *items = arg;
+    [X11App.controller set_window_menu:items];
+    [items release];
+}
+
 void
 X11ApplicationSetWindowMenu(int nitems, const char **items,
                             const char *shortcuts)
 {
     @autoreleasepool {
-        NSMutableArray <NSArray <NSString *> *> * const allMenuItems = [NSMutableArray array];
+        NSMutableArray<NSArray<NSString *> *> *allMenuItems =
+            [[NSMutableArray alloc] init];
 
         for (int i = 0; i < nitems; i++) {
-            NSMutableArray <NSString *> * const menuItem = [NSMutableArray array];
+            NSMutableArray<NSString *> *menuItem =
+                [[NSMutableArray alloc] init];
+
             [menuItem addObject:@(items[i])];
 
             if (shortcuts[i] == 0) {
                 [menuItem addObject:@""];
             } else {
-                [menuItem addObject:[NSString stringWithFormat:@"%d", shortcuts[i]]];
+                [menuItem addObject:
+                    [NSString stringWithFormat:@"%d", shortcuts[i]]];
             }
 
             [allMenuItems addObject:menuItem];
+            [menuItem release];
         }
 
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [X11App.controller set_window_menu:allMenuItems];
-        });
+        dispatch_async_f(dispatch_get_main_queue(),
+                         allMenuItems,
+                         setWindowMenuOnMain_fptr);
     }
+}
+
+static void
+setWindowMenuCheck_fptr(void *arg)
+{
+    NSNumber *idx = arg;
+    [X11App.controller set_window_menu_check:idx];
+    [idx release];
 }
 
 void
 X11ApplicationSetWindowMenuCheck(int idx)
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [X11App.controller set_window_menu_check:@(idx)];
-    });
+    NSNumber *num = [[NSNumber alloc] initWithInt:idx];
+    dispatch_async_f(dispatch_get_main_queue(), num, setWindowMenuCheck_fptr);
 }
 
+
+static void
+appSetFrontProcess_fptr(void* unused)
+{
+    (void) unused;
+    [X11App set_front_process:nil];
+}
 void
 X11ApplicationSetFrontProcess(void)
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [X11App set_front_process:nil];
-    });
+    dispatch_async_f(dispatch_get_main_queue(), NULL, appSetFrontProcess_fptr);
 }
 
+static void
+appSetCanQuit_fptr(void *__state)
+{
+    NSNumber *state = __state;
+    X11App.controller.can_quit = [state boolValue];
+    [state release];
+}
 void
 X11ApplicationSetCanQuit(int state)
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        X11App.controller.can_quit = !!state;
-    });
+    NSNumber *state_alloc = [[NSNumber alloc] initWithInt:state];
+    dispatch_async_f(dispatch_get_main_queue(), state_alloc, appSetCanQuit_fptr);
 }
 
+static void
+appServerReady_fptr(void* unused)
+{
+    (void) unused;
+    [X11App.controller server_ready];
+}
 void
 X11ApplicationServerReady(void)
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [X11App.controller server_ready];
-    });
+    dispatch_async_f(dispatch_get_main_queue(), NULL, appServerReady_fptr);
 }
 
+static void
+appShowHideMenubar_fptr(void *state_ptr)
+{
+    NSNumber *state = state_ptr;
+    [X11App show_hide_menubar:state];
+    [state release];
+}
 void
 X11ApplicationShowHideMenubar(int state)
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [X11App show_hide_menubar:@(state)];
-    });
+    NSNumber *state_alloc = [[NSNumber alloc] initWithInt:state];
+    dispatch_async_f(dispatch_get_main_queue(), state_alloc, appShowHideMenubar_fptr);
 }
 
+static void
+appLaunchClient_fptr(void *string_ptr)
+{
+    NSString *string = string_ptr;
+    [X11App launch_client:string];
+    [string release];
+}
 void
 X11ApplicationLaunchClient(const char *cmd)
 {
     @autoreleasepool {
-        NSString *string = @(cmd);
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [X11App launch_client:string];
-        });
+        NSString *string_alloc = [[NSString alloc] initWithUTF8String:cmd];
+        dispatch_async_f(dispatch_get_main_queue(), string_alloc, appLaunchClient_fptr);
     }
+}
+
+
+
+/* helper function for X11ApplicationCanEnterRandR(),
+ * extracted from previous Apple block */
+static void
+runAlertPanel(void *result_ptr)
+{
+    NSString *title, *msg;
+    NSInteger *result = result_ptr;
+    title = NSLocalizedString(@"Enter RandR mode?",
+                              @"Dialog title when switching to RandR");
+
+    msg = NSLocalizedString(
+        @"An application has requested X11 to change the resolution of your display.  X11 will restore the display to its previous state when the requesting application requests to return to the previous state.  Alternatively, you can use the ⌥⌘A key sequence to force X11 to return to the previous state.",
+        @"Dialog when switching to RandR"
+    );
+
+    *result = NSRunAlertPanel(title, @"%@",
+                              NSLocalizedString(@"Allow", @""),
+                              NSLocalizedString(@"Cancel", @""),
+                              NSLocalizedString(@"Always Allow", @""), msg);
 }
 
 /* This is a special function in that it is run from the *SERVER* thread and
@@ -645,29 +722,18 @@ X11ApplicationLaunchClient(const char *cmd)
 Bool
 X11ApplicationCanEnterRandR(void)
 {
-    NSString *title, *msg;
+    
     NSUserDefaults * const defaults = NSUserDefaults.xquartzDefaults;
 
     if ([defaults boolForKey:XQuartzPrefKeyNoRANDRAlert] ||
         XQuartzShieldingWindowLevel != 0)
         return TRUE;
 
-    title = NSLocalizedString(@"Enter RandR mode?",
-                              @"Dialog title when switching to RandR");
-    msg = NSLocalizedString(
-        @"An application has requested X11 to change the resolution of your display.  X11 will restore the display to its previous state when the requesting application requests to return to the previous state.  Alternatively, you can use the ⌥⌘A key sequence to force X11 to return to the previous state.",
-        @"Dialog when switching to RandR");
-
     if (!XQuartzIsRootless)
         QuartzShowFullscreen(FALSE);
 
-    NSInteger __block alert_result;
-    dispatch_sync(dispatch_get_main_queue(), ^{
-        alert_result = NSRunAlertPanel(title, @"%@",
-                                       NSLocalizedString(@"Allow", @""),
-                                       NSLocalizedString(@"Cancel", @""),
-                                       NSLocalizedString(@"Always Allow", @""), msg);
-    });
+    NSInteger alert_result;
+    dispatch_sync_f(dispatch_get_main_queue(), &alert_result, runAlertPanel);
 
     switch (alert_result) {
     case NSAlertOtherReturn:
@@ -871,6 +937,17 @@ untrusted_str(NSEvent *e)
 
 extern void
 wait_for_mieq_init(void);
+
+typedef struct _CopyKeyboardLayoutCtx {
+    TISInputSourceRef *key_layout;
+} CopyKeyboardLayoutCtx;
+
+static void
+copyKeyboardLayout_fptr(void *arg)
+{
+    CopyKeyboardLayoutCtx *ctx = arg;
+    *(ctx->key_layout) = TISCopyCurrentKeyboardLayoutInputSource();
+}
 
 - (void) sendX11NSEvent:(NSEvent *)e
 {
@@ -1322,15 +1399,14 @@ handle_mouse:
     }
 
         if (darwinSyncKeymap) {
-            __block TISInputSourceRef key_layout;
-            dispatch_block_t copyCurrentKeyboardLayoutInputSource = ^{
-                key_layout = TISCopyCurrentKeyboardLayoutInputSource();
-            };
+            TISInputSourceRef key_layout;
+            CopyKeyboardLayoutCtx ctx = { .key_layout = &key_layout };
+
             /* This is an ugly ant-pattern, but it is more expedient to address the problem right now. */
             if (pthread_main_np()) {
-                copyCurrentKeyboardLayoutInputSource();
+                copyKeyboardLayout_fptr(&ctx);
             } else {
-                dispatch_sync(dispatch_get_main_queue(), copyCurrentKeyboardLayoutInputSource);
+                dispatch_sync_f(dispatch_get_main_queue(), &ctx, copyKeyboardLayout_fptr);
             }
 
             TISInputSourceRef clear;

--- a/hw/xquartz/quartzKeyboard.c
+++ b/hw/xquartz/quartzKeyboard.c
@@ -193,6 +193,11 @@ typedef struct darwinKeyboardInfo_struct {
     unsigned char modifierKeycodes[32][2];
 } darwinKeyboardInfo;
 
+typedef struct _KeyboardDataContext {
+    UInt32 kbd_type;
+    const void *chr_data;
+} KeyboardDataContext;
+
 darwinKeyboardInfo keyInfo;
 pthread_mutex_t keyInfo_mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -741,39 +746,38 @@ make_dead_key(KeySym in)
     return in;
 }
 
+static void getKeyboardData(void *keyboard_ctx) {
+    KeyboardDataContext *ctx = keyboard_ctx;
+    ctx->kbd_type = LMGetKbdType();
+    TISInputSourceRef currentKeyLayoutRef = TISCopyCurrentKeyboardLayoutInputSource();
+
+    if (currentKeyLayoutRef) {
+        CFDataRef currentKeyLayoutDataRef = (CFDataRef)TISGetInputSourceProperty(currentKeyLayoutRef,
+                                                                                 kTISPropertyUnicodeKeyLayoutData);
+        if (currentKeyLayoutDataRef)
+            ctx->chr_data = CFDataGetBytePtr(currentKeyLayoutDataRef);
+
+        CFRelease(currentKeyLayoutRef);
+    }
+}
+
 static Bool
 QuartzReadSystemKeymap(darwinKeyboardInfo *info)
 {
-    __block const void *chr_data = NULL;
     int num_keycodes = NUM_KEYCODES;
-    __block UInt32 keyboard_type;
+    KeyboardDataContext ctx = { 0 };
     int i, j;
     OSStatus err;
     KeySym *k;
 
-    dispatch_block_t getKeyboardData = ^{
-        keyboard_type = LMGetKbdType();
-
-        TISInputSourceRef currentKeyLayoutRef = TISCopyCurrentKeyboardLayoutInputSource();
-
-        if (currentKeyLayoutRef) {
-            CFDataRef currentKeyLayoutDataRef = (CFDataRef)TISGetInputSourceProperty(currentKeyLayoutRef,
-                                                                                     kTISPropertyUnicodeKeyLayoutData);
-            if (currentKeyLayoutDataRef)
-                chr_data = CFDataGetBytePtr(currentKeyLayoutDataRef);
-
-            CFRelease(currentKeyLayoutRef);
-        }
-    };
-
     /* This is an ugly ant-pattern, but it is more expedient to address the problem right now. */
     if (pthread_main_np()) {
-        getKeyboardData();
+        getKeyboardData(&ctx);
     } else {
-        dispatch_sync(dispatch_get_main_queue(), getKeyboardData);
+        dispatch_sync_f(dispatch_get_main_queue(), &ctx, getKeyboardData);
     }
 
-    if (chr_data == NULL) {
+    if (ctx.chr_data == NULL) {
         ErrorF("Couldn't get uchr or kchr resource\n");
         return FALSE;
     }
@@ -799,16 +803,16 @@ QuartzReadSystemKeymap(darwinKeyboardInfo *info)
             UniCharCount len;
             UInt32 dead_key_state = 0, extra_dead = 0;
 
-            err = UCKeyTranslate(chr_data, i, kUCKeyActionDown,
-                                 mods[j] >> 8, keyboard_type, 0,
+            err = UCKeyTranslate(ctx.chr_data, i, kUCKeyActionDown,
+                                 mods[j] >> 8, ctx.kbd_type, 0,
                                  &dead_key_state, 8, &len, s);
             if (err != noErr) continue;
 
             if (len == 0 && dead_key_state != 0) {
                 /* Found a dead key. Work out which one it is, but
                    remembering that it's dead. */
-                err = UCKeyTranslate(chr_data, i, kUCKeyActionDown,
-                                     mods[j] >> 8, keyboard_type,
+                err = UCKeyTranslate(ctx.chr_data, i, kUCKeyActionDown,
+                                     mods[j] >> 8, ctx.kbd_type,
                                      kUCKeyTranslateNoDeadKeysMask,
                                      &extra_dead, 8, &len, s);
                 if (err != noErr) continue;

--- a/hw/xquartz/xpr/xprEvent.c
+++ b/hw/xquartz/xpr/xprEvent.c
@@ -35,51 +35,53 @@
 
 #include "xpr.h"
 
-#include   <X11/X.h>
-#include   <X11/Xmd.h>
-#include   <X11/Xproto.h>
-#include   "misc.h"
-#include   "windowstr.h"
-#include   "pixmapstr.h"
-#include   "inputstr.h"
-#include   "eventstr.h"
-#include   "mi.h"
-#include   "scrnintstr.h"
-#include   "mipointer.h"
+#include "eventstr.h"
+#include "inputstr.h"
+#include "mi.h"
+#include "mipointer.h"
+#include "misc.h"
+#include "pixmapstr.h"
+#include "scrnintstr.h"
+#include "windowstr.h"
+#include <X11/X.h>
+#include <X11/Xmd.h>
+#include <X11/Xproto.h>
 
+#include "darwinEvents.h"
 #include "quartz.h"
 #include "quartzKeyboard.h"
-#include "darwinEvents.h"
-
 
 #include <dispatch/dispatch.h>
 
 #include "rootlessWindow.h"
 #include "xprEvent.h"
 
-bool QuartzModeEventHandler(int screenNum, XQuartzEvent *e, DeviceIntPtr dev)
-{
-    switch (e->subtype) {
-    case kXquartzWindowState:
-        DEBUG_LOG("kXquartzWindowState\n");
-        RootlessNativeWindowStateChanged(xprGetXWindow(e->data[0]),
-                                         e->data[1]);
-        return TRUE;
+static void bringAllToFront(void *unused) {
+  (void)unused; /* to silence the compiler warning */
+  xp_window_bring_all_to_front();
+}
 
-    case kXquartzWindowMoved:
-        DEBUG_LOG("kXquartzWindowMoved\n");
-        RootlessNativeWindowMoved(xprGetXWindow(e->data[0]));
-        return TRUE;
+bool QuartzModeEventHandler(int screenNum, XQuartzEvent *e, DeviceIntPtr dev) {
+  switch (e->subtype) {
+  case kXquartzWindowState:
+    DEBUG_LOG("kXquartzWindowState\n");
+    RootlessNativeWindowStateChanged(xprGetXWindow(e->data[0]), e->data[1]);
+    return TRUE;
 
-    case kXquartzBringAllToFront:
-        DEBUG_LOG("kXquartzBringAllToFront\n");
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            xp_window_bring_all_to_front();
-        });
+  case kXquartzWindowMoved:
+    DEBUG_LOG("kXquartzWindowMoved\n");
+    RootlessNativeWindowMoved(xprGetXWindow(e->data[0]));
+    return TRUE;
 
-        return TRUE;
+  case kXquartzBringAllToFront:
+    DEBUG_LOG("kXquartzBringAllToFront\n");
+    dispatch_async_f(
+        dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), NULL,
+        bringAllToFront);
 
-    default:
-        return FALSE;
-    }
+    return TRUE;
+
+  default:
+    return FALSE;
+  }
 }

--- a/hw/xquartz/xpr/xprFrame.c
+++ b/hw/xquartz/xpr/xprFrame.c
@@ -54,6 +54,11 @@
 
 DEFINE_ATOM_HELPER(xa_native_window_id, "_NATIVE_WINDOW_ID")
 
+typedef struct _WindowHashInsertCtx {
+    xp_window_id wid;
+    RootlessWindowPtr frame;
+} WindowHashInsertCtx;
+
 /* Maps xp_window_id -> RootlessWindowRec */
 static x_hash_table * window_hash;
 
@@ -136,6 +141,14 @@ xprColormapCallback(void *data, int first_color, int n_colors,
                                     colors) ? XP_Success : XP_BadMatch);
 }
 
+static void
+windowHashInsert(void *arg)
+{
+    WindowHashInsertCtx *ctx = arg;
+    x_hash_table_insert(window_hash, x_cvt_uint_to_vptr(ctx->wid), ctx->frame);
+    free(ctx);
+}
+
 /*
  * Create and display a new frame.
  */
@@ -193,13 +206,40 @@ xprCreateFrame(RootlessWindowPtr pFrame, ScreenPtr pScreen,
         return FALSE;
     }
 
-    dispatch_async(window_hash_serial_q, ^ {
-                       x_hash_table_insert(window_hash, pFrame->wid, pFrame);
-                   });
+    WindowHashInsertCtx *ctx = malloc(sizeof(WindowHashInsertCtx));
+    if (!ctx) return FALSE;
 
+    ctx->wid = x_cvt_vptr_to_uint(pFrame->wid);
+    ctx->frame = pFrame;
+
+    dispatch_async_f(window_hash_serial_q, ctx, windowHashInsert);
     xprSetNativeProperty(pFrame);
 
     return TRUE;
+}
+
+/* For heap allocation */
+typedef struct _WindowHashRemoveCtx {
+    RootlessFrameID wid;
+} WindowHashRemoveCtx;
+
+typedef struct _WindowLookupCtx {
+    RootlessFrameID wid;
+    RootlessWindowRec **winrec;
+} WindowLookupCtx;
+
+/* the members are gonna be the same, so no reason to duplicate code */
+typedef WindowLookupCtx WindowGetCtx;
+
+static void windowHashRemove(void *arg) {
+    WindowHashRemoveCtx *ctx = arg;
+    x_hash_table_remove(window_hash, ctx->wid);
+    free(ctx);
+}
+
+static void windowLookup(void *arg) {
+    WindowLookupCtx *ctx = (WindowLookupCtx *)arg;
+    *(ctx->winrec) = x_hash_table_lookup(window_hash, ctx->wid, NULL);
 }
 
 /*
@@ -208,13 +248,13 @@ xprCreateFrame(RootlessWindowPtr pFrame, ScreenPtr pScreen,
 static void
 xprDestroyFrame(RootlessFrameID wid)
 {
-    xp_error err;
+    WindowHashRemoveCtx *ctx = malloc(sizeof(WindowHashRemoveCtx));
+    if (!ctx) FatalError("Could not allocate memory for the hash removal context.");
 
-    dispatch_async(window_hash_serial_q, ^ {
-                       x_hash_table_remove(window_hash, wid);
-                   });
+    ctx->wid = wid;
+    dispatch_async_f(window_hash_serial_q, ctx, windowHashRemove);
 
-    err = xp_destroy_window(x_cvt_vptr_to_uint(wid));
+    xp_error err = xp_destroy_window(x_cvt_vptr_to_uint(wid));
     if (err != Success)
         FatalError("Could not destroy window %d (%d).",
                    (int)x_cvt_vptr_to_uint(
@@ -265,8 +305,12 @@ xprRestackFrame(RootlessFrameID wid, RootlessFrameID nextWid)
 {
     xp_window_changes wc;
     unsigned int mask = XP_STACKING;
-    __block
     RootlessWindowRec * winRec;
+
+    WindowLookupCtx ctx = {
+        .wid = wid,
+        .winrec = &winRec
+    };
 
     /* Stack frame below nextWid it if it exists, or raise
        frame above everything otherwise. */
@@ -280,9 +324,7 @@ xprRestackFrame(RootlessFrameID wid, RootlessFrameID nextWid)
         wc.sibling = x_cvt_vptr_to_uint(nextWid);
     }
 
-    dispatch_sync(window_hash_serial_q, ^ {
-                      winRec = x_hash_table_lookup(window_hash, wid, NULL);
-                  });
+    dispatch_sync_f(window_hash_serial_q, &ctx, windowLookup);
 
     if (winRec) {
         if (XQuartzIsRootless)
@@ -480,6 +522,11 @@ xprInit(ScreenPtr pScreen)
     return TRUE;
 }
 
+static void windowGet(void *arg) {
+    WindowGetCtx *ctx = arg;
+    *(ctx->winrec) = x_hash_table_lookup(window_hash, ctx->wid, NULL);
+}
+
 /*
  * Given the id of a physical window, try to find the top-level (or root)
  * X window that it represents.
@@ -487,12 +534,13 @@ xprInit(ScreenPtr pScreen)
 WindowPtr
 xprGetXWindow(xp_window_id wid)
 {
-    RootlessWindowRec *winRec __block;
-    dispatch_sync(window_hash_serial_q, ^ {
-                      winRec =
-                          x_hash_table_lookup(window_hash,
-                                              x_cvt_uint_to_vptr(wid), NULL);
-                  });
+    RootlessWindowRec *winRec;
+    WindowGetCtx ctx = {
+        .wid = x_cvt_uint_to_vptr(wid),
+        .winrec = &winRec
+    };
+
+    dispatch_sync_f(window_hash_serial_q, &ctx, windowGet);
 
     return winRec != NULL ? winRec->win : NULL;
 }

--- a/os/client.c
+++ b/os/client.c
@@ -124,7 +124,7 @@ DetermineClientPid(struct _Client * client)
 
 #ifdef __APPLE__ /* only required on macOS */
 static void
-get_argmax_fptr(void *arg)
+get_argmax_from_kern(void *arg)
 {
     int *argmax = arg;
     int mib[2];
@@ -183,7 +183,7 @@ DetermineClientCmd(pid_t pid, const char **cmdname, const char **cmdargs)
     {
         static dispatch_once_t once;
         static int argmax;
-        dispatch_once_f(&once, &argmax, get_argmax_fptr);
+        dispatch_once_f(&once, &argmax, get_argmax_from_kern);
 
         int mib[3];
         size_t len = argmax;


### PR DESCRIPTION
Apple blocks are an extension specific to some very old GCC versions and clang. Replace them by writing normal functions that can be used by `dispatch_(a)sync_f` with function pointers, therefore no longer having to rely on that extension and allowing XLibre to build on older macOS versions and hardware.

~~TODO: According to [this comment](https://github.com/X11Libre/xserver/issues/1719#issuecomment-3686117552), the relevant Objective C parts must also be patched out since `gcc-objc` doesn't support them. (Should this be split into two PRs instead?)~~ (done)

Closes: #1719 