### PR TITLE
xfree86: xf86Module.h: macro for declaring input driver module version

### DIFF
--- a/hw/xfree86/common/xf86Module.h
+++ b/hw/xfree86/common/xf86Module.h
@@ -167,4 +167,22 @@ typedef struct {
     ModuleTearDownProc teardown;
 } XF86ModuleData;
 
-#endif                          /* _XF86STR_H */
+/*
+ * declare module version info structure for an input driver module
+ */
+#define XF86_MODULE_VERSION_INPUT(_name, _major, _minor, _patchlevel)   \
+    static XF86ModuleVersionInfo modVersion = { \
+        .modname      = _name,                  \
+        .vendor       = MODULEVENDORSTRING,     \
+        ._modinfo1_   = MODINFOSTRING1,         \
+        ._modinfo2_   = MODINFOSTRING2,         \
+        .xf86version  = XORG_VERSION_CURRENT,   \
+        .majorversion = _major,                 \
+        .minorversion = _minor,                 \
+        .patchlevel   = _patchlevel,            \
+        .abiclass     = ABI_CLASS_XINPUT,       \
+        .abiversion   = ABI_XINPUT_VERSION,     \
+        .moduleclass  = MOD_CLASS_XINPUT,       \
+    };
+
+#endif                          /* _XF86MODULE_H */


### PR DESCRIPTION
Reduce the effort of declaring/filling an input driver's module version
struct to short statement like this:

    XF86_MODULE_VERSION_INPUT("egalax",
                              PACKAGE_VERSION_MAJOR,
                              PACKAGE_VERSION_MINOR,
                              PACKAGE_VERSION_PATCHLEVEL);

This will create a properly filled XF86ModuleVersionInfo structure
named `modInfo`.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
