### PR TITLE
xfree86: os-support: bsd: scope "result" variable in xf86OpenConsole()

### DIFF
--- a/hw/xfree86/os-support/bsd/bsd_init.c
+++ b/hw/xfree86/os-support/bsd/bsd_init.c
@@ -150,7 +150,6 @@ xf86OpenConsole(void)
     xf86ConsOpen_t *driver;
 
 #if defined (SYSCONS_SUPPORT) || defined (PCVT_SUPPORT)
-    int result;
 
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
     struct utsname uts;
@@ -237,6 +236,7 @@ xf86OpenConsole(void)
  acquire_vt:
 #endif
             if (!xf86Info.ShareVTs) {
+                int result;
                 /*
                  * now get the VT
                  */


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
