### PR TITLE
meson: move strlcat() and strlcpy() detection into os/meson.build

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -166,8 +166,6 @@ conf_data.set('HAVE_SIGPROCMASK', cc.has_function('sigprocmask') ? '1' : false)
 # HAVE_SOCKLEN_T is used by xtrans when IPv6 is disabled
 conf_data.set('HAVE_SOCKLEN_T', cc.has_type('socklen_t', prefix: '#include <sys/socket.h>') ? '1' : false)
 conf_data.set('HAVE_STRCASESTR', cc.has_function('strcasestr') ? '1' : false)
-conf_data.set('HAVE_STRLCAT', cc.has_function('strlcat', dependencies: libbsd_dep) ? '1' : false)
-conf_data.set('HAVE_STRLCPY', cc.has_function('strlcpy', dependencies: libbsd_dep) ? '1' : false)
 conf_data.set('HAVE_STRNDUP', cc.has_function('strndup') and cc.has_header_symbol('string.h', 'strndup') ? '1' : false)
 # HAVE_STRUCT_SOCKADDR_STORAGE is used by xtrans >= 1.6
 conf_data.set('HAVE_STRUCT_SOCKADDR_STORAGE', cc.has_type('struct sockaddr_storage', prefix: '#include <sys/socket.h>') ? '1' : false)

--- a/os/meson.build
+++ b/os/meson.build
@@ -27,6 +27,12 @@ srcs_os = [
 
 conf_data.set('CONFIG_SYSLOG', cc.has_header('syslog.h') ? '1' : false)
 
+have_strlcpy = cc.has_function('strlcpy', dependencies: libbsd_dep)
+have_strlcat = cc.has_function('strlcat', dependencies: libbsd_dep)
+
+conf_data.set('HAVE_STRLCAT', have_strlcat ? '1' : false)
+conf_data.set('HAVE_STRLCPY', have_strlcpy ? '1' : false)
+
 # Wrapper code for missing C library functions. Note that conf_data contains either '1' or false.
 srcs_libc = []
 if conf_data.get('HAVE_REALLOCARRAY').to_int() == 0
@@ -35,10 +41,10 @@ endif
 if conf_data.get('HAVE_STRCASESTR').to_int() == 0
     srcs_libc += 'strcasestr.c'
 endif
-if conf_data.get('HAVE_STRLCAT').to_int() == 0
+if not have_strlcat
     srcs_libc += 'strlcat.c'
 endif
-if conf_data.get('HAVE_STRLCPY').to_int() == 0
+if not have_strlcpy
     srcs_libc += 'strlcpy.c'
 endif
 if conf_data.get('HAVE_STRNDUP').to_int() == 0


### PR DESCRIPTION
That's OS specific, and the fallback implementations are in os/,
so it's better to also move the detection there.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
