### PR TITLE
xfree86: add exported xf86GetConsoleFd()

### DIFF
--- a/hw/xfree86/common/xf86.h
+++ b/hw/xfree86/common/xf86.h
@@ -282,4 +282,10 @@ extern _X_EXPORT ScreenPtr xf86ScrnToScreen(ScrnInfoPtr pScrn);
 #define xf86MsgVerb LogMessageVerb
 #define xf86Msg(type, ...) LogMessageVerb(type, 1, __VA_ARGS__)
 
+/*
+ * retrieve file descriptor to opened console device.
+ * only for some legacy keyboard drivers (xf86-input-keyboard)
+ */
+_X_EXPORT int xf86GetConsoleFd(void);
+
 #endif                          /* _XF86_H */

--- a/hw/xfree86/common/xf86Globals.c
+++ b/hw/xfree86/common/xf86Globals.c
@@ -196,3 +196,8 @@ Bool xf86VidModeDisabled = FALSE;
 Bool xf86VidModeAllowNonLocal = FALSE;
 #endif
 Bool xorgHWAccess = FALSE;
+
+int xf86GetConsoleFd(void)
+{
+    return xf86Info.consoleFd;
+}


### PR DESCRIPTION
This functions is designed for some legacy keyboard drivers
(eg. xf86-input-keyboard) that need to get the fd to the console
device, so they don't need to directly access xf86Info field anymore.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
