### PR TITLE
More egl platforms v3

### DIFF
--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -1187,6 +1187,11 @@ glamor_egl_screen_init(ScreenPtr screen, struct glamor_context *glamor_ctx)
 static void glamor_egl_cleanup(struct glamor_egl_screen_private *glamor_egl)
 {
     if (glamor_egl->display != EGL_NO_DISPLAY) {
+        if (glamor_egl->context != EGL_NO_CONTEXT) {
+            eglDestroyContext(glamor_egl->display, glamor_egl->context);
+            glamor_egl->context = EGL_NO_CONTEXT;
+        }
+
         eglMakeCurrent(glamor_egl->display,
                        EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
         /*
@@ -1195,7 +1200,9 @@ static void glamor_egl_cleanup(struct glamor_egl_screen_private *glamor_egl)
          */
         lastGLContext = NULL;
         eglTerminate(glamor_egl->display);
+        glamor_egl->display = EGL_NO_DISPLAY;
     }
+
     if (glamor_egl->gbm)
         gbm_device_destroy(glamor_egl->gbm);
     free(glamor_egl->device_path);

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -1638,6 +1638,8 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
         glamor_egl->gbm = NULL;
 
         /* Return FALSE for compat with drivers */
+        xf86DrvMsg(scrn->scrnIndex, X_INFO, "glamor X acceleration enabled on %s\n",
+                   renderer);
         return FALSE;
     }
 

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -1397,13 +1397,6 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
 		goto error;  \
 	}
 
