### PR TITLE
kdrive/ephyr: Fix typo when checking for `EGL_KHR_platform_x11`

### DIFF
--- a/hw/kdrive/ephyr/ephyr_glamor.c
+++ b/hw/kdrive/ephyr/ephyr_glamor.c
@@ -243,7 +243,7 @@ ephyr_glamor_connect(void)
     }
 
     if (epoxy_has_egl_extension(EGL_NO_DISPLAY, "EGL_EXT_platform_x11") ||
-        epoxy_has_egl_extension(EGL_NO_DISPLAY, "EGL_KHR_platform_x11)")) {
+        epoxy_has_egl_extension(EGL_NO_DISPLAY, "EGL_KHR_platform_x11")) {
         void *lib = NULL;
         xcb_connection_t *ret = NULL;
         void *(*x_open_display)(void *) =


### PR DESCRIPTION


## Backport dashboard

| Branch | PR | Status |
|--------|----|--------|
| `release/25.2` | — | ✅ Already contained |
| `release/25.1` | [#3583](https://github.com/X11Libre/xserver/pull/3583) | 🔄 Open |
| `release/25.0` | [#3598](https://github.com/X11Libre/xserver/pull/3598) | 🔄 Open |
