### PR TITLE
kdrive: linux: replace __uid_t and __gid_t by standard types

### DIFF
--- a/hw/kdrive/linux/linux.c
+++ b/hw/kdrive/linux/linux.c
@@ -66,14 +66,12 @@ static void
 LinuxCheckChown(const char *file)
 {
     struct stat st;
-    __uid_t u;
-    __gid_t g;
     int r;
 
     if (stat(file, &st) < 0)
         return;
-    u = getuid();
-    g = getgid();
+    uid_t u = getuid();
+    gid_t g = getgid();
     if (st.st_uid != u || st.st_gid != g) {
         r = chown(file, u, g);
         (void) r;


### PR DESCRIPTION
Fix build on musl.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
