### PR TITLE
xfree86: vgahw: don't ifdef on HAVE_XORG_CONFIG_H anymore

### DIFF
--- a/hw/xfree86/vgahw/vgaHW.c
+++ b/hw/xfree86/vgahw/vgaHW.c
@@ -7,9 +7,7 @@
  *   Copyright 1990,91 by Thomas Roell, Dinkelscherben, Germany.
  *
  */
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include <stdlib.h>
 #include <string.h>

--- a/hw/xfree86/vgahw/vgaHWmodule.c
+++ b/hw/xfree86/vgahw/vgaHWmodule.c
@@ -1,10 +1,7 @@
 /*
  * Copyright 1998 by The XFree86 Project, Inc
  */
-
-#ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
-#endif
 
 #include "xf86Module.h"
 


### PR DESCRIPTION
it's always present, so no need to check for it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
