### PR TITLE
os: meson: dix: added support NUMA platforms for X allocation

### DIFF
--- a/dix/main.c
+++ b/dix/main.c
@@ -153,6 +153,7 @@ dix_main(int argc, char *argv[], char *envp[])
         InitBlockAndWakeupHandlers();
         /* Perform any operating system dependent initializations you'd like */
         OsInit();
+        OsNumaInit();
 
             CreateWellKnownSockets();
             for (int i = 1; i < LimitClients; i++)

--- a/glamor/glamor.c
+++ b/glamor/glamor.c
@@ -35,6 +35,9 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <unistd.h>
+#ifdef HAVE_NUMA
+#include <numa.h>
+#endif
 
 #include "dix/screen_hooks_priv.h"
 #include "os/bug_priv.h"
@@ -649,6 +652,11 @@ glamor_init(ScreenPtr screen, unsigned int flags)
         ErrorF("glamor_init: Invalid flags %x\n", flags);
         return FALSE;
     }
+#ifdef HAVE_NUMA
+    if (numa_available() != -1)
+        glamor_priv = numa_alloc_interleaved(sizeof(*glamor_priv));
+    else
+#endif
     glamor_priv = calloc(1, sizeof(*glamor_priv));
     if (glamor_priv == NULL)
         return FALSE;
@@ -907,6 +915,11 @@ glamor_init(ScreenPtr screen, unsigned int flags)
     return TRUE;
 
 fail:
+#ifdef HAVE_NUMA
+    if (numa_available() != -1)
+        numa_free(glamor_priv, sizeof(*glamor_priv));
+    else
+#endif
     free(glamor_priv);
     glamor_set_screen_private(screen, NULL);
     return FALSE;
@@ -920,6 +933,11 @@ glamor_release_screen_priv(ScreenPtr screen)
     glamor_priv = glamor_get_screen_private(screen);
     glamor_fini_vbo(screen);
     glamor_pixmap_fini(screen);
+#ifdef HAVE_NUMA
+    if (numa_available() != -1)
+        numa_free(glamor_priv, sizeof(*glamor_priv));
+    else
+#endif
     free(glamor_priv);
 
     glamor_set_screen_private(screen, NULL);

--- a/hw/xfree86/common/xf86Config.c
+++ b/hw/xfree86/common/xf86Config.c
@@ -46,6 +46,9 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <grp.h>
+#ifdef HAVE_NUMA
+#include <numa.h>
+#endif
 
 #include "dix/dix_priv.h"
 #include "dix/resource_priv.h"
@@ -181,6 +184,11 @@ xf86ValidateFontPath(char *path)
     int flag;
     int dirlen;
 
+#ifdef HAVE_NUMA
+    if (numa_available() != -1)
+        tmp_path = numa_alloc_interleaved(strlen(path) + 1);
+    else
+#endif
     tmp_path = calloc(1, strlen(path) + 1);
     out_pnt = tmp_path;
     path_elem = NULL;

--- a/hw/xfree86/common/xf86Option.c
+++ b/hw/xfree86/common/xf86Option.c
@@ -43,6 +43,9 @@
 #include "xf86Parser.h"
 #include "xf86platformBus_priv.h"
 #include "optionstr.h"
+#ifdef HAVE_NUMA
+#include <numa.h>
+#endif
 
 static Bool ParseOptionValue(int scrnIndex, XF86OptionPtr options,
                              OptionInfoPtr p, Bool markUsed);
