### PR TITLE
randr: clear primary screen's primaryOutput when the output is deleted

### DIFF
--- a/randr/rroutput.c
+++ b/randr/rroutput.c
@@ -372,6 +372,8 @@ RROutputDestroyResource(void *value, XID pid)
 {
     RROutputPtr output = (RROutputPtr) value;
     ScreenPtr pScreen = output->pScreen;
+    ScreenPtr primary;
+    rrScrPrivPtr primarysp;
     int m;
 
     if (pScreen) {
@@ -391,6 +393,15 @@ RROutputDestroyResource(void *value, XID pid)
 
         if (pScrPriv->primaryOutput == output)
             pScrPriv->primaryOutput = NULL;
+
+        if (pScreen->isGPU) {
+            primary = pScreen->current_primary;
+            if (primary) {
+                primarysp = rrGetScrPriv(primary);
+                if (primarysp->primaryOutput == output)
+                    primarysp->primaryOutput = NULL;
+            }
+        }
 
         for (i = 0; i < pScrPriv->numOutputs; i++) {
             if (pScrPriv->outputs[i] == output) {


### PR DESCRIPTION
This fix use after free when a pluggable gpu screen (such as displaylink) was set as primary screen and unpluged.

gdb backtrace:
```
 0 OssigHandler (signo=11, sip=0x7fff2e0a50f0, unused=0x7fff2e0a4fc0) at ../../../../os/osinit.c:138
 1 <signal handler called>
 2 rrGetscreenResources (client=0x3195160, query=0) at ../../../../randr/rrscreen.c:577
 3 0x0000000000562bae in ProcRRGetscreenResourcesCurrent (client=0x3195160) at ../../../../randr/rrscreen.c:652
 4 OxOOOOB0000054de63 in ProcRRDispatch (client=0x3195160) at ../../../../randr/randr.c:717
 5 0x00000000004322c6 in Dispatch () at ../../../../dix/dispatch.c:485
 6 0x0900900990443139 in dix_main (argc=12, argv=0x7fff2e0a5f78, envp=0x7fff2e0a5fe0) at ../../../../dix/main.c:276
 7 0X0000000000421d9a in main (argc=12, argv=0x7fff2e0a5f78, envp=0x7fff2e0a5fe0) at ../../../../dix/stubmain.c:34
```


Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1553>