### PR TITLE
Change driver location to modules/xlibre-25.0 like all others

### DIFF
--- a/hw/xfree86/meson.build
+++ b/hw/xfree86/meson.build
@@ -1,4 +1,4 @@
-module_abi_tag = 'xlibre-25'
+module_abi_tag = 'xlibre-25.0'
 module_abi_dir = join_paths(module_dir, module_abi_tag)
 
 xorg_inc = include_directories(


### PR DESCRIPTION
Without this change the drivers are installed as:
/usr/lib/xorg/modules/xlibre-25/drivers/modesetting_drv.so
/usr/lib/xorg/modules/xlibre-25/input/inputtest_drv.so

while all others are installed in:
/usr/lib/xorg/modules/xlibre-25.0/drivers
/usr/lib/xorg/modules/xlibre-25.0/input