### PR TITLE
xfree86: ddc: replace NEXT_DT_MD_SECTION() macro

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -286,7 +286,6 @@
 #define ADD_DUMMY 0x10
 
 #define _NEXT_DT_MD_SECTION(x) (x = (x + DET_TIMING_INFO_LEN))
-#define NEXT_DT_MD_SECTION _NEXT_DT_MD_SECTION(c)
 
 #endif                          /* _PARSE_EDID_ */
 

--- a/hw/xfree86/ddc/interpret_edid.c
+++ b/hw/xfree86/ddc/interpret_edid.c
@@ -640,7 +640,7 @@ get_dt_md_section(uint8_t * c, struct edid_version *ver,
 
     for (i = 0; i < DET_TIMINGS; i++) {
         fetch_detailed_block(c, ver, det_mon + i);
-        NEXT_DT_MD_SECTION;
+        _NEXT_DT_MD_SECTION(c);
     }
 }
 


### PR DESCRIPTION
trivial enough to be replaced easily.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
