### PR TITLE
doc: replace DDXPoint by xPoint

### DIFF
--- a/doc/Xserver-spec.xml
+++ b/doc/Xserver-spec.xml
@@ -3387,7 +3387,7 @@ The sample server implementation is in Xserver/mi/miwindow.c.</para>
 
         void pScreen->CopyWindow(pWin, oldpt, oldRegion);
                 WindowPtr pWin;
-                DDXPointRec oldpt;
+                xPoint oldpt;
                 RegionPtr oldRegion;
 
 </programlisting></blockquote>


### PR DESCRIPTION
DDXPoint is just an alias to xPoint

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
