### PR TITLE
dix: Usage preferred allocation memory on stack

### DIFF
--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -734,7 +734,7 @@ doUpdateColors(ColormapPtr pmap)
 
     pVisual = pmap->pVisual;
     size = pVisual->ColormapEntries;
-    defs = calloc(size, sizeof(xColorItem));
+    defs = alloca(size * sizeof(xColorItem));
     if (!defs)
         return;
     n = 0;
@@ -778,7 +778,6 @@ doUpdateColors(ColormapPtr pmap)
     }
     if (n)
         (*pmap->pScreen->StoreColors) (pmap, n, defs);
-    free(defs);
 }
 
 /* Tries to find a color in pmap that exactly matches the one requested in prgb
@@ -1684,13 +1683,10 @@ AllocDirect(int client, ColormapPtr pmap, int c, int r, int g, int b,
     for (Pixel *p = pixels; p < pixels + c; p++)
         *p = 0;
 
-    ppixRed = calloc(npixR, sizeof(Pixel));
-    ppixGreen = calloc(npixG, sizeof(Pixel));
-    ppixBlue = calloc(npixB, sizeof(Pixel));
+    ppixRed = alloca(npixR * sizeof(Pixel));
+    ppixGreen = alloca(npixG * sizeof(Pixel));
+    ppixBlue = alloca(npixB * sizeof(Pixel));
     if (!ppixRed || !ppixGreen || !ppixBlue) {
-        free(ppixBlue);
-        free(ppixGreen);
-        free(ppixRed);
         return BadAlloc;
     }
 
@@ -1732,9 +1728,6 @@ AllocDirect(int client, ColormapPtr pmap, int c, int r, int g, int b,
             for (int npix = npixB; --npix >= 0; ppix++)
                 pmap->blue[*ppix].refcnt = 0;
         }
-        free(ppixBlue);
-        free(ppixGreen);
-        free(ppixRed);
         return BadAlloc;
     }
 
@@ -1772,10 +1765,6 @@ AllocDirect(int client, ColormapPtr pmap, int c, int r, int g, int b,
     for (Pixel *pDst = pixels; pDst < pixels + c; pDst++)
         *pDst |= ALPHAMASK(pmap->pVisual);
 
-    free(ppixBlue);
-    free(ppixGreen);
-    free(ppixRed);
-
     return Success;
 }
 
@@ -1790,7 +1779,7 @@ AllocPseudo(int client, ColormapPtr pmap, int c, int r, Bool contig,
     npix = c << r;
     if ((r >= 32) || (npix > pmap->freeRed) || (npix < c))
         return BadAlloc;
-    if (!(ppixTemp = calloc(npix, sizeof(Pixel))))
+    if (!(ppixTemp = alloca(npix * sizeof(Pixel))))
         return BadAlloc;
     ok = AllocCP(pmap, pmap->red, c, r, contig, ppixTemp, pmask);
 
@@ -1803,7 +1792,6 @@ AllocPseudo(int client, ColormapPtr pmap, int c, int r, Bool contig,
         if (!ppix) {
             for (Pixel *p = ppixTemp; p < ppixTemp + npix; p++)
                 pmap->red[*p].refcnt = 0;
-            free(ppixTemp);
             return BadAlloc;
         }
         pmap->clientPixelsRed[client] = ppix;
@@ -1818,7 +1806,6 @@ AllocPseudo(int client, ColormapPtr pmap, int c, int r, Bool contig,
         pmap->numPixelsRed[client] += npix;
         pmap->freeRed -= npix;
     }
-    free(ppixTemp);
     return ok ? Success : BadAlloc;
 }
 
@@ -2002,15 +1989,12 @@ AllocShared(ColormapPtr pmap, Pixel * ppix, int c, int r, int g, int b,
 
     npixClientNew = c << (r + g + b);
     npixShared = (c << r) + (c << g) + (c << b);
-    psharedList = calloc(npixShared, sizeof(SHAREDCOLOR *));
+    psharedList = alloca(npixShared * sizeof(SHAREDCOLOR *));
     if (!psharedList)
         return FALSE;
     ppshared = psharedList;
     for (int z = npixShared; --z >= 0;) {
-        if (!(ppshared[z] = calloc(1, sizeof(SHAREDCOLOR)))) {
-            for (z++; z < npixShared; z++)
-                free(ppshared[z]);
-            free(psharedList);
+        if (!(ppshared[z] = alloca(sizeof(SHAREDCOLOR)))) {
             return FALSE;
         }
     }
@@ -2099,7 +2083,6 @@ AllocShared(ColormapPtr pmap, Pixel * ppix, int c, int r, int g, int b,
             }
         }
     }
-    free(psharedList);
     return TRUE;
 }
 
@@ -2519,7 +2502,7 @@ IsMapInstalled(Colormap map, WindowPtr pWin)
     Colormap *pmaps;
     int nummaps, found;
 
-    pmaps = calloc(pWin->drawable.pScreen->maxInstalledCmaps,
+    pmaps = alloca(pWin->drawable.pScreen->maxInstalledCmaps *
                    sizeof(Colormap));
     if (!pmaps)
         return FALSE;
@@ -2532,7 +2515,6 @@ IsMapInstalled(Colormap map, WindowPtr pWin)
             break;
         }
     }
-    free(pmaps);
     return found;
 }
 

--- a/dix/cursor.c
+++ b/dix/cursor.c
@@ -241,9 +241,10 @@ AllocARGBCursor(unsigned char *psrcbits, unsigned char *pmaskbits,
     int rc;
 
     *ppCurs = NULL;
-    pCurs = (CursorPtr) calloc(CURSOR_REC_SIZE + CURSOR_BITS_SIZE, 1);
+    pCurs = alloca(CURSOR_REC_SIZE + CURSOR_BITS_SIZE);
     if (!pCurs)
         return BadAlloc;
+    memset(pCurs, 0, CURSOR_REC_SIZE + CURSOR_BITS_SIZE);
 
     bits = (CursorBitsPtr) ((char *) pCurs + CURSOR_REC_SIZE);
     dixInitPrivates(pCurs, pCurs + 1, PRIVATE_CURSOR);
@@ -311,7 +312,6 @@ AllocARGBCursor(unsigned char *psrcbits, unsigned char *pmaskbits,
  error:
     FreeCursorBits(bits);
     dixFiniPrivates(pCurs, PRIVATE_CURSOR);
-    free(pCurs);
 
     return rc;
 }

--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -725,7 +725,7 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
         goto bail;
     }
 
- finish:
+ finish: ;
 
     names = c->names;
     client = c->client;
@@ -1733,11 +1733,12 @@ SetDefaultFontPath(const char *path)
 
     /* get enough for string, plus values -- use up commas */
     len = strlen(temp_path) + 1;
