### PR TITLE
meson.build: move build_xephyr and build_xfbdev to toplevel

### DIFF
--- a/hw/kdrive/meson.build
+++ b/hw/kdrive/meson.build
@@ -1,5 +1,3 @@
-build_xfbdev = get_option('xfbdev')
-build_xephyr = get_option('xephyr')
 build_kdrive = build_xephyr or build_xfbdev
 
 build_kdrive_kbd = false

--- a/meson.build
+++ b/meson.build
@@ -277,14 +277,18 @@ endif
 
 build_xvfb = get_option('xvfb')
 
+build_xephyr = get_option('xephyr')
+
+build_xfbdev = get_option('xfbdev')
+
 summary({
         'Xorg': build_xorg,
         'Xnest': build_xnest,
         'Xvfb': build_xvfb,
         'Xwin': build_xwin,
         'Xquartz': build_xquartz,
-        'Xephyr': get_option('xephyr'),
-        'Xfbdev': get_option('xfbdev'),
+        'Xephyr': build_xephyr,
+        'Xfbdev': build_xfbdev,
     },
     section: 'DDX',
     bool_yn: true,


### PR DESCRIPTION
These values are also used in at the toplevel, and we're going to
have more uses there for xorg-sdk-only builds.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
