### PR TITLE
modesetting: Port modesetting to glamor_egl_init2

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -862,7 +862,7 @@ redisplay_dirty(ScreenPtr screen, PixmapDirtyUpdatePtr dirty, int *timeout)
          * copy to its own framebuffer (some secondarys scanout directly from
          * the shared pixmap, but not all).
          */
-        if (ms->drmmode.glamor)
+        if (ms->drmmode.glamor_gbm)
             ms->glamor.finish(screen);
 #endif
         /* Ensure the secondary processes the damage immediately */
@@ -1070,7 +1070,7 @@ load_glamor(ScrnInfoPtr pScrn)
     ms->glamor.egl_create_textured_pixmap_from_gbm_bo = LoaderSymbolFromModule(mod, "glamor_egl_create_textured_pixmap_from_gbm_bo");
     ms->glamor.egl_exchange_buffers = LoaderSymbolFromModule(mod, "glamor_egl_exchange_buffers");
     ms->glamor.egl_get_gbm_device = LoaderSymbolFromModule(mod, "glamor_egl_get_gbm_device");
-    ms->glamor.egl_init = LoaderSymbolFromModule(mod, "glamor_egl_init");
+    ms->glamor.egl_init2 = LoaderSymbolFromModule(mod, "glamor_egl_init2");
     ms->glamor.finish = LoaderSymbolFromModule(mod, "glamor_finish");
     ms->glamor.gbm_bo_from_pixmap = LoaderSymbolFromModule(mod, "glamor_gbm_bo_from_pixmap");
     ms->glamor.init = LoaderSymbolFromModule(mod, "glamor_init");
@@ -1096,6 +1096,7 @@ try_enable_glamor(ScrnInfoPtr pScrn)
                       strcmp(accel_method_str, "glamor") == 0);
 
     ms->drmmode.glamor = FALSE;
