### PR TITLE
dri2: fix declaration after label error (*BSD)

### DIFF
--- a/Xext/dri2/dri2.c
+++ b/Xext/dri2/dri2.c
@@ -203,11 +203,15 @@ DRI2GetDrawable(DrawablePtr pDraw)
 {
     switch (pDraw->type) {
     case DRAWABLE_WINDOW:
+    {
         WindowPtr pWin = (WindowPtr) pDraw;
         return dixLookupPrivate(&pWin->devPrivates, &dri2WindowPrivateKeyRec);
+    }
     case DRAWABLE_PIXMAP:
+    {
         PixmapPtr pPixmap = (PixmapPtr) pDraw;
         return dixLookupPrivate(&pPixmap->devPrivates, &dri2PixmapPrivateKeyRec);
+    }
     default:
         return NULL;
     }


### PR DESCRIPTION
BSD compilers dont like declarations directly following labels
(eg. within a switch/case statement), thus we need to scrope those.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
