### PR TITLE
os: unexport SeatId and move it to dix settings

### DIFF
--- a/config/hotplug_priv.h
+++ b/config/hotplug_priv.h
@@ -31,6 +31,8 @@
 
 #include <X11/Xfuncproto.h>
 
+#include "dix/settings_priv.h"
+
 #include "list.h"
 
 /* Bump this each time you add something to the struct
@@ -76,7 +78,7 @@ void NewGPUDeviceRequest(struct OdevAttributes *attribs);
 void DeleteGPUDeviceRequest(struct OdevAttributes *attribs);
 #endif
 
-#define ServerIsNotSeat0() (SeatId && strcmp(SeatId, "seat0"))
+#define ServerIsNotSeat0() (dixSettingSeatId && strcmp(dixSettingSeatId, "seat0"))
 
 struct xf86_platform_device *
 xf86_find_platform_device_by_devnum(unsigned int major, unsigned int minor);

--- a/config/udev.c
+++ b/config/udev.c
@@ -29,6 +29,7 @@
 #include <ctype.h>
 #include <unistd.h>
 
+#include "dix/settings_priv.h"
 #include "config/hotplug_priv.h"
 #include "os/fmt.h"
 
@@ -75,10 +76,10 @@ check_seat(struct udev_device *udev_device)
     if (!dev_seat)
         dev_seat = "seat0";
 
-    if (SeatId && strcmp(dev_seat, SeatId))
+    if (dixSettingSeatId && strcmp(dev_seat, dixSettingSeatId))
         return FALSE;
 
-    if (!SeatId && strcmp(dev_seat, "seat0"))
+    if (!dixSettingSeatId && strcmp(dev_seat, "seat0"))
         return FALSE;
 
     return TRUE;
@@ -406,7 +407,7 @@ config_udev_pre_init(void)
 
 #ifdef HAVE_UDEV_MONITOR_FILTER_ADD_MATCH_TAG
     if (ServerIsNotSeat0())
-        udev_monitor_filter_add_match_tag(udev_monitor, SeatId);
+        udev_monitor_filter_add_match_tag(udev_monitor, dixSettingSeatId);
 #endif
     if (udev_monitor_enable_receiving(udev_monitor)) {
         ErrorF("config/udev: failed to bind the udev monitor\n");
@@ -435,7 +436,7 @@ config_udev_init(void)
 
 #ifdef HAVE_UDEV_ENUMERATE_ADD_MATCH_TAG
     if (ServerIsNotSeat0())
-        udev_enumerate_add_match_tag(enumerate, SeatId);
+        udev_enumerate_add_match_tag(enumerate, dixSettingSeatId);
 #endif
 
     udev_enumerate_scan_devices(enumerate);
@@ -580,7 +581,7 @@ config_udev_odev_probe(config_odev_probe_proc_ptr probe_callback)
     udev_enumerate_add_match_sysname(enumerate, "card[0-9]*");
 #ifdef HAVE_UDEV_ENUMERATE_ADD_MATCH_TAG
     if (ServerIsNotSeat0())
-        udev_enumerate_add_match_tag(enumerate, SeatId);
+        udev_enumerate_add_match_tag(enumerate, dixSettingSeatId);
 #endif
     udev_enumerate_scan_devices(enumerate);
     devices = udev_enumerate_get_list_entry(enumerate);

--- a/dix/settings.c
+++ b/dix/settings.c
@@ -11,7 +11,9 @@
 #include <dix-config.h>
 
 #include <stdbool.h>
+#include <stddef.h>
 
 #include "dix/settings_priv.h"
 
 bool dixSettingAllowByteSwappedClients = false;
+char *dixSettingSeatId = NULL;

--- a/dix/settings_priv.h
+++ b/dix/settings_priv.h
@@ -15,5 +15,6 @@
  */
 
 extern bool dixSettingAllowByteSwappedClients;
+extern char *dixSettingSeatId;
 
 #endif

--- a/hw/kdrive/ephyr/ephyrinit.c
+++ b/hw/kdrive/ephyr/ephyrinit.c
@@ -26,6 +26,7 @@
 #include <kdrive-config.h>
 
 #include "dix/dix_priv.h"
+#include "dix/settings_priv.h"
 #include "os/cmdline.h"
 #include "os/ddx_priv.h"
 #include "os/log_priv.h"
@@ -385,7 +386,7 @@ OsVendorInit(void)
 {
     EPHYR_DBG("mark");
 
-    if (SeatId)
+    if (dixSettingSeatId)
         hostx_use_sw_cursor();
 
     if (hostx_want_host_cursor())

--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -27,10 +27,10 @@
 #include "config/hotplug_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/settings_priv.h"
+#include "mi/mi_priv.h"
 #include "os/cmdline.h"
 #include "os/ddx_priv.h"
-
-#include "mi/mi_priv.h"
 #include "os/osdep.h"
 
 #include "kdrive.h"
@@ -1140,7 +1140,7 @@ KdInitOutput(int argc, char **argv)
     xorgGlxCreateVendor();
 
 #if defined(CONFIG_UDEV) || defined(CONFIG_HAL)
-    if (SeatId) /* Enable input hot-plugging */
+    if (dixSettingSeatId) /* Enable input hot-plugging */
         config_pre_init();
 #endif
 }

