### PR TITLE
xfree86: move pci_device_is_boot_display to priv header and document it

### DIFF
--- a/hw/xfree86/common/xf86_pci_priv.h
+++ b/hw/xfree86/common/xf86_pci_priv.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef _XSERVER_XF86_PCI_PRIV_H
+#define _XSERVER_XF86_PCI_PRIV_H
+
+#ifdef XSERVER_LIBPCIACCESS
+#include <pciaccess.h>
+#else
+struct pci_device;
+#endif
+
+/*
+ * placeholder for a new libpciaccess function in upcoming releases:
+ * https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/merge_requests/39/
+ *
+ * callee code is already prepared for using it, but for the time being
+ * we need a dummy - until the actual one is really there.
+ */
+#ifndef pci_device_is_boot_display
+static inline int pci_device_is_boot_display(struct pci_device *dev)
+{
+    return 0;
+}
+#endif
+
+#endif /* _XSERVER_XF86_PCI_PRIV_H */

--- a/hw/xfree86/common/xf86pciBus.c
+++ b/hw/xfree86/common/xf86pciBus.c
@@ -33,6 +33,7 @@
 #endif
 
 #include <ctype.h>
+#include <dirent.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <pciaccess.h>
@@ -41,11 +42,11 @@
 #include "os/log_priv.h"
 #include "os/osdep.h"
 
+#include "xf86_pci_priv.h"
 #include "os.h"
 #include "Pci.h"
 #include "xf86_priv.h"
 #include "xf86Priv.h"
-#include "dirent.h"             /* DIR, FILE type definitions */
 
 /* Bus-specific headers */
 #include "xf86Bus.h"

--- a/hw/xfree86/common/xf86platformBus.c
+++ b/hw/xfree86/common/xf86platformBus.c
@@ -45,6 +45,7 @@
 #include "os.h"
 #include "../os-support/linux/systemd-logind.h"
 
+#include "xf86_pci_priv.h"
 #include "loaderProcs.h"
 #include "xf86_priv.h"
 #include "xf86_os_support.h"

--- a/hw/xfree86/common/xf86platformBus.h
+++ b/hw/xfree86/common/xf86platformBus.h
@@ -89,11 +89,4 @@ xf86PlatformDeviceCheckBusID(struct xf86_platform_device *device, const char *bu
 
 #endif
 
-#ifndef pci_device_is_boot_display
-static inline Bool pci_device_is_boot_display(struct pci_device *dev)
-{
-    return FALSE;
-}
-#endif
-
 #endif


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
