### PR TITLE
Xext: replace DDXPoint by xPoint

### DIFF
--- a/Xext/panoramiX.c
+++ b/Xext/panoramiX.c
@@ -111,8 +111,8 @@ static DevPrivateKeyRec PanoramiXGCKeyRec;
 static DevPrivateKeyRec PanoramiXScreenKeyRec;
 
 typedef struct {
-    DDXPointRec clipOrg;
-    DDXPointRec patOrg;
+    xPoint clipOrg;
+    xPoint patOrg;
     const GCFuncs *wrapFuncs;
 } PanoramiXGCRec, *PanoramiXGCPtr;
 

--- a/Xext/panoramiXprocs.c
+++ b/Xext/panoramiXprocs.c
@@ -1764,15 +1764,15 @@ PanoramiXFillPoly(ClientPtr client)
 
     count = bytes_to_int32((client->req_len << 2) - sizeof(xFillPolyReq));
     if (count > 0) {
-        DDXPointPtr locPts = calloc(count, sizeof(DDXPointRec));
+        DDXPointPtr locPts = calloc(count, sizeof(xPoint));
         if (!locPts)
             return BadAlloc;
         memcpy((char *) locPts, (char *) &stuff[1],
-               count * sizeof(DDXPointRec));
+               count * sizeof(xPoint));
 
         XINERAMA_FOR_EACH_SCREEN_FORWARD({
             if (walkScreenIdx) /* skip screen #0 */
-                memcpy(&stuff[1], locPts, count * sizeof(DDXPointRec));
+                memcpy(&stuff[1], locPts, count * sizeof(xPoint));
 
             if (isRoot) {
                 int x_off = walkScreen->x;


### PR DESCRIPTION
DDXPoint is just an alias to xPoint

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
