### PR TITLE
(release/25.0) xkb: Fix serialization of key type without level names

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -3831,7 +3831,8 @@ XkbAssembleNames(ClientPtr client, XkbDescPtr xkb, xkbGetNamesReply rep, char *b
             XkbKeyTypePtr type = xkb->map->types;
 
             for (i = 0; i < rep.nTypes; i++, type++) {
-                *desc++ = type->num_levels;
+                /* Either no name or all of them, even empty ones */
+                *desc++ = (type->level_names) ? type->num_levels : 0;
             }
             desc += XkbPaddedSize(rep.nTypes) - rep.nTypes;
 


### PR DESCRIPTION
Before this commit the count of key type level names was wrongly set
in `XkbGetNames`: for key type without names, it was set to the level
count, while it should be 0:
- `XkbComputeGetNamesReplySize()` does not account key type without
  level names;
- `XkbSendNames()` does not write any level entry for key types without
  level names.

This causes a mismatch offset while parsing the response and its
processing would ultimately fail.

Fixed by setting the correct level name count: 0 if there is no level
name, else the number of levels.

Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2082>
