### PR TITLE
mi: drop including dix-config.h from headers

### DIFF
--- a/mi/miinitext.h
+++ b/mi/miinitext.h
@@ -70,13 +70,8 @@ SOFTWARE.
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
 #ifndef MIINITEXT_H
 #define MIINITEXT_H
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
 
 void ListStaticExtensions(void);
 

--- a/mi/mioverlay.h
+++ b/mi/mioverlay.h
@@ -1,10 +1,6 @@
 #ifndef __MIOVERLAY_H
 #define __MIOVERLAY_H
 
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 typedef void (*miOverlayTransFunc) (ScreenPtr, int, BoxPtr);
 typedef Bool (*miOverlayInOverlayFunc) (WindowPtr);
 

--- a/mi/miscanfill.h
+++ b/mi/miscanfill.h
@@ -25,13 +25,8 @@ other dealings in this Software without prior written authorization
 from The Open Group.
 
 */
-
 #ifndef SCANFILLINCLUDED
 #define SCANFILLINCLUDED
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
 
 /*
  *     scanfill.h

--- a/mi/mivalidate.h
+++ b/mi/mivalidate.h
@@ -29,10 +29,6 @@ from The Open Group.
 #ifndef MIVALIDATE_H
 #define MIVALIDATE_H
 
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #include "regionstr.h"
 
 typedef union _Validate {


### PR DESCRIPTION
It needs to be included from the very top of source files anyways,
should not be done from individual headers.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
