### PR TITLE
(release/25.0) Revert "glamor: explicitly draw endpoints of line segments"

### DIFF
--- a/glamor/glamor_lines.c
+++ b/glamor/glamor_lines.c
@@ -120,7 +120,6 @@ glamor_poly_lines_solid_gl(DrawablePtr drawable, GCPtr gc,
                       box->y2 - box->y1);
             box++;
             glDrawArrays(GL_LINE_STRIP, 0, n + add_last);
-            glDrawArrays(GL_POINTS, 0, n + add_last);
         }
     }
 


### PR DESCRIPTION
This reverts commit 530e80375ebbe825247646d5225e0ebb91f940cb.

The commit breaks xts5/Xlib9/XDrawLines/XDrawLines test as per
https://gitlab.freedesktop.org/xorg/xserver/-/issues/1801#note_2812218

Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1858>
