### PR TITLE
composite: replace DDXPoint by xPoint

### DIFF
--- a/composite/compint.h
+++ b/composite/compint.h
@@ -310,7 +310,7 @@ RegionPtr
  compGetRedirectBorderClip(WindowPtr pWin);
 
 void
- compCopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr prgnSrc);
+ compCopyWindow(WindowPtr pWin, xPoint ptOldOrg, RegionPtr prgnSrc);
 
 void
  compPaintChildrenToWindow(WindowPtr pWin);

--- a/composite/compwindow.c
+++ b/composite/compwindow.c
@@ -474,7 +474,7 @@ compReparentWindow(WindowPtr pWin, WindowPtr pPriorParent)
 }
 
 void
-compCopyWindow(WindowPtr pWin, DDXPointRec ptOldOrg, RegionPtr prgnSrc)
+compCopyWindow(WindowPtr pWin, xPoint ptOldOrg, RegionPtr prgnSrc)
 {
     ScreenPtr pScreen = pWin->drawable.pScreen;
     CompScreenPtr cs = GetCompScreen(pScreen);


### PR DESCRIPTION
DDXPoint is just an alias to xPoint

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
