### PR TITLE
(release/25.0) pr/render fix multiple mem leaks on err paths  2026 04 18 16 41 38

### DIFF
--- a/render/picture.c
+++ b/render/picture.c
@@ -900,6 +900,7 @@ CreateLinearGradientPicture(Picture pid, xPointFixed * p1, xPointFixed * p2,
 
     initGradient(pPicture->pSourcePict, nStops, stops, colors, error);
     if (*error) {
+        free(pPicture->pSourcePict);
         free(pPicture);
         return 0;
     }
@@ -945,6 +946,7 @@ CreateRadialGradientPicture(Picture pid, xPointFixed * inner,
 
     initGradient(pPicture->pSourcePict, nStops, stops, colors, error);
     if (*error) {
+        free(pPicture->pSourcePict);
         free(pPicture);
         return 0;
     }
@@ -983,6 +985,7 @@ CreateConicalGradientPicture(Picture pid, xPointFixed * center, xFixed angle,
 
     initGradient(pPicture->pSourcePict, nStops, stops, colors, error);
     if (*error) {
+        free(pPicture->pSourcePict);
         free(pPicture);
         return 0;
     }


### PR DESCRIPTION
Free nested allocations when initialization fails.
Several code paths returned early on error without releasing
memory owned by embedded structures, leading to leaks.

Found by Linux Verification Center (linuxtesting.org) with SVACE.

Signed-off-by: Mikhail Dmitrichenko <m.dmitrichenko222@gmail.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2125>
