### PR TITLE
modesetting: clear bo in `drmmode_create_front_bo`

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -1175,6 +1175,8 @@ static Bool
 drmmode_create_front_bo(drmmode_ptr drmmode, drmmode_bo *bo,
                         unsigned width, unsigned height, unsigned bpp)
 {
+    memset(bo, 0, sizeof(*bo));
+
     bo->width = width;
     bo->height = height;
 


### PR DESCRIPTION
Master was fixed, This one  to 25.1 version

Fixes:  https://github.com/X11Libre/xserver/issues/2107

