### PR TITLE
xfixes: drop including dix-config.h

### DIFF
--- a/xfixes/xfixes.h
+++ b/xfixes/xfixes.h
@@ -23,10 +23,6 @@
 #ifndef _XFIXES_H_
 #define _XFIXES_H_
 
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #include "resource.h"
 
 extern RESTYPE RegionResType;

--- a/xfixes/xfixesint.h
+++ b/xfixes/xfixesint.h
@@ -45,10 +45,6 @@
 #ifndef _XFIXESINT_H_
 #define _XFIXESINT_H_
 
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #include <X11/X.h>
 #include <X11/Xproto.h>
 #include <X11/extensions/xfixesproto.h>


### PR DESCRIPTION
All xserver sources need to include it at the very top anyways, so
no need to clutter public SDK headers with extra complexity.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
