### PR TITLE
.github: build drivers against xorg-sdk without actual Xserver compile

### DIFF
--- a/.github/scripts/install-prereq-drivers.sh
+++ b/.github/scripts/install-prereq-drivers.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+. .github/scripts/util.sh
+
+mkdir -p $X11_BUILD_DIR
+cd $X11_BUILD_DIR
+
+if [ "$X11_OS" = "Linux" ]; then
+build_meson   drm               $(fdo_mirror drm)                          libdrm-2.4.121   -Domap=enabled -Dfreedreno=enabled
+fi
+build_meson   xorgproto         $(fdo_mirror xorgproto)                    xorgproto-2024.1

--- a/.github/scripts/ubuntu/install-pkg.sh
+++ b/.github/scripts/ubuntu/install-pkg.sh
@@ -91,4 +91,5 @@ apt-get install -y \
 	xkb-data \
 	xutils-dev \
 	libxaw7-dev \
-	python3-mako
+	python3-mako \
+	libxcvt-dev

--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -78,7 +78,7 @@ jobs:
 
     drivers-build-ubuntu:
         env:
-            MESON_ARGS: -Dprefix=/usr -Dxephyr=false -Dwerror=false -Dxcsecurity=false -Dxorg=true -Dxvfb=false -Dxnest=false -Dxfbdev=false
+            MESON_ARGS: -Dprefix=/usr -Dxorg-sdk=true -Dxorg=false -Dxephyr=false -Dwerror=false -Dxcsecurity=false -Dxorg=true -Dxvfb=false -Dxnest=false -Dxfbdev=false
         runs-on: ubuntu-latest
         steps:
             - name: Check out repository code
@@ -112,7 +112,7 @@ jobs:
                 restore-keys: ${{ runner.name }}-x11-deps-
 
             - name: generic prereq
-              run:  .github/scripts/install-prereq.sh
+              run:  .github/scripts/install-prereq-drivers.sh
 
             - name: build xserver sdk
               run:  |

--- a/meson.build
+++ b/meson.build
@@ -250,10 +250,10 @@ endif
 
 if build_xorg
     build_xorg_sdk = true
+    libxcvt_dep = dependency('libxcvt', fallback: ['libxcvt', 'libxcvt_dep'], required: build_xorg)
 endif
 
 xorgsdkdir = join_paths(get_option('prefix'), get_option('includedir'), 'xorg')
-libxcvt_dep = dependency('libxcvt', fallback: ['libxcvt', 'libxcvt_dep'], required: build_xorg)
 
 ## configure Xnest - nesting X server
 build_xnest = get_option('xnest') != 'false'


### PR DESCRIPTION
Use the new xorg-sdk build type instead of building a complete Xserver,
to compile our drivers against.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
