### PR TITLE
xfree86: os-support: bsd: tiny logging simplification on PCVT

### DIFF
--- a/hw/xfree86/os-support/bsd/bsd_init.c
+++ b/hw/xfree86/os-support/bsd/bsd_init.c
@@ -485,23 +485,11 @@ xf86OpenPcvt(void)
             }
             xf86Info.consType = PCVT;
 #ifdef WSCONS_SUPPORT
-#ifdef __NetBSD__
-            LogMessageVerb(X_PROBED, 1,
-                           "Using wscons driver on %s in pcvt compatibility mode "
-                           "(version %d.%d)\n", vtname,
-                           pcvt_version.rmajor, pcvt_version.rminor);
-#else
             LogMessageVerb(X_PROBED, 1,
                            "Using wscons driver on %s in pcvt compatibility mode ",
                            vtname);
-#endif
 #else
-# ifdef __NetBSD__
-            LogMessageVerb(X_PROBED, 1, "Using pcvt driver (version %d.%d)\n",
-                           pcvt_version.rmajor, pcvt_version.rminor);
-# else
             LogMessageVerb(X_PROBED, 1, "Using pcvt driver\n");
-# endif
 #endif
 #ifdef __NetBSD__
         }


### PR DESCRIPTION
There isn't much practical value of printing kernel PCVT driver
version into our log on NetBSD. Let's simplify this a bit and
get cut down the #ifdef wood a little bit.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
