### PR TITLE
xquartz: replace DDXPoint by xPoint

### DIFF
--- a/hw/xquartz/xpr/dri.c
+++ b/hw/xquartz/xpr/dri.c
@@ -565,7 +565,7 @@ DRIDrawablePrivDelete(void *pResource, XID id)
 }
 
 void
-DRICopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr prgnSrc)
+DRICopyWindow(WindowPtr pWin, xPoint ptOldOrg, RegionPtr prgnSrc)
 {
     ScreenPtr pScreen = pWin->drawable.pScreen;
     DRIScreenPrivPtr pDRIPriv = DRI_SCREEN_PRIV(pScreen);

--- a/hw/xquartz/xpr/dri.h
+++ b/hw/xquartz/xpr/dri.h
@@ -101,8 +101,7 @@ DRIDrawablePrivDelete(void *pResource, XID id);
 extern DRIWrappedFuncsRec *
 DRIGetWrappedFuncs(ScreenPtr pScreen);
 
-extern void
-DRICopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr prgnSrc);
+void DRICopyWindow(WindowPtr pWin, xPoint ptOldOrg, RegionPtr prgnSrc);
 
 extern void
 DRIClipNotify(WindowPtr pWin, int dx, int dy);


### PR DESCRIPTION
DDXPoint is just an alias to xPoint

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
