### PR TITLE
os/log: Fix syslog identification

### DIFF
--- a/os/log.c
+++ b/os/log.c
@@ -218,7 +218,7 @@ static inline void doLogSync(void) {
 
 static void initSyslog(void) {
 #ifdef CONFIG_SYSLOG
-    char buffer[4096];
+    static char buffer[4096];
     strcpy(buffer, xorgSyslogIdent);
 
     snprintf(buffer, sizeof(buffer), "%s :%s", xorgSyslogIdent, (display ? display : "<>"));


### PR DESCRIPTION
Fixes the syslog identification from being garbled memory to the default one (process name), right now the display is skipped as it introduces some problems with some parsers and their units detection
Now:

<img width="1123" height="699" alt="Image" src="https://github.com/user-attachments/assets/c9663f62-e01b-4c06-a625-d7f980f77959" />

<img width="1507" height="739" alt="Image" src="https://github.com/user-attachments/assets/3c439deb-c1f6-4809-8ea0-5a07ccbeb7a9" />

Before:

<img width="1159" height="518" alt="Image" src="https://github.com/user-attachments/assets/9d599356-0a9d-4d87-a1f2-891d9ad83055" />

<img width="1213" height="864" alt="Image" src="https://github.com/user-attachments/assets/532c10c8-cb1a-407f-a439-837d19a593fa" />
