### PR TITLE
xv: change FOURCC_RGBA32 to AMD one

### DIFF
--- a/include/fourcc.h
+++ b/include/fourcc.h
@@ -176,7 +176,7 @@
         XvTopToBottom \
    }
 
-#define FOURCC_RGBA32 0x34325241
+#define FOURCC_RGBA32 0x41424752
 #define XVIMAGE_RGB32 \
    { \
         FOURCC_RGBA32, \


### PR DESCRIPTION
Initally we used value of DRM_FORMAT_ARGB8888, but it seems than xf86-video-ati has established other value for years. So, change it to well established one.

Because we define a different values, this breaks compilation of xf86-video-ati. I am unsure, who is right in this situation, but I guess better to use an established value, to make AMD xorg driver compile.

I do not aware about any of the side effects of this change.

Fixes: https://gitlab.freedesktop.org/xorg/xserver/-/commit/15412e78c83bf3d15bcd343ccc40afda072d3f9e - glamor: xv: add rgba32 format

Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1321>