### PR TITLE
(release/25.0) xkb: fix buffer re-use in _XkbSetCompatMap

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -2964,7 +2964,7 @@ _XkbSetCompatMap(ClientPtr client, DeviceIntPtr dev,
                 return BadAlloc;
             }
         }
-        else if (req->truncateSI) {
+        else if (req->truncateSI || req->firstSI + req->nSI > compat->num_si) {
             compat->num_si = req->firstSI + req->nSI;
         }
         sym = &compat->sym_interpret[req->firstSI];


### PR DESCRIPTION
If the "compat" buffer has previously been truncated, there will be
unused space in the buffer. The code uses this space, but does not
update the number of valid entries in the buffer.

In the best case, this leads to the new compat entries being ignored. In the
worst case, if there are any "skipped" compat entries, the number of
valid entries will be corrupted, potentially leading to a buffer read
overrun when processing a future request.

Set the number of used "compat" entries when re-using previously
allocated space in the buffer.

CVE-2026-33999, ZDI-CAN-28593

This vulnerability was discovered by:
Jan-Niklas Sohn working with TrendAI Zero Day Initiative

Signed-off-by: Peter Harris <pharris2@rocketsoftware.com>
Acked-by: Olivier Fourdan <ofourdan@redhat.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2176>
