### PR TITLE
os: fix sha1 build error with Nettle 4.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -421,7 +421,7 @@ foreach t : test_sha1
             sha1_dep = libsha1_dep
         endif
     elif t == 'libnettle'
-        nettle_dep = dependency('nettle', required: false)
+        nettle_dep = dependency('nettle', version: '>= 2.6', required: false)
         if nettle_dep.found()
             sha1_found = true
             sha1_dep = nettle_dep

--- a/os/xsha1.c
+++ b/os/xsha1.c
@@ -152,7 +152,8 @@ x_sha1_final(void *ctx, unsigned char result[20])
 
 #elif defined(HAVE_SHA1_IN_LIBNETTLE)   /* Use libnettle for SHA1 */
 
-#include <nettle/sha.h>
+#include <nettle/sha1.h>
+#include <nettle/version.h>
 
 void *
 x_sha1_init(void)
@@ -175,7 +176,11 @@ x_sha1_update(void *ctx, void *data, int size)
 int
 x_sha1_final(void *ctx, unsigned char result[20])
 {
+#if NETTLE_VERSION_MAJOR < 4
     sha1_digest(ctx, 20, result);
+#else
+    sha1_digest(ctx, result);
+#endif
     free(ctx);
     return 1;
 }


### PR DESCRIPTION
Nettle 2.6 (released in 2013) split the sha.h header into sha1.h & sha2.h,
but left the sha.h header for compatibility until the recent Nettle 4.0
release finally removed it.

Nettle 4.0 also dropped the length argument from the sha1_digest function.

Closes: #1871
Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2133>
