### PR TITLE
modesetting: pageflip: clear new_front_bo struct in ms_do_pageflip

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/pageflip.c
+++ b/hw/xfree86/drivers/video/modesetting/pageflip.c
@@ -414,8 +414,8 @@ ms_do_pageflip(ScreenPtr screen,
 
     ms->glamor.block_handler(screen);
 
+    memset(&new_front_bo,0,sizeof(new_front_bo));
     new_front_bo.gbm = ms->glamor.gbm_bo_from_pixmap(screen, new_front);
-    new_front_bo.dumb = NULL;
 
     if (!new_front_bo.gbm) {
         xf86DrvMsg(scrn->scrnIndex, X_ERROR,


### PR DESCRIPTION
That fixes crash with xfce and turned on compositor on master after f4362fc4ec146fab846a215471e3f7f6632e053d commit.

ms_do_pageflip function temporary creates and destroy drmmode_bo object, but the structure is stack ( values goes uninitialized). This became problem because in f4362fc4ec146fab846a215471e3f7f6632e053d drmmode_bo struct got extra fields which is checked during drmmode_bo_destroy and causes crash.