### PR TITLE
musl: fix cross building

### DIFF
--- a/include/os.h
+++ b/include/os.h
@@ -71,7 +71,7 @@ SOFTWARE.
 #endif
 
 #ifndef _X_ATTRIBUTE_VPRINTF
-# if defined(__GNUC__) && (__GNUC__ >= 2) && (!defined(__APPLE__)) && (!defined(__FreeBSD__))
+# if defined(__GNUC__) && (__GNUC__ >= 2) && !defined(__clang__)
 #  define _X_ATTRIBUTE_VPRINTF(fmt, firstarg) \
           __attribute__((__format__(gnu_printf, fmt, firstarg)))
 # else

--- a/os/busfault.h
+++ b/os/busfault.h
@@ -29,11 +29,11 @@
 
 #include "misc.h"                         /* for TRUE/FALSE */
 
+typedef void (*busfault_notify_ptr) (void *context);
+
 #ifdef HAVE_SIGACTION
 
 #include <sys/types.h>
-
-typedef void (*busfault_notify_ptr) (void *context);
 
 struct busfault *
 busfault_register_mmap(void *addr, size_t size, busfault_notify_ptr notify, void *context);
@@ -48,6 +48,24 @@ Bool
 busfault_init(void);
 
 #else
+
+struct busfault;
+
+static inline struct busfault *
+busfault_register_mmap(void *addr, size_t size, busfault_notify_ptr notify, void *context)
+{
+    (void) addr;
+    (void) size;
+    (void) notify;
+    (void) context;
+    return NULL;
+}
+
+static inline void
+busfault_unregister(struct busfault *busfault)
+{
+    (void) busfault;
+}
 
 static inline void busfault_check(void) {}
 static inline Bool busfault_init(void) { return FALSE; }


### PR DESCRIPTION
This is a small step towards #1979 to get a musl sysroot building with clang. I tested the build works with `xfbdev` enabled too.