### PR TITLE
Xext: namespace: Allow using tabs as delimiters

### DIFF
--- a/Xext/namespace/config.c
+++ b/Xext/namespace/config.c
@@ -78,7 +78,7 @@ static void parseLine(char *line, struct Xnamespace **walk_ns)
         *c1 = 0;
 
     /* get the first token */
-    char *token = strtok(line, " ");
+    char *token = strtok(line, " \t");
 
     if (token == NULL)
         return;
@@ -101,7 +101,7 @@ static void parseLine(char *line, struct Xnamespace **walk_ns)
 
     if (strcmp(token, "auth") == 0)
     {
-        token = strtok(NULL, " ");
+        token = strtok(NULL, " \t");
         if (token == NULL)
             return;
 
@@ -132,7 +132,7 @@ static void parseLine(char *line, struct Xnamespace **walk_ns)
 
     if (strcmp(token, "allow") == 0)
     {
-        while ((token = strtok(NULL, " ")) != NULL)
+        while ((token = strtok(NULL, " \t")) != NULL)
         {
             if (strcmp(token, "mouse-motion") == 0)
                 curr->allowMouseMotion = TRUE;


### PR DESCRIPTION
Allow the `parseLine()` function to use tabs alongside spaces to separate tokens. Without this patch, using tabs in the config file actually confuses the parser and makes it think that the tab is part of the option's name.
