### PR TITLE
(release/25.0) composite: fix potential mem leak in PanoramiXCompositeNameWindowPixmap

### DIFF
--- a/composite/compext.c
+++ b/composite/compext.c
@@ -761,8 +761,10 @@ ProcCompositeNameWindowPixmap(ClientPtr client)
             return BadMatch;
         }
 
-        if (!AddResource(newPix->info[i].id, X11_RESTYPE_PIXMAP, (void *) pPixmap))
+        if (!AddResource(newPix->info[i].id, X11_RESTYPE_PIXMAP, (void *) pPixmap)) {
+            free(newPix);
             return BadAlloc;
+        }
 
         ++pPixmap->refcnt;
     }


### PR DESCRIPTION
newPix leaks if AddResource() call failes inside the FOR_NSCREENS
loop (per-screen pixmap IDs).

free newPix in mentioned execution path to prevent potential leak.

Found by Linux Verification Center (linuxtesting.org) with SVACE.

Signed-off-by: Mikhail Dmitrichenko <m.dmitrichenko222@gmail.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2173>