-    nump = cp = newpath = calloc(1, len);
+    nump = cp = newpath = alloca(len);
     if (!newpath) {
         free(temp_path);
         return BadAlloc;
     }
+    memset(newpath, 0, len);
     pp = (unsigned char *) temp_path;
     cp++;
     while (*pp) {
@@ -1757,7 +1758,6 @@ SetDefaultFontPath(const char *path)
 
     err = SetFontPathElements(num, newpath, &bad, TRUE);
 
-    free(newpath);
     free(temp_path);
 
     return err;

--- a/dix/events.c
+++ b/dix/events.c
@@ -4757,9 +4757,8 @@ DeviceEnterLeaveEvent(DeviceIntPtr mouse,
     btlen = bytes_to_int32(btlen);
     len = sizeof(xXIEnterEvent) + btlen * 4;
 
-    xXIEnterEvent *event = calloc(1, len);
-    if (!event)
-        return;
+    xXIEnterEvent *event = alloca(len);
+    memset(event, 0, len);
 
     event->type = GenericEvent;
     event->extension = EXTENSION_MAJOR_XINPUT;
@@ -4813,7 +4812,7 @@ DeviceEnterLeaveEvent(DeviceIntPtr mouse,
     }
 
  out:
-    free(event);
+    ;
 }
 
 void
@@ -5593,7 +5592,7 @@ ProcUngrabKey(ClientPtr client)
 {
     REQUEST(xUngrabKeyReq);
     WindowPtr pWin;
-    GrabPtr tempGrab;
+    GrabRec tempGrab;
     DeviceIntPtr keybd = PickKeyboard(client);
     int rc;
 
@@ -5613,23 +5612,19 @@ ProcUngrabKey(ClientPtr client)
         client->errorValue = stuff->modifiers;
         return BadValue;
     }
-    tempGrab = alloca(sizeof(GrabRec));
-    if (!tempGrab)
-        return BadAlloc;
-    memset(tempGrab, 0, sizeof(GrabRec));
-    tempGrab->resource = client->clientAsMask;
-    tempGrab->device = keybd;
-    tempGrab->window = pWin;
-    tempGrab->modifiersDetail.exact = stuff->modifiers;
-    tempGrab->modifiersDetail.pMask = NULL;
-    tempGrab->modifierDevice = keybd;
-    tempGrab->type = KeyPress;
-    tempGrab->grabtype = CORE;
-    tempGrab->detail.exact = stuff->key;
-    tempGrab->detail.pMask = NULL;
-    tempGrab->next = NULL;
+    tempGrab.resource = client->clientAsMask;
+    tempGrab.device = keybd;
+    tempGrab.window = pWin;
+    tempGrab.modifiersDetail.exact = stuff->modifiers;
+    tempGrab.modifiersDetail.pMask = NULL;
+    tempGrab.modifierDevice = keybd;
+    tempGrab.type = KeyPress;
+    tempGrab.grabtype = CORE;
+    tempGrab.detail.exact = stuff->key;
+    tempGrab.detail.pMask = NULL;
+    tempGrab.next = NULL;
 
-    if (!DeletePassiveGrabFromList(tempGrab))
+    if (!DeletePassiveGrabFromList(&tempGrab))
         rc = BadAlloc;
 
     return rc;

--- a/dix/events.c
+++ b/dix/events.c
@@ -1214,7 +1214,7 @@ EnqueueEvent(InternalEvent *ev, DeviceIntPtr device)
 
     eventlen = sizeof(InternalEvent);
 
-    QdEventPtr qe = alloca(sizeof(QdEventRec) + eventlen);
+    QdEventPtr qe = calloc(1, sizeof(QdEventRec) + eventlen);
     if (!qe)
         return;
     xorg_list_init(&qe->next);
@@ -2166,10 +2166,9 @@ ActivateImplicitGrab(DeviceIntPtr dev, ClientPtr client, WindowPtr win,
     else
         return FALSE;
 
-    tempGrab = alloca(sizeof(GrabRec));
+    tempGrab = AllocGrab(NULL);
     if (!tempGrab)
         return FALSE;
-    memset(tempGrab, 0, sizeof(GrabRec));
     tempGrab->next = NULL;
     tempGrab->device = dev;
     tempGrab->resource = client->clientAsMask;
@@ -2192,6 +2191,7 @@ ActivateImplicitGrab(DeviceIntPtr dev, ClientPtr client, WindowPtr win,
 
     (*dev->deviceGrab.ActivateGrab) (dev, tempGrab,
                                      currentTime, TRUE | ImplicitGrabMask);
+    FreeGrab(tempGrab);
     return TRUE;
 }
 

--- a/dix/events.c
+++ b/dix/events.c
@@ -1214,7 +1214,7 @@ EnqueueEvent(InternalEvent *ev, DeviceIntPtr device)
 
     eventlen = sizeof(InternalEvent);
 
-    QdEventPtr qe = calloc(1, sizeof(QdEventRec) + eventlen);
+    QdEventPtr qe = alloca(sizeof(QdEventRec) + eventlen);
     if (!qe)
         return;
     xorg_list_init(&qe->next);
@@ -2166,9 +2166,10 @@ ActivateImplicitGrab(DeviceIntPtr dev, ClientPtr client, WindowPtr win,
     else
         return FALSE;
 
-    tempGrab = AllocGrab(NULL);
+    tempGrab = alloca(sizeof(GrabRec));
     if (!tempGrab)
         return FALSE;
+    memset(tempGrab, 0, sizeof(GrabRec));
     tempGrab->next = NULL;
     tempGrab->device = dev;
     tempGrab->resource = client->clientAsMask;
@@ -2191,7 +2192,6 @@ ActivateImplicitGrab(DeviceIntPtr dev, ClientPtr client, WindowPtr win,
 
     (*dev->deviceGrab.ActivateGrab) (dev, tempGrab,
                                      currentTime, TRUE | ImplicitGrabMask);
-    FreeGrab(tempGrab);
     return TRUE;
 }
 
@@ -5613,9 +5613,10 @@ ProcUngrabKey(ClientPtr client)
         client->errorValue = stuff->modifiers;
         return BadValue;
     }
-    tempGrab = AllocGrab(NULL);
+    tempGrab = alloca(sizeof(GrabRec));
     if (!tempGrab)
         return BadAlloc;
+    memset(tempGrab, 0, sizeof(GrabRec));
     tempGrab->resource = client->clientAsMask;
     tempGrab->device = keybd;
     tempGrab->window = pWin;
@@ -5630,8 +5631,6 @@ ProcUngrabKey(ClientPtr client)
 
     if (!DeletePassiveGrabFromList(tempGrab))
         rc = BadAlloc;
-
-    FreeGrab(tempGrab);
 
     return rc;
 }
@@ -5817,9 +5816,10 @@ ProcUngrabButton(ClientPtr client)
 
     ptr = PickPointer(client);
 
-    tempGrab = AllocGrab(NULL);
+    tempGrab = alloca(sizeof(GrabRec));
     if (!tempGrab)
         return BadAlloc;
+    memset(tempGrab, 0, sizeof(GrabRec));
     tempGrab->resource = client->clientAsMask;
     tempGrab->device = ptr;
     tempGrab->window = pWin;
@@ -5835,7 +5835,6 @@ ProcUngrabButton(ClientPtr client)
     if (!DeletePassiveGrabFromList(tempGrab))
         rc = BadAlloc;
 
-    FreeGrab(tempGrab);
     return rc;
 }
 

