### PR TITLE
xfree86: ddc: drop obsolete DFP1() macro

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -297,9 +297,6 @@
 /* input type */
 #define DIGITAL(x) x
 
-/* DFP */
-#define DFP1(x) x
-
 /* input voltage level */
 #define V070 0                  /* 0.700V/0.300V */
 #define V071 1                  /* 0.714V/0.286V */

--- a/hw/xfree86/ddc/print_edid.c
+++ b/hw/xfree86/ddc/print_edid.c
@@ -71,7 +71,7 @@ print_input_features(int scrnIndex, struct disp_features *c,
     if (DIGITAL(c->input_type)) {
         xf86DrvMsg(scrnIndex, X_INFO, "Digital Display Input\n");
         if (v->revision == 2 || v->revision == 3) {
-            if (DFP1(c->input_dfp))
+            if (c->input_dfp)
                 xf86DrvMsg(scrnIndex, X_INFO, "DFP 1.x compatible TMDS\n");
         }
         else if (v->revision >= 4) {


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
