### PR TITLE
xfree86: ddc: move some defines into private header

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -204,14 +204,4 @@ typedef struct {
 
 extern _X_EXPORT xf86MonPtr ConfiguredMonitor;
 
-#define IEEE_ID_HDMI    0x000C03
-#define CEA_AUDIO_BLK   1
-#define CEA_VIDEO_BLK   2
-#define CEA_VENDOR_BLK  3
-#define CEA_SPEAKER_ALLOC_BLK 4
-#define CEA_VESA_DTC_BLK 5
-#define VENDOR_LATENCY_PRESENT(x)     ( (x) >> 7)
-#define VENDOR_LATENCY_PRESENT_I(x) ( ( (x) >> 6) & 0x01)
-#define HDMI_MAX_TMDS_UNIT   (5000)
-
 #endif                          /* _EDID_H_ */

--- a/hw/xfree86/ddc/interpret_edid.c
+++ b/hw/xfree86/ddc/interpret_edid.c
@@ -50,6 +50,10 @@
 #define CEA_EXT_MAX_DATA_OFFSET 127
 #define CEA_EXT_DET_TIMING_NUM 6
 
+#define IEEE_ID_HDMI    0x000C03
+#define CEA_VIDEO_BLK   2
+#define CEA_VENDOR_BLK  3
+
 struct cea_ext_body {
     uint8_t tag;
     uint8_t rev;


### PR DESCRIPTION
Those aren't used by any external driver, so no need to keep them public.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
