### PR TITLE
xfree86: move xf86_platform_device_odev_attributes() into private header

### DIFF
--- a/hw/xfree86/common/xf86platformBus.h
+++ b/hw/xfree86/common/xf86platformBus.h
@@ -37,11 +37,6 @@ struct xf86_platform_device {
 #define XF86_PDEV_PAUSED        0x04
 
 #ifdef XSERVER_PLATFORM_BUS
-static inline struct OdevAttributes *
-xf86_platform_device_odev_attributes(struct xf86_platform_device *device)
-{
-    return device->attribs;
-}
 
 /*
  * Define the legacy API only for external builds

--- a/hw/xfree86/common/xf86platformBus_priv.h
+++ b/hw/xfree86/common/xf86platformBus_priv.h
@@ -19,6 +19,12 @@ xf86_platform_odev_attributes(int index)
     return device->attribs;
 }
 
+static inline struct OdevAttributes *
+xf86_platform_device_odev_attributes(struct xf86_platform_device *device)
+{
+    return device->attribs;
+}
+
 int xf86platformProbe(void);
 int xf86platformProbeDev(DriverPtr drvp);
 int xf86platformAddGPUDevices(DriverPtr drvp);

--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -65,7 +65,7 @@
 #include "xf86xv.h"
 #include <xorg-config.h>
 #ifdef XSERVER_PLATFORM_BUS
-#include "xf86platformBus.h"
+#include "xf86platformBus_priv.h"
 #endif
 #ifdef XSERVER_LIBPCIACCESS
 #include <pciaccess.h>


### PR DESCRIPTION
Not used by external drivers, and not part of ABI (just an inline),
so no need to keep it it public SDK header.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
