### PR TITLE
test: drop unncessary include of dix-config.h from headers

### DIFF
--- a/test/xi2/protocol-common.h
+++ b/test/xi2/protocol-common.h
@@ -24,10 +24,6 @@
 #ifndef PROTOCOL_COMMON_H
 #define PROTOCOL_COMMON_H
 
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #include "dix/resource_priv.h"
 
 #include "scrnintstr.h"


### PR DESCRIPTION
This header needs to be included at the top of source files,
should not be done from other headers.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
