### PR TITLE
dri2: declare variables where needed DRI2WakeClient()

### DIFF
--- a/Xext/dri2/dri2.c
+++ b/Xext/dri2/dri2.c
@@ -1006,9 +1006,7 @@ DRI2WakeClient(ClientPtr client, DrawablePtr pDraw, int frame,
                unsigned int tv_sec, unsigned int tv_usec)
 {
     ScreenPtr pScreen = pDraw->pScreen;
-    DRI2DrawablePtr pPriv;
-
-    pPriv = DRI2GetDrawable(pDraw);
+    DRI2DrawablePtr pPriv = DRI2GetDrawable(pDraw);
     if (pPriv == NULL) {
         xf86DrvMsg(pScreen->myNum, X_ERROR,
                    "[DRI2] %s: bad drawable\n", __func__);


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
