### PR TITLE
xfree86: ddc: move sync characteristics macros to print_edid.c

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -25,12 +25,6 @@
 /* input type */
 #define DIGITAL(x) x
 
-/* sync characteristics */
-#define SEP_SYNC(x) (x & 0x08)
-#define COMP_SYNC(x) (x & 0x04)
-#define SYNC_O_GREEN(x) (x & 0x02)
-#define SYNC_SERR(x) (x & 0x01)
-
 /* Msc stuff EDID Ver > 1.1 */
 #define PREFERRED_TIMING_MODE(x) (x & 0x2)
 #define GTF_SUPPORTED(x) (x & 0x1)

--- a/hw/xfree86/ddc/print_edid.c
+++ b/hw/xfree86/ddc/print_edid.c
@@ -64,6 +64,12 @@
 #define IS_LEFT_STEREO(x) (x & 0x02)
 #define IS_4WAY_STEREO(x) (x & 0x03)
 
+/* sync characteristics */
+#define SEP_SYNC(x) (x & 0x08)
+#define COMP_SYNC(x) (x & 0x04)
+#define SYNC_O_GREEN(x) (x & 0x02)
+#define SYNC_SERR(x) (x & 0x01)
+
 static void
 print_vendor(int scrnIndex, struct vendor *c)
 {


### PR DESCRIPTION
Only used there, so no need to keep them in public header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
