### PR TITLE
xfree86: ddc: move DPMS_*() macros into print_edid.c

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -308,11 +308,6 @@
 #define SYNC_O_GREEN(x) (x & 0x02)
 #define SYNC_SERR(x) (x & 0x01)
 
-/* DPMS features */
-#define DPMS_STANDBY(x) (x & 0x04)
-#define DPMS_SUSPEND(x) (x & 0x02)
-#define DPMS_OFF(x) (x & 0x01)
-
 /* Msc stuff EDID Ver > 1.1 */
 #define PREFERRED_TIMING_MODE(x) (x & 0x2)
 #define GTF_SUPPORTED(x) (x & 0x1)

--- a/hw/xfree86/ddc/print_edid.c
+++ b/hw/xfree86/ddc/print_edid.c
@@ -46,6 +46,11 @@
 #define DISP_YCRCB444 0x01
 #define DISP_YCRCB422 0x02
 
+/* DPMS features */
+#define DPMS_STANDBY(x) (x & 0x04)
+#define DPMS_SUSPEND(x) (x & 0x02)
+#define DPMS_OFF(x) (x & 0x01)
+
 #define STD_COLOR_SPACE(x) (x & 0x4)
 #define GFT_SUPPORTED(x) (x & 0x1)
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
