### PR TITLE
rootless: Fix Glyphs damage bounding box to correctly compute union

### DIFF
--- a/miext/rootless/rootlessScreen.c
+++ b/miext/rootless/rootlessScreen.c
@@ -315,8 +315,8 @@ RootlessGlyphs(CARD8 op, PicturePtr pSrc, PicturePtr pDst,
                     x2 = x1 + glyph->info.width;
                     y2 = y1 + glyph->info.height;
 
-                    box.x1 = max(box.x1, x1);
-                    box.y1 = max(box.y1, y1);
+                    box.x1 = min(box.x1, x1);
+                    box.y1 = min(box.y1, y1);
                     box.x2 = max(box.x2, x2);
                     box.y2 = max(box.y2, y2);
 


### PR DESCRIPTION
RootlessGlyphs used max() for box.x1 and box.y1 when accumulating the
bounding box across glyphs in a list.  Computing the union of bounding
boxes requires min() for the lower coordinate corner and max for the
higher coordinate corner.

Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
