### PR TITLE
xkb: Fix locked/latched indicator desync across multiple keyboards

### DIFF
--- a/xkb/xkbActions.c
+++ b/xkb/xkbActions.c
@@ -1240,6 +1240,12 @@ XkbPushLockedStateToSlaves(DeviceIntPtr master, int evtype, int key)
 
         dev->key->xkbInfo->state.locked_mods =
             master->key->xkbInfo->state.locked_mods;
+        dev->key->xkbInfo->state.locked_group =
+            master->key->xkbInfo->state.locked_group;
+        dev->key->xkbInfo->state.latched_mods =
+            master->key->xkbInfo->state.latched_mods;
+        dev->key->xkbInfo->state.latched_group =
+            master->key->xkbInfo->state.latched_group;
 
         _XkbApplyState(dev, genStateNotify, evtype, key);
     }


### PR DESCRIPTION
When a group indicator (or a latched indicator of any kind) is defined,
e.g.:
  indicator "Scroll Lock" { groups = Group2; }
the logical and physical indicator state may desync across multiple
connected keyboards.

This is caused by XkbPushLockedStateToSlaves only pushing locked_mods to
the slave devices. Pushing locked_group (as well as latched groups/mods)
along with locked_mods resolves the issue.

The issue is not observed with API calls because a different code path
is taken (avoiding XkbPushLockedStateToSlaves altogether).

Signed-off-by: Alexander Melnyk <inboxnumberzero@zoho.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2120>
