### PR TITLE
include: new header for fundamental pointer types

### DIFF
--- a/include/dix.h
+++ b/include/dix.h
@@ -47,13 +47,16 @@ SOFTWARE.
 #ifndef DIX_H
 #define DIX_H
 
+#include <X11/extensions/XI.h>
+
+#include "xlibre_ptrtypes.h"
+
 #include "callback.h"
 #include "gc.h"
 #include "window.h"
 #include "input.h"
 #include "cursor.h"
 #include "events.h"
-#include <X11/extensions/XI.h>
 
 #define EARLIER -1
 #define SAMETIME 0
@@ -91,12 +94,6 @@ SOFTWARE.
     } while (0)
 
 typedef struct _TimeStamp *TimeStampPtr;
-
-#ifndef _XTYPEDEF_CLIENTPTR
-typedef struct _Client *ClientPtr;
-
-#define _XTYPEDEF_CLIENTPTR
-#endif
 
 extern _X_EXPORT ClientPtr clients[];
 extern _X_EXPORT ClientPtr serverClient;

--- a/include/dixfont.h
+++ b/include/dixfont.h
@@ -24,6 +24,8 @@ SOFTWARE.
 #ifndef DIXFONT_H
 #define DIXFONT_H 1
 
+#include "xlibre_ptrtypes.h"
+
 #include "dix.h"
 #include <X11/fonts/font.h>
 #include <X11/fonts/fontstruct.h>

--- a/include/dixstruct.h
+++ b/include/dixstruct.h
@@ -26,6 +26,8 @@ SOFTWARE.
 
 #include <X11/Xmd.h>
 
+#include "xlibre_ptrtypes.h"
+
 #include "callback.h"
 #include "dix.h"
 #include "resource.h"
@@ -33,9 +35,6 @@ SOFTWARE.
 #include "gc.h"
 #include "pixmap.h"
 #include "privates.h"
-
-struct _Client;
-typedef struct _ClientId *ClientIdPtr;
 
 /*
  * 	direct-mapped hash table, used by resource manager to store
@@ -72,9 +71,7 @@ typedef struct _saveSet {
 #define SaveSetAssignToRoot(ss,tr)  ((ss).toRoot = (tr))
 #define SaveSetAssignMap(ss,m)      ((ss).map = (m))
 
-struct _ClientId;
-
-typedef struct _Client {
+struct _Client {
     void *requestBuffer;
     void *osPrivate;             /* for OS layer, including scheduler */
     struct xorg_list ready;      /* List of clients ready to run */
@@ -112,7 +109,7 @@ typedef struct _Client {
     DeviceIntPtr clientPtr;
     struct _ClientId *clientIds;
     int req_fds;
-} ClientRec;
+};
 
 extern _X_EXPORT TimeStamp currentTime;
 

--- a/include/extension.h
+++ b/include/extension.h
@@ -76,6 +76,7 @@ SOFTWARE.
 
 #include <X11/Xfuncproto.h>
 
+#include "xlibre_ptrtypes.h"
 #include "dixstruct.h"
 
 typedef void (*InitExtension) (void);

--- a/include/extnsionst.h
+++ b/include/extnsionst.h
@@ -47,6 +47,7 @@ SOFTWARE.
 #ifndef EXTENSIONSTRUCT_H
 #define EXTENSIONSTRUCT_H
 
+#include "xlibre_ptrtypes.h"
 #include "dix.h"
 #include "misc.h"
 #include "screenint.h"

--- a/include/glxvndabi.h
+++ b/include/glxvndabi.h
@@ -59,6 +59,8 @@
 #ifndef GLXVENDORABI_H
 #define GLXVENDORABI_H
 
+#include "xlibre_ptrtypes.h"
+
 #include <scrnintstr.h>
 #include <extnsionst.h>
 #include <GL/glxproto.h>

--- a/include/input.h
+++ b/include/input.h
@@ -47,6 +47,8 @@ SOFTWARE.
 #ifndef INPUT_H
 #define INPUT_H
 
+#include "xlibre_ptrtypes.h"
+
 #include "misc.h"
 #include "screenint.h"
 #include <X11/Xmd.h>

--- a/include/meson.build
+++ b/include/meson.build
@@ -518,6 +518,7 @@ if build_xorg
             'Xprintf.h',
             'xf86sbusBus.h',
             'xserver-properties.h',
