### PR TITLE
miext: drop unncessary include of dix-config.h from headers

### DIFF
--- a/miext/damage/damage.h
+++ b/miext/damage/damage.h
@@ -19,13 +19,8 @@
  * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  * PERFORMANCE OF THIS SOFTWARE.
  */
-
 #ifndef _DAMAGE_H_
 #define _DAMAGE_H_
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
 
 typedef struct _damage *DamagePtr;
 

--- a/miext/damage/damagestr.h
+++ b/miext/damage/damagestr.h
@@ -19,13 +19,8 @@
  * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  * PERFORMANCE OF THIS SOFTWARE.
  */
-
 #ifndef _DAMAGESTR_H_
 #define _DAMAGESTR_H_
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
 
 #include "damage.h"
 #include "gcstruct.h"

--- a/miext/rootless/rootless.h
+++ b/miext/rootless/rootless.h
@@ -27,13 +27,8 @@
  * holders shall not be used in advertising or otherwise to promote the sale,
  * use or other dealings in this Software without prior written authorization.
  */
-
 #ifndef _ROOTLESS_H
 #define _ROOTLESS_H
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
 
 #include "rootlessConfig.h"
 #include "mi.h"

--- a/miext/rootless/rootlessCommon.h
+++ b/miext/rootless/rootlessCommon.h
@@ -27,13 +27,8 @@
  * holders shall not be used in advertising or otherwise to promote the sale,
  * use or other dealings in this Software without prior written authorization.
  */
-
 #ifndef _ROOTLESSCOMMON_H
 #define _ROOTLESSCOMMON_H
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
 
 #include <stdint.h>
 

--- a/miext/rootless/rootlessConfig.h
+++ b/miext/rootless/rootlessConfig.h
@@ -26,13 +26,8 @@
  * holders shall not be used in advertising or otherwise to promote the sale,
  * use or other dealings in this Software without prior written authorization.
  */
-
 #ifndef _ROOTLESSCONFIG_H
 #define _ROOTLESSCONFIG_H
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
 
 /*# define ROOTLESSDEBUG*/
 

--- a/miext/rootless/rootlessWindow.h
+++ b/miext/rootless/rootlessWindow.h
@@ -26,13 +26,8 @@
  * holders shall not be used in advertising or otherwise to promote the sale,
  * use or other dealings in this Software without prior written authorization.
  */
-
 #ifndef _ROOTLESSWINDOW_H
 #define _ROOTLESSWINDOW_H
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
 
 #include "dix/screen_hooks_priv.h"
 

--- a/miext/shadow/shrotpack.h
+++ b/miext/shadow/shrotpack.h
@@ -25,11 +25,6 @@
  * Thanks to Daniel Chemko <dchemko@intrinsyc.com> for making the 90 and 180
  * orientations work.
  */
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
-
 #include <stdlib.h>
 
 #include    <X11/X.h>

--- a/miext/sync/misync.h
+++ b/miext/sync/misync.h
@@ -20,13 +20,8 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
 #ifndef _MISYNC_H_
 #define _MISYNC_H_
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
 
 typedef struct _SyncObject SyncObject;
 typedef struct _SyncFence SyncFence;

--- a/miext/sync/misyncstr.h
+++ b/miext/sync/misyncstr.h
@@ -20,13 +20,8 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
 #ifndef _MISYNCSTR_H_
 #define _MISYNCSTR_H_
-
-#ifdef HAVE_DIX_CONFIG_H
-#include <dix-config.h>
-#endif
 
 #include <stdint.h>
 #include "dix.h"


### PR DESCRIPTION
This header needs to be included at the top of source files,
should not be done from other headers.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
