### PR TITLE
xfree86: utils: don't ifdef on HAVE_XORG_CONFIG_H anymore

### DIFF
--- a/hw/xfree86/utils/gtf/gtf.c
+++ b/hw/xfree86/utils/gtf/gtf.c
@@ -102,10 +102,7 @@
  * o Error checking.
  *
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
