### PR TITLE
Backport PR 1651 "composite: Skip copying parent pixmap contents when possible" to 25.1

### DIFF
--- a/composite/compalloc.c
+++ b/composite/compalloc.c
@@ -524,6 +524,15 @@ compUnredirectOneSubwindow(WindowPtr pParent, WindowPtr pWin)
     return Success;
 }
 
+static unsigned
+compGetBackgroundState(WindowPtr pWin)
+{
+    while (pWin->backgroundState == ParentRelative)
+        pWin = pWin->parent;
+
+    return pWin->backgroundState;
+}
+
 static PixmapPtr
 compNewPixmap(WindowPtr pWin, int x, int y, int w, int h)
 {
@@ -565,7 +574,7 @@ compNewPixmap(WindowPtr pWin, int x, int y, int w, int h)
             FreeScratchGC(pGC);
         }
     }
-    else {
+    else if (compGetBackgroundState(pWin) == None) {
         PictFormatPtr pSrcFormat = PictureWindowFormat(pParent);
         PictFormatPtr pDstFormat = PictureWindowFormat(pWin);
         XID inferiors = IncludeInferiors;

--- a/composite/compalloc.c
+++ b/composite/compalloc.c
@@ -540,10 +540,6 @@ compNewPixmap(WindowPtr pWin, int x, int y, int w, int h)
     pPixmap->screen_x = x;
     pPixmap->screen_y = y;
 
-    if (pWin->backgroundState != None) {
-        return pPixmap;
-    }
-
     /*
      * Copy bits from the parent into the new pixmap so that it will
      * have "reasonable" contents in case for background None areas.


### PR DESCRIPTION
Fixes: https://github.com/X11Libre/xserver/issues/1924