### PR TITLE
(master) os: handle memory allocation failure in set_font_authorizations()

### DIFF
--- a/os/utils.c
+++ b/os/utils.c
@@ -841,8 +841,14 @@ set_font_authorizations(char **authorizations, int *authlen, void *client)
 
         len = strlen(hnameptr) + 1;
         result = calloc(1, len + sizeof(AUTHORIZATION_NAME) + 4);
-        if (!result)
+        if (result == NULL) {
+#if defined(HAVE_GETADDRINFO)
+            if (ai) {
+                freeaddrinfo(ai);
+            }
+#endif
             return 0;
+        }
 
         p = result;
         *p++ = sizeof(AUTHORIZATION_NAME) >> 8;


### PR DESCRIPTION
Reported in #1817:
xwayland-24.1.6/redhat-linux-build/../os/utils.c:1108:9:
 warning[-Wanalyzer-possible-null-dereference]:
  dereference of possibly-NULL ‘result’
xwayland-24.1.6/redhat-linux-build/../os/utils.c:1108:9:
 danger: ‘malloc((long unsigned int)len + 18)’ could be NULL:
  unchecked value from (3)

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2163>
