### PR TITLE
kdrive: Fix other kinds of vt switches

### DIFF
--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -277,6 +277,9 @@ struct _KdKeyboardInfo {
     int minScanCode;
     int maxScanCode;
 
+    /* Not set by the input driver */
+    int last_scan_code;
+
     int leds;
     int bellPitch;
     int bellDuration;


### PR DESCRIPTION
When starting an X server from a terminal running
inside another X server, the "host" X server sees
the key press event, but not the key release event, and misinterprets this as a long keypress.

With this patch, we forge the missing key release event, so the server doesn't think that the user is holding a key down.

This is different from Ctrl + Alt + F* vt switching, because there we don't want the X server to see the key press event at all, and we want to forge key release events for the Ctrl + Alt keys.