### PR TITLE
render: replace DDXPoint by xPoint

### DIFF
--- a/render/picturestr.h
+++ b/render/picturestr.h
@@ -139,9 +139,9 @@ typedef struct _Picture {
     PicturePtr pNext;           /* chain on same drawable */
 
     PicturePtr alphaMap;
-    DDXPointRec alphaOrigin;
+    xPoint alphaOrigin;
 
-    DDXPointRec clipOrigin;
+    xPoint clipOrigin;
     RegionPtr clientClip;
 
     unsigned long serialNumber;


### PR DESCRIPTION
DDXPoint is just an alias to xPoint

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
