### PR TITLE
xfree86: ddc: move remaining struct cea_* to private header

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -214,16 +214,4 @@ extern _X_EXPORT xf86MonPtr ConfiguredMonitor;
 #define VENDOR_LATENCY_PRESENT_I(x) ( ( (x) >> 6) & 0x01)
 #define HDMI_MAX_TMDS_UNIT   (5000)
 
-struct cea_video_block {
-    uint8_t video_code;
-};
-
-struct cea_audio_block_descriptor {
-    uint8_t audio_code[3];
-};
-
-struct cea_audio_block {
-    struct cea_audio_block_descriptor descriptor[10];
-};
-
 #endif                          /* _EDID_H_ */

--- a/hw/xfree86/ddc/edid_priv.h
+++ b/hw/xfree86/ddc/edid_priv.h
@@ -318,6 +318,18 @@ struct cea_vendor_block {
     };
 };
 
+struct cea_video_block {
+    uint8_t video_code;
+};
+
+struct cea_audio_block_descriptor {
+    uint8_t audio_code[3];
+};
+
+struct cea_audio_block {
+    struct cea_audio_block_descriptor descriptor[10];
+};
+
 struct cea_data_block {
     uint8_t len:5;
     uint8_t tag:3;

--- a/hw/xfree86/ddc/xf86DDC_priv.h
+++ b/hw/xfree86/ddc/xf86DDC_priv.h
@@ -7,6 +7,7 @@
 #define _XSERVER_XF86_DDC_PRIV_H
 
 #include "xf86DDC.h"
+#include "edid_priv.h"
 
 /*
  * Quirks to work around broken EDID data from various monitors.


### PR DESCRIPTION
Not needed in public SDK headers.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
