### PR TITLE
Improve security xserver deny working with sockets

### DIFF
--- a/os/access.c
+++ b/os/access.c
@@ -1471,6 +1471,10 @@ InvalidHost(register struct sockaddr *saddr, int len, ClientPtr client)
     if (!AccessEnabled)         /* just let them in */
         return 0;
     family = ConvertAddr(saddr, &len, (void **) &addr);
+#ifdef HAVE_SECCOMP
+    if (family != FamilyLocal)
+        return 1;
+#endif
     if (family == -1)
         return 1;
     if (family == FamilyLocal) {

--- a/os/meson.build
+++ b/os/meson.build
@@ -25,6 +25,16 @@ srcs_os = [
     'log.c',
 ]
 
+os_dep = []
+
+isolate_sockets = false
+if isolate_sockets and cc.has_header('linux/seccomp.h')
+    srcs_os += 'seccomp.c'
+    conf_data.set('HAVE_SECCOMP', 1)
+else
+    conf_data.set('HAVE_SECCOMP', false)
+endif
+
 conf_data.set('CONFIG_SYSLOG', cc.has_header('syslog.h') ? '1' : false)
 
 have_strlcpy = cc.has_function('strlcpy', dependencies: libbsd_dep)
@@ -65,7 +75,6 @@ if build_xdmcp
     srcs_os += 'xdmcp.c'
 endif
 
-os_dep = []
 os_c_args = []
 
 # eg. struct msghdr -> msg_control 

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -135,6 +135,7 @@ typedef void (*OsSigHandlerPtr) (int sig);
 OsSigHandlerPtr OsSignal(int sig, OsSigHandlerPtr handler);
 
 void OsInit(void);
+void OsSeccompInit(void);
 
 _X_EXPORT /* needed by the int10 module, but should not be used by OOT drivers */
 void OsBlockSignals(void);

--- a/os/osinit.c
+++ b/os/osinit.c
@@ -226,4 +226,7 @@ OsInit(void)
      */
     LogInit(NULL, NULL);
     SmartScheduleInit();
+#ifdef HAVE_SECCOMP
+    OsSeccompInit();
+#endif
 }

--- a/os/seccomp.c
+++ b/os/seccomp.c
@@ -1,0 +1,87 @@
+#ifdef HAVE_DIX_CONFIG_H
+#include <dix-config.h>
+#endif
+
+#include <errno.h>
+#include <sys/utsname.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+
+#include "os.h"
+
+#ifdef HAVE_SECCOMP
+#include <sys/prctl.h>
+#include <linux/seccomp.h>
+#include <linux/filter.h>
+#include <linux/audit.h>
+#include <stddef.h>
+
+#ifndef SECCOMP_MODE_FILTER
+#define SECCOMP_MODE_FILTER	2 /* uses user-supplied filter. */
+#endif
+#ifndef PR_SET_NO_NEW_PRIVS
+#define PR_SET_NO_NEW_PRIVS 38
+#endif
+#ifndef SYS_socket
+#if defined(__i386__)
+#define SYS_socket 359
+#elif defined(__x86_64__)
+#define SYS_socket 41
+#elif defined(__arm__)
+#define SYS_socket 281
+#elif defined(__aarch64__)
+#define SYS_socket 198
+#else
+#error "Unsupported architecture"
+#endif
+#endif
+
+static int
+seccomp_set_filter(void)
+{
+    struct sock_filter filter[] = {
+        /* 1. Load syscall number */
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, (offsetof(struct seccomp_data, nr))),
+        /* 2. Is it socket()? if not, jump to allow. */
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, SYS_socket, 0, 3),
+        /* 3. It is socket(). Load domain argument. */
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, (offsetof(struct seccomp_data, args[0]))),
+        /* 4. Is it AF_UNIX? if so, jump to allow. */
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, AF_UNIX, 1, 0),
+        /* 5. Not AF_UNIX. Kill. */
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL),
+        /* 6. Allow. */
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    };
+
+    struct sock_fprog prog = {
+        .len = (unsigned short)(sizeof(filter) / sizeof(filter[0])),
+        .filter = filter,
+    };
+
+    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
+        ErrorF("prctl(PR_SET_NO_NEW_PRIVS) failed: %s\n", strerror(errno));
+        return -1;
+    }
+
+    if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog)) {
+        ErrorF("prctl(PR_SET_SECCOMP) failed: %s\n", strerror(errno));
+        return -1;
+    }
+
+    return 0;
+}
+
+#endif /* HAVE_SECCOMP */
+
+void
+OsSeccompInit(void)
+{
+#ifdef HAVE_SECCOMP
+    if (seccomp_set_filter()) {
+        FatalError("Failed to set seccomp filter\n");
+    }
+#endif
+}


### PR DESCRIPTION
Since some local xserver users do not use remote desktops and terminals, they do not need to handle network traffic, this blocking at the level of Linux seccomp kernel component will reduce vector of attacks from xf86 drivers and X applications that, for example, try to scan ports via `/proc/tcp` on local and remote hosts. Obviously, this malicious action to disclose information about user's network should be stopped or notified of suspicious activity. I suggest blocking sockets at the compilation level for now in meson.build, but in the future can make a separate flag in X config.

References:
- https://en.wikipedia.org/wiki/Seccomp
- https://man7.org/linux/man-pages/man2/seccomp.2.html