### PR TITLE
xfree86: shadowfb: don't ifdef on HAVE_XORG_CONFIG_H anymore

### DIFF
--- a/hw/xfree86/shadowfb/sfbmodule.c
+++ b/hw/xfree86/shadowfb/sfbmodule.c
@@ -1,6 +1,4 @@
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "xf86Module.h"
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
