### PR TITLE
fb: replace DDXPoint by xPoint

### DIFF
--- a/fb/fb.h
+++ b/fb/fb.h
@@ -1000,8 +1000,7 @@ fbCopyWindowProc(DrawablePtr pSrcDrawable,
                  int dy,
                  Bool reverse, Bool upsidedown, Pixel bitplane, void *closure);
 
-extern _X_EXPORT void
- fbCopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr prgnSrc);
+_X_EXPORT void fbCopyWindow(WindowPtr pWin, xPoint ptOldOrg, RegionPtr prgnSrc);
 
 extern _X_EXPORT Bool
  fbChangeWindowAttributes(WindowPtr pWin, unsigned long mask);

--- a/fb/fboverlay.c
+++ b/fb/fboverlay.c
@@ -187,7 +187,7 @@ fbOverlayUpdateLayerRegion(ScreenPtr pScreen, int layer, RegionPtr prgn)
  * Copy only areas in each layer containing real bits
  */
 static void
-fbOverlayCopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr prgnSrc)
+fbOverlayCopyWindow(WindowPtr pWin, xPoint ptOldOrg, RegionPtr prgnSrc)
 {
     ScreenPtr pScreen = pWin->drawable.pScreen;
     FbOverlayScrPrivPtr pScrPriv = fbOverlayGetScrPriv(pScreen);

--- a/fb/fbwindow.c
+++ b/fb/fbwindow.c
@@ -98,7 +98,7 @@ fbCopyWindowProc(DrawablePtr pSrcDrawable,
 }
 
 void
-fbCopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr prgnSrc)
+fbCopyWindow(WindowPtr pWin, xPoint ptOldOrg, RegionPtr prgnSrc)
 {
     RegionRec rgnDst;
     int dx, dy;


### PR DESCRIPTION
DDXPoint is just an alias to xPoint

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