@@ -843,11 +846,17 @@ xf86NormalizeName(const char *s)
 {
     char *q;
     const char *p;
+    char *ret;
 
     if (s == NULL)
         return NULL;
 
-    char *ret = calloc(1, strlen(s) + 1);
+#ifdef HAVE_NUMA
+    if (numa_available() != -1)
+        ret = numa_alloc_interleaved(strlen(s) + 1);
+    else
+#endif
+    ret = calloc(1, strlen(s) + 1);
     if (!ret)
         return NULL;
     for (p = s, q = ret; *p != 0; p++) {

--- a/hw/xfree86/ddc/ddc.c
+++ b/hw/xfree86/ddc/ddc.c
@@ -12,6 +12,9 @@
 #include <xorg-config.h>
 
 #include "os/osdep.h"
+#ifdef HAVE_NUMA
+#include <numa.h>
+#endif
 
 #include "misc.h"
 #include "xf86.h"
@@ -97,13 +100,19 @@ resort(unsigned char *s_block)
 {
     unsigned char *d_ptr, *d_end, *s_ptr, *s_end;
     unsigned char tmp;
+    unsigned char *d_new;
 
     s_ptr = find_header(s_block);
     if (!s_ptr)
         return NULL;
     s_end = s_block + EDID1_LEN;
 
-    unsigned char *d_new = calloc(1, EDID1_LEN);
+#ifdef HAVE_NUMA
+    if (numa_available() != -1)
+        d_new = numa_alloc_interleaved(EDID1_LEN);
+    else
+#endif
+    d_new = calloc(1, EDID1_LEN);
     if (!d_new)
         return NULL;
     d_end = d_new + EDID1_LEN;
@@ -156,6 +165,11 @@ GetEDID_DDC1(unsigned int *s_ptr)
         return NULL;
     s_end = s_ptr + NUM;
     s_pos = s_ptr + s_start;
+#ifdef HAVE_NUMA
+    if (numa_available() != -1)
+        d_block = numa_alloc_interleaved(EDID1_LEN);
+    else
+#endif
     d_block = calloc(1, EDID1_LEN);
     if (!d_block)
         return NULL;
@@ -191,7 +205,13 @@ FetchEDID_DDC1(register ScrnInfoPtr pScrn,
     int count = NUM;
     unsigned int *ptr, *xp;
 
-    ptr = xp = calloc(NUM, sizeof(int));
+#ifdef HAVE_NUMA
+    if (numa_available() != -1)
+        ptr = numa_alloc_interleaved(NUM * sizeof(int));
+    else
+#endif
+    ptr = calloc(NUM, sizeof(int));
+    xp = ptr;
 
     if (!ptr)
         return NULL;
@@ -276,6 +296,11 @@ xf86DoEDID_DDC1(ScrnInfoPtr pScrn, DDC1SetSpeedProc DDC1SetSpeed,
     Bool noddc = FALSE, noddc1 = FALSE;
     OptionInfoPtr options;
 
+#ifdef HAVE_NUMA
+    if (numa_available() != -1)
+        options = numa_alloc_interleaved(sizeof(DDCOptions));
+    else
+#endif
     options = XNFalloc(sizeof(DDCOptions));
     (void) memcpy(options, DDCOptions, sizeof(DDCOptions));
     xf86ProcessOptions(pScrn->scrnIndex, pScrn->options, options);
@@ -418,7 +443,13 @@ xf86DoEEDID(ScrnInfoPtr pScrn, I2CBusPtr pBus, Bool complete)
 
     /* Default DDC and DDC2 to enabled. */
     Bool noddc = FALSE, noddc2 = FALSE;
-    OptionInfoPtr options = calloc(1, sizeof(DDCOptions));
+    OptionInfoPtr options;
+#ifdef HAVE_NUMA
+    if (numa_available() != -1)
+        options = numa_alloc_interleaved(sizeof(DDCOptions));
+    else
+#endif
+    options = calloc(1, sizeof(DDCOptions));
     if (!options)
         return NULL;
     memcpy(options, DDCOptions, sizeof(DDCOptions));
@@ -434,6 +465,11 @@ xf86DoEEDID(ScrnInfoPtr pScrn, I2CBusPtr pBus, Bool complete)
     if (!(dev = DDC2Init(pBus)))
         return NULL;
 
+#ifdef HAVE_NUMA
+    if (numa_available() != -1)
+        EDID_block = numa_alloc_interleaved(EDID1_LEN);
+    else
+#endif
     EDID_block = calloc(1, EDID1_LEN);
     if (!EDID_block)
         return NULL;

--- a/include/os.h
+++ b/include/os.h
@@ -189,6 +189,8 @@ Xstrdup(const char *s);
 extern _X_EXPORT char *
 XNFstrdup(const char *s);
 
+extern _X_EXPORT void Xfree(void *ptr);
+
 /* Include new X*asprintf API */
 #include "Xprintf.h"
 

--- a/meson.build
+++ b/meson.build
@@ -687,6 +687,20 @@ if get_option('xselinux') != 'false'
     endif
 endif
 
+numa_dep = dependency('numa', required: get_option('numa'))
+if get_option('numa')
+    if numa_dep.found()
+        conf_data.set('HAVE_NUMA', 1)
+        common_dep += numa_dep
+        message('NUMA support: YES')
+    else
+        if get_option('numa')
+            error('NUMA support requested but libnuma not found')
+        endif
+        message('NUMA support: NO')
+    endif
+endif
+
 socket_dep = []
 if host_machine.system() == 'windows'
     socket_dep = meson.get_compiler('c').find_library('ws2_32')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,7 +14,7 @@ option('xwin', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
        description: 'Enable XWin X server')
 option('xquartz', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
        description: 'Enable Xquartz X server')
-option('numa', type: 'boolean', value: true, description: 'Enable NUMA support')
+option('numa', type: 'boolean', value: false, description: 'Enable NUMA support')
 
 option('kdrive_kbd', type: 'boolean', value: true,
        description: 'Build kbd driver for kdrive')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,6 +14,7 @@ option('xwin', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
        description: 'Enable XWin X server')
 option('xquartz', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
        description: 'Enable Xquartz X server')
+option('numa', type: 'boolean', value: true, description: 'Enable NUMA support')
 
 option('kdrive_kbd', type: 'boolean', value: true,
        description: 'Build kbd driver for kdrive')

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -48,6 +48,10 @@ SOFTWARE.
 
 #include <dix-config.h>
 
+#ifdef HAVE_NUMA
+#include <numa.h>
+#endif
+
 #include <X11/Xdefs.h>
 
 #include <limits.h>
@@ -135,6 +139,7 @@ typedef void (*OsSigHandlerPtr) (int sig);
 OsSigHandlerPtr OsSignal(int sig, OsSigHandlerPtr handler);
 
 void OsInit(void);
+void OsNumaInit(void);
 
 _X_EXPORT /* needed by the int10 module, but should not be used by OOT drivers */
 void OsBlockSignals(void);

--- a/os/utils.c
+++ b/os/utils.c
@@ -146,6 +146,17 @@ sig_atomic_t inSignalContext = FALSE;
 static clockid_t clockid;
 #endif
 
+void
+OsNumaInit(void)
+{
+#ifdef HAVE_NUMA
+    if (numa_available() != -1) {
+        numa_set_interleave_mask(numa_all_nodes_ptr);
+        numa_set_localalloc();
+    }
+#endif
+}
+
 OsSigHandlerPtr
 OsSignal(int sig, OsSigHandlerPtr handler)
 {

--- a/render/mipict.c
+++ b/render/mipict.c
@@ -24,6 +24,9 @@
 #include <dix-config.h>
 
 #include "os/osdep.h"
+#ifdef HAVE_NUMA
+#include <numa.h>
+#endif
 
 #include "scrnintstr.h"
 #include "gcstruct.h"
@@ -508,6 +511,11 @@ miTriStrip(CARD8 op,
     int ntri;
 
     ntri = npoints - 2;
+#ifdef HAVE_NUMA
+    if (numa_available() != -1)
+        tris = numa_alloc_interleaved(ntri * sizeof(xTriangle));
+    else
+#endif
     tris = calloc(ntri, sizeof(xTriangle));
     if (!tris)
         return;
@@ -518,6 +526,11 @@ miTriStrip(CARD8 op,
         tri->p3 = points[2];
     }
     CompositeTriangles(op, pSrc, pDst, maskFormat, xSrc, ySrc, ntri, tris);
+#ifdef HAVE_NUMA
+    if (numa_available() != -1)
+        numa_free(tris, ntri * sizeof(xTriangle));
+    else
+#endif
     free(tris);
 }
 
@@ -533,6 +546,11 @@ miTriFan(CARD8 op,
     int ntri;
 
     ntri = npoints - 2;
+#ifdef HAVE_NUMA
+    if (numa_available() != -1)
+        tris = numa_alloc_interleaved(ntri * sizeof(xTriangle));
+    else
+#endif
     tris = calloc(ntri, sizeof(xTriangle));
     if (!tris)
         return;
@@ -544,6 +562,11 @@ miTriFan(CARD8 op,
         tri->p3 = points[1];
     }
     CompositeTriangles(op, pSrc, pDst, maskFormat, xSrc, ySrc, ntri, tris);
+#ifdef HAVE_NUMA
+    if (numa_available() != -1)
+        numa_free(tris, ntri * sizeof(xTriangle));
+    else
+#endif
     free(tris);
 }
 


### PR DESCRIPTION
@metux,
This commits fix ignoring data locality with the distance to the nearest processor cache on multi-CPU platforms. By default select mask on all CPU sockets and local touch allocation memory.

References:
- https://www.kernel.org/doc/html/v5.6/vm/numa.html
- https://hpc-wiki.info/hpc/NUMA
- https://man7.org/linux/man-pages/man3/numa.3.html
- https://en.wikipedia.org/wiki/Non-uniform_memory_access
- https://stackoverflow.com/questions/8154162/numa-aware-cache-aligned-memory-allocation

Raspberry have increase performance with memory, if use fake numa nodes from linux kernel params.

- https://www.phoronix.com/news/ARM64-NUMA-Emulation-RPi5
- https://www.jeffgeerling.com/blog/2024/numa-emulation-speeds-pi-5-and-other-improvements/


Playstation 3 used NUMA but commercial failed.
In the future, due to the increasing complexity of crystal area development, it will be more profitable to create chiplet multicrystalline systems, so this is becoming more and more relevant. Although most NUMA devices are still and server platforms (Intel Xeon, AMD Epyc, Ampere Ultra).
- https://www.cs.york.ac.uk/rts/docs/ESWEEK-2007-tutorials/PS3_cell_tutorial.pdf

My topology:

<img width="808" height="489" alt="image" src="https://github.com/user-attachments/assets/9d7424f2-6a25-4419-8275-247d60e5e2a8" />
