### PR TITLE
glamor: enable dmabuf_capable by default for radeonsi

### DIFF
--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -1381,6 +1381,8 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
             glamor_egl->dmabuf_capable = TRUE;
         else if (strstr((const char *)renderer, "NVIDIA"))
             glamor_egl->dmabuf_capable = TRUE;
+        else if (strstr((const char *)renderer, "radeonsi"))
+            glamor_egl->dmabuf_capable = TRUE;
         else
             glamor_egl->dmabuf_capable = FALSE;
     }


### PR DESCRIPTION
This is needed by radeonsi to support multi plane modifier when using modesetting DDX.

xserver reject any multi plane buffer (in DRI3PixmapFromBuffers) without the dmabuf_capable debug option. It's OK for single plane buffer as xserver will fallback to DRI3BufferFromPixmap path. amdgpu DDX does not expose DRI3PixmapFromBuffers, mesa just use the single plane path anyway, so amdgpu DDX does not have this problem.

Reviewed-by: Sultan Alsawaf <sultan@kerneltoast.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2091>