### PR TITLE
xfree86: parser: dont ifdef on HAVE_XORG_CONFIG_H

### DIFF
--- a/hw/xfree86/parser/Configint.h
+++ b/hw/xfree86/parser/Configint.h
@@ -56,13 +56,10 @@
  * These definitions are used through out the configuration file parser, but
  * they should not be visible outside of the parser.
  */
-
 #ifndef _Configint_h_
 #define _Configint_h_
 
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include <stdio.h>
 #include <string.h>

--- a/hw/xfree86/parser/DRI.c
+++ b/hw/xfree86/parser/DRI.c
@@ -26,10 +26,7 @@
  *
  *
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "os.h"
 #include "xf86Parser.h"

--- a/hw/xfree86/parser/Device.c
+++ b/hw/xfree86/parser/Device.c
@@ -51,10 +51,7 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "xf86Parser.h"
 #include "xf86tokens.h"

--- a/hw/xfree86/parser/Extensions.c
+++ b/hw/xfree86/parser/Extensions.c
@@ -30,10 +30,7 @@
  *   Kevin E. Martin <kem@redhat.com>
  *
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "os.h"
 #include "xf86Parser.h"

--- a/hw/xfree86/parser/Files.c
+++ b/hw/xfree86/parser/Files.c
@@ -50,10 +50,7 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include <assert.h>
 

--- a/hw/xfree86/parser/Flags.c
+++ b/hw/xfree86/parser/Flags.c
@@ -50,10 +50,7 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include <assert.h>
 

--- a/hw/xfree86/parser/Input.c
+++ b/hw/xfree86/parser/Input.c
@@ -51,10 +51,7 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "os.h"
 #include "xf86Parser.h"

--- a/hw/xfree86/parser/InputClass.c
+++ b/hw/xfree86/parser/InputClass.c
@@ -22,10 +22,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  * OTHER DEALINGS IN THE SOFTWARE.
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include <string.h>
 

--- a/hw/xfree86/parser/Layout.c
+++ b/hw/xfree86/parser/Layout.c
@@ -51,10 +51,7 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "xf86Parser_priv.h"
 #include "xf86tokens.h"

--- a/hw/xfree86/parser/Module.c
+++ b/hw/xfree86/parser/Module.c
@@ -51,10 +51,7 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include <assert.h>
 

--- a/hw/xfree86/parser/Monitor.c
+++ b/hw/xfree86/parser/Monitor.c
@@ -51,10 +51,7 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "xf86Parser.h"
 #include "xf86tokens.h"

--- a/hw/xfree86/parser/OutputClass.c
+++ b/hw/xfree86/parser/OutputClass.c
@@ -22,10 +22,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  * OTHER DEALINGS IN THE SOFTWARE.
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "os/fmt.h"
 

--- a/hw/xfree86/parser/Pointer.c
+++ b/hw/xfree86/parser/Pointer.c
@@ -51,10 +51,7 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "xf86Parser.h"
 #include "xf86tokens.h"

--- a/hw/xfree86/parser/Screen.c
+++ b/hw/xfree86/parser/Screen.c
@@ -51,10 +51,7 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "xf86Parser.h"
 #include "xf86tokens.h"

--- a/hw/xfree86/parser/Vendor.c
+++ b/hw/xfree86/parser/Vendor.c
@@ -51,10 +51,7 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "xf86Parser.h"
 #include "xf86tokens.h"

--- a/hw/xfree86/parser/Video.c
+++ b/hw/xfree86/parser/Video.c
@@ -51,10 +51,7 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "xf86Parser.h"
 #include "xf86tokens.h"

--- a/hw/xfree86/parser/configProcs.h
+++ b/hw/xfree86/parser/configProcs.h
@@ -148,14 +148,4 @@ void xf86printMatchPattern(FILE * cf,
                            const xf86MatchPattern *pattern,
                            Bool not_first);
 
-#ifdef HAVE_XORG_CONFIG_H
-#include <xorg-config.h>
-#endif
-
-#ifndef HAVE_XORG_CONFIG_H
-/* Externally provided functions */
-void
-ErrorF(const char *f, ...);
-#endif
-
 #endif /* XSERVER_XFREE86_CONFIGPROCS_H */

--- a/hw/xfree86/parser/patterns.c
+++ b/hw/xfree86/parser/patterns.c
@@ -3,10 +3,7 @@
  * Copyright (c) 2025 Oleh Nykyforchyn <oleh.nyk@gmail.com>
  *
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/hw/xfree86/parser/read.c
+++ b/hw/xfree86/parser/read.c
@@ -51,10 +51,7 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "xf86Config.h"
 #include "xf86Parser_priv.h"

--- a/hw/xfree86/parser/scan.c
+++ b/hw/xfree86/parser/scan.c
@@ -50,10 +50,7 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include <ctype.h>
 #include <stdio.h>

--- a/hw/xfree86/parser/write.c
+++ b/hw/xfree86/parser/write.c
@@ -50,10 +50,7 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "os.h"
 #include "xf86Parser_priv.h"

--- a/hw/xfree86/parser/xf86tokens.h
+++ b/hw/xfree86/parser/xf86tokens.h
@@ -51,13 +51,10 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
 #ifndef _xf86_tokens_h
 #define _xf86_tokens_h
 
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 /*
  * Each token should have a unique value regardless of the section


### PR DESCRIPTION
The header is always present (we're inside xfree86), so no need
for that #ifdef.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
