### PR TITLE
include: replace DDXPoint by xPoint

### DIFF
--- a/include/gcstruct.h
+++ b/include/gcstruct.h
@@ -271,8 +271,8 @@ typedef struct _GC {
      */
     PixUnion tile;
     PixmapPtr stipple;
-    DDXPointRec patOrg;         /* origin for (tile, stipple) */
-    DDXPointRec clipOrg;
+    xPoint patOrg;         /* origin for (tile, stipple) */
+    xPoint clipOrg;
     struct _Font *font;
     RegionPtr clientClip;
     unsigned int stateChanges; /* masked with GC_<kind> */

--- a/include/scrnintstr.h
+++ b/include/scrnintstr.h
@@ -168,7 +168,7 @@ typedef void (*PaintWindowProcPtr) (WindowPtr /*pWindow*/,
                                     int /*what*/);
 
 typedef void (*CopyWindowProcPtr) (WindowPtr /*pWindow */ ,
-                                   DDXPointRec /*ptOldOrg */ ,
+                                   xPoint /*ptOldOrg */ ,
                                    RegionPtr /*prgnSrc */ );
 
 typedef void (*ClearToBackgroundProcPtr) (WindowPtr /*pWindow */ ,

--- a/include/windowstr.h
+++ b/include/windowstr.h
@@ -127,7 +127,7 @@ typedef struct _Window {
     union _Validate *valdata;
     RegionRec winSize;
     RegionRec borderSize;
-    DDXPointRec origin;         /* position relative to parent */
+    xPoint origin;         /* position relative to parent */
     unsigned short borderWidth;
     unsigned short deliverableEvents;   /* all masks from all clients */
     Mask eventMask;             /* mask from the creating client */


### PR DESCRIPTION
DDXPoint is just an alias to xPoint

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