+    ms->drmmode.glamor_gbm = FALSE;
 
 #ifdef GLAMOR
     if (ms->drmmode.force_24_32) {
@@ -1109,7 +1110,9 @@ try_enable_glamor(ScrnInfoPtr pScrn)
     }
 
     if (load_glamor(pScrn)) {
-        if (ms->glamor.egl_init(pScrn, ms->fd)) {
+        int caps = GLAMOR_EGL_CAP_NONE;
+        if (ms->glamor.egl_init2(pScrn, ms->fd, &caps, 0)) {
+            ms->drmmode.glamor_gbm = !!(caps & GLAMOR_EGL_CAP_TEXTURE_GBM_BO);
             xf86DrvMsg(pScrn->scrnIndex, X_INFO, "glamor initialized\n");
             ms->drmmode.glamor = TRUE;
         } else {
@@ -1329,7 +1332,7 @@ PreInit(ScrnInfoPtr pScrn, int flags)
 
     try_enable_glamor(pScrn);
 
-    if (!ms->drmmode.glamor) {
+    if (!ms->drmmode.glamor_gbm) {
         Bool prefer_shadow = TRUE;
 
         if (ms->drmmode.force_24_32) {
@@ -1376,11 +1379,11 @@ PreInit(ScrnInfoPtr pScrn, int flags)
     if (ret == 0) {
         if (connector_count && (value & DRM_PRIME_CAP_IMPORT)) {
             pScrn->capabilities |= RR_Capability_SinkOutput;
-            if (ms->drmmode.glamor)
+            if (ms->drmmode.glamor_gbm)
                 pScrn->capabilities |= RR_Capability_SinkOffload;
         }
 #if defined(GLAMOR) && defined(GBM_HAVE_BO_USE_LINEAR)
-        if (value & DRM_PRIME_CAP_EXPORT && ms->drmmode.glamor)
+        if (value & DRM_PRIME_CAP_EXPORT && ms->drmmode.glamor_gbm)
             pScrn->capabilities |= RR_Capability_SourceOutput | RR_Capability_SourceOffload;
 #endif
     }
@@ -1409,7 +1412,7 @@ PreInit(ScrnInfoPtr pScrn, int flags)
         if (pScrn->is_gpu) {
             xf86DrvMsg(pScrn->scrnIndex, X_WARNING,
                        "TearFree cannot synchronize PRIME; use 'PRIME Synchronization' instead\n");
-        } else if (ms->drmmode.glamor) {
+        } else if (ms->drmmode.glamor_gbm) {
             /* Atomic modesetting implicitly enables universal planes */
             if (!ms->drmmode.pageflip || ms->atomic_modeset ||
                 !drmSetClientCap(ms->fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1)) {
@@ -1737,7 +1740,7 @@ modesetCreateScreenResources(ScreenPtr pScreen)
 
     drmmode_uevent_init(pScrn, &ms->drmmode);
 
-    if (!ms->drmmode.glamor) {
+    if (!ms->drmmode.glamor_gbm) {
         pixels = gbm_bo_get_map(ms->drmmode.front_bo);
     }
 
@@ -2005,10 +2008,12 @@ ScreenInit(ScreenPtr pScreen, int argc, char **argv)
 
 #ifdef GLAMOR
     if (ms->drmmode.glamor) {
+        ms->drmmode.glamor_gbm_device = TRUE;
         ms->drmmode.gbm = ms->glamor.egl_get_gbm_device(pScreen);
-    } else
+    }
 #endif
-    {
+    if (!ms->drmmode.gbm) {
+        ms->drmmode.glamor_gbm_device = FALSE;
         ms->drmmode.gbm = gbm_create_device(ms->drmmode.fd);
         if (!ms->drmmode.gbm) {
             ms->drmmode.gbm = gbm_create_device_by_name(ms->drmmode.fd, "dumb");
@@ -2124,7 +2129,7 @@ ScreenInit(ScreenPtr pScreen, int argc, char **argv)
      * later memory should be bound when allocating, e.g rotate_mem */
     pScrn->vtSema = TRUE;
 
-    if (serverGeneration == 1 && bgNoneRoot && ms->drmmode.glamor) {
+    if (serverGeneration == 1 && bgNoneRoot && ms->drmmode.glamor_gbm) {
         ms->CreateWindow = pScreen->CreateWindow;
         pScreen->CreateWindow = CreateWindow_oneshot;
     }
@@ -2182,7 +2187,7 @@ ScreenInit(ScreenPtr pScreen, int argc, char **argv)
     }
 
 #ifdef GLAMOR
-    if (ms->drmmode.glamor) {
+    if (ms->drmmode.glamor_gbm) {
         if (!(ms->drmmode.dri2_enable = ms_dri2_screen_init(pScreen))) {
             xf86DrvMsg(pScrn->scrnIndex, X_ERROR,
                        "Failed to initialize the DRI2 extension.\n");
@@ -2348,7 +2353,7 @@ CloseScreen(ScreenPtr pScreen)
 
 #ifdef GLAMOR
     /* If we didn't get the gbm device from glamor, we have to free it ourserves */
-    if (!ms->drmmode.glamor)
+    if (!ms->drmmode.glamor_gbm_device)
 #endif
     {
         gbm_device_destroy(ms->drmmode.gbm);

--- a/hw/xfree86/drivers/video/modesetting/driver.h
+++ b/hw/xfree86/drivers/video/modesetting/driver.h
@@ -176,7 +176,7 @@ typedef struct _modesettingRec {
                                                        Bool);
         void (*egl_exchange_buffers)(PixmapPtr, PixmapPtr);
         struct gbm_device *(*egl_get_gbm_device)(ScreenPtr);
-        Bool (*egl_init)(ScrnInfoPtr, int);
+        Bool (*egl_init2)(ScrnInfoPtr, int, int*, int);
         void (*finish)(ScreenPtr);
         struct gbm_bo *(*gbm_bo_from_pixmap)(ScreenPtr, PixmapPtr);
         Bool (*init)(ScreenPtr, unsigned int);

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -862,7 +862,7 @@ drmmode_crtc_set_mode(xf86CrtcPtr crtc, Bool test_only)
 
 #ifdef GLAMOR
     /* Make sure any pending drawing will be visible in a new scanout buffer */
-    if (drmmode->glamor)
+    if (drmmode->glamor_gbm)
         glamor_finish(crtc->scrn->pScreen);
 #endif
 
@@ -2184,7 +2184,7 @@ drmmode_clear_pixmap(PixmapPtr pixmap)
 #ifdef GLAMOR
     modesettingPtr ms = modesettingPTR(xf86ScreenToScrn(screen));
 
-    if (ms->drmmode.glamor) {
+    if (ms->drmmode.glamor_gbm) {
         ms->glamor.clear_pixmap(pixmap);
         return;
     }
@@ -2204,7 +2204,7 @@ drmmode_shadow_fb_allocate(xf86CrtcPtr crtc, int width, int height,
     drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
     drmmode_ptr drmmode = drmmode_crtc->drmmode;
 
-    struct gbm_bo *ret = gbm_create_best_bo(drmmode, !drmmode->glamor, width, height, DRMMODE_FRONT_BO);
+    struct gbm_bo *ret = gbm_create_best_bo(drmmode, !drmmode->glamor_gbm, width, height, DRMMODE_FRONT_BO);
     if (ret == NULL) {
         xf86DrvMsg(crtc->scrn->scrnIndex, X_ERROR,
                "Couldn't allocate shadow memory for rotated CRTC\n");
@@ -3866,7 +3866,7 @@ drmmode_set_pixmap_bo(drmmode_ptr drmmode, PixmapPtr pixmap, struct gbm_bo *bo)
     ScrnInfoPtr scrn = drmmode->scrn;
     modesettingPtr ms = modesettingPTR(scrn);
 
-    if (!drmmode->glamor)
+    if (!drmmode->glamor_gbm)
         return TRUE;
 
     if (!ms->glamor.egl_create_textured_pixmap_from_gbm_bo(pixmap, bo,
@@ -3919,7 +3919,7 @@ drmmode_xf86crtc_resize(ScrnInfoPtr scrn, int width, int height)
     old_fb_id = drmmode->fb_id;
     drmmode->fb_id = 0;
 
-    drmmode->front_bo = gbm_create_best_bo(drmmode, !drmmode->glamor, width, height, DRMMODE_FRONT_BO);
+    drmmode->front_bo = gbm_create_best_bo(drmmode, !drmmode->glamor_gbm, width, height, DRMMODE_FRONT_BO);
     if (!drmmode->front_bo)
         goto fail;
 
@@ -3929,7 +3929,7 @@ drmmode_xf86crtc_resize(ScrnInfoPtr scrn, int width, int height)
     scrn->virtualY = height;
     scrn->displayWidth = pitch / kcpp;
 
-    if (!drmmode->glamor) {
+    if (!drmmode->glamor_gbm) {
         new_pixels = gbm_bo_get_map(drmmode->front_bo);
     }
 
@@ -4850,7 +4850,7 @@ drmmode_create_initial_bos(ScrnInfoPtr pScrn, drmmode_ptr drmmode)
     width = pScrn->virtualX;
     height = pScrn->virtualY;
 
-    drmmode->front_bo = gbm_create_best_bo(drmmode, !drmmode->glamor, width, height, DRMMODE_FRONT_BO);
+    drmmode->front_bo = gbm_create_best_bo(drmmode, !drmmode->glamor_gbm, width, height, DRMMODE_FRONT_BO);
     if (!drmmode->front_bo) {
         return FALSE;
     }

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.h
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.h
@@ -100,6 +100,8 @@ typedef struct {
     OptionInfoPtr Options;
 
     Bool glamor;
+    Bool glamor_gbm;
+    Bool glamor_gbm_device;
     Bool shadow_enable;
     Bool shadow_enable2;
     /** Is Option "PageFlip" enabled? */


### PR DESCRIPTION
Pull all generic glamor stuff into dix, and all the xf86 stuff into hw/xfree86
Now Xfbdev uses this too.
Perhaps Xvfb can use this too? https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/235