### PR TITLE
(master) xkb: Fix bounds check in _CheckSetGeom()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -5350,7 +5350,7 @@ _CheckSetGeom(XkbGeometryPtr geom, xkbSetGeometryReq * req, ClientPtr client)
     }
 
     for (i = 0; i < req->nKeyAliases; i++) {
-        if (!_XkbCheckRequestBounds(client, req, wire, wire + XkbKeyNameLength))
+        if (!_XkbCheckRequestBounds(client, req, wire, wire + 2 * XkbKeyNameLength))
                 return BadLength;
 
         if (XkbAddGeomKeyAlias(geom, &wire[XkbKeyNameLength], wire) == NULL)


### PR DESCRIPTION
As reported by valgrind:

  == Conditional jump or move depends on uninitialised value(s)
  ==    at 0x5CBE66: SrvXkbAddGeomKeyAlias (XKBGAlloc.c:585)
  ==    by 0x5AC7D5: _CheckSetGeom (xkb.c:5607)
  ==    by 0x5AC952: _XkbSetGeometry (xkb.c:5643)
  ==    by 0x5ACB58: ProcXkbSetGeometry (xkb.c:5684)
  ==    by 0x5B0DAC: ProcXkbDispatch (xkb.c:7070)
  ==    by 0x4A28C5: Dispatch (dispatch.c:553)
  ==    by 0x4B0B24: dix_main (main.c:274)
  ==    by 0x42915E: main (stubmain.c:34)
  ==  Uninitialised value was created by a heap allocation
  ==    at 0x4840B26: malloc (vg_replace_malloc.c:447)
  ==    by 0x5E13B0: AllocateInputBuffer (io.c:981)
  ==    by 0x5E05CD: InsertFakeRequest (io.c:516)
  ==    by 0x4AA860: NextAvailableClient (dispatch.c:3629)
  ==    by 0x5DE0D7: AllocNewConnection (connection.c:628)
  ==    by 0x5DE2C6: EstablishNewConnections (connection.c:692)
  ==    by 0x5DE600: HandleNotifyFd (connection.c:809)
  ==    by 0x5E2598: ospoll_wait (ospoll.c:660)
  ==    by 0x5DA00C: WaitForSomething (WaitFor.c:208)
  ==    by 0x4A26E5: Dispatch (dispatch.c:493)
  ==    by 0x4B0B24: dix_main (main.c:274)
  ==    by 0x42915E: main (stubmain.c:34)

Each key alias entry contains two key names (the alias and the real key
name), each of size XkbKeyNameLength.

The current bounds check only validates the first name, allowing
XkbAddGeomKeyAlias to potentially read uninitialized memory when
accessing the second name at &wire[XkbKeyNameLength].

To fix this, change the value to check to use 2 * XkbKeyNameLength to
validate the bounds.

CVE-2026-34000, ZDI-CAN-28679

This vulnerability was discovered by:
Jan-Niklas Sohn working with TrendAI Zero Day Initiative

Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
Acked-by: Peter Hutterer <peter.hutterer@who-t.net>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2176>
