### PR TITLE
(release/25.0) hw/xwin: Use revert-to-parent X focus mode in multiwindow WM

### DIFF
--- a/hw/xwin/winmultiwindowwm.c
+++ b/hw/xwin/winmultiwindowwm.c
@@ -915,7 +915,7 @@ winMultiWindowWMProc(void *pArg)
               }
 
               if (!neverFocus)
-                xcb_set_input_focus(pWMInfo->conn, XCB_INPUT_FOCUS_POINTER_ROOT,
+                xcb_set_input_focus(pWMInfo->conn, XCB_INPUT_FOCUS_PARENT,
                                     pNode->msg.iWindow, XCB_CURRENT_TIME);
 
               if (IsWmProtocolAvailable(pWMInfo,


### PR DESCRIPTION
Use revert-to-parent X focus mode, as recommended in ICCCM 4.1.7

Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/736>
