### PR TITLE
dri2: declare variables where needed in DRI2CanFlip()

### DIFF
--- a/Xext/dri2/dri2.c
+++ b/Xext/dri2/dri2.c
@@ -952,17 +952,15 @@ Bool
 DRI2CanFlip(DrawablePtr pDraw)
 {
     ScreenPtr pScreen = pDraw->pScreen;
-    WindowPtr pWin, pRoot;
-    PixmapPtr pWinPixmap, pRootPixmap;
 
     if (pDraw->type == DRAWABLE_PIXMAP)
         return TRUE;
 
-    pRoot = pScreen->root;
-    pRootPixmap = pScreen->GetWindowPixmap(pRoot);
+    WindowPtr pRoot = pScreen->root;
+    PixmapPtr pRootPixmap = pScreen->GetWindowPixmap(pRoot);
 
-    pWin = (WindowPtr) pDraw;
-    pWinPixmap = pScreen->GetWindowPixmap(pWin);
+    WindowPtr pWin = (WindowPtr) pDraw;
+    PixmapPtr pWinPixmap = pScreen->GetWindowPixmap(pWin);
     if (pRootPixmap != pWinPixmap)
         return FALSE;
     if (!RegionEqual(&pWin->clipList, &pRoot->winSize))


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
