### PR TITLE
xfree86: ddc: move CVT_SUPPORTED to private header

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -34,7 +34,6 @@
 /* Msc stuff EDID Ver > 1.1 */
 #define PREFERRED_TIMING_MODE(x) (x & 0x2)
 #define GTF_SUPPORTED(x) (x & 0x1)
-#define CVT_SUPPORTED(x) (x & 0x1)
 
 struct vendor {
     char name[4];

--- a/hw/xfree86/ddc/edid_priv.h
+++ b/hw/xfree86/ddc/edid_priv.h
@@ -274,4 +274,7 @@
 
 #define _NEXT_DT_MD_SECTION(x) (x = (x + DET_TIMING_INFO_LEN))
 
+/* Msc stuff EDID Ver > 1.1 */
+#define CVT_SUPPORTED(x) (x & 0x1)
+
 #endif /* _XFREE86_EDID_PRIV_H_ */


### PR DESCRIPTION
Not used by any external driver, so no need to keep it in public header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
