### PR TITLE
meson.build: don't set HAVE_DIX_CONFIG_H

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,6 @@ project('xserver', 'c',
 )
 release_date = '2025-12-21'
 
-add_project_arguments('-DHAVE_DIX_CONFIG_H', language: ['c', 'objc'])
 cc = meson.get_compiler('c')
 
 add_project_arguments('-fno-strict-aliasing', language : 'c')


### PR DESCRIPTION
The symbol isn't used anywhere anymore, so no need to keep it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
