### PR TITLE
meson.build: fix .pc and .m4 install on xorg-sdk-only build

### DIFF
--- a/hw/xfree86/meson.build
+++ b/hw/xfree86/meson.build
@@ -1,4 +1,3 @@
-module_abi_tag = 'xlibre-25'
 module_abi_dir = join_paths(module_dir, module_abi_tag)
 
 xorg_inc = include_directories(

--- a/meson.build
+++ b/meson.build
@@ -765,6 +765,8 @@ if build_docs or build_docs_devel
     ]
 endif
 
+module_abi_tag = 'xlibre-25'
+
 # Include must come first, as it sets up dix-config.h
 subdir('include')
 
@@ -839,7 +841,7 @@ if (get_option('tests') and host_machine.system() != 'windows' and build_xserver
     subdir('test')
 endif
 
-if build_xorg
+if build_xorg_sdk
     sdkconfig = configuration_data()
     awk = find_program('awk')
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