+            'xlibre_ptrtypes.h',
         ],
         install_dir: xorgsdkdir,
     )

--- a/include/misyncstr.h
+++ b/include/misyncstr.h
@@ -24,6 +24,8 @@
 #define _MISYNCSTR_H_
 
 #include <stdint.h>
+
+#include "xlibre_ptrtypes.h"
 #include "dix.h"
 #include "misync.h"
 #include "scrnintstr.h"

--- a/include/os.h
+++ b/include/os.h
@@ -47,9 +47,6 @@ SOFTWARE.
 #ifndef OS_H
 #define OS_H
 
-#include "callback.h"
-#include "misc.h"
-
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -59,6 +56,10 @@ SOFTWARE.
 #endif
 
 #include <X11/Xfuncproto.h>
+
+#include "xlibre_ptrtypes.h"
+#include "callback.h"
+#include "misc.h"
 
 /*
  * @brief macro for specifying non-null arguments

--- a/include/property.h
+++ b/include/property.h
@@ -47,6 +47,7 @@ SOFTWARE.
 #ifndef PROPERTY_H
 #define PROPERTY_H
 
+#include "xlibre_ptrtypes.h"
 #include "window.h"
 
 extern _X_EXPORT int dixChangeWindowProperty(ClientPtr pClient,

--- a/include/randrstr.h
+++ b/include/randrstr.h
@@ -30,6 +30,8 @@
 
 #include <X11/X.h>
 #include <X11/Xproto.h>
+
+#include "xlibre_ptrtypes.h"
 #include "misc.h"
 #include "os.h"
 #include "dixstruct.h"

--- a/include/resource.h
+++ b/include/resource.h
@@ -47,8 +47,9 @@ SOFTWARE.
 #ifndef RESOURCE_H
 #define RESOURCE_H 1
 
-#include "callback.h"
+#include "xlibre_ptrtypes.h"
 
+#include "callback.h"
 #include "misc.h"
 #include "dixaccess.h"
 

--- a/include/scrnintstr.h
+++ b/include/scrnintstr.h
@@ -47,6 +47,7 @@ SOFTWARE.
 #ifndef SCREENINTSTRUCT_H
 #define SCREENINTSTRUCT_H
 
+#include "xlibre_ptrtypes.h"
 #include "screenint.h"
 #include "regionstr.h"
 #include "colormap.h"

--- a/include/window.h
+++ b/include/window.h
@@ -49,6 +49,7 @@ SOFTWARE.
 
 #include <X11/Xproto.h>
 
+#include "xlibre_ptrtypes.h"
 #include "misc.h"
 #include "regionstr.h"
 #include "screenint.h"

--- a/include/windowstr.h
+++ b/include/windowstr.h
@@ -47,6 +47,7 @@ SOFTWARE.
 #ifndef WINDOWSTRUCT_H
 #define WINDOWSTRUCT_H
 
+#include "xlibre_ptrtypes.h"
 #include "window.h"
 #include "pixmapstr.h"
 #include "regionstr.h"
@@ -114,7 +115,7 @@ typedef struct _WindowOpt {
 #define RedirectDrawAutomatic	1
 #define RedirectDrawManual	2
 
-typedef struct _Window {
+struct _Window {
     DrawableRec drawable;
     PrivateRec *devPrivates;
     WindowPtr parent;           /* ancestor chain */
@@ -154,7 +155,7 @@ typedef struct _Window {
     unsigned inhibitBGPaint:1;  /* paint the background? */
 
     PropertyPtr properties;     /* default: NULL */
-} WindowRec;
+};
 
 extern _X_EXPORT Mask DontPropagateMasks[];
 

--- a/include/xf86.h
+++ b/include/xf86.h
@@ -35,6 +35,7 @@
 #ifndef _XF86_H
 #define _XF86_H
 
+#include "xlibre_ptrtypes.h"
 #include "xf86str.h"
 #include "xf86Opt.h"
 #include <X11/Xfuncproto.h>

--- a/include/xf86Priv.h
+++ b/include/xf86Priv.h
@@ -35,6 +35,7 @@
 #ifndef _XF86PRIV_H
 #define _XF86PRIV_H
 
+#include "xlibre_ptrtypes.h"
 #include "xf86Privstr.h"
 #include "input.h"
 

