### PR TITLE
xfree86: ddc: move struct cea_ext_body into interpret_edid.c

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -611,12 +611,4 @@ struct cea_data_block {
     } u;
 };
 
-struct cea_ext_body {
-    uint8_t tag;
-    uint8_t rev;
-    uint8_t dt_offset;
-    uint8_t flags;
-    struct cea_data_block data_collection;
-};
-
 #endif                          /* _EDID_H_ */

--- a/hw/xfree86/ddc/interpret_edid.c
+++ b/hw/xfree86/ddc/interpret_edid.c
@@ -37,6 +37,14 @@
 #define _PARSE_EDID_
 #include "xf86DDC_priv.h"
 
+struct cea_ext_body {
+    uint8_t tag;
+    uint8_t rev;
+    uint8_t dt_offset;
+    uint8_t flags;
+    struct cea_data_block data_collection;
+};
+
 static void get_vendor_section(uint8_t *, struct vendor *);
 static void get_version_section(uint8_t *, struct edid_version *);
 static void get_display_section(uint8_t *, struct disp_features *,


### PR DESCRIPTION
It's only used there, so no need to keep it in public header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
