### PR TITLE
xwin: drop useless including of mman.h

### DIFF
--- a/hw/xwin/win.h
+++ b/hw/xwin/win.h
@@ -131,13 +131,6 @@
 #include <pthread.h>
 #undef HANDLE
 
-#ifdef HAVE_MMAP
-#include <sys/mman.h>
-#ifndef MAP_FILE
-#define MAP_FILE 0
-#endif                          /* MAP_FILE */
-#endif                          /* HAVE_MMAP */
-
 #include <X11/X.h>
 #include <X11/Xfuncproto.h>
 #include <X11/Xproto.h>


### PR DESCRIPTION
We don't use mmap() anyhwere, so no need for that include.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
