### PR TITLE
(master) selinux: remap security classes on policyload

### DIFF
--- a/Xext/xselinux_hooks.c
+++ b/Xext/xselinux_hooks.c
@@ -333,6 +333,21 @@ SELinuxLog(int type, const char *fmt, ...)
     return 0;
 }
 
+static int
+SELinuxPolicyLoad(int seqno)
+{
+    LogMessage(X_INFO, "SELinux: PolicyLoad (%d) detected, remapping security classes\n", seqno);
+
+    if (selinux_set_mapping(map) < 0) {
+        if (errno == EINVAL)
+            ErrorF("SELinux: Invalid object class mapping\n");
+        else
+            ErrorF("SELinux: Failed to set up security class mapping\n");
+    }
+
+    return 0;
+}
+
 /*
  * XACE Callbacks
  */
@@ -877,9 +892,9 @@ SELinuxFlaskInit(void)
     }
 
     /* Set up SELinux stuff */
-    selinux_set_callback(SELINUX_CB_LOG, (union selinux_callback) SELinuxLog);
-    selinux_set_callback(SELINUX_CB_AUDIT,
-                         (union selinux_callback) SELinuxAudit);
+    selinux_set_callback(SELINUX_CB_LOG, (union selinux_callback) { .func_log = SELinuxLog });
+    selinux_set_callback(SELINUX_CB_AUDIT, (union selinux_callback) { .func_audit = SELinuxAudit });
+    selinux_set_callback(SELINUX_CB_POLICYLOAD, (union selinux_callback) { .func_policyload = SELinuxPolicyLoad });
 
     if (selinux_set_mapping(map) < 0) {
         if (errno == EINVAL) {


### PR DESCRIPTION
Re-map the SELinux security classes on policy loads, as the mapping will
be desynchronized (see man:selinux_set_mapping(3)) and audit messages
will not show the actual class and permission names:

    USER_AVC pid=24283 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:xorg_t:s0 msg='avc:  denied  { 0x10 } for request=XFIXES:SelectSelectionInput comm=/usr/bin/python3 resid=6400001 restype=WINDOW scontext=xuser_u:xuser_r:systemd_user_instance_generic_bin_t:s0 tcontext=xuser_u:object_r:xorg_t:s0 tclass=(null) permissive=1

In addition use type-safe assignments.

Signed-off-by: Christian Göttsche <cgzones@googlemail.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/801>
