### PR TITLE
tests: plug leak of results in compute_expected_damage()

### DIFF
--- a/test/damage/primitives.c
+++ b/test/damage/primitives.c
@@ -106,6 +106,7 @@ compute_expected_damage(struct test_setup *setup)
 
     /* Make sure that the testcases actually render something! */
     assert(any_modified_pixels);
+    free(results);
 }
 
 /**


### PR DESCRIPTION
Reported in #1817:
xwayland-24.1.6/redhat-linux-build/../test/damage/primitives.c:68:43:
 warning[-Wanalyzer-malloc-leak]: leak of ‘get_image(setup, *setup.d)’

Fixes: 89901e14d ("test: Add the start of a testsuite for damage.")
Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2167>
