### PR TITLE
dri2: declare variables when needed in DRI2ThrottleClient()

### DIFF
--- a/Xext/dri2/dri2.c
+++ b/Xext/dri2/dri2.c
@@ -741,9 +741,7 @@ DRI2InvalidateDrawable(DrawablePtr pDraw)
 Bool
 DRI2ThrottleClient(ClientPtr client, DrawablePtr pDraw)
 {
-    DRI2DrawablePtr pPriv;
-
-    pPriv = DRI2GetDrawable(pDraw);
+    DRI2DrawablePtr pPriv = DRI2GetDrawable(pDraw);
     if (pPriv == NULL)
         return FALSE;
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
