### PR TITLE
xfree86: ddc: drop obsolete IS_RIGHT_ON_SYNC() and IS_LEFT_STEREO()

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -337,8 +337,6 @@
 #define IS_RIGHT_STEREO(x) (x & 0x01)
 #define IS_LEFT_STEREO(x) (x & 0x02)
 #define IS_4WAY_STEREO(x) (x & 0x03)
-#define IS_RIGHT_ON_SYNC(x) IS_RIGHT_STEREO(x)
-#define IS_LEFT_ON_SYNC(x) IS_LEFT_STEREO(x)
 
 struct vendor {
     char name[4];


### PR DESCRIPTION
Not used anymore, so no need to keep them around any longer.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
