### PR TITLE
.github: fix XTS build on MacOS

### DIFF
--- a/.github/scripts/install-prereq.sh
+++ b/.github/scripts/install-prereq.sh
@@ -17,7 +17,7 @@ if [ "$X11_OS" = "Darwin" ]; then
 build_ac      xset              $(fdo_mirror xset)                         xset-1.2.5
 fi
 # really must be build via autoconf instead of meson, otherwise piglit wont find the test programs
-build_ac_xts  xts               $(fdo_mirror xts)                          12a887c2c72c4258962b56ced7b0aec782f1ffed
+build_ac_xts  xts               $(fdo_mirror xts)                          hotfix/for-macos-and-25.0
 
 clone_source piglit             $(fdo_mirror piglit)                       28d1349844eacda869f0f82f551bcd4ac0c4edfe
 

--- a/.github/scripts/util.sh
+++ b/.github/scripts/util.sh
@@ -1,6 +1,8 @@
 
 . .github/scripts/conf.sh
 
+[ "$X11_INSTALL_PREFIX" ] || X11_INSTALL_PREFIX="$X11_PREFIX"
+
 SOURCE_DIR=`pwd`
 
 clone_source() {
@@ -41,13 +43,14 @@ build_ac() {
     shift
     shift
     shift || true
+    mkdir -p $X11_PREFIX
     if [ -f $X11_PREFIX/$pkgname.DONE ]; then
         echo "package $pkgname already built"
     else
         clone_source "$pkgname" "$url" "$ref"
         (
             cd $pkgname
-            ./autogen.sh --prefix=$X11_PREFIX
+            ./autogen.sh --prefix=$X11_INSTALL_PREFIX
             make -j${FDO_CI_CONCURRENT:-4} install
         )
         touch $X11_PREFIX/$pkgname.DONE
@@ -85,23 +88,7 @@ build_ac_xts() {
             cd $pkgname
             CFLAGS='-fcommon'
             if [ "$X11_OS" = "Darwin" ]; then
-                # xts5/include/XtTest.h includes <X11/Intrinsic.h> => needs xt
-                # xts5/src/libXtaw/*.c include <X11/Xaw/*.h> and <X11/Xmu/*.h> => need xmu and xaw7
-                sed -E -i~ 's|(\[XTS\], \[)|\1xt xmu xaw7 |' configure.ac
-                # xts5/Xlib14/X{mb,wc}TextListToTextProperty.m define a function accepting `XTextProperty` but call it passing
-                #`XTextProperty*`; since the parameter is seemingly meant for output, accept it as pointer
-                sed -E -i~ -e 's|(XTextProperty)[[:space:]]+(text_prop_good)|\1 *\2|' -e 's|(style_good),[[:space:]]*&(text_prop_good)|\1,\2|' -e 's|text_prop_good\.|text_prop_good->|' xts5/Xlib14/X{mb,wc}TextListToTextProperty.m
-                # xts5/Xlib*/*.m forward-declare `strcpy()` which is incompatible with _FORTIFY_SOURCE > 0 where `strcpy` is
-                # a macro; set _FORTIFY_SOURCE to 0 as we don't care much about security in this test code
-                CFLAGS="$CFLAGS -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0"
-                # declarations for `XtAppSetError{,Msg}Handler()` in <X11/Intrinsic.h> (libXt) make it hard to write warning-
-                # free code: they want a noreturn-annotated handler as input but return old handler without noreturn annotation,
-                # so e.g. `XtAppSetErrorHandler(XtAppSetErrorHandler(NULL))` (similar to xts5/Xt13/XtAppSetError*Handler.m)
-                # doesn't compile complaining about incompatible function pointers, at least with Apple Clang 16 (not sure why
-                # it treats this warning as error by default though)
-                if cc -Werror=unknown-warning-option -Wincompatible-function-pointer-types -c -xc -o /dev/null /dev/null 2>/dev/null; then
-                    CFLAGS="$CFLAGS -Wno-error=incompatible-function-pointer-types"
-                fi
+                CFLAGS="$CFLAGS -Wno-error=incompatible-function-pointer-types"
             fi
             ./autogen.sh --prefix=$X11_PREFIX CFLAGS="$CFLAGS"
             if [ "$X11_OS" = "Darwin" ]; then


### PR DESCRIPTION
For strange reasons, our MacOS build breaks old XTS code, due their
compiler suddenly not accepting old K&R style function declarations.
(weird: that happens only on the 25.0 release, not newer ones, even
they're using the same build hosts and XTS revisions).

Fixing this by adding a special hotfix branch on our XTS mirror,
where all old K&S style function declations have been converted
to modern ones.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
