### PR TITLE
xwin: glx: fix VLA issue

### DIFF
--- a/hw/xwin/glx/indirect.c
+++ b/hw/xwin/glx/indirect.c
@@ -2108,7 +2108,7 @@ glxWinCreateConfigsExt(HDC hdc, glxWinScreen * screen, PixelFormatRejectStats * 
 
     /* fill in configs */
     for (i = 0; i < numConfigs; i++) {
-        int values[num_attrs];
+        int values[ARRAY_SIZE(attrs)];
         GLXWinConfig temp;
         GLXWinConfig *c = &temp;
         GLXWinConfig *work;


### PR DESCRIPTION
We don't wanna use VLAs, because they're inherently unsafe.
Since the values[] array can never be bigger than attrs,
just use attr's size here.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
