### PR TITLE
Xext/dri2: dix: xfree86: Add `ddx_log_msg` function pointer

### DIFF
--- a/Xext/dri2/dri2.c
+++ b/Xext/dri2/dri2.c
@@ -53,11 +53,8 @@
 #define xf86DrvMsg(scrnIndex, type, /* format, */ ...) \
     do { \
         (void)scrnIndex; \
-        if (type == X_ERROR) { \
-            printf(__VA_ARGS__); \
-        } \
+        LogMessage(type, __VA_ARGS__); \
     } while (0);
-
 
 CARD8 dri2_major;               /* version of DRI2 supported by DDX */
 CARD8 dri2_minor;


### PR DESCRIPTION
Since the dri2 extension has been moved to Xext, we were no longer able to call `xf86DrvMsg`, since only the xfree86 X server implements it.

This patch makes it so that we can still log info about dri2 with `xf86DrvMsg` when using the xfree86 X server, while still being able to use the dri2 extension with other X servers and do logging.