### PR TITLE
xfree86: ddc: drop obsolete IS_STEREO() macro

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -40,7 +40,6 @@
 #define CVT_SUPPORTED(x) (x & 0x1)
 
 /* detailed timing misc */
-#define IS_STEREO(x)  (x)
 #define IS_RIGHT_STEREO(x) (x & 0x01)
 #define IS_LEFT_STEREO(x) (x & 0x02)
 #define IS_4WAY_STEREO(x) (x & 0x03)

--- a/hw/xfree86/ddc/print_edid.c
+++ b/hw/xfree86/ddc/print_edid.c
@@ -363,7 +363,7 @@ print_detailed_timings(int scrnIndex, struct detailed_timings *t)
                    t->v_sync_off + t->v_sync_width + t->v_active,
                    t->v_active + t->v_blanking);
         xf86ErrorF("v_border: %i\n", t->v_border);
-        if (IS_STEREO(t->stereo)) {
+        if (t->stereo) {
             xf86DrvMsg(scrnIndex, X_INFO, "Stereo: ");
             if (IS_RIGHT_STEREO(t->stereo)) {
                 if (!t->stereo_1)


### PR DESCRIPTION
It's not actually doing something, so we don't really need it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
