### PR TITLE
modesetting: Empty damage once dispatch is done

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -781,6 +781,8 @@ dispatch_dirty(ScreenPtr pScreen)
             return;
         }
     }
+
+    DamageEmpty(ms->damage);
 }
 
 static void
@@ -792,6 +794,8 @@ dispatch_dirty_pixmap(ScrnInfoPtr scrn, xf86CrtcPtr crtc, PixmapPtr ppix)
     int fb_id = ppriv->fb_id;
 
     dispatch_dirty_region(scrn, crtc, ppix, damage, fb_id, 0, 0);
+    if (damage)
+        DamageEmpty(damage);
 }
 
 static void


### PR DESCRIPTION
This commit is to fix some regression caused by

commit https://gitlab.freedesktop.org/xorg/xserver/-/commit/995e60a91997a00768517d1ab6b40fc4f78b7cdc

where DamageEmpty on damage was missing in several places.


Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1486>