### PR TITLE
dri2: declare variables where needed in DRI2BlockClient()

### DIFF
--- a/Xext/dri2/dri2.c
+++ b/Xext/dri2/dri2.c
@@ -762,9 +762,7 @@ DRI2ThrottleClient(ClientPtr client, DrawablePtr pDraw)
 void
 DRI2BlockClient(ClientPtr client, DrawablePtr pDraw)
 {
-    DRI2DrawablePtr pPriv;
-
-    pPriv = DRI2GetDrawable(pDraw);
+    DRI2DrawablePtr pPriv = DRI2GetDrawable(pDraw);
     if (pPriv == NULL)
         return;
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
