### PR TITLE
stop defining _XF86DRI_SERVER_

### DIFF
--- a/glx/glx_dri/glxdri2.c
+++ b/glx/glx_dri/glxdri2.c
@@ -36,7 +36,6 @@
 #include <windowstr.h>
 #include <os.h>
 
-#define _XF86DRI_SERVER_
 #include <xf86.h>
 #include <dri2.h>
 

--- a/hw/xfree86/dri/dri.c
+++ b/hw/xfree86/dri/dri.c
@@ -61,7 +61,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "scrnintstr.h"
 #include "windowstr.h"
 #include "servermd.h"
-#define _XF86DRI_SERVER_
 #include <X11/dri/xf86driproto.h>
 #include "swaprep.h"
 #include "xf86str.h"

--- a/hw/xfree86/dri/xf86dri.c
+++ b/hw/xfree86/dri/xf86dri.c
@@ -53,7 +53,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "cursorstr.h"
 #include "scrnintstr.h"
 #include "servermd.h"
-#define _XF86DRI_SERVER_
 #include <X11/dri/xf86driproto.h>
 #include "swaprep.h"
 #include "xf86str.h"


### PR DESCRIPTION
This once was needed on including xf86driproto.h, but these day
have gone now for aeons.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
