### PR TITLE
glamor/glamor_egl: xfree86/glamor_egl: try more egl platforms

### DIFF
--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -32,6 +32,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 #include <errno.h>
 
 #ifdef WITH_LIBDRM
@@ -51,6 +52,7 @@
 
 #include "glamor.h"
 #include "glamor_egl.h"
+#include "glamor_egl_ext.h"
 #include "glamor_glx_provider.h"
 #include "dri3.h"
 
@@ -1242,6 +1244,212 @@ glamor_egl_screen_init(ScreenPtr screen, struct glamor_context *glamor_ctx)
 #endif
 }
 
+static Bool
+glamor_query_devices_ext(EGLDeviceEXT **devices, EGLint *num_devices)
+{
+    EGLint max_devices = 0;
+
+    *devices = NULL;
+    *num_devices = 0;
+
+    if (!epoxy_has_egl_extension(NULL, "EGL_EXT_device_base") &&
+        !(epoxy_has_egl_extension(NULL, "EGL_EXT_device_query") &&
+          epoxy_has_egl_extension(NULL, "EGL_EXT_device_enumeration"))) {
+        return FALSE;
+    }
+
+    if (!eglQueryDevicesEXT(0, NULL, &max_devices) || max_devices < 1) {
+         return FALSE;
+    }
+
+    *devices = calloc(max_devices, sizeof(**devices));
+    if (*devices == NULL) {
+         return FALSE;
+    }
+
+    if (!eglQueryDevicesEXT(max_devices, *devices, num_devices) || *num_devices < 1) {
+         free(*devices);
+         *devices = NULL;
+         *num_devices = 0;
+         return FALSE;
+    }
+
+    if (*num_devices < max_devices) {
+         /* Shouldn't happen */
+         void *tmp = realloc(*devices, *num_devices * sizeof(**devices));
+         if (tmp) {
+             *devices = tmp;
+         }
+    }
+
+    return TRUE;
+}
+
+/* Perhaps we should move this function to os/ ? */
+static inline Bool
+glamor_egl_device_matches_fd(EGLDeviceEXT device, int fd)
+{
+    const char *dev_file = eglQueryDeviceStringEXT(device, EGL_DRM_DEVICE_FILE_EXT);
+    if (!dev_file) {
+        return FALSE;
+    }
+
+    int dev_fd = open(dev_file, O_RDWR);
+    if (dev_fd < 0) {
+        return FALSE;
+    }
+
+    /**
+     * From https://pubs.opengroup.org/onlinepubs/009696699/basedefs/sys/stat.h.html
+     *
+     * The st_ino and st_dev fields taken together uniquely identify the file within the system.
+     */
+    struct stat stat1, stat2;
+    if(fstat(dev_fd, &stat2) < 0) {
+        close(dev_fd);
+        return FALSE;
+    }
+
+    close(dev_fd);
+
+    if(fstat(fd, &stat1) < 0) {
+        return FALSE;
+    }
+
+    return (stat1.st_dev == stat2.st_dev) && (stat1.st_ino == stat2.st_ino);
+}
+
+static inline const char*
+glamor_egl_device_get_name(EGLDeviceEXT device)
+{
+/**
+ * For some reason, this isn't part of the epoxy headers.
+ * It is part of EGL/eglext.h, but we can't include that
+ * alongside the epoxy headers.
+ *
+ * See: https://registry.khronos.org/EGL/extensions/EXT/EGL_EXT_device_persistent_id.txt
+ * for the spec where this is defined
+ */
+#ifndef EGL_DRIVER_NAME_EXT
+#define EGL_DRIVER_NAME_EXT 0x335E
+#endif
+
+/**
+ * Same for this one
+ *
+ * See: https://registry.khronos.org/EGL/extensions/EXT/EGL_EXT_device_query_name.txt
+ * for the spec where this is defined
+ */
+#ifndef EGL_RENDERER_EXT
+#define EGL_RENDERER_EXT 0x335F
+#endif
+
+    const char *dev_ext = eglQueryDeviceStringEXT(device, EGL_EXTENSIONS);
+
+    const char *driver_name = epoxy_extension_in_string(dev_ext, "EGL_EXT_device_persistent_id") ?
+                              eglQueryDeviceStringEXT(device, EGL_DRIVER_NAME_EXT) : NULL;
+
+    if (driver_name) {
+        return driver_name;
+    }
+
+    /* This might seem like overkill, but it's actually needed for the nvidia 470 driver */
+    if (epoxy_extension_in_string(dev_ext, "EGL_EXT_device_query_name")) {
+        const char *egl_renderer = eglQueryDeviceStringEXT(device, EGL_RENDERER_EXT);
+        if (egl_renderer) {
+            return strstr(egl_renderer, "NVIDIA") ? "nvidia" : "mesa";
+        }
+        const char *egl_vendor = eglQueryDeviceStringEXT(device, EGL_VENDOR);
+        if (egl_vendor) {
+            return strstr(egl_vendor, "NVIDIA") ? "nvidia" : "mesa";
+        }
+    }
+
+    return NULL;
+}
+
+/**
+ * Find the desired EGLDevice for our config.
+ *
+ * If strict == 2, we are looking for EGLDevices with names and,
+ * if a glvnd vendor was passed, an exact match between the
+ * device's name, and the desired vendor.
+ *
+ * If strict == 1, we are looking for EGLDevices with names and,
+ * if a glvnd vendor was passed, a match between the gl vendor library
+ * provider and the desired vendor's library.
+ *
+ * If strict == 0, we accept all devices, even those with no names.
+ *
+ * Regardless of success/failure, and regardless of strictness level,
+ * we save the statically allocated string with the EGLDevice's name
+ * in *driver_name, even if that name is NULL.
+ */
+static inline Bool
+glamor_egl_device_matches_config(EGLDeviceEXT device,
+                                 glamor_egl_priv_t *glamor_egl,
+                                 int strict,
+                                 const char** driver_name)
+{
+    *driver_name = glamor_egl_device_get_name(device);
+
+    /**
+     * If we're trying to do direct rendering,
+     * we can't have a mismatch between the gpu and the device we pick
+     *
+     * If not, we don't have any strict requirements for out device
+     */
+    if (glamor_egl->fd >= 0 &&
+        !glamor_egl_device_matches_fd(device, glamor_egl->fd)) {
+        return FALSE;
+    }
+
+    /* We have no further requirements, mark this as valid */
+    if (strict <= 0) {
+        return TRUE;
+    }
+
+    /* From here on, strict >= 1, we want the device to have a name */
+    if (*driver_name == NULL) {
+        return FALSE;
+    }
+
+    /* No glvnd vendor was requested, we have no further requirements */
+    if (!glamor_egl->glvnd_vendor) {
+        return TRUE;
+    }
+
+    /**
+     * A glvnd vendor was requested.
+     * Check for an exact match between the driver name and the requested
+     * vendor.
+     *
+     * We're looking for _driver_ names, not library names here.
+     * If we find an exact match, that's the most we ask.
+     */
+    if (!strcmp(*driver_name, glamor_egl->glvnd_vendor)) {
+        return TRUE;
+    }
+
+    /* We don't have an exact driver name match, reject this device is strict == 2 */
+    if (strict >= 2) {
+        return FALSE;
+    }
+
+    /**
+     * Here, strict == 1
+     * We're looking for a glvnd library name match.
+     *
+     * This is not specific to nvidia,
+     * but I don't know of any gl library vendors
+     * other than mesa and nvidia
+     */
+    Bool device_is_nvidia = !!strstr(*driver_name, "nvidia");
+    Bool config_is_nvidia = !!strstr(glamor_egl->glvnd_vendor, "nvidia");
+
+    return device_is_nvidia == config_is_nvidia;
+}
+
 static void
 glamor_egl_pre_close_screen_cleanup(glamor_egl_priv_t *glamor_egl)
 {
@@ -1378,10 +1586,113 @@ gbm_create_device_by_name(int fd, const char* name)
 }
 #endif
 
