### PR TITLE
modesetting: fix defined(GBM_BO_*) enum compile checks

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -312,7 +312,7 @@ check_outputs(int fd, int *count)
         *count = res->count_connectors;
 
     ret = res->count_connectors > 0;
-#if defined(GLAMOR) && defined(GBM_BO_USE_LINEAR)
+#if defined(GLAMOR) && defined(GBM_HAVE_BO_USE_LINEAR)
     if (ret == FALSE) {
         uint64_t value = 0;
         if (drmGetCap(fd, DRM_CAP_PRIME, &value) == 0 &&
@@ -1379,7 +1379,7 @@ PreInit(ScrnInfoPtr pScrn, int flags)
             if (ms->drmmode.glamor)
                 pScrn->capabilities |= RR_Capability_SinkOffload;
         }
-#if defined(GLAMOR) && defined(GBM_BO_USE_LINEAR)
+#if defined(GLAMOR) && defined(GBM_HAVE_BO_USE_LINEAR)
         if (value & DRM_PRIME_CAP_EXPORT && ms->drmmode.glamor)
             pScrn->capabilities |= RR_Capability_SourceOutput | RR_Capability_SourceOffload;
 #endif

--- a/hw/xfree86/drivers/video/modesetting/drmmode_bo.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_bo.c
@@ -27,11 +27,11 @@ typedef struct {
     Bool used_modifiers;
 } bo_priv_t;
 
-#ifndef GBM_BO_USE_LINEAR
+#ifndef GBM_HAVE_BO_USE_LINEAR
 #define GBM_BO_USE_LINEAR 0
 #endif
 
-#ifndef GBM_BO_USE_FRONT_RENDERING
+#ifndef GBM_HAVE_BO_USE_FRONT_RENDERING
 #define GBM_BO_USE_FRONT_RENDERING 0
 #endif
 

--- a/include/meson.build
+++ b/include/meson.build
@@ -112,6 +112,10 @@ conf_data.set('GBM_BO_FD_FOR_PLANE',
               build_glamor and gbm_dep.found() and gbm_dep.version().version_compare('>= 21.1') ? '1' : false)
 conf_data.set('GBM_BO_WITH_MODIFIERS2',
               build_glamor and gbm_dep.found() and gbm_dep.version().version_compare('>= 21.3') ? '1' : false)
+conf_data.set('GBM_HAVE_BO_USE_LINEAR',
+              build_glamor and gbm_dep.found() and cc.has_header_symbol('gbm.h', 'GBM_BO_USE_LINEAR', dependencies : gbm_dep )  ? '1' : false)
+conf_data.set('GBM_HAVE_BO_USE_FRONT_RENDERING',
+              build_glamor and gbm_dep.found() and cc.has_header_symbol('gbm.h','GBM_BO_USE_FRONT_RENDERING', dependencies: gbm_dep ) ? '1' : false)
 
 conf_data.set_quoted('SERVER_MISC_CONFIG_PATH', serverconfigdir)
 conf_data.set_quoted('PROJECTROOT', get_option('prefix'))


### PR DESCRIPTION
Apparently the enum values cannot be checked during preprocessor phase. Fix it with checking gbm version using meson and defining additional symbols which are visible during compile time.

before pr:
```
xrandr --listproviders
Providers: number : 2
Provider 0: id: 0x47 cap: 0xa, Sink Output, Sink Offload crtcs: 4 outputs: 5 associated providers: 0 name:modesetting
Provider 1: id: 0x87 cap: 0xa, Sink Output, Sink Offload crtcs: 4 outputs: 4 associated providers: 0 name:modesetting
```

after pr:
```
Providers: number : 2
Provider 0: id: 0x47 cap: 0xf, Source Output, Sink Output, Source Offload, Sink Offload crtcs: 4 outputs: 5 associated providers: 1 name:modesetting
Provider 1: id: 0x87 cap: 0xf, Source Output, Sink Output, Source Offload, Sink Offload crtcs: 4 outputs: 4 associated providers: 1 name:modesetting
```
