### PR TITLE
xfree86: ddc: drop unused IS_INTERLACED() macro

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -332,7 +332,6 @@
 #define CVT_SUPPORTED(x) (x & 0x1)
 
 /* detailed timing misc */
-#define IS_INTERLACED(x)  (x)
 #define IS_STEREO(x)  (x)
 #define IS_RIGHT_STEREO(x) (x & 0x01)
 #define IS_LEFT_STEREO(x) (x & 0x02)


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
