### PR TITLE
xfree86: edid.h: drop Uint typedef

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -389,12 +389,10 @@
 #define IS_RIGHT_ON_SYNC(x) IS_RIGHT_STEREO(x)
 #define IS_LEFT_ON_SYNC(x) IS_LEFT_STEREO(x)
 
-typedef unsigned int Uint;
-
 struct vendor {
     char name[4];
     int prod_id;
-    Uint serial;
+    unsigned int serial;
     int week;
     int year;
 };


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
