### PR TITLE
xwin: drop dead XWIN_XF86CONFIG code pathes

### DIFF
--- a/hw/xwin/InitOutput.c
+++ b/hw/xwin/InitOutput.c
@@ -725,12 +725,6 @@ winUseMsg(void)
            "\tX window, so window contents which are occluded show correctly in\n"
            "\ttask bar and task switcher previews.\n");
 
-#ifdef XWIN_XF86CONFIG
-    ErrorF("-config\n" "\tSpecify a configuration file.\n");
-
-    ErrorF("-configdir\n" "\tSpecify a configuration directory.\n");
-#endif
-
     ErrorF("-depth bits_per_pixel\n"
            "\tSpecify an optional bitdepth to use in fullscreen mode\n"
            "\twith a DirectDraw engine.\n");
@@ -762,11 +756,6 @@ winUseMsg(void)
     ErrorF("-icon icon_specifier\n" "\tSet screen window icon in windowed mode.\n");
 
     ErrorF("-ignoreinput\n" "\tIgnore keyboard and mouse input.\n");
-
-#ifdef XWIN_XF86CONFIG
-    ErrorF("-keyboard\n"
-           "\tSpecify a keyboard device from the configuration file.\n");
-#endif
 
     ErrorF("-[no]keyhook\n"
            "\tGrab special Windows keypresses like Alt-Tab or the Menu "
@@ -912,16 +901,7 @@ InitOutput(int argc, char *argv[])
                    "Exiting.\n");
     }
 
-#ifdef XWIN_XF86CONFIG
-    /* Try to read the xorg.conf-style configuration file */
-    if (!winReadConfigfile())
-        winErrorFVerb(1, "InitOutput - Error reading config file\n");
-#else
-    winMsg(X_INFO, "xorg.conf is not supported\n");
-    winMsg(X_INFO, "See http://x.cygwin.com/docs/faq/cygwin-x-faq.html "
-           "for more information\n");
     winConfigFiles();
-#endif
 
     /* Load preferences from XWinrc file */
     LoadPreferences();

--- a/hw/xwin/winconfig.c
+++ b/hw/xwin/winconfig.c
@@ -38,38 +38,8 @@
 
 #include "xkbsrv.h"
 
