### PR TITLE
Xext: damage: rename "screen" to "pScreen" in DamageExtSubtractWindowClip()

### DIFF
--- a/Xext/damage/damageext.c
+++ b/Xext/damage/damageext.c
@@ -375,17 +375,16 @@ DamageExtSubtractWindowClip(DamageExtPtr pDamageExt)
         return NULL;
 
     XINERAMA_FOR_EACH_SCREEN_FORWARD({
-        ScreenPtr screen;
         if (Success != dixLookupWindow(&win, res->info[walkScreenIdx].id, serverClient,
                                        DixReadAccess))
             goto out;
 
-        screen = win->drawable.pScreen;
+        ScreenPtr pScreen = win->drawable.pScreen;
 
-        RegionTranslate(ret, -screen->x, -screen->y);
+        RegionTranslate(ret, -pScreen->x, -pScreen->y);
         if (!RegionUnion(ret, ret, &win->borderClip))
             goto out;
-        RegionTranslate(ret, screen->x, screen->y);
+        RegionTranslate(ret, pScreen->x, pScreen->y);
     });
 
     return ret;


### PR DESCRIPTION
Better align with common naming scheme.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
