### PR TITLE
include: drop including dix-config.h

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -26,10 +26,6 @@
 #ifndef CLIENT_H
 #define CLIENT_H
 
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif                          /* HAVE_DIX_CONFIG_H */
-
 struct _Client;
 typedef struct _ClientId *ClientIdPtr;
 

--- a/include/displaymode.h
+++ b/include/displaymode.h
@@ -1,10 +1,6 @@
 #ifndef _DISMODEPROC_H_
 #define _DISMODEPROC_H_
 
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #include "scrnintstr.h"
 
 #define MAXCLOCKS   128

--- a/include/servermd.h
+++ b/include/servermd.h
@@ -47,11 +47,6 @@ SOFTWARE.
 #ifndef SERVERMD_H
 #define SERVERMD_H 1
 
-#if !defined(_DIX_CONFIG_H_) && !defined(_XORG_SERVER_H_)
-#error Drivers must include xorg-server.h before any other xserver headers
-#error xserver code must include dix-config.h before any other headers
-#endif
-
 #include <X11/Xarch.h>		/* for X_LITTLE_ENDIAN/X_BIG_ENDIAN */
 
 #if X_BYTE_ORDER == X_LITTLE_ENDIAN

--- a/include/vidmodestr.h
+++ b/include/vidmodestr.h
@@ -1,10 +1,6 @@
 #ifndef _VIDMODEPROC_H_
 #define _VIDMODEPROC_H_
 
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #include "displaymode.h"
 
 typedef enum {


### PR DESCRIPTION
All xserver sources need to include it at the very top anyways, so
no need to clutter public SDK headers with extra complexity.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
