### PR TITLE
xfree86: ddc: move IS_*_STEREO() macros into print_edid.c

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -36,11 +36,6 @@
 #define GTF_SUPPORTED(x) (x & 0x1)
 #define CVT_SUPPORTED(x) (x & 0x1)
 
-/* detailed timing misc */
-#define IS_RIGHT_STEREO(x) (x & 0x01)
-#define IS_LEFT_STEREO(x) (x & 0x02)
-#define IS_4WAY_STEREO(x) (x & 0x03)
-
 struct vendor {
     char name[4];
     int prod_id;

--- a/hw/xfree86/ddc/print_edid.c
+++ b/hw/xfree86/ddc/print_edid.c
@@ -59,6 +59,11 @@
 
 #define EDID_WIDTH	16
 
+/* detailed timing misc */
+#define IS_RIGHT_STEREO(x) (x & 0x01)
+#define IS_LEFT_STEREO(x) (x & 0x02)
+#define IS_4WAY_STEREO(x) (x & 0x03)
+
 static void
 print_vendor(int scrnIndex, struct vendor *c)
 {


### PR DESCRIPTION
Only used there, so no need to keep them in public header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
