### PR TITLE
(master) os: use winsock2.h definitions on mingw in xserver_poll.h

### DIFF
--- a/os/xserver_poll.h
+++ b/os/xserver_poll.h
@@ -34,8 +34,9 @@
 #define xserver_poll(fds, nfds, timeout) poll(fds, nfds, timeout)
 #else
 
-#ifndef WIN32
-
+#ifdef WIN32
+#include <X11/Xwinsock.h>
+#else
 #define POLLIN		0x01
 #define POLLPRI		0x02
 #define POLLOUT		0x04


### PR DESCRIPTION
Avoids build warnings & failures, such as:

../os/xserver_poll.h:40: warning: "POLLNVAL" redefined
   40 | #define POLLNVAL        0x20
      |
/usr/share/mingw-w64/include/winsock2.h:1190: note: this is the location
 of the previous definition
 1190 | #define POLLNVAL   0x0004
      |
../os/xserver_poll.h:42:8: error: redefinition of ‘struct pollfd’
   42 | struct pollfd
      |        ^~~~~~
/usr/share/mingw-w64/include/winsock2.h:1192:16: note: originally defined here
 1192 | typedef struct pollfd {
      |                ^~~~~~

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2141>
