### PR TITLE
xfree86: ddc: move EDID1_LEN into edid_priv.h

### DIFF
--- a/hw/xfree86/ddc/ddc.c
+++ b/hw/xfree86/ddc/ddc.c
@@ -21,6 +21,7 @@
 #include "xf86_OSproc.h"
 #include "xf86DDC.h"
 #include <string.h>
+#include "edid_priv.h"
 
 #define RETRIES 4
 

--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -16,9 +16,6 @@
 #include <X11/Xmd.h>
 #include <X11/Xfuncproto.h>
 
-/* read complete EDID record */
-#define EDID1_LEN 128
-
 #define STD_TIMINGS 8
 #define DET_TIMINGS 4
 

--- a/hw/xfree86/ddc/edid_priv.h
+++ b/hw/xfree86/ddc/edid_priv.h
@@ -14,6 +14,9 @@
 
 #include "edid.h"
 
+/* read complete EDID record */
+#define EDID1_LEN 128
+
 /* header: 0x00 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0x00  */
 #define HEADER_SECTION 0
 #define HEADER_LENGTH 8


### PR DESCRIPTION
Not used by any external drivers, so no need to keep it public.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
