### PR TITLE
utils: cast to CARD64 for avoiding 32-bit time_t overflow

### DIFF
--- a/os/utils.c
+++ b/os/utils.c
@@ -229,11 +229,11 @@ GetTimeInMillis(void)
             clockid = ~0L;
     }
     if (clockid != ~0L && clock_gettime(clockid, &tp) == 0)
-        return (tp.tv_sec * 1000) + (tp.tv_nsec / 1000000L);
+        return ((CARD64)tp.tv_sec * 1000) + (tp.tv_nsec / 1000000L);
 #endif
 
     X_GETTIMEOFDAY(&tv);
-    return (tv.tv_sec * 1000) + (tv.tv_usec / 1000);
+    return ((CARD64)tv.tv_sec * 1000) + (tv.tv_usec / 1000);
 }
 
 CARD64


### PR DESCRIPTION
In `getTimeInMillis()` function, result of multiplying `tv.tv_sec * 1000` may exceed the maximum value for a 32-bit signed integer, resulting in incorrect timestamps.

Reference:
- https://man7.org/linux/man-pages/man3/time_t.3type.html