### PR TITLE
Feature: select memory allocators for X11Libre

### DIFF
--- a/hw/xfree86/meson.build
+++ b/hw/xfree86/meson.build
@@ -93,6 +93,7 @@ xorg_deps = [
     config_dep,
     libdrm_dep,
     mimalloc_dep,
+    tcmalloc_dep,
 ]
 
 if get_option('suid_wrapper')

--- a/hw/xfree86/meson.build
+++ b/hw/xfree86/meson.build
@@ -92,6 +92,7 @@ xorg_deps = [
     xshmfence_dep,
     config_dep,
     libdrm_dep,
+    mimalloc_dep,
 ]
 
 if get_option('suid_wrapper')

--- a/hw/xfree86/meson.build
+++ b/hw/xfree86/meson.build
@@ -94,6 +94,7 @@ xorg_deps = [
     libdrm_dep,
     mimalloc_dep,
     tcmalloc_dep,
+    jemalloc_dep,
 ]
 
 if get_option('suid_wrapper')

--- a/meson.build
+++ b/meson.build
@@ -35,8 +35,19 @@ add_project_link_arguments('-fvisibility=hidden', language : 'c')
 conf_data = configuration_data()
 conf_data.set('_DIX_CONFIG_H_', '1')
 
-if get_option('mimalloc') and get_option('tcmalloc')
-    error('mimalloc and tcmalloc are mutually exclusive. Please enable only one.')
+allocator_count = 0
+if get_option('mimalloc')
+    allocator_count += 1
+endif
+if get_option('tcmalloc')
+    allocator_count += 1
+endif
+if get_option('jemalloc')
+    allocator_count += 1
+endif
+
+if allocator_count > 1
+    error('Only one memory allocator (mimalloc, tcmalloc, jemalloc) can be enabled at a time.')
 elif get_option('mimalloc')
     mimalloc_dep = dependency('mimalloc', required: true)
     conf_data.set('HAVE_MIMALLOC', 1)
@@ -48,6 +59,7 @@ elif get_option('mimalloc')
     add_project_arguments('-Dstrdup=mi_strdup', language: 'c')
     add_project_arguments('-Dstrndup=mi_strndup', language: 'c')
     tcmalloc_dep = dependency('', required: false)
+    jemalloc_dep = dependency('', required: false)
 elif get_option('tcmalloc')
     tcmalloc_dep = dependency('libtcmalloc_minimal', required: true)
     conf_data.set('HAVE_TCMALLOC', 1)
@@ -59,9 +71,23 @@ elif get_option('tcmalloc')
     add_project_arguments('-Dstrdup=tc_strdup', language: 'c')
     add_project_arguments('-Dstrndup=tc_strndup', language: 'c')
     mimalloc_dep = dependency('', required: false)
+    jemalloc_dep = dependency('', required: false)
+elif get_option('jemalloc')
+    jemalloc_dep = dependency('jemalloc', required: true)
+    conf_data.set('HAVE_JEMALLOC', 1)
+    add_project_arguments('-Dmalloc=je_malloc', language: 'c')
+    add_project_arguments('-Dcalloc=je_calloc', language: 'c')
+    add_project_arguments('-Drealloc=je_realloc', language: 'c')
+    add_project_arguments('-Dfree=je_free', language: 'c')
+    add_project_arguments('-Dposix_memalign=je_posix_memalign', language: 'c')
+    add_project_arguments('-Dstrdup=je_strdup', language: 'c')
+    add_project_arguments('-Dstrndup=je_strndup', language: 'c')
+    mimalloc_dep = dependency('', required: false)
+    tcmalloc_dep = dependency('', required: false)
 else
     mimalloc_dep = dependency('', required: false)
     tcmalloc_dep = dependency('', required: false)
+    jemalloc_dep = dependency('', required: false)
 endif
 
 if cc.get_id() == 'gcc' or cc.get_id() == 'clang'
