### PR TITLE
xfree86: ddc: move struct cea_speaker_block into private header

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -248,20 +248,4 @@ struct cea_vendor_block {
     };
 };
 
-struct cea_speaker_block {
-    uint8_t FLR:1;
-    uint8_t LFE:1;
-    uint8_t FC:1;
-    uint8_t RLR:1;
-    uint8_t RC:1;
-    uint8_t FLRC:1;
-    uint8_t RLRC:1;
-    uint8_t FLRW:1;
-    uint8_t FLRH:1;
-    uint8_t TC:1;
-    uint8_t FCH:1;
-    uint8_t Resv:5;
-    uint8_t ResvByte;
-};
-
 #endif                          /* _EDID_H_ */

--- a/hw/xfree86/ddc/edid_priv.h
+++ b/hw/xfree86/ddc/edid_priv.h
@@ -280,6 +280,22 @@
 /* Msc stuff EDID Ver > 1.1 */
 #define CVT_SUPPORTED(x) (x & 0x1)
 
+struct cea_speaker_block {
+    uint8_t FLR:1;
+    uint8_t LFE:1;
+    uint8_t FC:1;
+    uint8_t RLR:1;
+    uint8_t RC:1;
+    uint8_t FLRC:1;
+    uint8_t RLRC:1;
+    uint8_t FLRW:1;
+    uint8_t FLRH:1;
+    uint8_t TC:1;
+    uint8_t FCH:1;
+    uint8_t Resv:5;
+    uint8_t ResvByte;
+};
+
 struct cea_data_block {
     uint8_t len:5;
     uint8_t tag:3;


### PR DESCRIPTION
Not used by any external drivers, so no need to keep it in public header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
