### PR TITLE
xfree86: loader: don't ifdef on HAVE_XORG_CONFIG_H anymore

### DIFF
--- a/hw/xfree86/loader/loader.h
+++ b/hw/xfree86/loader/loader.h
@@ -45,13 +45,10 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
 #ifndef _LOADER_H
 #define _LOADER_H
 
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include <X11/Xosdefs.h>
 #include <X11/Xfuncproto.h>

--- a/hw/xfree86/loader/loaderProcs.h
+++ b/hw/xfree86/loader/loaderProcs.h
@@ -45,13 +45,10 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
 #ifndef _LOADERPROCS_H
 #define _LOADERPROCS_H
 
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "xf86Module.h"
 

--- a/hw/xfree86/loader/loadmod.c
+++ b/hw/xfree86/loader/loadmod.c
@@ -45,10 +45,7 @@
  * the sale, use or other dealings in this Software without prior written
  * authorization from the copyright holder(s) and author(s).
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "dix.h"
 #include "os.h"


### PR DESCRIPTION
It's always present, so no need to ifdef on it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