@@ -691,6 +717,7 @@ common_dep = [
     xdmcp_dep,
     mimalloc_dep,
     tcmalloc_dep,
+    jemalloc_dep,
 ]
 
 inc = include_directories(

--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,20 @@ add_project_link_arguments('-fvisibility=hidden', language : 'c')
 conf_data = configuration_data()
 conf_data.set('_DIX_CONFIG_H_', '1')
 
+if get_option('mimalloc')
+    mimalloc_dep = dependency('mimalloc', required: true)
+    conf_data.set('HAVE_MIMALLOC', 1)
+    add_project_arguments('-Dmalloc=mi_malloc', language: 'c')
+    add_project_arguments('-Dcalloc=mi_calloc', language: 'c')
+    add_project_arguments('-Drealloc=mi_realloc', language: 'c')
+    add_project_arguments('-Dfree=mi_free', language: 'c')
+    add_project_arguments('-Dposix_memalign=mi_posix_memalign', language: 'c')
+    add_project_arguments('-Dstrdup=mi_strdup', language: 'c')
+    add_project_arguments('-Dstrndup=mi_strndup', language: 'c')
+else
+    mimalloc_dep = dependency('', required: false)
+endif
+
 if cc.get_id() == 'gcc' or cc.get_id() == 'clang'
     test_wflags = [
         '-Wall',
@@ -660,6 +674,7 @@ common_dep = [
     xkbfile_dep,
     xfont2_dep,
     xdmcp_dep,
+    mimalloc_dep,
 ]
 
 inc = include_directories(

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,9 @@ add_project_link_arguments('-fvisibility=hidden', language : 'c')
 conf_data = configuration_data()
 conf_data.set('_DIX_CONFIG_H_', '1')
 
-if get_option('mimalloc')
+if get_option('mimalloc') and get_option('tcmalloc')
+    error('mimalloc and tcmalloc are mutually exclusive. Please enable only one.')
+elif get_option('mimalloc')
     mimalloc_dep = dependency('mimalloc', required: true)
     conf_data.set('HAVE_MIMALLOC', 1)
     add_project_arguments('-Dmalloc=mi_malloc', language: 'c')
@@ -45,8 +47,21 @@ if get_option('mimalloc')
     add_project_arguments('-Dposix_memalign=mi_posix_memalign', language: 'c')
     add_project_arguments('-Dstrdup=mi_strdup', language: 'c')
     add_project_arguments('-Dstrndup=mi_strndup', language: 'c')
+    tcmalloc_dep = dependency('', required: false)
+elif get_option('tcmalloc')
+    tcmalloc_dep = dependency('libtcmalloc_minimal', required: true)
+    conf_data.set('HAVE_TCMALLOC', 1)
+    add_project_arguments('-Dmalloc=tc_malloc', language: 'c')
+    add_project_arguments('-Dcalloc=tc_calloc', language: 'c')
+    add_project_arguments('-Drealloc=tc_realloc', language: 'c')
+    add_project_arguments('-Dfree=tc_free', language: 'c')
+    add_project_arguments('-Dposix_memalign=tc_posix_memalign', language: 'c')
+    add_project_arguments('-Dstrdup=tc_strdup', language: 'c')
+    add_project_arguments('-Dstrndup=tc_strndup', language: 'c')
+    mimalloc_dep = dependency('', required: false)
 else
     mimalloc_dep = dependency('', required: false)
+    tcmalloc_dep = dependency('', required: false)
 endif
 
 if cc.get_id() == 'gcc' or cc.get_id() == 'clang'
@@ -675,6 +690,7 @@ common_dep = [
     xfont2_dep,
     xdmcp_dep,
     mimalloc_dep,
+    tcmalloc_dep,
 ]
 
 inc = include_directories(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -176,5 +176,7 @@ option('test_xephyr_gles', type: 'boolean', value: true,
 # Memory allocators specific options
 option('mimalloc', type: 'boolean', value: false,
        description: 'Use mimalloc instead default glibc allocator')
-option('tcmalloc', type: 'boolean', value: true,
+option('tcmalloc', type: 'boolean', value: false,
        description: 'Use tcmalloc instead default glibc allocator')
+option('jemalloc', type: 'boolean', value: false,
+       description: 'Use jemalloc instead default glibc allocator')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -172,3 +172,7 @@ option('test_rendercheck_triangles', type: 'boolean', value: false,
        description: 'testsuite: run rendercheck triangles tests (might fail on Xephyr)')
 option('test_xephyr_gles', type: 'boolean', value: true,
        description: 'testsuite: run gles2/gles3 tests on Xephyr (might fail w/o DRI)')
+
+# Memory allocators specific options
+option('mimalloc', type: 'boolean', value: false,
+       description: 'Use mimalloc instead default glibc allocator')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -176,3 +176,5 @@ option('test_xephyr_gles', type: 'boolean', value: true,
 # Memory allocators specific options
 option('mimalloc', type: 'boolean', value: false,
        description: 'Use mimalloc instead default glibc allocator')
+option('tcmalloc', type: 'boolean', value: true,
+       description: 'Use tcmalloc instead default glibc allocator')

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -52,6 +52,10 @@ SOFTWARE.
 #include <mimalloc.h>
 #endif
 
+#ifdef HAVE_TCMALLOC
+#include <gperftools/tcmalloc.h>
+#endif
+
 #include <X11/Xdefs.h>
 
 #include <limits.h>

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -48,6 +48,10 @@ SOFTWARE.
 
 #include <dix-config.h>
 
+#ifdef HAVE_MIMALLOC
+#include <mimalloc.h>
+#endif
+
 #include <X11/Xdefs.h>
 
 #include <limits.h>

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -56,6 +56,10 @@ SOFTWARE.
 #include <gperftools/tcmalloc.h>
 #endif
 
+#ifdef HAVE_JEMALLOC
+#include <jemalloc/jemalloc.h>
+#endif
+
 #include <X11/Xdefs.h>
 
 #include <limits.h>

--- a/test/meson.build
+++ b/test/meson.build
@@ -2,7 +2,7 @@ simple_xinit = executable(
     'simple-xinit',
     'simple-xinit.c',
     include_directories: inc,
-    dependencies: [ xproto_dep, mimalloc_dep ],
+    dependencies: [ xproto_dep, mimalloc_dep, tcmalloc_dep ],
 )
 
 piglit_env = environment()

--- a/test/meson.build
+++ b/test/meson.build
@@ -2,7 +2,7 @@ simple_xinit = executable(
     'simple-xinit',
     'simple-xinit.c',
     include_directories: inc,
-    dependencies: [ xproto_dep, mimalloc_dep, tcmalloc_dep ],
+    dependencies: [ xproto_dep, mimalloc_dep, tcmalloc_dep, jemalloc_dep ],
 )
 
 piglit_env = environment()

--- a/test/meson.build
+++ b/test/meson.build
@@ -2,7 +2,7 @@ simple_xinit = executable(
     'simple-xinit',
     'simple-xinit.c',
     include_directories: inc,
-    dependencies: [ xproto_dep ],
+    dependencies: [ xproto_dep, mimalloc_dep ],
 )
 
 piglit_env = environment()

--- a/test/sync/meson.build
+++ b/test/sync/meson.build
@@ -3,7 +3,7 @@ xcb_sync_dep = dependency('xcb-sync', required: false)
 
 if get_option('xvfb')
     if xcb_dep.found() and xcb_sync_dep.found()
-        sync = executable('sync', 'sync.c', dependencies: [xcb_dep, xcb_sync_dep, mimalloc_dep, tcmalloc_dep])
+        sync = executable('sync', 'sync.c', dependencies: [xcb_dep, xcb_sync_dep, mimalloc_dep, tcmalloc_dep, jemalloc_dep])
         test('sync', simple_xinit, args: [sync, '--', xvfb_server])
     endif
 endif

--- a/test/sync/meson.build
+++ b/test/sync/meson.build
@@ -3,7 +3,7 @@ xcb_sync_dep = dependency('xcb-sync', required: false)
 
 if get_option('xvfb')
     if xcb_dep.found() and xcb_sync_dep.found()
-        sync = executable('sync', 'sync.c', dependencies: [xcb_dep, xcb_sync_dep])
+        sync = executable('sync', 'sync.c', dependencies: [xcb_dep, xcb_sync_dep, mimalloc_dep])
         test('sync', simple_xinit, args: [sync, '--', xvfb_server])
     endif
 endif

--- a/test/sync/meson.build
+++ b/test/sync/meson.build
@@ -3,7 +3,7 @@ xcb_sync_dep = dependency('xcb-sync', required: false)
 
 if get_option('xvfb')
     if xcb_dep.found() and xcb_sync_dep.found()
-        sync = executable('sync', 'sync.c', dependencies: [xcb_dep, xcb_sync_dep, mimalloc_dep])
+        sync = executable('sync', 'sync.c', dependencies: [xcb_dep, xcb_sync_dep, mimalloc_dep, tcmalloc_dep])
         test('sync', simple_xinit, args: [sync, '--', xvfb_server])
     endif
 endif


### PR DESCRIPTION
I think people who understand that glibc is slow for their tasks, for example, computing-calculation or gaming, can build  X11libre package for their distribution with fastest mimalloc allocator. Perhaps someone prefers jemalloc and tcmalloc, so I add them. By default, memory allocator will be Glibc since it is balanced to RAM consumption, but less multithreaded.

Benchmarks:

- https://dustri.org/b/files/blackalps_2022.pdf
- https://forums.factorio.com/viewtopic.php?t=83875
- https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156632/Reduce+Memory+usage+by+choosing+a+different+low+level+allocator
- https://www.reddit.com/r/cpp/comments/1k30fcd/reasons_to_use_the_system_allocator_instead_of_a/