### PR TITLE
dri2: declare variables when needed in dri2WakeClient()

### DIFF
--- a/Xext/dri2/dri2.c
+++ b/Xext/dri2/dri2.c
@@ -163,12 +163,10 @@ dri2WakeClient(ClientPtr client, void *closure)
 static Bool
 dri2WakeAll(ClientPtr client, DRI2DrawablePtr pPriv, enum DRI2WakeType t)
 {
-    int count;
-
     if (!pPriv->blocked[t])
         return FALSE;
 
-    count = ClientSignalAll(client, dri2WakeClient, Wake(pPriv, t));
+    int count = ClientSignalAll(client, dri2WakeClient, Wake(pPriv, t));
     pPriv->blocked[t] -= count;
     return count;
 }


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
