### PR TITLE
xfree86: ddc: new entry point for EDID parsing

### DIFF
--- a/hw/xfree86/ddc/xf86DDC.h
+++ b/hw/xfree86/ddc/xf86DDC.h
@@ -42,4 +42,17 @@ extern _X_EXPORT xf86MonPtr xf86InterpretEEDID(int screenIndex, uint8_t * block)
 
 extern _X_EXPORT Bool xf86SetDDCproperties(ScrnInfoPtr pScreen, xf86MonPtr DDC);
 
+/*
+ * parse EDID block and return a newly allocated xf86Monitor
+ *
+ * the data block will be copied into the structure (actually right after the struct)
+ * and thus automatically be freed when the returned struct is freed.
+ *
+ * @param screenIndex   index of the screen, will be recorded in the xf86Monitor
+ * @param block         the EDID block to parse
+ * @param size          size of the EDID block (128 or larger for extended types)
+ * @return              newly allocated xf86MonRec or NULL on failure
+ */
+_X_EXPORT xf86MonPtr xf86ParseEDID(ScrnInfoPtr pScreen, uint8_t *block, size_t size);
+
 #endif


### PR DESCRIPTION
The old ones didn't know the block size, so couldn't deduce the block
type version. With upcoming new features, eg. HDR, we need to know the
block type version in order to know what we can extract from it.

This new function should now be used by all drivers, the old ones shall
be phased out.

That commit should be backported to 25.0 and 25.1 releases, so drivers
can remain compatible with all existing release lines.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
