### PR TITLE
xfree86: ddc: move struct cea_data_block into private header

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -264,15 +264,4 @@ struct cea_speaker_block {
     uint8_t ResvByte;
 };
 
-struct cea_data_block {
-    uint8_t len:5;
-    uint8_t tag:3;
-    union {
-        struct cea_video_block video;
-        struct cea_audio_block audio;
-        struct cea_vendor_block vendor;
-        struct cea_speaker_block speaker;
-    } u;
-};
-
 #endif                          /* _EDID_H_ */

--- a/hw/xfree86/ddc/edid_priv.h
+++ b/hw/xfree86/ddc/edid_priv.h
@@ -280,4 +280,15 @@
 /* Msc stuff EDID Ver > 1.1 */
 #define CVT_SUPPORTED(x) (x & 0x1)
 
+struct cea_data_block {
+    uint8_t len:5;
+    uint8_t tag:3;
+    union {
+        struct cea_video_block video;
+        struct cea_audio_block audio;
+        struct cea_vendor_block vendor;
+        struct cea_speaker_block speaker;
+    } u;
+};
+
 #endif /* _XFREE86_EDID_PRIV_H_ */

--- a/hw/xfree86/modes/xf86Crtc.c
+++ b/hw/xfree86/modes/xf86Crtc.c
@@ -33,6 +33,7 @@
 #include "dix/screen_hooks_priv.h"
 #include "randr/randrstr_priv.h"
 
+#include "edid_priv.h"
 #include "xf86_priv.h"
 #include "xf86DDC_priv.h"
 #include "xf86Config.h"


### PR DESCRIPTION
Not used by any external drivers, so no need to keep it in public header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