--- a/dix/gc.c
+++ b/dix/gc.c
@@ -360,7 +360,7 @@ ChangeGC(ClientPtr client, GCPtr pGC, BITS32 mask, ChangeGCValPtr pUnion)
                 }
             }
             else if (newdash != 0) {
-                unsigned char *dash = calloc(2, sizeof(unsigned char));
+                unsigned char *dash = alloca(2 * sizeof(unsigned char));
                 if (dash) {
                     if (pGC->dash != DefaultDash)
                         free(pGC->dash);
@@ -725,7 +725,7 @@ CopyGC(GCPtr pgcSrc, GCPtr pgcDst, BITS32 mask)
                 }
             }
             else {
-                unsigned char *dash = calloc(pgcSrc->numInDashList, sizeof(unsigned char));
+                unsigned char *dash = alloca(pgcSrc->numInDashList * sizeof(unsigned char));
                 if (dash) {
                     if (pgcDst->dash != DefaultDash)
                         free(pgcDst->dash);
@@ -909,9 +909,9 @@ SetDashes(GCPtr pGC, unsigned offset, unsigned ndash, unsigned char *pdash)
     }
 
     if (ndash & 1)
-        p = calloc(2 * ndash, sizeof(unsigned char));
+        p = alloca(2 * ndash * sizeof(unsigned char));
     else
-        p = calloc(ndash, sizeof(unsigned char));
+        p = alloca(ndash * sizeof(unsigned char));
     if (!p)
         return BadAlloc;
 
@@ -996,7 +996,7 @@ SetClipRects(GCPtr pGC, INT16 xOrigin, INT16 yOrigin, size_t nrects,
         return BadMatch;
     size = nrects * sizeof(xRectangle);
 
-    xRectangle *prectsNew = calloc(1, size);
+    xRectangle *prectsNew = alloca(size);
     if (!prectsNew && size)
         return BadAlloc;
 

--- a/dix/getevents.c
+++ b/dix/getevents.c
@@ -422,9 +422,8 @@ GetMotionHistory(DeviceIntPtr pDev, xTimecoord ** buff, unsigned long start,
     else
         size = (sizeof(INT32) * pDev->valuator->numAxes) + sizeof(Time);
 
-    *buff = calloc(size, pDev->valuator->numMotionEvents);
-    if (!(*buff))
-        return 0;
+    *buff = alloca(size * pDev->valuator->numMotionEvents);
+    memset(*buff, 0, size * pDev->valuator->numMotionEvents);
     obuff = (char *) *buff;
 
     for (int i = pDev->valuator->first_motion;

--- a/dix/main.c
+++ b/dix/main.c
@@ -157,9 +157,9 @@ dix_main(int argc, char *argv[], char *envp[])
             CreateWellKnownSockets();
             for (int i = 1; i < LimitClients; i++)
                 clients[i] = NULL;
-            serverClient = calloc(1, sizeof(ClientRec));
-            if (!serverClient)
-                FatalError("couldn't create server client");
+            ClientRec serverClientRec;
+            serverClient = &serverClientRec;
+            memset(serverClient, 0, sizeof(ClientRec));
             InitClient(serverClient, 0, (void *) NULL);
 
         clients[0] = serverClient;

--- a/dix/property.c
+++ b/dix/property.c
@@ -208,8 +208,8 @@ ProcRotateProperties(ClientPtr client)
     if (rc != Success || stuff->nAtoms <= 0)
         return rc;
 
-    props = calloc(p.nAtoms, sizeof(PropertyPtr));
-    saved = calloc(p.nAtoms, sizeof(PropertyRec));
+    props = alloca(p.nAtoms * sizeof(PropertyPtr));
+    saved = alloca(p.nAtoms * sizeof(PropertyRec));
     if (!props || !saved) {
         rc = BadAlloc;
         goto out;
@@ -257,8 +257,6 @@ ProcRotateProperties(ClientPtr client)
         }
     }
  out:
-    free(saved);
-    free(props);
     return rc;
 }
 

--- a/dix/window.c
+++ b/dix/window.c
@@ -3222,11 +3222,9 @@ TileScreenSaver(ScreenPtr pScreen, int kind)
     cm.height = 16;
     cm.xhot = 8;
     cm.yhot = 8;
-    unsigned char *srcbits = calloc(16, BitmapBytePad(32));
-    unsigned char *mskbits = calloc(16, BitmapBytePad(32));
+    unsigned char *srcbits = alloca(BitmapBytePad(32) * 16);
+    unsigned char *mskbits = alloca(BitmapBytePad(32) * 16);
     if (!srcbits || !mskbits) {
-        free(srcbits);
-        free(mskbits);
         cursor = 0;
     }
     else {
@@ -3242,10 +3240,6 @@ TileScreenSaver(ScreenPtr pScreen, int kind)
             }
             else
                 cursor = 0;
-        }
-        else {
-            free(srcbits);
-            free(mskbits);
         }
     }
 


### PR DESCRIPTION
@metux,
There are many changes in dix core that aim to use stack more logically for a small amount data than heap.
I also noticed a bug that `grab->xi2mask` is freed by usual `free()`, not `xi2mask_free()`

References:
- https://publicwork.wordpress.com/2019/06/27/stack-allocation-vs-heap-allocation-performance-benchmark/
- https://stackoverflow.com/a/56798629