### PR TITLE
dix & record: Opt-in keyboard isolation from CLI and unfocused clients.

### DIFF
--- a/Xext/record/record.c
+++ b/Xext/record/record.c
@@ -294,6 +294,22 @@ RecordAProtocolElement(RecordContextPtr pContext, ClientPtr pClient,
     Bool gotServerTime = FALSE;
     int replylen;
 
+    /*
+     * Do not deliver keyboard input data.
+     * Affects both 'device_events' and 'delivered_events' ranges,
+     * which could be used to listen keyboard input events.
+     */
+    if (globalIsolateKeyboard && data) {
+        xEvent *pev = (void *) data;
+        switch (pev->u.u.type) {
+        case KeyPress:
+        case KeyRelease:
+            return;
+        default:
+            break;
+        }
+    }
+
     if (futurelen >= 0) {       /* start of new protocol element */
         xRecordEnableContextReply *pRep = (xRecordEnableContextReply *)
             pContext->replyBuffer;

--- a/dix/events.c
+++ b/dix/events.c
@@ -2487,6 +2487,21 @@ DeliverRawEvent(RawDeviceEvent *ev, DeviceIntPtr device)
     if (grab)
         DeliverGrabbedEvent((InternalEvent *) ev, device, FALSE);
 
+    /*
+     * To prevent keylogging, not grabbed raw keyboard event
+     * should not be sent to any client.
+     */
+    if (globalIsolateKeyboard) {
+        switch (ev->type) {
+        case ET_RawKeyPress:
+        case ET_RawKeyRelease:
+            free(xi);
+            return;
+        default:
+            break;
+        }
+    }
+
     filter = GetEventFilter(device, xi);
 
     DIX_FOR_EACH_SCREEN({
@@ -2826,6 +2841,24 @@ static int
 DeliverOneEvent(InternalEvent *event, DeviceIntPtr dev, enum InputLevel level,
                 WindowPtr win, Window child, GrabPtr grab)
 {
+    /*
+     * Deliver keyboard events only if client is focused.
+     * Even if it does not have a window, that means unfocused.
+     */
+    if (globalIsolateKeyboard) {
+        WindowPtr focus = inputInfo.keyboard->focus->win;
+
+        if (win != focus) {
+            switch (event->any.type) {
+            case ET_KeyPress:
+            case ET_KeyRelease:
+                return 0;
+            default:
+                break;
+            }
+        }
+    }
+
     xEvent *xE = NULL;
     int count = 0;
     int deliveries = 0;
@@ -4203,10 +4236,38 @@ DeliverFocusedEvent(DeviceIntPtr keybd, InternalEvent *event, WindowPtr window)
     int count, rc;
     int deliveries = 0;
 
-    if (focus == FollowKeyboardWin)
+    /*
+     * With keyboard isolation, 'inputInfo.keyboard->focus->win' is
+     * more reliable choice to decide how to route input.
+     *
+     * For example, being focused on root window, we will not detect
+     * that with 'keybd->focus->win', but will with 'inputInfo'.
+     */
+    if (focus == FollowKeyboardWin || globalIsolateKeyboard)
         focus = inputInfo.keyboard->focus->win;
     if (!focus)
         return;
+
+    /*
+    * Do not deliver keyboard input events to the root window,
+    * because that makes CLI clients see input when root window
+    * becomes focused.
+    * 
+    * Some DEs/WMs put window on top of root window, so this is not
+    * an issue there, but an issue everywhere else.
+    */
+    if (globalIsolateKeyboard) {
+        if (focus == window->drawable.pScreen->root) {
+            switch (event->any.type) {
+            case ET_KeyPress:
+            case ET_KeyRelease:
+                return;
+            default:
+                break;
+            }
+        }
+    }
+
     if (focus == PointerRootWin) {
         DeliverDeviceEvents(window, event, NullGrab, NullWindow, keybd);
         return;

--- a/dix/globals.c
+++ b/dix/globals.c
@@ -122,3 +122,5 @@ int monitorResolution = 0;
 
 Bool explicit_display = FALSE;
 char *ConnectionInfo;
+
+Bool globalIsolateKeyboard = FALSE;

--- a/hw/xfree86/common/xf86Config.c
+++ b/hw/xfree86/common/xf86Config.c
@@ -653,6 +653,7 @@ typedef enum {
     FLAG_DEBUG,
     FLAG_ALLOW_BYTE_SWAPPED_CLIENTS,
     FLAG_SINGLE_DRIVER,
+    FLAG_ISOLATE_KEYBOARD,
 } FlagValues;
 
 /**
@@ -715,6 +716,8 @@ static OptionInfoRec FlagOptions[] = {
     {FLAG_ALLOW_BYTE_SWAPPED_CLIENTS, "AllowByteSwappedClients", OPTV_BOOLEAN,
      {0}, FALSE},
     {FLAG_SINGLE_DRIVER, "SingleDriver", OPTV_BOOLEAN,
+     {0}, FALSE},
+    {FLAG_ISOLATE_KEYBOARD, "IsolateKeyboard", OPTV_BOOLEAN,
      {0}, FALSE},
     {-1, NULL, OPTV_NONE,
      {0}, FALSE},
@@ -823,6 +826,16 @@ configServerFlags(XF86ConfFlagsPtr flagsconf, XF86OptionPtr layoutopts)
     }
     LogMessageVerb(from, 1, "Allowing %s one driver to add non-GPU screens\n",
                    xf86Info.singleDriver ? "only" : "more than");
+
+    if (xf86IsOptionSet(FlagOptions, FLAG_ISOLATE_KEYBOARD)) {
+        xf86GetOptValBool(FlagOptions, FLAG_ISOLATE_KEYBOARD,
+                          &globalIsolateKeyboard);
+        from = X_CONFIG;
+    } else {
+        from = X_DEFAULT;
+    }
+    LogMessageVerb(from, 1, "Keyboard isolation is turned %s\n",
+                   globalIsolateKeyboard ? "on" : "off");
 
     /*
      * Set things up based on the config file information.  Some of these

--- a/hw/xfree86/man/xorg.conf.man
+++ b/hw/xfree86/man/xorg.conf.man
@@ -692,6 +692,14 @@ Allow clients with a different byte-order than the server. Disabled by default.
 Only the first successfully probed driver is allowed to add screens to the current layout, others may
 add secondary GPU screens only (e.g., if non-primary GPUs are used for offloading).
 Disabled by default.
+.TP 7
+.BI "Option \*qIsolateKeyboard\*q \*q" boolean \*q
+Disallows delivery of raw keyboard input events to clients that have not
+grabbed the keyboard. Disallows delivery of XI2 keyboard events to
+clients that are either unfocused or do not own the window. Disallows
+listening keyboard input events through RECORD extension. As a result,
+prevents common keylogging methods that depend on X server features.
+Disabled by default.
 .SH "MODULE SECTION"
 The
 .B Module

--- a/include/globals.h
+++ b/include/globals.h
@@ -10,4 +10,6 @@ extern _X_EXPORT const char *defaultFontPath;
 extern _X_EXPORT int monitorResolution;
 extern _X_EXPORT int defaultColorVisualClass;
 
+extern Bool globalIsolateKeyboard;
+
 #endif                          /* !_XSERV_GLOBAL_H_ */

--- a/os/utils.c
+++ b/os/utils.c
@@ -108,6 +108,7 @@ __stdcall unsigned long GetTickCount(void);
 #include "dix/settings_priv.h"
 #include "dix/screensaver_priv.h"
 #include "include/misc.h"
+#include "include/globals.h"
 #include "miext/extinit_priv.h"
 #include "os/audit_priv.h"
 #include "os/auth.h"
@@ -291,6 +292,7 @@ UseMsg(void)
     ErrorF("-help                  prints message with these options\n");
     ErrorF("+iglx                  Allow creating indirect GLX contexts\n");
     ErrorF("-iglx                  Prohibit creating indirect GLX contexts (default)\n");
+    ErrorF("-isolatekeyboard       Prevent keyboard input delivery to CLI and unfocused clients\n");
     ErrorF("-I                     ignore all remaining arguments\n");
 #ifdef CONFIG_NAMESPACE
     ErrorF("-namespace <conf>      Enable NAMESPACE extension with given config file\n");
@@ -559,6 +561,9 @@ ProcessCommandLine(int argc, char *argv[])
                 i += skip - 1;
             else
                 UseMsg();
+        }
+        else if (strcmp(argv[i], "-isolatekeyboard") == 0) {
+            globalIsolateKeyboard = TRUE;
         }
 #ifdef LOCK_SERVER
         else if (strcmp(argv[i], "-nolock") == 0) {


### PR DESCRIPTION
In case you all interested in isolating keyboard from keyloggers and unfocused windows (as that is done in Wayland), we could implement this in X server. My idea is that we could provide `IsolateKeyboard` option (or whatever name fits it) to `xorg.conf` so everybody who interested in hardening their systems can enable this feature. Like this: `Option "IsolateKeyboard" "true"`.

This is just testing, and you guys know better where and how that should be implemented, there is just variable with hardcoded `true` (should be set in `xorg.conf` as option) and changes I did to achieve proper behavior.

After some tinkering I found out that keyloggers may listen raw input while applications do not listen those (at least I did not find any). So I decided to not handle these events if `IsolateKeyboard` is `true`. More details in commented lines. As a result, CLI tools which listen raw input just do not see any input. Test: `xinput test <keyboard>`.

Also it seems that `DeliverOneEvent()` is used to deliver input-related events to clients, so I added filter that denies keyboard-related events in case those are requested by an unfocused window or even CLI tool if `IsolateKeyboard` is `true`. As a result, applications see input when those are focused, while CLI tools like `xinput` can see only pointer motion events and ~~presses on Super button~~ (only FocusIn and FocusOut, it does not see any key press). Test: `xinput test-xi2 --root`.

I can't do these checks in `TryClientEvents()` (which is executed before sending event to client and all checks should be done there) as there is no way to get information about whether window we want to send event is focused or not.

I did not touch passive grab, so that DE/WM and apps (like OBS) can handle keyboard properly without being focused. As far as I understand, passive grab does not allow listen input and just waits until X server will tell to application that expected keybinding is pressed. Right?

Total (from my testing):
Broken:
- Keylogging software that listens raw input (test: `xinput test <keyboard>`) or XI2 input (test: `xinput test-xi2 --root`). Those do not have a window, so those can't be focused, so those will not get any event.

Works:
- Keybindings in: applications (OBS Studio), DEs (tested on Cinnamon), WMs, keybinding daemons (sxhkd and xbindkeys work, I've checked). As far as I understand, those are using passive grabbing.
- Input in display manager's login screen (tested with SDDM).
- Regular input in all applications.