### PR TITLE
Backport 25.1: split KdInitInput for mixed use in Xephyr and Xfbdev

### DIFF
--- a/hw/kdrive/fbdev/fbinit.c
+++ b/hw/kdrive/fbdev/fbinit.c
@@ -64,7 +64,8 @@ void
 InitInput(int argc, char **argv)
 {
     KdOsAddInputDrivers();
-    kdInitInputPre();
+    KdAddConfigInputDrivers();
+    KdInitInput();
 }
 
 void

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -473,7 +473,7 @@ void
 void
  KdInitInput(void);
  void
- kdInitInputPre(void);
+ KdAddConfigInputDrivers(void);
 void
  KdCloseInput(void);
 

--- a/hw/kdrive/src/kinput.c
+++ b/hw/kdrive/src/kinput.c
@@ -1387,7 +1387,7 @@ KdPointerInfo *KdParsePointer(const char *arg)
 }
 
 void
-kdInitInputPre(void)
+KdAddConfigInputDrivers(void)
 {
     #ifdef KDRIVE_KBD
     if (!kdConfigKeyboards) {
@@ -1400,7 +1400,6 @@ kdInitInputPre(void)
         KdAddConfigPointer("mouse");
     }
     #endif
-    KdInitInput();
 }
 
 void


### PR DESCRIPTION
Backporting https://github.com/X11Libre/xserver/pull/1800