### PR TITLE
split KdInitInput for mixed use in Xephyr and Xfbdev

### DIFF
--- a/hw/kdrive/fbdev/fbinit.c
+++ b/hw/kdrive/fbdev/fbinit.c
@@ -51,7 +51,8 @@ void
 InitInput(int argc, char **argv)
 {
     KdOsAddInputDrivers();
-    kdInitInputPre();
+    KdAddConfigInputDrivers();
+    KdInitInput();
 }
 
 void

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -473,7 +473,7 @@ void
 void
  KdInitInput(void);
  void
- kdInitInputPre(void);
+ KdAddConfigInputDrivers(void);
 void
  KdCloseInput(void);
 

--- a/hw/kdrive/src/kinput.c
+++ b/hw/kdrive/src/kinput.c
@@ -1310,7 +1310,7 @@ KdPointerInfo *KdParsePointer(const char *arg)
 }
 
 void
-kdInitInputPre(void)
+KdAddConfigInputDrivers(void)
 {
     #ifdef KDRIVE_KBD
     if (!kdConfigKeyboards) {
@@ -1323,7 +1323,6 @@ kdInitInputPre(void)
         KdAddConfigPointer("mouse");
     }
     #endif
-    KdInitInput();
 }
 
 void


### PR DESCRIPTION
fix for https://github.com/X11Libre/xserver/issues/1782 as opposed to https://github.com/X11Libre/xserver/pull/1799