### PR TITLE
xfree86: ddc: move STD_COLOR_SPACE() and GFT_SUPPORTED() macros

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -314,9 +314,7 @@
 #define DPMS_OFF(x) (x & 0x01)
 
 /* Msc stuff EDID Ver > 1.1 */
-#define STD_COLOR_SPACE(x) (x & 0x4)
 #define PREFERRED_TIMING_MODE(x) (x & 0x2)
-#define GFT_SUPPORTED(x) (x & 0x1)
 #define GTF_SUPPORTED(x) (x & 0x1)
 #define CVT_SUPPORTED(x) (x & 0x1)
 

--- a/hw/xfree86/ddc/print_edid.c
+++ b/hw/xfree86/ddc/print_edid.c
@@ -46,6 +46,9 @@
 #define DISP_YCRCB444 0x01
 #define DISP_YCRCB422 0x02
 
+#define STD_COLOR_SPACE(x) (x & 0x4)
+#define GFT_SUPPORTED(x) (x & 0x1)
+
 #define EDID_WIDTH	16
 
 static void


### PR DESCRIPTION
These are only used in print_edid.c, so no need to keep them
in a global header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
