### PR TITLE
config: don't include dix-config.h in header

### DIFF
--- a/config/config-backends.h
+++ b/config/config-backends.h
@@ -26,8 +26,6 @@
 #ifndef XSERVER_CONFIG_BACKENDS_H
 #define XSERVER_CONFIG_BACKENDS_H
 
-#include <dix-config.h>
-
 #include "input.h"
 #include "list.h"
 


### PR DESCRIPTION
The dix-config.h file needs to be included by sources at the very
top, it shouldn't be included by other headers.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
