### PR TITLE
render: handle -Wanalyzer-null-dereference in AllocateGlyphHash()

### DIFF
--- a/render/glyph.c
+++ b/render/glyph.c
@@ -386,7 +386,8 @@ AllocateGlyph(xGlyphInfo * gi, int fdepth)
 static Bool
 AllocateGlyphHash(GlyphHashPtr hash, GlyphHashSetPtr hashSet)
 {
-    assert(hashSet);
+    if (hashSet == NULL)
+        return FALSE;
     hash->table = calloc(hashSet->size, sizeof(GlyphRefRec));
     if (!hash->table)
         return FALSE;


### PR DESCRIPTION
Reported in #1817:
xwayland-24.1.6/redhat-linux-build/../render/glyph.c:388:26:
 warning[-Wanalyzer-null-dereference]: dereference of NULL ‘hashSet’

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2166>
