### PR TITLE
xfree86: ddc: add xf86Monitor_gtf_supported()

### DIFF
--- a/hw/xfree86/ddc/edid.h
+++ b/hw/xfree86/ddc/edid.h
@@ -12,6 +12,7 @@
 #ifndef _EDID_H_
 #define _EDID_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <X11/Xmd.h>
 #include <X11/Xfuncproto.h>
@@ -203,5 +204,13 @@ typedef struct {
 } xf86Monitor, *xf86MonPtr;
 
 extern _X_EXPORT xf86MonPtr ConfiguredMonitor;
+
+/*
+ * check whether monitor supports Generalized Timing Formula
+ *
+ * @param  monitor the monitor information structure to check
+ * @return true if GTF is supported by the monitor
+ */
+_X_EXPORT bool xf86Monitor_gtf_supported(xf86MonPtr monitor);
 
 #endif                          /* _EDID_H_ */

--- a/hw/xfree86/ddc/interpret_edid.c
+++ b/hw/xfree86/ddc/interpret_edid.c
@@ -801,3 +801,11 @@ gtf_supported(xf86MonPtr mon)
 
     return FALSE;
 }
+
+bool xf86Monitor_gtf_supported(xf86MonPtr monitor)
+{
+    if (!monitor)
+        return false;
+
+    return GTF_SUPPORTED(monitor->features.msc);
+}


### PR DESCRIPTION
replacement for GTF_SUPPORTED() macro that's not a good API isolation
at all. Drivers should use that function instead for checking whether
the monitor supports GTF.

Should be backported to older releases, too - so drivers don't need
extra per-Xserver-version tweaks.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