-#define GLAMOR_CHECK_EGL_EXTENSIONS(EXT1, EXT2)	 \
-	if (!epoxy_has_egl_extension(glamor_egl->display, "EGL_" #EXT1) &&  \
-	    !epoxy_has_egl_extension(glamor_egl->display, "EGL_" #EXT2)) {  \
-		ErrorF("EGL_" #EXT1 " or EGL_" #EXT2 " required.\n");  \
-		goto error;  \
-	}
-
     GLAMOR_CHECK_EGL_EXTENSION(KHR_surfaceless_context);
     GLAMOR_CHECK_EGL_EXTENSION(KHR_no_config_context);
 

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -827,21 +827,20 @@ glamor_pixmap_from_fd(ScreenPtr screen,
     return pixmap;
 }
 
-Bool
-glamor_get_formats(ScreenPtr screen,
-                   CARD32 *num_formats, CARD32 **formats)
+static Bool
+glamor_get_formats_internal(struct glamor_egl_screen_private *glamor_egl,
+                            CARD32 *num_formats, CARD32 **formats)
 {
 #ifdef GLAMOR_HAS_EGL_QUERY_DMABUF
-    struct glamor_egl_screen_private *glamor_egl;
     EGLint num;
+#else
+    (void)glamor_egl;
 #endif
 
     /* Explicitly zero the count and formats as the caller may ignore the return value */
     *num_formats = 0;
     *formats = NULL;
 #ifdef GLAMOR_HAS_EGL_QUERY_DMABUF
-    glamor_egl = glamor_egl_get_screen_private(xf86ScreenToScrn(screen));
-
     if (!glamor_egl->dmabuf_capable)
         return TRUE;
 
@@ -865,6 +864,15 @@ glamor_get_formats(ScreenPtr screen,
     *num_formats = num;
 #endif
     return TRUE;
+}
+
+Bool
+glamor_get_formats(ScreenPtr screen,
+                   CARD32 *num_formats, CARD32 **formats)
+{
+    struct glamor_egl_screen_private *glamor_egl;
+    glamor_egl = glamor_egl_get_screen_private(xf86ScreenToScrn(screen));
+    return glamor_get_formats_internal(glamor_egl, num_formats, formats);
 }
 
 static void
@@ -892,22 +900,21 @@ glamor_filter_modifiers(uint32_t *num_modifiers, uint64_t **modifiers,
     }
 }
 
-Bool
-glamor_get_modifiers(ScreenPtr screen, uint32_t format,
-                     uint32_t *num_modifiers, uint64_t **modifiers)
+static Bool
+glamor_get_modifiers_internal(struct glamor_egl_screen_private *glamor_egl, uint32_t format,
+                              uint32_t *num_modifiers, uint64_t **modifiers)
 {
 #ifdef GLAMOR_HAS_EGL_QUERY_DMABUF
-    struct glamor_egl_screen_private *glamor_egl;
     EGLBoolean *external_only;
     EGLint num;
+#else
+    (void)glamor_egl;
 #endif
 
     /* Explicitly zero the count and modifiers as the caller may ignore the return value */
     *num_modifiers = 0;
     *modifiers = NULL;
 #ifdef GLAMOR_HAS_EGL_QUERY_DMABUF
-    glamor_egl = glamor_egl_get_screen_private(xf86ScreenToScrn(screen));
-
     if (!glamor_egl->dmabuf_capable)
         return FALSE;
 
@@ -951,6 +958,15 @@ glamor_get_modifiers(ScreenPtr screen, uint32_t format,
     }
 #endif
     return TRUE;
+}
+
+Bool
+glamor_get_modifiers(ScreenPtr screen, uint32_t format,
+                     uint32_t *num_modifiers, uint64_t **modifiers)
+{
+    struct glamor_egl_screen_private *glamor_egl;
+    glamor_egl = glamor_egl_get_screen_private(xf86ScreenToScrn(screen));
+    return glamor_get_modifiers_internal(glamor_egl, format, num_modifiers, modifiers);
 }
 
 const char *

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -1625,11 +1625,20 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
     glamor_egl->saved_free_screen = scrn->FreeScreen;
     scrn->FreeScreen = glamor_egl_free_screen;
 
-    if (glamor_egl->fd != -1 && !glamor_egl_init_drm(scrn, glamor_egl)) {
+    if (glamor_egl->fd != -1) {
+        if (glamor_egl_init_drm(scrn, glamor_egl)) {
+            xf86DrvMsg(scrn->scrnIndex, X_INFO, "glamor dri X acceleration enabled on %s\n",
+                       renderer);
+            return TRUE;
+        }
+
         /* Fall back to no dri */
         glamor_egl->fd = -1;
         gbm_device_destroy(glamor_egl->gbm);
         glamor_egl->gbm = NULL;
+
+        /* Return FALSE for compat with drivers */
+        return FALSE;
     }
 
     xf86DrvMsg(scrn->scrnIndex, X_INFO, "glamor X acceleration enabled on %s\n",

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -62,7 +62,7 @@ struct glamor_egl_screen_private {
     xf86FreeScreenProc *saved_free_screen;
 };
 
-int xf86GlamorEGLPrivateIndex = -1;
+static int xf86GlamorEGLPrivateIndex = -1;
 
 
 static struct glamor_egl_screen_private *

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -32,6 +32,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 #include <errno.h>
 #include <xf86.h>
 #include <xf86Priv.h>

--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -1081,11 +1081,11 @@ try_enable_glamor(ScrnInfoPtr pScrn)
 
     if (load_glamor(pScrn)) {
         if (ms->glamor.egl_init(pScrn, ms->fd)) {
-            xf86DrvMsg(pScrn->scrnIndex, X_INFO, "glamor initialized\n");
+            xf86DrvMsg(pScrn->scrnIndex, X_INFO, "glamor dri initialized\n");
             ms->drmmode.glamor = TRUE;
         } else {
             xf86DrvMsg(pScrn->scrnIndex, X_INFO,
-                       "glamor initialization failed\n");
+                       "glamor dri initialization failed\n");
         }
     } else {
         xf86DrvMsg(pScrn->scrnIndex, X_ERROR,

--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -1066,6 +1066,7 @@ try_enable_glamor(ScrnInfoPtr pScrn)
     Bool do_glamor = (!accel_method_str ||
                       strcmp(accel_method_str, "glamor") == 0);
 
+    ms->drmmode.glamor_base = FALSE;
     ms->drmmode.glamor = FALSE;
 
 #ifdef GLAMOR
@@ -1080,6 +1081,7 @@ try_enable_glamor(ScrnInfoPtr pScrn)
     }
 
     if (load_glamor(pScrn)) {
+        ms->drmmode.glamor_base = TRUE;
         if (ms->glamor.egl_init(pScrn, ms->fd)) {
             xf86DrvMsg(pScrn->scrnIndex, X_INFO, "glamor dri initialized\n");
             ms->drmmode.glamor = TRUE;
@@ -2131,7 +2133,7 @@ ScreenInit(ScreenPtr pScreen, int argc, char **argv)
         xf86DPMSInit(pScreen, xf86DPMSSet, 0);
 
 #if defined(GLAMOR) && defined(XV)
-    if (ms->drmmode.glamor) {
+    if (ms->drmmode.glamor_base) {
         XF86VideoAdaptorPtr     glamor_adaptor;
 
         glamor_adaptor = ms->glamor.xv_init(pScreen, 16);

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -4189,7 +4189,7 @@ drmmode_init(ScrnInfoPtr pScrn, drmmode_ptr drmmode)
     ScreenPtr pScreen = xf86ScrnToScreen(pScrn);
     modesettingPtr ms = modesettingPTR(pScrn);
 
-    if (!ms->glamor.init(pScreen, GLAMOR_USE_EGL_SCREEN)) {
+    if (drmmode->glamor_base && !ms->glamor.init(pScreen, GLAMOR_USE_EGL_SCREEN)) {
         if (drmmode->glamor) {
             return FALSE;
         }

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -4189,14 +4189,17 @@ drmmode_init(ScrnInfoPtr pScrn, drmmode_ptr drmmode)
     ScreenPtr pScreen = xf86ScrnToScreen(pScrn);
     modesettingPtr ms = modesettingPTR(pScrn);
 
-    if (drmmode->glamor) {
-        if (!ms->glamor.init(pScreen, GLAMOR_USE_EGL_SCREEN)) {
+    if (!ms->glamor.init(pScreen, GLAMOR_USE_EGL_SCREEN)) {
+        if (drmmode->glamor) {
             return FALSE;
         }
-#ifdef GBM_BO_WITH_MODIFIERS
-        ms->glamor.set_drawable_modifiers_func(pScreen, get_drawable_modifiers);
-#endif
     }
+
+#ifdef GBM_BO_WITH_MODIFIERS
+    if (drmmode->glamor) {
+        ms->glamor.set_drawable_modifiers_func(pScreen, get_drawable_modifiers);
+    }
+#endif
 #endif
 
     return TRUE;

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.h
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.h
@@ -97,6 +97,7 @@ typedef struct {
     /* Broken-out options. */
     OptionInfoPtr Options;
 
+    Bool glamor_base;
     Bool glamor;
     Bool shadow_enable;
     Bool shadow_enable2;


### PR DESCRIPTION
A combination of https://github.com/X11Libre/xserver/pull/1758 and the glamor code from Xfbdev.

With this, hw acceleration works on 470 and 390 cards with the modesetting driver.
From my testing, performance is slightly better than in Xfbdev, but not the same as what I get with the 580 driver with dri enabled.

I only tested this with me gtx 1050, with the 470 and 390 drivers. I don't have an older card to test with.