### PR TITLE
os: add a generic -verbose option instead of making each server add its own

### DIFF
--- a/hw/kdrive/ephyr/ephyrinit.c
+++ b/hw/kdrive/ephyr/ephyrinit.c
@@ -282,10 +282,12 @@ ddxProcessArgument(int argc, char **argv, int i)
         ephyrFuncs.finiAccel = ephyrDrawFini;
         return 1;
     }
+    /* Xephyr adopted a different spelling before the common -verbose option
+     *  was added, so it's been left for compatibility */
     else if (!strcmp(argv[i], "-verbosity")) {
         if (i + 1 < argc && argv[i + 1][0] != '-') {
             xorgLogVerbosity = atoi(argv[i + 1]);
-            EPHYR_LOG("set verbosiry to %d\n", xorgLogVerbosity);
+            EPHYR_LOG("set verbosity to %d\n", xorgLogVerbosity);
             return 2;
         }
         else {

--- a/man/Xserver.man
+++ b/man/Xserver.man
@@ -306,6 +306,15 @@ sets video-off screen-saver preference.
 .B \-v
 sets video-on screen-saver preference.
 .TP 8
+.BR \-verbose " [\fIn\fP]"
+Sets the verbosity level for information printed on stderr.  If the
+.I n
+value isn't supplied, each occurrence of this option increments the
+verbosity level.  When the
+.I n
+value is supplied, the verbosity level is set to that value.  The default
+verbosity level is 0.
+.TP 8
 .B \-wr
 sets the default root window to solid white instead of the standard root weave
 pattern.

--- a/os/utils.c
+++ b/os/utils.c
@@ -314,6 +314,7 @@ UseMsg(void)
     ErrorF("ttyxx                  server started from init on /dev/ttyxx\n");
     ErrorF("v                      video blanking for screen-saver\n");
     ErrorF("-v                     screen-saver without video blanking\n");
+    ErrorF("-verbose [n]           verbose startup messages\n");
     ErrorF("-wr                    create root window with white background\n");
     ErrorF("-maxbigreqsize         set maximal bigrequest size \n");
 #ifdef XINERAMA
@@ -404,6 +405,7 @@ void
 ProcessCommandLine(int argc, char *argv[])
 {
     int i, skip;
+    int verbosity = 0;
 
     defaultKeyboardControl.autoRepeat = TRUE;
 
@@ -660,6 +662,21 @@ ProcessCommandLine(int argc, char *argv[])
             defaultScreenSaverBlanking = PreferBlanking;
         else if (strcmp(argv[i], "-v") == 0)
             defaultScreenSaverBlanking = DontPreferBlanking;
+        else if (strcmp(argv[i], "-verbose") == 0) {
+            int n = i + 1; /* next argument */
+            verbosity++;
+            if (n < argc && argv[n] && argv[n][0] != '-') {
+                char *end;
+                long val;
+
+                val = strtol(argv[n], &end, 0);
+                if (*end == '\0') {
+                    verbosity = val;
+                    i = n;
+                }
+            }
+            xorgLogVerbosity = verbosity;
+        }
         else if (strcmp(argv[i], "-wr") == 0)
             whiteRoot = TRUE;
         else if (strcmp(argv[i], "-background") == 0) {


### PR DESCRIPTION
Replaces Xwayland's server-specific implementation, but leaves Xorg's since it sets global variables in the xfree86 ddx layer.  Also leaves Xephyr's differently-spelled "-verbosity" for backwards compatibility.


Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2131>