### PR TITLE
xfree86: add macros for declaring XF86ModuleData fields

### DIFF
--- a/hw/xfree86/common/xf86Module.h
+++ b/hw/xfree86/common/xf86Module.h
@@ -213,4 +213,20 @@ typedef struct {
         .moduleclass  = MOD_CLASS_VIDEODRV,     \
     };
 
+#define XF86_MODULE_DATA_INPUT(_modname, _setup, _teardown, _name, _major, _minor, _patchlevel) \
+    XF86_MODULE_VERSION_INPUT(_name, _major, _minor, _patchlevel) \
+    _X_EXPORT XF86ModuleData _modname##ModuleData = { \
+        .vers = &modVersion, \
+        .setup = _setup, \
+        .teardown = _teardown, \
+    };
+
+#define XF86_MODULE_DATA_VIDEO(_modname, _setup, _teardown, _name, _major, _minor, _patchlevel) \
+    XF86_MODULE_VERSION_VIDEO(_name, _major, _minor, _patchlevel) \
+    _X_EXPORT XF86ModuleData _modname##ModuleData = { \
+        .vers = &modVersion, \
+        .setup = _setup, \
+        .teardown = _teardown, \
+    };
+
 #endif /* _XF86MODULE_H */


### PR DESCRIPTION
XF86_MODULE_DATA_INPUT() creates XF86ModuleData field for input driver,
while XF86_MODULE_DATA_VIDEO creating one for a video driver.

These are filled with given values, _X_EXPORT'ed and properly named so
the module loader can find them. Also creating the associated
XF86ModuleVersionInfo field and link them into the XF86ModuleData.

Example:

    XF86_MODULE_DATA_INPUT(
        egalax,
        eGalaxPlug,
        eGalaxUnplug,
        "egalax",
        PACKAGE_VERSION_MAJOR,
        PACKAGE_VERSION_MINOR,
        PACKAGE_VERSION_PATCHLEVEL);

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
