### PR TITLE
glx: avoid null dereference in validGlxFBConfigForWindow()

### DIFF
--- a/glx/glxcmds.c
+++ b/glx/glxcmds.c
@@ -127,7 +127,8 @@ validGlxFBConfigForWindow(ClientPtr client, __GLXconfig * config,
     BUG_RETURN_VAL(!pVisual, FALSE);
 
     /* FIXME: What exactly should we check here... */
-    if (pVisual->class != glxConvertToXVisualType(config->visualType) ||
+    if (pVisual == NULL ||
+        pVisual->class != glxConvertToXVisualType(config->visualType) ||
         !(config->drawableType & GLX_WINDOW_BIT)) {
         client->errorValue = pDraw->id;
         *err = BadMatch;


### PR DESCRIPTION
Reported in #1817:

xwayland-24.1.6/redhat-linux-build/../glx/glxcmds.c:126:9:
 warning[-Wanalyzer-null-dereference]: dereference of NULL ‘pVisual’

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2160>
