### PR TITLE
xfree86: ddc: move ext tag defines into interpret_edid.c

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -211,18 +211,6 @@ typedef struct {
 
 extern _X_EXPORT xf86MonPtr ConfiguredMonitor;
 
-#define EXT_TAG 0
-#define EXT_REV 1
-#define CEA_EXT   0x02
-#define VTB_EXT   0x10
-#define DI_EXT    0x40
-#define LS_EXT    0x50
-#define MI_EXT    0x60
-
-#define CEA_EXT_MIN_DATA_OFFSET 4
-#define CEA_EXT_MAX_DATA_OFFSET 127
-#define CEA_EXT_DET_TIMING_NUM 6
-
 #define IEEE_ID_HDMI    0x000C03
 #define CEA_AUDIO_BLK   1
 #define CEA_VIDEO_BLK   2

--- a/hw/xfree86/ddc/interpret_edid.c
+++ b/hw/xfree86/ddc/interpret_edid.c
@@ -38,6 +38,18 @@
 #include "xf86_OSproc.h"
 #include "xf86DDC_priv.h"
 
+#define EXT_TAG   0x00
+#define EXT_REV   0x01
+#define CEA_EXT   0x02
+#define VTB_EXT   0x10
+#define DI_EXT    0x40
+#define LS_EXT    0x50
+#define MI_EXT    0x60
+
+#define CEA_EXT_MIN_DATA_OFFSET 4
+#define CEA_EXT_MAX_DATA_OFFSET 127
+#define CEA_EXT_DET_TIMING_NUM 6
+
 struct cea_ext_body {
     uint8_t tag;
     uint8_t rev;


### PR DESCRIPTION
Not used anywhere outside, so no need to keep them in public header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
