### PR TITLE
dri3: update version check to include 1.1 check

### DIFF
--- a/dri3/dri3_request.c
+++ b/dri3/dri3_request.c
@@ -38,17 +38,6 @@
 #include "dixstruct_priv.h"
 
 static Bool
-dri3_screen_can_one_point_four(ScreenPtr screen)
-{
-    dri3_screen_priv_ptr dri3 = dri3_screen_priv(screen);
-
-    return dri3 &&
-        dri3->info &&
-        dri3->info->version >= 4 &&
-        dri3->info->import_syncobj;
-}
-
-static Bool
 dri3_screen_can_one_point_one(ScreenPtr screen)
 {
     dri3_screen_priv_ptr dri3 = dri3_screen_priv(screen);
@@ -72,6 +61,17 @@ dri3_screen_can_one_point_two(ScreenPtr screen)
         return TRUE;
 
     return FALSE;
+}
+
+static Bool
+dri3_screen_can_one_point_four(ScreenPtr screen)
+{
+    dri3_screen_priv_ptr dri3 = dri3_screen_priv(screen);
+
+    return dri3 &&
+        dri3->info &&
+        dri3->info->version >= 4 &&
+        dri3->info->import_syncobj;
 }
 
 static int
@@ -98,6 +98,9 @@ proc_dri3_query_version(ClientPtr client)
         if (!dri3_screen_can_one_point_four(walkScreen)) {
             reply.minorVersion = 2;
             break;
+        } else {
+            reply.minorVersion = 4;
+            break;
         }
     });
 
@@ -112,6 +115,9 @@ proc_dri3_query_version(ClientPtr client)
         }
         if (!dri3_screen_can_one_point_four(walkScreen)) {
             reply.minorVersion = 2;
+            break;
+        } else {
+            reply.minorVersion = 4;
             break;
         }
     });


### PR DESCRIPTION
This will help some older cards/drivers report that they at least support DRI3 version 1.1. It currently helps the amdgpu driver but won't be a problem with it for long.