### PR TITLE
xfree86: ddc: replace SIG_SETUP()

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -293,9 +293,6 @@
 /* input type */
 #define DIGITAL(x) x
 
-/* Signal level setup */
-#define SIG_SETUP(x) (x)
-
 /* sync characteristics */
 #define SEP_SYNC(x) (x & 0x08)
 #define COMP_SYNC(x) (x & 0x04)

--- a/hw/xfree86/ddc/print_edid.c
+++ b/hw/xfree86/ddc/print_edid.c
@@ -131,7 +131,7 @@ print_input_features(int scrnIndex, struct disp_features *c,
         default:
             xf86ErrorF("undefined\n");
         }
-        if (SIG_SETUP(c->input_setup))
+        if (c->input_setup)
             xf86DrvMsg(scrnIndex, X_INFO, "Signal levels configurable\n");
         xf86DrvMsg(scrnIndex, X_INFO, "Sync:");
         if (SEP_SYNC(c->input_sync))


### PR DESCRIPTION
Trivial enough to replace it easily.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
