### PR TITLE
modesetting: Work around vm cursor pitch quirks

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -4715,6 +4715,40 @@ drmmode_reset_cursor(drmmode_crtc_private_ptr drmmode_crtc)
     drmmode_crtc->cursor_pitches = NULL;
 }
 
+/**
+ * Some setups have different requirements for the
+ * cursor pitch compared to intel and nvidia.
+ *
+ * See: https://github.com/X11Libre/xserver/issues/1816
+ *
+ * This function detects whether we are running in a vm,
+ * or on bare metal.
+ *
+ * Driver names are taken from https://drmdb.emersion.fr/drivers
+ */
+static inline Bool
+drmmode_legacy_cursor_probe_allowed(drmmode_ptr drmmode)
+{
+    drmVersionPtr version = drmGetVersion(drmmode->fd);
+    if (!version) {
+        return FALSE;
+    }
+
+    if (!version->name ||
+        strstr(version->name, "bochs-drm") ||
+        strstr(version->name, "evdi") ||
+        strstr(version->name, "vboxvideo") ||
+        strstr(version->name, "virtio_gpu") ||
+        strstr(version->name, "vkms") ||
+        strstr(version->name, "vmwgfx")) {
+        drmFreeVersion(version);
+        return FALSE;
+    }
+
+    drmFreeVersion(version);
+    return TRUE;
+}
+
 /*
  * This is the old probe method for the minimum cursor size.
  * This is only used if the SIZE_HINTS probe fails.
@@ -4734,6 +4768,10 @@ static void drmmode_probe_cursor_size(xf86CrtcPtr crtc)
     }
 
     drmmode_crtc->cursor_probed = TRUE;
+
+    if (!drmmode_legacy_cursor_probe_allowed(drmmode)) {
+        return;
+    }
 
     xf86DrvMsg(crtc->scrn->scrnIndex, X_WARNING,
                "Probing the cursor size using the old method\n");


### PR DESCRIPTION
When running in a virtual machine, the cursor pitch
may not behave the same as it does on bare metal.

This patch disables a power consumption optimization
when running in a vm, working around the cursor pitch issues.

This means that some vm users who previously had a working
cursor pitch may now see some increased power consumption.

Fixes: https://github.com/X11Libre/xserver/issues/1816

Signed-off-by: stefan11111 <stefan11111@shitposting.expert>