+static Bool
+glamor_egl_init_display(struct glamor_egl_screen_private *glamor_egl)
+{
+    EGLDeviceEXT *devices = NULL;
+    EGLint num_devices = 0;
+    const char *driver_name = NULL;
+    /**
+     * If the user didn't give us a GL driver/library name,
+     * we populate it with what we queried
+     */
+#define GLAMOR_EGL_TRY_PLATFORM(platform, native, platform_fallback) \
+    glamor_egl->display = glamor_egl_get_display2(platform, native, platform_fallback); \
+    if (glamor_egl->display == EGL_NO_DISPLAY) { \
+        LogMessage(X_ERROR, "eglGetDisplay(" #platform ", " #native ") failed\n"); \
+    } else { \
+        if (eglInitialize(glamor_egl->display, NULL, NULL)) { \
+            if (!glamor_egl->glvnd_vendor && driver_name) { \
+                glamor_egl->glvnd_vendor = strdup(driver_name); \
+            } \
+            LogMessage(X_INFO, "eglInitialize() succeeded on " #platform "\n"); \
+            free(devices); \
+            return TRUE; \
+        } \
+        LogMessage(X_ERROR, "eglInitialize() failed on " #platform "\n"); \
+        eglTerminate(glamor_egl->display); \
+        glamor_egl->display = EGL_NO_DISPLAY; \
+    }
+
+#ifdef GLAMOR_HAS_GBM
+    if (glamor_egl->fd >= 0) {
+        GLAMOR_EGL_TRY_PLATFORM(EGL_PLATFORM_GBM_KHR, glamor_egl->gbm, FALSE);
+        GLAMOR_EGL_TRY_PLATFORM(EGL_PLATFORM_GBM_MESA, glamor_egl->gbm, TRUE);
+    }
+#endif
+
+    if (glamor_query_devices_ext(&devices, &num_devices)) {
+#define GLAMOR_EGL_TRY_PLATFORM_DEVICE(strict) \
+        for (uint32_t i = 0; i < num_devices; i++) { \
+            if (glamor_egl_device_matches_config(devices[i], glamor_egl, strict, &driver_name)) { \
+                GLAMOR_EGL_TRY_PLATFORM(EGL_PLATFORM_DEVICE_EXT, devices[i], TRUE); \
+            } \
+        }
+
+        GLAMOR_EGL_TRY_PLATFORM_DEVICE(2);
+        GLAMOR_EGL_TRY_PLATFORM_DEVICE(1);
+        GLAMOR_EGL_TRY_PLATFORM_DEVICE(0);
+
+#undef GLAMOR_EGL_TRY_PLATFORM_DEVICE
+    }
+    driver_name = NULL;
+
+    /**
+     * We only try these falbacks if we don't have an fd passed, since we
+     * have to do some guessing anyway to find the desired gpu.
+     *
+     * Trying these in multi-card setups risks a screen driven by one card
+     * being mapped a, EGLDisplay backed by a different card, which can break.
+     *
+     * We actualy can specify the device using EGL_EXT_explicit_device:
+     * https://registry.khronos.org/EGL/extensions/EXT/EGL_EXT_explicit_device.txt
+     *
+     * However, it doesn't seem worth it to implement this fallback, given
+     * we're already trying the device platform, and the extension is
+     * relatively new (2022), which means that it will be missing on a lot of cards.
+     */
+    if (glamor_egl->fd < 0) {
+        GLAMOR_EGL_TRY_PLATFORM(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, FALSE);
+
+        /**
+         * From https://registry.khronos.org/EGL/extensions/KHR/EGL_KHR_platform_gbm.txt
+         *
+         * If <native_display> is EGL_DEFAULT_DISPLAY,
+         * then the resultant EGLDisplay will be backed by some
+         * implementation-chosen GBM device.
+         */
+        GLAMOR_EGL_TRY_PLATFORM(EGL_PLATFORM_GBM_KHR, EGL_DEFAULT_DISPLAY, FALSE);
+        GLAMOR_EGL_TRY_PLATFORM(EGL_PLATFORM_GBM_MESA, EGL_DEFAULT_DISPLAY, FALSE);
+
+        /**
+         * According to https://registry.khronos.org/EGL/extensions/EXT/EGL_EXT_platform_device.txt :
+         *
+         * When <platform> is EGL_PLATFORM_DEVICE_EXT, <native_display> must
+         * be an EGLDeviceEXT object.  Platform-specific extensions may
+         * define other valid values for <platform>.
+         *
+         * As far as I know, this is the relevant standard, and it has not been superceeded in this regard.
+         * However, some vendors do allow passing EGL_DEFAULT_DISPLAY as the <native_display> argument.
+         * So, while this is incorrect according to the standard, it doesn't hurt, and it actually does
+         * something with some vendors (notably intel from my testing).
+         */
+        GLAMOR_EGL_TRY_PLATFORM(EGL_PLATFORM_DEVICE_EXT, EGL_DEFAULT_DISPLAY, TRUE);
+    }
+
+#undef GLAMOR_EGL_TRY_PLATFORM
+
+    free(devices);
+    return FALSE;
+}
+
 Bool
-glamor_egl_init_internal(glamor_egl_priv_t* glamor_egl)
+glamor_egl_init_internal(glamor_egl_priv_t* glamor_egl, Bool *compat_ret)
 {
     const GLubyte *renderer;
+
+    if (compat_ret) {
+        *compat_ret = TRUE;
+    }
 
     glamor_egl_get_screen_private = glamor_egl->GLAMOR_EGL_PRIV_PROC;
 
@@ -1394,26 +1705,21 @@ glamor_egl_init_internal(glamor_egl_priv_t* glamor_egl)
 
         if (glamor_egl->gbm == NULL) {
             ErrorF("couldn't create gbm device\n");
-            goto error;
+            glamor_egl->fd = -1;
+            if (compat_ret) {
+                *compat_ret = FALSE;
+            }
         }
 
-        const char* gbm_backend = gbm_device_get_backend_name(glamor_egl->gbm);
+        const char* gbm_backend = glamor_egl->gbm ?
+                                  gbm_device_get_backend_name(glamor_egl->gbm) : NULL;
         if (gbm_backend && !strcmp(gbm_backend, "dumb")) {
             glamor_egl->linear_only = TRUE;
         }
     }
 #endif
 
-    glamor_egl->display = glamor_egl_get_display(EGL_PLATFORM_GBM_MESA,
-                                                 glamor_egl->gbm);
-    if (!glamor_egl->display) {
-        LogMessage(X_ERROR, "eglGetDisplay() failed\n");
-        goto error;
-    }
-
-    if (!eglInitialize(glamor_egl->display, NULL, NULL)) {
-        LogMessage(X_ERROR, "eglInitialize() failed\n");
-        glamor_egl->display = EGL_NO_DISPLAY;
+    if (!glamor_egl_init_display(glamor_egl)) {
         goto error;
     }
 

--- a/glamor/glamor_egl.h
+++ b/glamor/glamor_egl.h
@@ -31,7 +31,6 @@
 #define EGL_NO_X11
 #include <epoxy/gl.h>
 #include <epoxy/egl.h>
-#include <glamor_egl_ext.h>
 
 #include "scrnintstr.h"
 
@@ -67,7 +66,7 @@ typedef struct glamor_egl_screen_private {
 void glamor_egl_cleanup(glamor_egl_priv_t *glamor_egl);
 
 /* Initialize an egl context suitable to be used by glamor. */
-Bool glamor_egl_init_internal(glamor_egl_priv_t* glamor_egl);
+Bool glamor_egl_init_internal(glamor_egl_priv_t* glamor_egl, Bool *compat_ret);
 
 /*
  * Create an EGLDisplay from a native display type. This is a little quirky

--- a/hw/xfree86/glamor_egl/glamor_xf86_egl.c
+++ b/hw/xfree86/glamor_egl/glamor_xf86_egl.c
@@ -95,10 +95,12 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
         glamor_egl->dmabuf_capable = !!strstr(xf86Info.debug,
                                               "dmabuf_capable");
 
-    if (glamor_egl_init_internal(glamor_egl)) {
+    Bool compat_ret = TRUE;
+
+    if (glamor_egl_init_internal(glamor_egl, &compat_ret)) {
         glamor_egl->saved_free_screen = scrn->FreeScreen;
         scrn->FreeScreen = glamor_xf86_egl_free_screen;
-        return TRUE;
+        return compat_ret;
     }
 
     free(glamor_egl);


### PR DESCRIPTION
With this, glamor_egl now tries the platforms
`EGL_PLATFORM_GBM_{KHR,MESA}`, `EGL_PLATFORM_DEVICE_EXT`, and `EGL_PLATFORM_SURFACELESS_MESA`

`EGL_PLATFORM_SURFACELESS_MESA` is used as a fallback, and is probably not very useful in practice, since if it is supported, the GBM or Device platform is probably also supported.

After it, we try all platforms with `EGL_DEFAULT_DISPLAY` as the `native_display` argument.

Like Surfaceless, there are probably not very useful, and are there as a last-resort fallback path if we're sure they cannot break anything.

These fallbacks only take up 6 extra lines of code (excluding comments), and they allow us to be robust with our fallback paths.

The interesting platform in this patch is `EGL_PLATFORM_DEVICE_EXT` This one can be used without a dri fd, and is the only plaform supported on old nvidia cards (<= nvidia-470), regardless of whether a dri fd is passed or not.

As a side note, while I don't currently have any
concete plans, this is a step forward towards `EGLStream` support.

A further patch will add support for the nvidia-390 driver, since it does not support `EGL_KHR_no_config_context`, which glamor currently requires.

For related Xwayland `EGLStream` code, see:
https://gitlab.freedesktop.org/xorg/xserver/-/commit/feb35a2e6b0357bcbdb77ad10c3b8285c0e2f055

Though not very useful, here are the previous iterations of the patch:

v3: https://github.com/X11Libre/xserver/pull/2083

v2: https://github.com/X11Libre/xserver/pull/1758

v1: https://github.com/X11Libre/xserver/pull/1729