### PR TITLE
Fix Hurd support for the `vesa` driver.

### DIFF
--- a/hw/xfree86/common/xf86AutoConfig.c
+++ b/hw/xfree86/common/xf86AutoConfig.c
@@ -307,7 +307,7 @@ listPossibleVideoDrivers(XF86MatchedDrivers *md)
 #endif
 
     /* Fallback to platform default hardware */
-#if defined(__i386__) || defined(__amd64__) || defined(__hurd__)
+#if defined(__i386__) || defined(__amd64__) || defined(__GNU__)
     xf86AddMatchedDriver(md, "vesa");
 #elif defined(__sparc__) && !defined(__sun)
     xf86AddMatchedDriver(md, "sunffb");

--- a/hw/xfree86/os-support/meson.build
+++ b/hw/xfree86/os-support/meson.build
@@ -148,6 +148,7 @@ else
         'stub/stub_bell.c',
         'stub/stub_init.c',
         'stub/stub_video.c',
+        'misc/SlowBcopy.c',
     ]
 endif
 


### PR DESCRIPTION
Right now the vesa driver is a bit bugged on HURD but with this patch it works.

Also, nitpick, but `__GNU__` is the correct ifdef to use, not `__hurd__`.