### PR TITLE
xfree86: ramdac: unexport xf86CursorScreenKeyRec within private header

### DIFF
--- a/hw/xfree86/ramdac/xf86CursorPriv.h
+++ b/hw/xfree86/ramdac/xf86CursorPriv.h
@@ -41,7 +41,7 @@ void xf86RecolorCursor(ScreenPtr pScreen, CursorPtr pCurs, Bool displayed);
 Bool xf86InitHardwareCursor(ScreenPtr pScreen, xf86CursorInfoPtr infoPtr);
 
 Bool xf86CheckHWCursor(ScreenPtr pScreen, CursorPtr cursor, xf86CursorInfoPtr infoPtr);
-extern _X_EXPORT DevPrivateKeyRec xf86CursorScreenKeyRec;
+extern DevPrivateKeyRec xf86CursorScreenKeyRec;
 
 extern DevScreenPrivateKeyRec xf86ScreenCursorBitsKeyRec;
 


### PR DESCRIPTION
This symbol is defined in a private header (which never been part of SDK,
thus drivers couldn't compile against it). None of our drivers ever using it.
Same for the structure that this devPrivate is pointing to.

The proprietary Nvidia drivers seem to have some code path trying to look it
up dynamically. But we have no idea whether these are actually active and
still relevant today.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
