### PR TITLE
fb: quiet -Wanalyzer-out-of-bounds warnings in fbOverlayCopyWindow()

### DIFF
--- a/fb/fboverlay.c
+++ b/fb/fboverlay.c
@@ -24,6 +24,7 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <stdlib.h>
 
 #include "include/shmint.h"
@@ -210,6 +211,7 @@ fbOverlayCopyWindow(WindowPtr pWin, xPoint ptOldOrg, RegionPtr prgnSrc)
     /*
      * Compute the portion of each fb affected by this copy
      */
+    assert(pScrPriv->nlayers <= FB_OVERLAY_MAX);
     for (i = 0; i < pScrPriv->nlayers; i++) {
         RegionNull(&layerRgn[i]);
         RegionIntersect(&layerRgn[i], &rgnDst,


### PR DESCRIPTION
Reported in #1817:

xwayland-24.1.6/redhat-linux-build/../fb/fboverlay.c:230:13:
 warning[-Wanalyzer-out-of-bounds]: stack-based buffer over-read
xwayland-24.1.6/redhat-linux-build/../fb/fboverlay.c:233:9:
 warning[-Wanalyzer-out-of-bounds]: stack-based buffer over-read

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2162>
