### PR TITLE
(release/25.0) vfb: use snprintf when writing XWD window name

### DIFF
--- a/hw/vfb/InitOutput.c
+++ b/hw/vfb/InitOutput.c
@@ -749,8 +749,8 @@ vfbWriteXWDFileHeader(ScreenPtr pScreen)
         hostname[0] = 0;
     else
         hostname[XWD_WINDOW_NAME_LEN - 1] = 0;
-    sprintf((char *) (pXWDHeader + 1), "Xvfb %s:%s.%d", hostname, display,
-            pScreen->myNum);
+    snprintf((char *) (pXWDHeader + 1), XWD_WINDOW_NAME_LEN, "Xvfb %s:%s.%d", 
+            hostname, display, pScreen->myNum);
 
     /* write colormap pixel slot values */
 


### PR DESCRIPTION
The window name buffer after XWDFileHeader is fixed at
XWD_WINDOW_NAME_LEN (60 bytes).  sprintf could overflow when
hostname is close to maximum length and combined with the
prefix "Xvfb " + display + screen number.

Switch to snprintf to guarantee we never write beyond the
allocated buffer.

Found by Linux Verification Center (linuxtesting.org) with SVACE.

Signed-off-by: Mikhail Dmitrichenko <m.dmitrichenko222@gmail.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2172>
