### PR TITLE
glx: glxext fix memory leak when calling DestroyPixmap

### DIFF
--- a/glx/glxext.c
+++ b/glx/glxext.c
@@ -126,7 +126,7 @@ DrawableGone(__GLXdrawable * glxPriv, XID xid)
 
     /* drop our reference to any backing pixmap */
     if (glxPriv->type == GLX_DRAWABLE_PIXMAP)
-        glxPriv->pDraw->pScreen->DestroyPixmap((PixmapPtr) glxPriv->pDraw);
+        dixDestroyPixmap((PixmapPtr)glxPriv->pDraw, 0);
 
     glxPriv->destroy(glxPriv);
 


### PR DESCRIPTION
Call dixDestroyPixmap instead pScreen->DestroyPixmap, which is correct call to free resources as since cece84fa93b17275dfebb729e7ab443344f52cd4 the Screen->DestroyPixmap function is no longer wrapped.

Fixes: https://github.com/X11Libre/xserver/issues/1809