### PR TITLE
os: drop ifdef NO_PART_NET code path

### DIFF
--- a/os/utils.c
+++ b/os/utils.c
@@ -407,11 +407,7 @@ ProcessCommandLine(int argc, char *argv[])
 
     defaultKeyboardControl.autoRepeat = TRUE;
 
-#ifdef NO_PART_NET
-    PartialNetwork = FALSE;
-#else
     PartialNetwork = TRUE;
-#endif
 
     for (i = 0; defaultNoListenList[i] != NULL; i++) {
         if (_XSERVTransNoListen(defaultNoListenList[i]))


### PR DESCRIPTION
This symbol is never defined, so that code path isn't needed.
Disabling "partial network" (thus, not arborting when not all
requested interfaces can't be bound) can be done via command line.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