--- a/include/xf86Xinput.h
+++ b/include/xf86Xinput.h
@@ -53,6 +53,7 @@
 
 #include <X11/Xfuncproto.h>
 
+#include "xlibre_ptrtypes.h"
 #include "xf86.h"
 #include "xf86str.h"
 #include "inputstr.h"

--- a/include/xf86cmap.h
+++ b/include/xf86cmap.h
@@ -29,6 +29,7 @@
 #ifndef _XF86CMAP_H
 #define _XF86CMAP_H
 
+#include "xlibre_ptrtypes.h"
 #include "xf86str.h"
 
 #define CMAP_PALETTED_TRUECOLOR		0x0000001

--- a/include/xf86str.h
+++ b/include/xf86str.h
@@ -34,6 +34,7 @@
 #ifndef _XF86STR_H
 #define _XF86STR_H
 
+#include "xlibre_ptrtypes.h"
 #include "misc.h"
 #include "input.h"
 #include "scrnintstr.h"
@@ -160,7 +161,6 @@ typedef struct x_ClockRange {
  * FALSE. pointer can be used to pass arguments to the function or
  * to return data to the caller.
  */
-typedef struct _ScrnInfoRec *ScrnInfoPtr;
 
 /* do not change order */
 typedef enum {
@@ -564,8 +564,7 @@ typedef void xf86ModeSetProc(ScrnInfoPtr);
  * There is one of these for each screen, and it holds all the screen-specific
  * information.  Note: No fields are to be dependent on compile-time defines.
  */
-
-typedef struct _ScrnInfoRec {
+struct _ScrnInfoRec {
     int driverVersion;
     const char *driverName;     /* canonical name used in */
     /* the config file */
@@ -691,7 +690,7 @@ typedef struct _ScrnInfoRec {
     int reservedInt[NUM_RESERVED_INTS];
     void *reservedPtr[NUM_RESERVED_POINTERS];
     funcPointer reservedFuncs[NUM_RESERVED_FUNCS];
-} ScrnInfoRec;
+};
 
 typedef struct {
     Bool (*OpenFramebuffer) (ScrnInfoPtr pScrn,

--- a/include/xf86xv.h
+++ b/include/xf86xv.h
@@ -29,6 +29,7 @@
 #ifndef _XF86XV_H_
 #define _XF86XV_H_
 
+#include "xlibre_ptrtypes.h"
 #include "xvdix.h"
 #include "xf86str.h"
 

--- a/include/xf86xvmc.h
+++ b/include/xf86xvmc.h
@@ -29,6 +29,7 @@
 #ifndef _XF86XVMC_H
 #define _XF86XVMC_H
 
+#include "xlibre_ptrtypes.h"
 #include "xvmcext.h"
 #include "xf86xv.h"
 

--- a/include/xkbsrv.h
+++ b/include/xkbsrv.h
@@ -32,6 +32,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <X11/Xdefs.h>
 #include <X11/extensions/XKBproto.h>
 
+#include "xlibre_ptrtypes.h"
 #include "xkbstr.h"
 #include "xkbrules.h"
 #include "inputstr.h"

--- a/include/xlibre_ptrtypes.h
+++ b/include/xlibre_ptrtypes.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ *
+ * @brief
+ * This header holds forward definitions for pointer types used in many places.
+ * Helpful for uncluttering the includes a bit, so we have less complex dependencies.
+ *
+ * External drivers rarely have a reason for directly including it.
+ */
+#ifndef _XLIBRE_SDK_PTRTYPES_H
+#define _XLIBRE_SDK_PTRTYPES_H
+
+struct _Client;
+typedef struct _Client *ClientPtr;
+typedef struct _Client ClientRec;
+
+struct _ClientId;
+typedef struct _ClientId *ClientIdPtr;
+
+struct _Window;
+typedef struct _Window *WindowPtr;
+typedef struct _Window WindowRec;
+
+struct _ScrnInfoRec;
+typedef struct _ScrnInfoRec *ScrnInfoPtr;
+typedef struct _ScrnInfoRec ScrnInfoRec;
+
+#endif /* _XLIBRE_SDK_PTRTYPES_H */


### PR DESCRIPTION
This header is holding forward declarations that are needed in many places.
It's for helping us to unclutter the include files a little bit.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
