### PR TITLE
mi: drop ifdef on obsolete DAMAGE symbol

### DIFF
--- a/mi/miinitext.c
+++ b/mi/miinitext.c
@@ -134,9 +134,7 @@ static const ExtensionModule staticExtensions[] = {
 #ifndef DISABLE_EXT_COMPOSITE
     {CompositeExtensionInit, "COMPOSITE", &noCompositeExtension},
 #endif
-#ifdef DAMAGE
     {DamageExtensionInit, "DAMAGE", &noDamageExtension},
-#endif
 #ifdef SCREENSAVER
     {ScreenSaverExtensionInit, "MIT-SCREEN-SAVER", &noScreenSaverExtension},
 #endif


### PR DESCRIPTION
It's always set by meson.build and planned to be removed entirely.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
