### PR TITLE
kdrive: replace DDXPoint by xPoint

### DIFF
--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -92,7 +92,7 @@ int kdSubpixelOrder;
 int kdVirtualTerminal = -1;
 Bool kdSwitchPending;
 char *kdSwitchCmd;
-DDXPointRec kdOrigin;
+xPoint kdOrigin;
 Bool kdHasPointer = FALSE;
 Bool kdHasKbd = FALSE;
 const char *kdGlobalXkbRules = NULL;

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -103,7 +103,7 @@ typedef struct _KdScreenInfo {
     Bool dumb;
     Bool softCursor;
     int mynum;
-    DDXPointRec origin;
+    xPoint origin;
     KdFrameBuffer fb;
 } KdScreenInfo;
 

--- a/hw/kdrive/src/kxv.h
+++ b/hw/kdrive/src/kxv.h
@@ -175,7 +175,7 @@ typedef struct {
     DrawablePtr pDraw;
     unsigned char type;
     unsigned int subWindowMode;
-    DDXPointRec clipOrg;
+    xPoint clipOrg;
     RegionPtr clientClip;
     RegionPtr pCompositeClip;
     Bool FreeCompositeClip;


### PR DESCRIPTION
DDXPoint is just an alias to xPoint

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
