### PR TITLE
randr: randrstr.h: minor spelling fix

### DIFF
--- a/randr/randrstr.h
+++ b/randr/randrstr.h
@@ -251,7 +251,7 @@ typedef Bool (*RRProviderSetPropertyProcPtr) (ScreenPtr pScreen,
                                               RRPropertyValuePtr value);
 
 typedef Bool (*RRGetInfoProcPtr) (ScreenPtr pScreen, Rotation * rotations);
-typedef Bool (*RRCloseScreenProcPtr) (ScreenPtr pscreen);
+typedef Bool (*RRCloseScreenProcPtr) (ScreenPtr pScreen);
 
 typedef Bool (*RRProviderSetOutputSourceProcPtr)(ScreenPtr pScreen,
                                           RRProviderPtr provider,


### PR DESCRIPTION
Fix up to our convention of naming those "pScreen".

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
