### PR TITLE
xquartz: dont include dix-config.h in other headers

### DIFF
--- a/hw/xquartz/X11Controller.h
+++ b/hw/xquartz/X11Controller.h
@@ -31,8 +31,6 @@
 #ifndef X11CONTROLLER_H
 #define X11CONTROLLER_H 1
 
-#include <dix-config.h>
-
 #if __OBJC__
 
 #include "sanitizedCocoa.h"


### PR DESCRIPTION
dix-config.h needs to be included at the very top of all sources,
but it shouldn't be included from other headers.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