-#ifdef XWIN_XF86CONFIG
-#ifndef CONFIGPATH
-#define CONFIGPATH  "%A," "%R," \
-                    "/etc/X11/%R," "%P/etc/X11/%R," \
-                    "%E," "%F," \
-                    "/etc/X11/%F," "%P/etc/X11/%F," \
-                    "/etc/X11/%X-%M," "/etc/X11/%X," "/etc/%X," \
-                    "%P/etc/X11/%X.%H," "%P/etc/X11/%X-%M," \
-                    "%P/etc/X11/%X," \
-                    "%P/lib/X11/%X.%H," "%P/lib/X11/%X-%M," \
-                    "%P/lib/X11/%X"
-#endif
-#ifndef CONFIGDIRPATH
-#define CONFIGDIRPATH  "/etc/X11/%X-%M," "/etc/X11/%X," "/etc/%X," \
-                       "%P/etc/X11/%X.%H," "%P/etc/X11/%X-%M," \
-                       "%P/etc/X11/%X," \
-                       "%P/lib/X11/%X.%H," "%P/lib/X11/%X-%M," \
-                       "%P/lib/X11/%X"
-#endif
-
-XF86ConfigPtr g_xf86configptr = NULL;
-#endif
-
 WinCmdlineRec g_cmdline = {
-#ifdef XWIN_XF86CONFIG
-    NULL,                       /* configFile */
-    NULL,                       /* configDir */
-#endif
     NULL,                       /* fontPath */
-#ifdef XWIN_XF86CONFIG
-    NULL,                       /* keyboard */
-#endif
     NULL,                       /* xkbRules */
     NULL,                       /* xkbModel */
     NULL,                       /* xkbLayout */
@@ -103,118 +73,6 @@ winInfoRec g_winInfo = {
 
 #define NULL_IF_EMPTY(x) (winNameCompare(x,"")?x:NULL)
 
-#ifdef XWIN_XF86CONFIG
-serverLayoutRec g_winConfigLayout;
-
-static Bool ParseOptionValue(int scrnIndex, void *options, OptionInfoPtr p);
-static Bool configLayout(serverLayoutPtr, XF86ConfLayoutPtr, char *);
-static Bool configImpliedLayout(serverLayoutPtr, XF86ConfScreenPtr);
-static Bool GetBoolValue(OptionInfoPtr p, const char *s);
-
-Bool
-winReadConfigfile()
-{
-    Bool retval = TRUE;
-    char *filename, *dirname;
-    MessageType filefrom = X_DEFAULT;
-    MessageType dirfrom = X_DEFAULT;
-    char *xf86ConfigFile = NULL;
-    char *xf86ConfigDir = NULL;
-
-    if (g_cmdline.configFile) {
-        filefrom = X_CMDLINE;
-        xf86ConfigFile = g_cmdline.configFile;
-    }
-    if (g_cmdline.configDir) {
-        dirfrom = X_CMDLINE;
-        xf86ConfigDir = g_cmdline.configDir;
-    }
-
-    /* Parse config file into data structure */
-    xf86initConfigFiles();
-    dirname = xf86openConfigDirFiles(CONFIGDIRPATH, xf86ConfigDir, PROJECTROOT);
-    filename = xf86openConfigFile(CONFIGPATH, xf86ConfigFile, PROJECTROOT);
-
-    /* Hack for backward compatibility */
-    if (!filename && from == X_DEFAULT)
-        filename = xf86openConfigFile(CONFIGPATH, "XF86Config", PROJECTROOT);
-
-    if (filename) {
-        winMsg(from, "Using config file: \"%s\"\n", filename);
-    }
-    else {
-        winMsg(X_ERROR, "Unable to locate/open config file");
-        if (xf86ConfigFile)
-            ErrorF(": \"%s\"", xf86ConfigFile);
-        ErrorF("\n");
-    }
-    if (dirname) {
-        winMsg(from, "Using config directory: \"%s\"\n", dirname);
-    }
-    else {
-        winMsg(X_ERROR, "Unable to locate/open config directory");
-        if (xf86ConfigDir)
-            ErrorF(": \"%s\"", xf86ConfigDir);
-        ErrorF("\n");
-    }
-    if (!filename && !dirname) {
-        return FALSE;
-    }
-    free(filename);
-    free(dirname);
-    if ((g_xf86configptr = xf86readConfigFile()) == NULL) {
-        winMsg(X_ERROR, "Problem parsing the config file\n");
-        return FALSE;
-    }
-    xf86closeConfigFile();
-
-    LogPrintMarkers();
-
-    /* set options from data structure */
-
-    if (g_xf86configptr->conf_layout_lst == NULL ||
-        g_cmdline.screenname != NULL) {
-        if (g_cmdline.screenname == NULL) {
-            winMsg(X_WARNING,
-                   "No Layout section. Using the first Screen section.\n");
-        }
-        if (!configImpliedLayout(&g_winConfigLayout,
-                                 g_xf86configptr->conf_screen_lst)) {
-            winMsg(X_ERROR, "Unable to determine the screen layout\n");
-            return FALSE;
-        }
-    }
-    else {
-        /* Check if layout is given in the config file */
-        if (g_xf86configptr->conf_flags != NULL) {
-            char *dfltlayout = NULL;
-            void *optlist = g_xf86configptr->conf_flags->flg_option_lst;
-
-            if (optlist && winFindOption(optlist, "defaultserverlayout"))
-                dfltlayout =
-                    winSetStrOption(optlist, "defaultserverlayout", NULL);
-
-            if (!configLayout(&g_winConfigLayout,
-                              g_xf86configptr->conf_layout_lst, dfltlayout)) {
-                winMsg(X_ERROR, "Unable to determine the screen layout\n");
-                return FALSE;
-            }
-        }
-        else {
-            if (!configLayout(&g_winConfigLayout,
-                              g_xf86configptr->conf_layout_lst, NULL)) {
-                winMsg(X_ERROR, "Unable to determine the screen layout\n");
-                return FALSE;
-            }
-        }
-    }
-
-    /* setup special config files */
-    winConfigFiles();
-    return retval;
-}
-#endif
-
 /* load layout definitions */
 #include "winlayouts.h"
 
@@ -227,12 +85,6 @@ winConfigKeyboard(DeviceIntPtr pDevice)
     unsigned int layoutNum = 0;
     unsigned int deviceIdentifier = 0;
     int keyboardType;
-
-#ifdef XWIN_XF86CONFIG
-    XF86ConfInputPtr kbd = NULL;
-    XF86ConfInputPtr input_list = NULL;
-    MessageType kbdfrom = X_CONFIG;
-#endif
     MessageType from = X_DEFAULT;
     char *s = NULL;
 
@@ -366,214 +218,64 @@ winConfigKeyboard(DeviceIntPtr pDevice)
     }
 
     /* parse the configuration */
-#ifdef XWIN_XF86CONFIG
-    if (g_cmdline.keyboard)
-        kbdfrom = X_CMDLINE;
-
-    /*
-     * Until the layout code is finished, I search for the keyboard
-     * device and configure the server with it.
-     */
-
-    if (g_xf86configptr != NULL)
-        input_list = g_xf86configptr->conf_input_lst;
-
-    while (input_list != NULL) {
-        if (winNameCompare(input_list->inp_driver, "keyboard") == 0) {
-            /* Check if device name matches requested name */
-            if (g_cmdline.keyboard && winNameCompare(input_list->inp_identifier,
-                                                     g_cmdline.keyboard))
-                continue;
-            kbd = input_list;
-        }
-        input_list = input_list->list.next;
-    }
-
-    if (kbd != NULL) {
-
-        if (kbd->inp_identifier)
-            winMsg(kbdfrom, "Using keyboard \"%s\" as primary keyboard\n",
-                   kbd->inp_identifier);
-
-        if ((s = winSetStrOption(kbd->inp_option_lst, "AutoRepeat", NULL))) {
-            if ((sscanf(s, "%ld %ld", &g_winInfo.keyboard.delay,
-                        &g_winInfo.keyboard.rate) != 2) ||
-                (g_winInfo.keyboard.delay < 1) ||
-                (g_winInfo.keyboard.rate == 0) ||
-                (1000 / g_winInfo.keyboard.rate) < 1) {
-                winErrorFVerb(2, "\"%s\" is not a valid AutoRepeat value", s);
-                free(s);
-                return FALSE;
-            }
-            free(s);
-            winMsg(X_CONFIG, "AutoRepeat: %ld %ld\n",
-                   g_winInfo.keyboard.delay, g_winInfo.keyboard.rate);
-        }
-#endif
-
-        s = NULL;
-        if (g_cmdline.xkbRules) {
-            s = g_cmdline.xkbRules;
-            from = X_CMDLINE;
-        }
-#ifdef XWIN_XF86CONFIG
-        else {
-            s = winSetStrOption(kbd->inp_option_lst, "XkbRules", NULL);
-            from = X_CONFIG;
-        }
-#endif
-        if (s) {
-            g_winInfo.xkb.rules = NULL_IF_EMPTY(s);
-            winMsg(from, "XKB: rules: \"%s\"\n", s);
-        }
-
-        s = NULL;
-        if (g_cmdline.xkbModel) {
-            s = g_cmdline.xkbModel;
-            from = X_CMDLINE;
-        }
-#ifdef XWIN_XF86CONFIG
-        else {
-            s = winSetStrOption(kbd->inp_option_lst, "XkbModel", NULL);
-            from = X_CONFIG;
-        }
-#endif
-        if (s) {
-            g_winInfo.xkb.model = NULL_IF_EMPTY(s);
-            winMsg(from, "XKB: model: \"%s\"\n", s);
-        }
-
-        s = NULL;
-        if (g_cmdline.xkbLayout) {
-            s = g_cmdline.xkbLayout;
-            from = X_CMDLINE;
-        }
-#ifdef XWIN_XF86CONFIG
-        else {
-            s = winSetStrOption(kbd->inp_option_lst, "XkbLayout", NULL);
-            from = X_CONFIG;
-        }
-#endif
-        if (s) {
-            g_winInfo.xkb.layout = NULL_IF_EMPTY(s);
-            winMsg(from, "XKB: layout: \"%s\"\n", s);
-        }
-
-        s = NULL;
-        if (g_cmdline.xkbVariant) {
-            s = g_cmdline.xkbVariant;
-            from = X_CMDLINE;
-        }
-#ifdef XWIN_XF86CONFIG
-        else {
-            s = winSetStrOption(kbd->inp_option_lst, "XkbVariant", NULL);
-            from = X_CONFIG;
-        }
-#endif
-        if (s) {
-            g_winInfo.xkb.variant = NULL_IF_EMPTY(s);
-            winMsg(from, "XKB: variant: \"%s\"\n", s);
-        }
-
-        s = NULL;
-        if (g_cmdline.xkbOptions) {
-            s = g_cmdline.xkbOptions;
-            from = X_CMDLINE;
-        }
-#ifdef XWIN_XF86CONFIG
-        else {
-            s = winSetStrOption(kbd->inp_option_lst, "XkbOptions", NULL);
-            from = X_CONFIG;
-        }
-#endif
-        if (s) {
-            g_winInfo.xkb.options = NULL_IF_EMPTY(s);
-            winMsg(from, "XKB: options: \"%s\"\n", s);
-        }
-
-#ifdef XWIN_XF86CONFIG
-    }
-#endif
-
-    return TRUE;
-}
-
-#ifdef XWIN_XF86CONFIG
-Bool
-winConfigMouse(DeviceIntPtr pDevice)
-{
-    MessageType mousefrom = X_CONFIG;
-
-    XF86ConfInputPtr mouse = NULL;
-    XF86ConfInputPtr input_list = NULL;
-
-    if (g_cmdline.mouse)
-        mousefrom = X_CMDLINE;
-
-    if (g_xf86configptr != NULL)
-        input_list = g_xf86configptr->conf_input_lst;
-
-    while (input_list != NULL) {
-        if (winNameCompare(input_list->inp_driver, "mouse") == 0) {
-            /* Check if device name matches requested name */
-            if (g_cmdline.mouse && winNameCompare(input_list->inp_identifier,
-                                                  g_cmdline.mouse))
-                continue;
-            mouse = input_list;
-        }
-        input_list = input_list->list.next;
-    }
-
-    if (mouse != NULL) {
-        if (mouse->inp_identifier)
-            winMsg(mousefrom, "Using pointer \"%s\" as primary pointer\n",
-                   mouse->inp_identifier);
-
-        g_winInfo.pointer.emulate3Buttons =
-            winSetBoolOption(mouse->inp_option_lst, "Emulate3Buttons", FALSE);
-        if (g_cmdline.emulate3buttons)
-            g_winInfo.pointer.emulate3Buttons = g_cmdline.emulate3buttons;
-
-        g_winInfo.pointer.emulate3Timeout =
-            winSetIntOption(mouse->inp_option_lst, "Emulate3Timeout", 50);
-        if (g_cmdline.emulate3timeout)
-            g_winInfo.pointer.emulate3Timeout = g_cmdline.emulate3timeout;
-    }
-    else {
-        winMsg(X_ERROR, "No primary pointer configured\n");
-        winMsg(X_DEFAULT, "Using compiletime defaults for pointer\n");
-    }
-
-    return TRUE;
-}
-
-Bool
-winConfigFiles()
-{
-    MessageType from;
-    XF86ConfFilesPtr filesptr = NULL;
-
-    /* set some shortcuts */
-    if (g_xf86configptr != NULL) {
-        filesptr = g_xf86configptr->conf_files;
-    }
-
-    /* Fontpath */
-    from = X_DEFAULT;
-
-    if (g_cmdline.fontPath) {
+    s = NULL;
+    if (g_cmdline.xkbRules) {
+        s = g_cmdline.xkbRules;
         from = X_CMDLINE;
-        defaultFontPath = g_cmdline.fontPath;
     }
-    else if (filesptr != NULL && filesptr->file_fontpath) {
-        from = X_CONFIG;
-        defaultFontPath = strdup(filesptr->file_fontpath);
+
+    if (s) {
+        g_winInfo.xkb.rules = NULL_IF_EMPTY(s);
+        winMsg(from, "XKB: rules: \"%s\"\n", s);
     }
-    winMsg(from, "FontPath set to \"%s\"\n", defaultFontPath);
+
+    s = NULL;
+    if (g_cmdline.xkbModel) {
+        s = g_cmdline.xkbModel;
+        from = X_CMDLINE;
+    }
+
+    if (s) {
+        g_winInfo.xkb.model = NULL_IF_EMPTY(s);
+        winMsg(from, "XKB: model: \"%s\"\n", s);
+    }
+
+    s = NULL;
+    if (g_cmdline.xkbLayout) {
+        s = g_cmdline.xkbLayout;
+        from = X_CMDLINE;
+    }
+
+    if (s) {
+        g_winInfo.xkb.layout = NULL_IF_EMPTY(s);
+        winMsg(from, "XKB: layout: \"%s\"\n", s);
+    }
+
+    s = NULL;
+    if (g_cmdline.xkbVariant) {
+        s = g_cmdline.xkbVariant;
+        from = X_CMDLINE;
+    }
+
+    if (s) {
+        g_winInfo.xkb.variant = NULL_IF_EMPTY(s);
+        winMsg(from, "XKB: variant: \"%s\"\n", s);
+    }
+
+    s = NULL;
+    if (g_cmdline.xkbOptions) {
+        s = g_cmdline.xkbOptions;
+        from = X_CMDLINE;
+    }
+
+    if (s) {
+        g_winInfo.xkb.options = NULL_IF_EMPTY(s);
+        winMsg(from, "XKB: options: \"%s\"\n", s);
+    }
 
     return TRUE;
 }
-#else
+
 Bool
 winConfigFiles(void)
 {
@@ -585,7 +287,6 @@ winConfigFiles(void)
 
     return TRUE;
 }
-#endif
 
 Bool
 winConfigOptions(void)
@@ -598,71 +299,6 @@ winConfigScreens(void)
 {
     return TRUE;
 }
-
-#ifdef XWIN_XF86CONFIG
-char *
-winSetStrOption(void *optlist, const char *name, char *deflt)
-{
-    OptionInfoRec o;
-
-    o.name = name;
-    o.type = OPTV_STRING;
-    if (ParseOptionValue(-1, optlist, &o))
-        deflt = o.value.str;
-    if (deflt)
-        return strdup(deflt);
-    else
-        return NULL;
-}
-
-int
-winSetBoolOption(void *optlist, const char *name, int deflt)
-{
-    OptionInfoRec o;
-
-    o.name = name;
-    o.type = OPTV_BOOLEAN;
-    if (ParseOptionValue(-1, optlist, &o))
-        deflt = o.value.boolean;
-    return deflt;
-}
-
-int
-winSetIntOption(void *optlist, const char *name, int deflt)
-{
-    OptionInfoRec o;
-
-    o.name = name;
-    o.type = OPTV_INTEGER;
-    if (ParseOptionValue(-1, optlist, &o))
-        deflt = o.value.num;
-    return deflt;
-}
-
-double
-winSetRealOption(void *optlist, const char *name, double deflt)
-{
-    OptionInfoRec o;
-
-    o.name = name;
-    o.type = OPTV_REAL;
-    if (ParseOptionValue(-1, optlist, &o))
-        deflt = o.value.realnum;
-    return deflt;
-}
-
-double
-winSetPercentOption(void *optlist, const char *name, double deflt)
-{
-    OptionInfoRec o;
-
-    o.name = name;
-    o.type = OPTV_PERCENT;
-    if (ParseOptionValue(-1, optlist, &o))
-        deflt = o.value.realnum;
-    return deflt;
-}
-#endif
 
 /*
  * Compare two strings for equality. This is caseinsensitive  and
@@ -706,291 +342,6 @@ winNameCompare(const char *s1, const char *s2)
     }
     return c1 - c2;
 }
-
-#ifdef XWIN_XF86CONFIG
-/*
- * Find the named option in the list.
- * @return the pointer to the option record, or NULL if not found.
- */
-
-XF86OptionPtr
-winFindOption(XF86OptionPtr list, const char *name)
-{
-    while (list) {
-        if (winNameCompare(list->opt_name, name) == 0)
-            return list;
-        list = list->list.next;
-    }
-    return NULL;
-}
-
-/*
- * Find the Value of an named option.
- * @return The option value or NULL if not found.
- */
-
-char *
-winFindOptionValue(XF86OptionPtr list, const char *name)
-{
-    list = winFindOption(list, name);
-    if (list) {
-        if (list->opt_val)
-            return list->opt_val;
-        else
-            return "";
-    }
-    return NULL;
-}
-
-/*
- * Parse the option.
- */
-
-static Bool
-ParseOptionValue(int scrnIndex, void *options, OptionInfoPtr p)
-{
-    char *s, *end;
-
-    if ((s = winFindOptionValue(options, p->name)) != NULL) {
-        switch (p->type) {
-        case OPTV_INTEGER:
-            if (*s == '\0') {
-                winDrvMsg(scrnIndex, X_WARNING,
-                          "Option \"%s\" requires an integer value\n", p->name);
-                p->found = FALSE;
-            }
-            else {
-                p->value.num = strtoul(s, &end, 0);
-                if (*end == '\0') {
-                    p->found = TRUE;
-                }
-                else {
-                    winDrvMsg(scrnIndex, X_WARNING,
-                              "Option \"%s\" requires an integer value\n",
-                              p->name);
-                    p->found = FALSE;
-                }
-            }
-            break;
-        case OPTV_STRING:
-            if (*s == '\0') {
-                winDrvMsg(scrnIndex, X_WARNING,
-                          "Option \"%s\" requires a string value\n", p->name);
-                p->found = FALSE;
-            }
-            else {
-                p->value.str = s;
-                p->found = TRUE;
-            }
-            break;
-        case OPTV_ANYSTR:
-            p->value.str = s;
-            p->found = TRUE;
-            break;
-        case OPTV_REAL:
-            if (*s == '\0') {
-                winDrvMsg(scrnIndex, X_WARNING,
-                          "Option \"%s\" requires a floating point value\n",
-                          p->name);
-                p->found = FALSE;
-            }
-            else {
-                p->value.realnum = strtod(s, &end);
-                if (*end == '\0') {
-                    p->found = TRUE;
-                }
-                else {
-                    winDrvMsg(scrnIndex, X_WARNING,
-                              "Option \"%s\" requires a floating point value\n",
-                              p->name);
-                    p->found = FALSE;
-                }
-            }
-            break;
-        case OPTV_BOOLEAN:
-            if (GetBoolValue(p, s)) {
-                p->found = TRUE;
-            }
-            else {
-                winDrvMsg(scrnIndex, X_WARNING,
-                          "Option \"%s\" requires a boolean value\n", p->name);
-                p->found = FALSE;
-            }
-            break;
-        case OPTV_PERCENT:
-            if (*s == '\0') {
-                winDrvMsg(scrnIndex, X_WARNING,
-                          "Option \"%s\" requires a percent value\n", p->name);
-                p->found = FALSE;
-            }
-            else {
-                double percent = strtod(s, &end);
-
-                if (end != s && winNameCompare(end, "%")) {
-                    p->found = TRUE;
-                    p->value.realnum = percent;
-                }
-                else {
-                    winDrvMsg(scrnIndex, X_WARNING,
-                              "Option \"%s\" requires a frequency value\n",
-                              p->name);
-                    p->found = FALSE;
-                }
-            }
-        case OPTV_FREQ:
-            if (*s == '\0') {
-                winDrvMsg(scrnIndex, X_WARNING,
-                          "Option \"%s\" requires a frequency value\n",
-                          p->name);
-                p->found = FALSE;
-            }
-            else {
-                double freq = strtod(s, &end);
-                int units = 0;
-
-                if (end != s) {
-                    p->found = TRUE;
-                    if (!winNameCompare(end, "Hz"))
-                        units = 1;
-                    else if (!winNameCompare(end, "kHz") ||
-                             !winNameCompare(end, "k"))
-                        units = 1000;
-                    else if (!winNameCompare(end, "MHz") ||
-                             !winNameCompare(end, "M"))
-                        units = 1000000;
-                    else {
-                        winDrvMsg(scrnIndex, X_WARNING,
-                                  "Option \"%s\" requires a frequency value\n",
-                                  p->name);
-                        p->found = FALSE;
-                    }
-                    if (p->found)
-                        freq *= (double) units;
-                }
-                else {
-                    winDrvMsg(scrnIndex, X_WARNING,
-                              "Option \"%s\" requires a frequency value\n",
-                              p->name);
-                    p->found = FALSE;
-                }
-                if (p->found) {
-                    p->value.freq.freq = freq;
-                    p->value.freq.units = units;
-                }
-            }
-            break;
-        case OPTV_NONE:
-            /* Should never get here */
-            p->found = FALSE;
-            break;
-        }
-        if (p->found) {
-            winDrvMsgVerb(scrnIndex, X_CONFIG, 2, "Option \"%s\"", p->name);
-            if (!(p->type == OPTV_BOOLEAN && *s == 0)) {
-                winErrorFVerb(2, " \"%s\"", s);
-            }
-            winErrorFVerb(2, "\n");
-        }
-    }
-    else if (p->type == OPTV_BOOLEAN) {
-        /* Look for matches with options with or without a "No" prefix. */
-        char *n, *newn;
-        OptionInfoRec opt;
-
-        n = winNormalizeName(p->name);
-        if (!n) {
-            p->found = FALSE;
-            return FALSE;
-        }
-        if (strncmp(n, "no", 2) == 0) {
-            newn = n + 2;
-        }
-        else {
-            free(n);
-            n = calloc(1, strlen(p->name) + 2 + 1);
-            if (!n) {
-                p->found = FALSE;
-                return FALSE;
-            }
-            strcpy(n, "No");
-            strcat(n, p->name);
-            newn = n;
-        }
-        if ((s = winFindOptionValue(options, newn)) != NULL) {
-            if (GetBoolValue(&opt, s)) {
-                p->value.boolean = !opt.value.boolean;
-                p->found = TRUE;
-            }
-            else {
-                winDrvMsg(scrnIndex, X_WARNING,
-                          "Option \"%s\" requires a boolean value\n", newn);
-                p->found = FALSE;
-            }
-        }
-        else {
-            p->found = FALSE;
-        }
-        if (p->found) {
-            winDrvMsgVerb(scrnIndex, X_CONFIG, 2, "Option \"%s\"", newn);
-            if (*s != 0) {
-                winErrorFVerb(2, " \"%s\"", s);
-            }
-            winErrorFVerb(2, "\n");
-        }
-        free(n);
-    }
-    else {
-        p->found = FALSE;
-    }
-    return p->found;
-}
-
-static Bool
-configLayout(serverLayoutPtr servlayoutp, XF86ConfLayoutPtr conf_layout,
-             char *default_layout)
-{
-#if 0
-#pragma warn UNIMPLEMENTED
-#endif
-    return TRUE;
-}
-
-static Bool
-configImpliedLayout(serverLayoutPtr servlayoutp, XF86ConfScreenPtr conf_screen)
-{
-#if 0
-#pragma warn UNIMPLEMENTED
-#endif
-    return TRUE;
-}
-
-static Bool
-GetBoolValue(OptionInfoPtr p, const char *s)
-{
-    if (*s == 0) {
-        p->value.boolean = TRUE;
-    }
-    else {
-        if (winNameCompare(s, "1") == 0)
-            p->value.boolean = TRUE;
-        else if (winNameCompare(s, "on") == 0)
-            p->value.boolean = TRUE;
-        else if (winNameCompare(s, "true") == 0)
-            p->value.boolean = TRUE;
-        else if (winNameCompare(s, "yes") == 0)
-            p->value.boolean = TRUE;
-        else if (winNameCompare(s, "0") == 0)
-            p->value.boolean = FALSE;
-        else if (winNameCompare(s, "off") == 0)
-            p->value.boolean = FALSE;
-        else if (winNameCompare(s, "false") == 0)
-            p->value.boolean = FALSE;
-        else if (winNameCompare(s, "no") == 0)
-            p->value.boolean = FALSE;
-    }
-    return TRUE;
-}
-#endif
 
 char *
 winNormalizeName(const char *s)

--- a/hw/xwin/winconfig.h
+++ b/hw/xwin/winconfig.h
@@ -31,9 +31,6 @@
  */
 
 #include "win.h"
-#ifdef XWIN_XF86CONFIG
-#include "../xfree86/parser/xf86Parser.h"
-#endif
 
 /* These are taken from hw/xfree86/common/xf86str.h */
 
@@ -150,15 +147,8 @@ typedef struct _serverlayoutrec {
 
 typedef struct {
     /* Files */
-#ifdef XWIN_XF86CONFIG
-    char *configFile;
-    char *configDir;
-#endif
     char *fontPath;
     /* input devices - keyboard */
-#ifdef XWIN_XF86CONFIG
-    char *keyboard;
-#endif
     char *xkbRules;
     char *xkbModel;
     char *xkbLayout;
@@ -174,9 +164,6 @@ typedef struct {
 
 extern WinCmdlineRec g_cmdline;
 
-#ifdef XWIN_XF86CONFIG
-extern XF86ConfigPtr g_xf86configptr;
-#endif
 extern serverLayoutRec g_winConfigLayout;
 
 /*
@@ -238,10 +225,6 @@ int winSetIntOption(void *optlist, const char *name, int deflt);
 double winSetRealOption(void *optlist, const char *name, double deflt);
 double winSetPercentOption(void *optlist, const char *name, double deflt);
 
-#ifdef XWIN_XF86CONFIG
-XF86OptionPtr winFindOption(XF86OptionPtr list, const char *name);
-char *winFindOptionValue(XF86OptionPtr list, const char *name);
-#endif
 int winNameCompare(const char *s1, const char *s2);
 char *winNormalizeName(const char *s);
 

--- a/hw/xwin/winmsg.c
+++ b/hw/xwin/winmsg.c
@@ -38,29 +38,6 @@
 #endif
 #include <stdarg.h>
 
-#ifdef XWIN_XF86CONFIG
-void
-winDrvMsg(int scrnIndex, MessageType type, const char *format, ...)
-{
-    va_list ap;
-
-    va_start(ap, format);
-    LogVMessageVerb(type, 0, format, ap);
-    va_end(ap);
-}
-
-void
-winDrvMsgVerb(int scrnIndex, MessageType type, int verb, const char *format,
-              ...)
-{
-    va_list ap;
-
-    va_start(ap, format);
-    LogVMessageVerb(type, verb, format, ap);
-    va_end(ap);
-}
-#endif
-
 void
 winErrorFVerb(int verb, const char *format, ...)
 {

--- a/hw/xwin/winmsg.h
+++ b/hw/xwin/winmsg.h
@@ -37,17 +37,6 @@
 /*
  * Function prototypes
  */
-
-#ifdef XWIN_XF86CONFIG
-void
-winDrvMsgVerb(int scrnIndex,
-              MessageType type, int verb, const char *format, ...)
-_X_ATTRIBUTE_PRINTF(4, 5);
-void
-winDrvMsg(int scrnIndex, MessageType type, const char *format, ...)
-_X_ATTRIBUTE_PRINTF(3, 4);
-#endif
-
 #define winMsg LogMessage
 
 void

--- a/hw/xwin/winprocarg.c
+++ b/hw/xwin/winprocarg.c
@@ -931,55 +931,6 @@ ddxProcessArgument(int argc, char *argv[], int i)
     }
 
     /*
-     * Look for the '-config' argument
-     */
-    if (IS_OPTION("-config")
-        || IS_OPTION("-xf86config")) {
-        CHECK_ARGS(1);
-#ifdef XWIN_XF86CONFIG
-        g_cmdline.configFile = argv[++i];
-#else
-        winMessageBoxF("The %s option is not supported in this "
-                       "release.\n"
-                       "Ignoring this option and continuing.\n",
-                       MB_ICONINFORMATION, argv[i]);
-#endif
-        return 2;
-    }
-
-    /*
-     * Look for the '-configdir' argument
-     */
-    if (IS_OPTION("-configdir")) {
-        CHECK_ARGS(1);
-#ifdef XWIN_XF86CONFIG
-        g_cmdline.configDir = argv[++i];
-#else
-        winMessageBoxF("The %s option is not supported in this "
-                       "release.\n"
-                       "Ignoring this option and continuing.\n",
-                       MB_ICONINFORMATION, argv[i]);
-#endif
-        return 2;
-    }
-
-    /*
-     * Look for the '-keyboard' argument
-     */
-    if (IS_OPTION("-keyboard")) {
-#ifdef XWIN_XF86CONFIG
-        CHECK_ARGS(1);
-        g_cmdline.keyboard = argv[++i];
-#else
-        winMessageBoxF("The -keyboard option is not supported in this "
-                       "release.\n"
-                       "Ignoring this option and continuing.\n",
-                       MB_ICONINFORMATION);
-#endif
-        return 2;
-    }
-
-    /*
      * Look for the '-logfile' argument
      */
     if (IS_OPTION("-logfile")) {


### PR DESCRIPTION
These never seemed to be actually active, ever. Since nobody ever seemed
to have an actual desire to use an xf86-style config file for Xwin,
let's just drop all that ancient dead code.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
