### PR TITLE
(release/25.1) xkb: fix incorrect size check when growing doodads in a section

### DIFF
--- a/xkb/XKBGAlloc.c
+++ b/xkb/XKBGAlloc.c
@@ -756,7 +756,7 @@ XkbAddGeomDoodad(XkbGeometryPtr geom, XkbSectionPtr section, Atom name)
             return doodad;
     }
     if (section) {
-        if ((section->num_doodads >= geom->sz_doodads) &&
+        if ((section->num_doodads >= section->sz_doodads) &&
             (_XkbAllocDoodads(section, 1) != Success)) {
             return NULL;
         }


### PR DESCRIPTION
In XkbAddGeomDoodad(), when adding a doodad to a specific section
(section != NULL), there is a comparison between section->num_doodads
and geom->sz_doodads instead of the section's own section->sz_doodads.

The else branch (global geometry doodads) was already correct.

Compare section->num_doodads against section->sz_doodads to prevent
a potential out-of-bounds.

Found by Linux Verification Center (linuxtesting.org) with SVACE.

Signed-off-by: Mikhail Dmitrichenko <m.dmitrichenko222@gmail.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2174>
