### PR TITLE
glamor: unexport glamor_destroy_pixmap()

### DIFF
--- a/glamor/glamor_priv.h
+++ b/glamor/glamor_priv.h
@@ -1069,6 +1069,12 @@ Bool glamor_change_window_attributes(WindowPtr pWin, unsigned long mask);
 
 void glamor_copy_window(WindowPtr window, xPoint old_origin, RegionPtr src_region);
 
+/*
+ * unref a glamor pixmap (specialized form of fbPixmap) and free
+ * if refcnt already had reached 1
+ */
+Bool glamor_destroy_pixmap(PixmapPtr pixmap);
+
 #include "glamor_utils.h"
 
 #if 0

--- a/include/glamor.h
+++ b/include/glamor.h
@@ -116,7 +116,6 @@ extern _X_EXPORT void glamor_block_handler(ScreenPtr screen);
 
 extern _X_EXPORT PixmapPtr glamor_create_pixmap(ScreenPtr screen, int w, int h,
                                                 int depth, unsigned int usage);
-extern _X_EXPORT Bool glamor_destroy_pixmap(PixmapPtr pixmap);
 
 /* needed by Xrdp module */
 #define GLAMOR_CREATE_PIXMAP_CPU        0x100


### PR DESCRIPTION
It's only used by glamor internally, on error pathes where the pixmap has been created only partially and something went wrong. Drivers don't call this function.

Recent proprietary Nvidia doesn't seem to reference this function. Haven't checked all the older ones yet.
