### PR TITLE
xfree86: ramdac: don't ifdef on HAVE_XORG_CONFIG_H

### DIFF
--- a/hw/xfree86/ramdac/xf86CursorPriv.h
+++ b/hw/xfree86/ramdac/xf86CursorPriv.h
@@ -1,9 +1,7 @@
 #ifndef _XF86CURSORPRIV_H
 #define _XF86CURSORPRIV_H
 
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "xf86Cursor.h"
 #include "mipointrst.h"

--- a/hw/xfree86/ramdac/xf86CursorRD.c
+++ b/hw/xfree86/ramdac/xf86CursorRD.c
@@ -1,7 +1,4 @@
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "dix/colormap_priv.h"
 #include "dix/cursor_priv.h"

--- a/hw/xfree86/ramdac/xf86HWCurs.c
+++ b/hw/xfree86/ramdac/xf86HWCurs.c
@@ -1,7 +1,4 @@
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include <string.h>
 #include <X11/X.h>


### PR DESCRIPTION
It's always present, so no need to ifdef on it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
