### PR TITLE
.github: increase xf86-video-intel version to 25.0.1

### DIFF
--- a/.github/scripts/compile-drivers.sh
+++ b/.github/scripts/compile-drivers.sh
@@ -34,7 +34,7 @@ build_xf86drv_ac    video-freedreno         25.0.0
 build_xf86drv_ac    video-geode             25.0.0
 build_xf86drv_ac    video-i128              25.0.0
 build_xf86drv_ac    video-i740              25.0.0
-build_xf86drv_ac    video-intel             25.0.0
+build_xf86drv_ac    video-intel             25.0.1
 build_xf86drv_ac    video-mach64            25.0.0
 build_xf86drv_ac    video-mga               25.0.0
 build_xf86drv_ac    video-neomagic          25.0.0


### PR DESCRIPTION
Upcoming work needs a few fixes in the Intel driver.
(mainly not using internal EDID parser defines anymore)

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