--- a/hw/kdrive/src/kinput.c
+++ b/hw/kdrive/src/kinput.c
@@ -43,6 +43,7 @@
 #include "dix/input_priv.h"
 #include "dix/inpututils_priv.h"
 #include "dix/screenint_priv.h"
+#include "dix/settings_priv.h"
 #include "mi/mi_priv.h"
 #include "mi/mipointer_priv.h"
 #include "os/cmdline.h"
@@ -1397,7 +1398,7 @@ KdInitInput(void)
     mieqInit();
 
 #if defined(CONFIG_UDEV) || defined(CONFIG_HAL)
-    if (SeatId) /* Enable input hot-plugging */
+    if (dixSettingSeatId) /* Enable input hot-plugging */
         config_init();
 #endif
 }
@@ -1406,7 +1407,7 @@ void
 KdCloseInput(void)
 {
 #if defined(CONFIG_UDEV) || defined(CONFIG_HAL)
-    if (SeatId) /* Input hot-plugging is enabled */
+    if (dixSettingSeatId) /* Input hot-plugging is enabled */
         config_fini();
 #endif
 
@@ -2422,7 +2423,7 @@ NewInputDeviceRequest(InputOption *options, InputAttributes * attrs,
 #ifdef CONFIG_HAL
         else if (strcmp(key, "_source") == 0 &&
                  strcmp(value, "server/hal") == 0) {
-            if (SeatId) {
+            if (dixSettingSeatId) {
                 /* Input hot-plugging is enabled */
                 if (attrs->flags & ATTR_POINTER) {
                     pi = KdNewPointer();
@@ -2449,7 +2450,7 @@ NewInputDeviceRequest(InputOption *options, InputAttributes * attrs,
 #ifdef CONFIG_UDEV
         else if (strcmp(key, "_source") == 0 &&
                  strcmp(value, "server/udev") == 0) {
-            if (SeatId) {
+            if (dixSettingSeatId) {
                 /* Input hot-plugging is enabled */
                 if (attrs->flags & ATTR_POINTER) {
                     pi = KdNewPointer();

--- a/hw/xfree86/common/xf86Config.c
+++ b/hw/xfree86/common/xf86Config.c
@@ -242,7 +242,7 @@ xf86ValidateFontPath(char *path)
         pointertype _l, _p;                                                                  \
                                                                                              \
         for (_l = (listhead), _p = NULL; !_p && _l; _l = (pointertype)_l->list.next) {       \
-            if (!_l->match_seat || (SeatId && xf86nameCompare(_l->match_seat, SeatId) == 0)) \
+            if (!_l->match_seat || (dixSettingSeatId && xf86nameCompare(_l->match_seat, dixSettingSeatId) == 0)) \
                 _p = _l;                                                                     \
         }                                                                                    \
                                                                                              \

--- a/hw/xfree86/common/xf86Init.c
+++ b/hw/xfree86/common/xf86Init.c
@@ -586,8 +586,8 @@ InitOutput(int argc, char **argv)
     if (xf86Info.vtno >= 0)
         AddCallback(&RootWindowFinalizeCallback, AddVTAtoms, NULL);
 
-    if (SeatId)
-        AddCallback(&RootWindowFinalizeCallback, AddSeatId, SeatId);
+    if (dixSettingSeatId)
+        AddCallback(&RootWindowFinalizeCallback, AddSeatId, dixSettingSeatId);
 
     /*
      * Use the previously collected parts to setup screenInfo

--- a/include/globals.h
+++ b/include/globals.h
@@ -10,6 +10,4 @@ extern _X_EXPORT const char *defaultFontPath;
 extern _X_EXPORT int monitorResolution;
 extern _X_EXPORT int defaultColorVisualClass;
 
-extern _X_EXPORT char *SeatId;
-
 #endif                          /* !_XSERV_GLOBAL_H_ */

--- a/os/utils.c
+++ b/os/utils.c
@@ -140,8 +140,6 @@ Bool enableIndirectGLX = FALSE;
 Bool PanoramiXExtensionDisabledHack = FALSE;
 #endif /* XINERAMA */
 
-char *SeatId = NULL;
-
 sig_atomic_t inSignalContext = FALSE;
 
 #ifdef MONOTONIC_CLOCK
@@ -420,7 +418,7 @@ ProcessCommandLine(int argc, char *argv[])
                     ErrorF("Failed to disable listen for %s transport",
                            defaultNoListenList[i]);
     }
-    SeatId = getenv("XDG_SEAT");
+    dixSettingSeatId = getenv("XDG_SEAT");
 
 #ifdef CONFIG_SYSLOG
     xorgSyslogIdent = getenv("SYSLOG_IDENT");
@@ -642,7 +640,7 @@ ProcessCommandLine(int argc, char *argv[])
         }
         else if (strcmp(argv[i], "-seat") == 0) {
             if (++i < argc)
-                SeatId = argv[i];
+                dixSettingSeatId = argv[i];
             else
                 UseMsg();
         }


### PR DESCRIPTION
Not used by any external module/driver, so no need to keep it
public. Also move it to the new dix settings code and rename it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
