### PR TITLE
(release/25.0) modesetting: properly use fb_id of front_bo for reverse PRIME CRTC

### DIFF
--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
@@ -644,8 +644,10 @@ drmmode_crtc_get_fb_id(xf86CrtcPtr crtc, uint32_t *fb_id, int *x, int *y)
                 msGetPixmapPriv(drmmode, drmmode_crtc->prime_pixmap);
             *fb_id = ppriv->fb_id;
             *x = 0;
-        } else
+        } else {
+            *fb_id = drmmode->fb_id;
             *x = drmmode_crtc->prime_pixmap_x;
+        }
         *y = 0;
     }
     else if (trf->buf[trf->back_idx ^ 1].px) {


### PR DESCRIPTION
When doing reverse PRIME, the buffer being scaned out is still the front
BO.

Properly reuse its fb_id, to prevent adding a FB for the front_bo each
time the fb_id is requested.

Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2064>
