### PR TITLE
dri2: declare variables where needed DRI2WaitMSCComplete()

### DIFF
--- a/Xext/dri2/dri2.c
+++ b/Xext/dri2/dri2.c
@@ -989,9 +989,7 @@ void
 DRI2WaitMSCComplete(ClientPtr client, DrawablePtr pDraw, int frame,
                     unsigned int tv_sec, unsigned int tv_usec)
 {
-    DRI2DrawablePtr pPriv;
-
-    pPriv = DRI2GetDrawable(pDraw);
+    DRI2DrawablePtr pPriv = DRI2GetDrawable(pDraw);
     if (pPriv == NULL)
         return;
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
