### PR TITLE
include: dont include xorg-config.h

### DIFF
--- a/include/xf86Optrec.h
+++ b/include/xf86Optrec.h
@@ -56,13 +56,8 @@
  * This file contains the Option Record that is passed between the Parser,
  * and Module setup procs.
  */
-
 #ifndef _xf86Optrec_h_
 #define _xf86Optrec_h_
-
-#ifdef HAVE_XORG_CONFIG_H
-#include <xorg-config.h>
-#endif
 
 #include <stdio.h>
 #include <string.h>

--- a/include/xf86Parser.h
+++ b/include/xf86Parser.h
@@ -56,13 +56,8 @@
  * This file contains the external interfaces for the XFree86 configuration
  * file parser.
  */
-
 #ifndef _xf86Parser_h_
 #define _xf86Parser_h_
-
-#ifdef HAVE_XORG_CONFIG_H
-#include <xorg-config.h>
-#endif
 
 #include <X11/Xdefs.h>
 #include "xf86Optrec.h"

--- a/include/xf86Sbus.h
+++ b/include/xf86Sbus.h
@@ -23,8 +23,6 @@
 #ifndef _XF86_SBUS_H
 #define _XF86_SBUS_H
 
-#include <xorg-config.h>
-
 #if defined(__linux__)
 #include <asm/types.h>
 #include <linux/fb.h>


### PR DESCRIPTION
Those public headers shouldn't ever attempt to include xorg-config.h.
All xfree86 source files need to include it at the very top anyway,
while drivers have to include xorg-server.h instead.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
