### PR TITLE
xfree86: fbdev: don't ifdef on HAVE_XORG_CONFIG_H

### DIFF
--- a/hw/xfree86/fbdevhw/fbdevhw.c
+++ b/hw/xfree86/fbdevhw/fbdevhw.c
@@ -1,7 +1,4 @@
-/* all drivers need this */
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include <fcntl.h>
 #include <errno.h>

--- a/hw/xfree86/fbdevhw/fbdevhwstub.c
+++ b/hw/xfree86/fbdevhw/fbdevhwstub.c
@@ -1,6 +1,4 @@
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "xf86.h"
 #include "xf86cmap.h"

--- a/hw/xfree86/fbdevhw/fbpriv.h
+++ b/hw/xfree86/fbdevhw/fbpriv.h
@@ -3,12 +3,10 @@
  * removed internal stuff (#ifdef __KERNEL__)
  */
 
-#ifndef _LINUX_FB_H
-#define _LINUX_FB_H
+#ifndef __XFREE86_FBPRIV_H
+#define __XFREE86_FBPRIV_H
 
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include <asm/types.h>
 


### PR DESCRIPTION
it's always present here, so no need to ifdef on it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
