### PR TITLE
xf86bigfont: add comment on including fontstruct.h

### DIFF
--- a/Xext/xf86bigfont.c
+++ b/Xext/xf86bigfont.c
@@ -55,7 +55,7 @@
 #include <X11/X.h>
 #include <X11/Xproto.h>
 #include <X11/extensions/xf86bigfproto.h>
-#include <X11/fonts/fontstruct.h>
+#include <X11/fonts/fontstruct.h> // libxfont2.h missed to include that
 #include <X11/fonts/libxfont2.h>
 
 #include "dix/dix_priv.h"


### PR DESCRIPTION
Document that this particular include is just a workaround for
a bug in libxfont2.h, which forgot to include this header.
