### PR TITLE
xfree86: xlibre-server.h: announce new EDID parsing feature

### DIFF
--- a/hw/xfree86/xlibre-server.h.meson.in
+++ b/hw/xfree86/xlibre-server.h.meson.in
@@ -212,4 +212,7 @@
 /* needed for os.h to prevent redefinition of timingsafe_memcmp in drivers */
 #mesondefine HAVE_TIMINGSAFE_MEMCMP
 
+/* Xserver has xf86ParseEDID() et al (since 25.2) */
+#define XLIBRE_API_EDID_PARSE_v1 1
+
 #endif /* _XORG_SERVER_H_ */


### PR DESCRIPTION
Adding a #define in xlibre-server.h that drivers can #ifdef on, in order to check for the new EDID parsing API.