### PR TITLE
config: Fix compiler warning

### DIFF
--- a/config/udev.c
+++ b/config/udev.c
@@ -483,7 +483,7 @@ static char *strrstr(const char *haystack, const char *needle)
 {
     char *prev, *last, *tmp;
 
-    prev = strstr(haystack, needle);
+    prev = (char *) strstr(haystack, needle);
     if (!prev)
         return NULL;
 


### PR DESCRIPTION
Compiler complains that:

 | config/udev.c: In function ‘strrstr’:
 | config/udev.c:485:10: warning: assignment discards ‘const’ qualifier
 |                    from pointer target type [-Wdiscarded-qualifiers]
 | 485 |     prev = strstr(haystack, needle);
 |     |          ^

Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2152>
