### PR TITLE
randr: don't ifdef on RANDR_10_INTERFACE anymore

### DIFF
--- a/include/randrstr.h
+++ b/include/randrstr.h
@@ -300,13 +300,9 @@ typedef struct _rrScreenSize {
     RRScreenRatePtr pRates;
 } RRScreenSize, *RRScreenSizePtr;
 
-#ifdef RANDR_10_INTERFACE
-
 typedef Bool (*RRSetConfigProcPtr) (ScreenPtr pScreen,
                                     Rotation rotation,
                                     int rate, RRScreenSizePtr pSize);
-
-#endif
 
 typedef Bool (*RRCrtcSetScanoutPixmapProcPtr)(RRCrtcPtr crtc, PixmapPtr pixmap);
 
@@ -328,9 +324,7 @@ typedef struct _rrScrPriv {
      * 'public' part of the structure; DDXen fill this in
      * as they initialize
      */
-#if RANDR_10_INTERFACE
     RRSetConfigProcPtr rrSetConfig;
-#endif
     RRGetInfoProcPtr rrGetInfo;
 #if RANDR_12_INTERFACE
     RRScreenSetSizeProcPtr rrScreenSetSize;
@@ -389,7 +383,6 @@ typedef struct _rrScrPriv {
     /* Last known pointer position */
     RRCrtcPtr pointerCrtc;
 
-#ifdef RANDR_10_INTERFACE
     /*
      * Configuration information
      */
@@ -402,7 +395,7 @@ typedef struct _rrScrPriv {
     Rotation rotation;
     int rate;
     int size;
-#endif
+
     Bool discontiguous;
 
     RRProviderPtr provider;
@@ -514,7 +507,6 @@ extern _X_EXPORT Bool RRScreenInit(ScreenPtr pScreen);
 
 extern _X_EXPORT RROutputPtr RRFirstOutput(ScreenPtr pScreen);
 
-#ifdef RANDR_10_INTERFACE
 /*
  * This is the old interface, deprecated but left
  * around for compatibility
@@ -539,8 +531,6 @@ extern _X_EXPORT void
 
 RRSetCurrentConfig(ScreenPtr pScreen,
                    Rotation rotation, int rate, RRScreenSizePtr pSize);
-
-#endif
 
 /* rrcrtc.c */
 

--- a/randr/randr.c
+++ b/randr/randr.c
@@ -325,12 +325,10 @@ RRScreenInit(ScreenPtr pScreen)
     pScrPriv->height = pScreen->height;
     pScrPriv->mmWidth = pScreen->mmWidth;
     pScrPriv->mmHeight = pScreen->mmHeight;
-#if RANDR_10_INTERFACE
     pScrPriv->rotations = RR_Rotate_0;
     pScrPriv->reqWidth = pScreen->width;
     pScrPriv->reqHeight = pScreen->height;
     pScrPriv->rotation = RR_Rotate_0;
-#endif
 
     /*
      * This value doesn't really matter -- any client must call

--- a/randr/rrcrtc.c
+++ b/randr/rrcrtc.c
@@ -814,7 +814,6 @@ RRCrtcSet(RRCrtcPtr crtc,
         else
 #endif
         {
-#if RANDR_10_INTERFACE
             if (pScrPriv->rrSetConfig) {
                 RRScreenSize size;
                 RRScreenRate rate;
@@ -850,7 +849,6 @@ RRCrtcSet(RRCrtcPtr crtc,
                     }
                 }
             }
-#endif
         }
         if (ret) {
 

--- a/randr/rrinfo.c
+++ b/randr/rrinfo.c
@@ -23,7 +23,6 @@
 
 #include "randr/randrstr_priv.h"
 
-#ifdef RANDR_10_INTERFACE
 static RRModePtr
 RROldModeAdd(RROutputPtr output, RRScreenSizePtr size, int refresh)
 {
@@ -165,7 +164,6 @@ RRScanOldConfig(ScreenPtr pScreen, Rotation rotations)
     if (newMode)
         RRCrtcNotify(crtc, newMode, 0, 0, pScrPriv->rotation, NULL, 1, &output);
 }
-#endif
 
 /*
  * Poll the driver for changed information
@@ -197,10 +195,9 @@ RRGetInfo(ScreenPtr pScreen, Bool force_query)
     if (!(*pScrPriv->rrGetInfo) (pScreen, &rotations))
         return FALSE;
 
-#if RANDR_10_INTERFACE
     if (pScrPriv->nSizes)
         RRScanOldConfig(pScreen, rotations);
-#endif
+
     RRTellChanged(pScreen);
     return TRUE;
 }
@@ -230,7 +227,6 @@ RRScreenSetSizeRange(ScreenPtr pScreen,
     pScrPriv->configChanged = TRUE;
 }
 
-#ifdef RANDR_10_INTERFACE
 static Bool
 RRScreenSizeMatches(RRScreenSizePtr a, RRScreenSizePtr b)
 {
@@ -310,4 +306,3 @@ RRSetCurrentConfig(ScreenPtr pScreen,
     pScrPriv->rotation = rotation;
     pScrPriv->rate = rate;
 }
-#endif

--- a/randr/rrscreen.c
+++ b/randr/rrscreen.c
@@ -178,11 +178,9 @@ RRScreenSizeSet(ScreenPtr pScreen,
                                              width, height, mmWidth, mmHeight);
     }
 #endif
-#if RANDR_10_INTERFACE
     if (pScrPriv->rrSetConfig) {
         return TRUE;            /* can't set size separately */
     }
-#endif
     return FALSE;
 }
 


### PR DESCRIPTION
It's always present (and wont go away), so no need to ifdef on it.
Still keeping the symbols, until we're sure no drivers still depending
on it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
