### PR TITLE
xfree86: ddc: drop unused GTF_SUPPORTED() macro

### DIFF
--- a/include/edid.h
+++ b/include/edid.h
@@ -25,7 +25,6 @@
 
 /* Msc stuff EDID Ver > 1.1 */
 #define PREFERRED_TIMING_MODE(x) (x & 0x2)
-#define GTF_SUPPORTED(x) (x & 0x1)
 
 struct vendor {
     char name[4];


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
