### PR TITLE
kdrive/fbdev: Allow force-enabling the ShadowFB layer

### DIFF
--- a/hw/kdrive/fbdev/fbdev.c
+++ b/hw/kdrive/fbdev/fbdev.c
@@ -35,6 +35,7 @@
 #endif
 
 const char *fbdevDevicePath = NULL;
+Bool fbDisableShadow = FALSE;
 
 static Bool
 fbdevInitialize(KdCardInfo * card, FbdevPriv * priv)
@@ -345,11 +346,14 @@ fbdevMapFramebuffer(KdScreenInfo * screen)
     KdPointerMatrix m;
     FbdevPriv *priv = screen->card->driver;
 
-    if (scrpriv->randr != RR_Rotate_0 ||
-        priv->fix.type != FB_TYPE_PACKED_PIXELS)
+    if (!fbDisableShadow) {
         scrpriv->shadow = TRUE;
-    else
+    } else if (scrpriv->randr != RR_Rotate_0 ||
+        priv->fix.type != FB_TYPE_PACKED_PIXELS) {
+        scrpriv->shadow = TRUE;
+    } else {
         scrpriv->shadow = FALSE;
+    }
 
     KdComputePointerMatrix(&m, scrpriv->randr, screen->width, screen->height);
 

--- a/hw/kdrive/fbdev/fbdev.h
+++ b/hw/kdrive/fbdev/fbdev.h
@@ -50,6 +50,7 @@ typedef struct _fbdevScrPriv {
 
 extern KdCardFuncs fbdevFuncs;
 extern const char *fbdevDevicePath;
+extern Bool fbDisableShadow;
 
 Bool fbdevCardInit(KdCardInfo * card);
 

--- a/hw/kdrive/fbdev/fbinit.c
+++ b/hw/kdrive/fbdev/fbinit.c
@@ -80,6 +80,8 @@ ddxUseMsg(void)
     ErrorF("\nXfbdev Device Usage:\n");
     ErrorF
         ("-fb path         Framebuffer device to use. Defaults to /dev/fb0\n");
+    ErrorF
+        ("-noshadow        Disable the ShadowFB layer if possible\n");
     ErrorF("\n");
 }
 
@@ -93,6 +95,11 @@ ddxProcessArgument(int argc, char **argv, int i)
         }
         UseMsg();
         exit(1);
+    }
+
+    if (!strcmp(argv[i], "-noshadow")) {
+        fbDisableShadow = TRUE;
+        return 1;
     }
 
     return KdProcessArgument(argc, argv, i);


### PR DESCRIPTION
For some reason, despite the fact that shadow is used, and the shadow drawing procs do get called, pixmaps still are created with raw fb backing memory,
instead of shadow memory.

I checked this be reverting https://github.com/X11Libre/xserver/commit/2ab24541515390b76c736e0949a9ab9bdb5c681c , which causes pixmaps backed by raw fb memory to incur a heavy performance penalty.

@metux Any idea why this happens?