### PR TITLE
.github: cygwin: use alternative mirrors

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -289,6 +289,15 @@ jobs:
                   # https://github.com/cygwin/cygwin-install-action/issues/39
                   check-installer-sig: false
                   platform: x86_64
+                  site: |
+                    https://mirror.wisegs.com/cygwin/
+                    https://mirrors.sonic.net/cygwin/
+                    https://mirror.cpsc.ucalgary.ca/mirror/cygwin.com/
+                    https://muug.ca/mirror/cygwin/
+                    https://mirror.csclub.uwaterloo.ca/cygwin/
+                    https://cygwin.mirror.gtcomm.net/
+                    http://cygwin.mirror.rafal.ca/
+
                   packages: >-
                    binutils, bison, ccache, flex, gcc-core, meson, ninja,
                    pkg-config, python39, windowsdriproto, xorgproto,


### PR DESCRIPTION
The primary one - mirrors.kernel.org - is down again, so our builds
are breaking. Using a list of alternative mirrors instead.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
