### PR TITLE
xfree86: unexport xf86PlatformDeviceCheckBusID()

### DIFF
--- a/hw/xfree86/common/xf86platformBus_priv.h
+++ b/hw/xfree86/common/xf86platformBus_priv.h
@@ -42,6 +42,8 @@ void xf86platformRemoveDevice(int index);
 void xf86platformVTProbe(void);
 void xf86platformPrimary(void);
 
+Bool xf86PlatformDeviceCheckBusID(struct xf86_platform_device *device, const char *busid);
+
 #else /* XSERVER_PLATFORM_BUS */
 
 static inline int xf86platformAddGPUDevices(DriverPtr drvp) { return FALSE; }

--- a/include/xf86platformBus.h
+++ b/include/xf86platformBus.h
@@ -84,9 +84,6 @@ _xf86_get_platform_device_int_attrib(struct xf86_platform_device *device, int at
 
 #define xf86_get_platform_device_int_attrib(device, attrib, def) _xf86_get_platform_device_int_attrib(device,attrib,_ODEV_ATTRIB_INT_CHECK(attrib,def))
 
-extern _X_EXPORT Bool
-xf86PlatformDeviceCheckBusID(struct xf86_platform_device *device, const char *busid);
-
 #endif
 
 #endif


### PR DESCRIPTION
Not used by any external drivers, so no need to keep it exported.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
