### PR TITLE
xfree86: ddc: move input voltage level defines into print_edid.c

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -293,12 +293,6 @@
 /* input type */
 #define DIGITAL(x) x
 
-/* input voltage level */
-#define V070 0                  /* 0.700V/0.300V */
-#define V071 1                  /* 0.714V/0.286V */
-#define V100 2                  /* 1.000V/0.400V */
-#define V007 3                  /* 0.700V/0.000V */
-
 /* Signal level setup */
 #define SIG_SETUP(x) (x)
 

--- a/hw/xfree86/ddc/print_edid.c
+++ b/hw/xfree86/ddc/print_edid.c
@@ -51,6 +51,12 @@
 #define DPMS_SUSPEND(x) (x & 0x02)
 #define DPMS_OFF(x) (x & 0x01)
 
+/* input voltage level */
+#define V070 0                  /* 0.700V/0.300V */
+#define V071 1                  /* 0.714V/0.286V */
+#define V100 2                  /* 1.000V/0.400V */
+#define V007 3                  /* 0.700V/0.000V */
+
 #define STD_COLOR_SPACE(x) (x & 0x4)
 #define GFT_SUPPORTED(x) (x & 0x1)
 


### PR DESCRIPTION
Only used in print_edid.c, so no need to keep them in global header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
