### PR TITLE
present: prevent memory leaks in present_create_notifies()

### DIFF
--- a/present/present_notify.c
+++ b/present/present_notify.c
@@ -78,6 +78,13 @@ present_create_notifies(ClientPtr client, int num_notifies, xPresentNotify *x_no
     int                 added = 0;
     int                 status;
 
+    if (num_notifies <= 0) {
+        if (num_notifies == 0)
+            return Success;
+        else
+            return BadLength;
+    }
+
     notifies = calloc (num_notifies, sizeof (present_notify_rec));
     if (!notifies)
         return BadAlloc;


### PR DESCRIPTION
Reported in #1817:
xwayland-24.1.6/redhat-linux-build/../present/present_notify.c:83:17:
 warning[-Wanalyzer-malloc-leak]: leak of ‘notifies’
xwayland-24.1.6/redhat-linux-build/../present/present_notify.c:83:17:
 branch_false: following ‘false’ branch (when ‘i >= num_notifies’)...

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2164>
