### PR TITLE
(master) xkb: fix potential buff overflow in XkbVModIndexText for XkbCFile format

### DIFF
--- a/xkb/xkbtext.c
+++ b/xkb/xkbtext.c
@@ -137,11 +137,11 @@ XkbVModIndexText(XkbDescPtr xkb, unsigned ndx, unsigned format)
 
     len = strlen(tmp) + 1;
     if (format == XkbCFile)
-        len += 4;
+        len += 5;
     rtrn = tbGetBuffer(len);
     if (format == XkbCFile) {
         strcpy(rtrn, "vmod_");
-        strncpy(&rtrn[5], tmp, len - 4);
+        strncpy(&rtrn[5], tmp, len - 5);
     }
     else
         strncpy(rtrn, tmp, len);


### PR DESCRIPTION
len calculation and strncpy limit were off by one when prefixing
"vmod_" to the virtual modifier name. This could write the final
NULL one byte past the allocated buffer from tbGetBuffer().

Use proper allocation len for prefix to avoid writing out-of-bounds.

Found by Linux Verification Center (linuxtesting.org) with SVACE

Signed-off-by: Mikhail Dmitrichenko <m.dmitrichenko222@gmail.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2175>
