### PR TITLE
xfree86: xkb: don't ifdef on HAVE_XORG_CONFIG_H anymore

### DIFF
--- a/hw/xfree86/xkb/xkbKillSrv.c
+++ b/hw/xfree86/xkb/xkbKillSrv.c
@@ -26,9 +26,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include <dix-config.h>
 
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include <stdio.h>
 #include <X11/X.h>

--- a/hw/xfree86/xkb/xkbPrivate.c
+++ b/hw/xfree86/xkb/xkbPrivate.c
@@ -1,9 +1,4 @@
-
-#include <dix-config.h>
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include <stdio.h>
 #include <X11/X.h>

--- a/hw/xfree86/xkb/xkbVT.c
+++ b/hw/xfree86/xkb/xkbVT.c
@@ -23,12 +23,7 @@ OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION  WITH
 THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ********************************************************/
-
-#include <dix-config.h>
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include <stdio.h>
 #include <X11/X.h>


### PR DESCRIPTION
it's always present, so no need to check for it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
