### PR TITLE
Xext/dri2: Fix small memory leak.

### DIFF
--- a/Xext/dri2/dri2.c
+++ b/Xext/dri2/dri2.c
@@ -1615,18 +1615,34 @@ DRI2ScreenInit(ScreenPtr pScreen, DRI2InfoPtr info)
             goto err_out;
 
         if (info->driverName) {
-            ds->driverNames[0] = info->driverName;
+            ds->driverNames[0] = strdup(info->driverName);
+            if (!ds->driverNames[0]) {
+                free(ds->driverNames);
+                ds->driverNames = NULL;
+                goto err_out;
+            }
         } else {
-            /* FIXME dri2_probe_driver_name() returns a strdup-ed string,
-             * currently this gets leaked */
-            ds->driverNames[0] = ds->driverNames[1] = dri2_probe_driver_name(pScreen, info);
-            if (!ds->driverNames[0])
-                return FALSE;
+            ds->driverNames[0] = dri2_probe_driver_name(pScreen, info);
+            if (!ds->driverNames[0]) {
+                free(ds->driverNames);
+                ds->driverNames = NULL;
+                goto err_out;
+            }
 
             /* There is no VDPAU driver for i965, fallback to the generic
              * OpenGL/VAAPI va_gl backend to emulate VDPAU on i965. */
-            if (strcmp(ds->driverNames[0], "i965") == 0)
-                ds->driverNames[1] = "va_gl";
+            if (strcmp(ds->driverNames[0], "i965") == 0) {
+                ds->driverNames[1] = strdup("va_gl");
+            } else {
+                ds->driverNames[1] = strdup(ds->driverNames[0]);
+            }
+
+            if (!ds->driverNames[1]) {
+                free((void*)ds->driverNames[0]);
+                free(ds->driverNames);
+                ds->driverNames = NULL;
+                goto err_out;
+            }
         }
     }
     else {
@@ -1674,7 +1690,12 @@ DRI2CloseScreen(ScreenPtr pScreen)
 
     if (ds->prime_id)
         prime_id_allocate_bitmask &= ~(1 << ds->prime_id);
-    free(ds->driverNames);
+    if (ds->driverNames) {
+        for (int i = 0; i < ds->numDrivers; i++) {
+            free((void*)ds->driverNames[i]);
+        }
+        free(ds->driverNames);
+    }
     free(ds);
     dixSetPrivate(&pScreen->devPrivates, dri2ScreenPrivateKey, NULL);
 }


### PR DESCRIPTION
Fixes: https://github.com/X11Libre/xserver/pull/1414
Fixes: https://github.com/X11Libre/xserver/issues/1413
(Fixes the small leak that was mentioned there,
not sure if there isn't a bigger one somewhere else)