### PR TITLE
xfree86: ddc: interpret_edid.c: minor whitespace fixes

### DIFF
--- a/hw/xfree86/ddc/interpret_edid.c
+++ b/hw/xfree86/ddc/interpret_edid.c
@@ -791,15 +791,15 @@ gtf_supported(xf86MonPtr mon)
 
     if ((mon->ver.version == 1) && (mon->ver.revision < 4)) {
         if (mon->features.msc & 0x1)
-	    return TRUE;
+            return TRUE;
     } else {
         for (i = 0; i < DET_TIMINGS; i++) {
             struct detailed_monitor_section *det_timing_des = &(mon->det_mon[i]);
             if (det_timing_des && (det_timing_des->type == DS_RANGES) && (mon->features.msc & 0x1) &&
                 (det_timing_des->section.ranges.display_range_timing_flags == DR_DEFAULT_GTF
-		|| det_timing_des->section.ranges.display_range_timing_flags == DR_SECONDARY_GTF))
-		    return TRUE;
-	}
+                || det_timing_des->section.ranges.display_range_timing_flags == DR_SECONDARY_GTF))
+                    return TRUE;
+        }
     }
 
     return FALSE;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
