### PR TITLE
hw/xfree86/compat: rename 10-nvidia.conf.in to 10-xlibre-nvidia.conf.in

### DIFF
--- a/hw/xfree86/compat/10-nvidia-modules.conf.in
+++ b/hw/xfree86/compat/10-nvidia-modules.conf.in
@@ -1,16 +1,16 @@
-# This xorg.conf.d configuration snippet configures the X server to
-# automatically load the nvidia X driver when it detects a device
-# driven by the nvidia-drm kernel driver.
+# This xorg.conf.d configuration snippet is a supplement to
+# 10-nvidia.conf that sets module paths for nvidia GLX libraries
+# when it detects a device driven by the nvidia-drm kernel driver.
 # Please note that this works on Linux kernels version 6.12 or higher
 # with CONFIG_DRM enabled, and only if the nvidia-drm.ko kernel module
 # for the versions 390 and later of the nvidia driver or the nvidia.ko
 # kernel module for the version 340 is loaded before the X server is started.
 
 Section "OutputClass"
-        Identifier "NVidia"
+        Identifier "NVidia-modules"
         MatchDriver "nvidia-drm"
-        Driver "nvidia"
-        Option "AllowEmptyInitialConfiguration"
+        Module "glx"
+        Module "glxserver_nvidia"
         ModulePath "@libdir@/nvidia/xorg"
         ModulePath "/usr/lib/x86_64-linux-gnu/nvidia/xorg" # libdir depends on --prefix
         ModulePath "/usr/lib/nvidia/nvidia"

--- a/hw/xfree86/compat/10-nvidia-modules.conf.in
+++ b/hw/xfree86/compat/10-nvidia-modules.conf.in
@@ -1,13 +1,13 @@
-# This xorg.conf.d configuration snippet configures the X server to
-# automatically load the nvidia X driver and nvidia GLX libraries
+# This xorg.conf.d configuration snippet is a supplement to 
+# 10-nvidia.conf that sets module paths for nvidia GLX libraries
 # when it detects a device driven by nvidia-drm.ko kernel module.
 # Please note that this works on Linux kernels version 6.12 or higher
 # with CONFIG_DRM enabled, and only if the nvidia-drm.ko kernel module
 # is loaded before the X server is started.
 
 Section "OutputClass"
-	Identifier "NVidia"
-	MatchDriver "nvidia-drm"
-	Driver "nvidia"
-	Option "AllowEmptyInitialConfiguration"
+        Identifier "NVidia-modules"
+        MatchDriver "nvidia-drm"
+        Module "glx"
+        Module "glxserver_nvidia"
 EndSection

--- a/hw/xfree86/compat/meson.build
+++ b/hw/xfree86/compat/meson.build
@@ -27,3 +27,9 @@ configure_file(
     configuration: nvidia_conf,
     install_dir: join_paths(get_option('datadir'), 'X11/xorg.conf.d'),
 )
+configure_file(
+    input: '10-nvidia-modules.conf.in',
+    output: '10-nvidia-modules.conf',
+    configuration: nvidia_conf,
+    install_dir: join_paths(get_option('datadir'), 'X11/xorg.conf.d'),
+)

--- a/hw/xfree86/compat/meson.build
+++ b/hw/xfree86/compat/meson.build
@@ -20,10 +20,17 @@ xorg_compat = static_library('xorg_compat',
 install_data('10-quirks.conf',
              install_dir: join_paths(get_option('datadir'), 'X11/xorg.conf.d'))
 nvidia_conf = configuration_data()
-nvidia_conf.set('libdir', join_paths(get_option('prefix'),get_option('libdir')))
+
 configure_file(
     input: '10-nvidia.conf.in',
     output: '10-nvidia.conf',
+    configuration: nvidia_conf,
+    install_dir: join_paths(get_option('datadir'), 'X11/xorg.conf.d'),
+)
+
+configure_file(
+    input: '10-nvidia-modules.conf.in',
+    output: '10-nvidia-modules.conf',
     configuration: nvidia_conf,
     install_dir: join_paths(get_option('datadir'), 'X11/xorg.conf.d'),
 )


### PR DESCRIPTION
Devuan users report that  vendor driver (such as xserver-xorg-video-nvidia-595 package) overwrites  10-nvidia.conf file. This patch renames to 10-xlibre-nvidia.conf.in as suggested by @chankongus user.

Closes: https://github.com/X11Libre/xserver/issues/2166


