### PR TITLE
(master) ephyr: add -title to Xephyr man page

### DIFF
--- a/hw/kdrive/ephyr/man/Xephyr.man
+++ b/hw/kdrive/ephyr/man/Xephyr.man
@@ -98,6 +98,8 @@ at the end is interpreted as the ascii character '+')
 .I a
 key is pressed)
 .RE
+.BI \-title " title"
+Set the window title in the WM_NAME property.
 .SH "SIGNALS"
 Send a SIGUSR1 to the server (e.g. pkill \-USR1 Xephyr) to
 toggle the debugging mode.


### PR DESCRIPTION
Fixes: e3c65cf1d ("xephyr: Add -title option.")
Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2137>
