### PR TITLE
xfree86: xlibre-server.h: fix missing HAVE_TIMINGSAFE_MEMCMP

### DIFF
--- a/hw/xfree86/xlibre-server.h.meson.in
+++ b/hw/xfree86/xlibre-server.h.meson.in
@@ -209,4 +209,7 @@
 #define XORG_API_DIX_SCREEN_HOOK_CLOSE 1
 #define XORG_API_DIX_SCREEN_HOOK_PIXMAP_DESTROY 1
 
+/* needed for os.h to prevent redefinition of timingsafe_memcmp in drivers */
+#mesondefine HAVE_TIMINGSAFE_MEMCMP
+
 #endif /* _XORG_SERVER_H_ */


### PR DESCRIPTION
os.h still defining our own timingsafe_memcmp() prototype when this
symbol isn't set - this is causing trouble with drivers on FreeBSD.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
