### PR TITLE
xfree86: ddc: move some parsing EDID macros into ddc.c

### DIFF
--- a/hw/xfree86/ddc/ddc.c
+++ b/hw/xfree86/ddc/ddc.c
@@ -24,6 +24,10 @@
 
 #define RETRIES 4
 
+#define HEADER 6
+#define BITS_PER_BYTE 9
+#define NUM BITS_PER_BYTE*EDID1_LEN
+
 typedef enum {
     DDCOPT_NODDC1,
     DDCOPT_NODDC2,

--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -18,9 +18,6 @@
 
 /* read complete EDID record */
 #define EDID1_LEN 128
-#define BITS_PER_BYTE 9
-#define NUM BITS_PER_BYTE*EDID1_LEN
-#define HEADER 6
 
 #define STD_TIMINGS 8
 #define DET_TIMINGS 4


### PR DESCRIPTION
Only used there, so no need to keep them in public header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
