### PR TITLE
xquartz: drop ifdef DAMAGE

### DIFF
--- a/hw/xquartz/xpr/xprScreen.c
+++ b/hw/xquartz/xpr/xprScreen.c
@@ -50,9 +50,7 @@
 
 #include "rootlessCommon.h"
 
-#ifdef DAMAGE
 #include "damage.h"
-#endif
 
 /* 10.4's deferred update makes X slower.. have to live with the tearing
  * for now.. */


### PR DESCRIPTION
It's always set anyways and planned to be removed.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
