### PR TITLE
dri2: declare variables when needed in DRI2InvalidateDrawable()

### DIFF
--- a/Xext/dri2/dri2.c
+++ b/Xext/dri2/dri2.c
@@ -720,13 +720,13 @@ static void
 DRI2InvalidateDrawable(DrawablePtr pDraw)
 {
     DRI2DrawablePtr pPriv = DRI2GetDrawable(pDraw);
-    DRI2DrawableRefPtr ref;
 
     if (!pPriv || !pPriv->needInvalidate)
         return;
 
     pPriv->needInvalidate = FALSE;
 
+    DRI2DrawableRefPtr ref;
     xorg_list_for_each_entry(ref, &pPriv->reference_list, link)
         ref->invalidate(pDraw, ref->priv, ref->id);
 }


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
