### PR TITLE
xwin: move winsock specific errno checks into ossock

### DIFF
--- a/hw/xwin/winclipboard/meson.build
+++ b/hw/xwin/winclipboard/meson.build
@@ -23,12 +23,14 @@ xwin_clipboard = static_library(
 srcs_xwinclip = [
     'xwinclip.c',
     'debug.c',
+    '../../../os/ossock.c',
 ]
 
 executable(
     'xwinclip',
     srcs_xwinclip,
     dependencies: dependency('xcb'),
+    include_directories: inc,
     link_with: xwin_clipboard,
     link_args: ['-lgdi32', '-lpthread'],
     install: true,

--- a/include/meson.build
+++ b/include/meson.build
@@ -389,8 +389,6 @@ endif
 
 xwin_data = configuration_data()
 xwin_data.set_quoted('DEFAULT_LOGDIR', log_dir)
-xwin_data.set('HAS_WINSOCK', host_machine.system() == 'windows' ? '1' : false,
-              description: 'Use Windows sockets')
 xwin_data.set('HAS_DEVWINDOWS', host_machine.system() == 'cygwin' ? '1' : false,
               description: 'Has /dev/windows for signaling new win32 messages')
 xwin_data.set('RELOCATE_PROJECTROOT', host_machine.system() == 'windows' ? '1' : false,

--- a/include/xwin-config.h.meson.in
+++ b/include/xwin-config.h.meson.in
@@ -10,9 +10,6 @@
 
 #include <dix-config.h>
 
-/* Winsock networking */
-#mesondefine HAS_WINSOCK
-
 /* Cygwin has /dev/windows for signaling new win32 messages */
 #mesondefine HAS_DEVWINDOWS
 

--- a/os/ossock.c
+++ b/os/ossock.c
@@ -5,6 +5,7 @@
 #include <dix-config.h>
 
 #include <unistd.h>
+#include <stdbool.h>
 
 #ifdef WIN32
 #include <X11/Xwinsock.h>
@@ -53,5 +54,23 @@ int ossock_wouldblock(int err)
     return ((err == EAGAIN) || (err == WSAEWOULDBLOCK));
 #else
     return ((err == EAGAIN) || (err == EWOULDBLOCK));
+#endif
+}
+
+bool ossock_eintr(int err)
+{
+#ifdef WIN32
+    return (err == WSAEINTR);
+#else
+    return (err == EINTR);
+#endif
+}
+
+int ossock_errno(void)
+{
+#ifdef WIN32
+    return WSAGetLastError();
+#else
+    return errno;
 #endif
 }

--- a/os/ossock.h
+++ b/os/ossock.h
@@ -6,6 +6,7 @@
 #define _XSERVER_OS_OSSOCK_H_
 
 #include <errno.h>
+#include <stdbool.h>
 
 /*
  * os specific initialization of the socket layer
@@ -26,5 +27,16 @@ int ossock_close(int fd);
  * os specific check for errno indicating operation would block
  */
 int ossock_wouldblock(int err);
+
+/*
+ * os specific check for errno indicating operation interrupted
+ */
+bool ossock_eintr(int err);
+
+/*
+ * os specific retrieval of last socket operation error
+ * on Unix: errno, on Win32: GetWSALastError()
+ */
+int ossock_errno(void);
 
 #endif /* _XSERVER_OS_OSSOCK_H_ */


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
