### PR TITLE
(release/25.1) miext/sync: Fix use-after-free in miSyncTriggerFence()

### DIFF
--- a/miext/sync/misync.c
+++ b/miext/sync/misync.c
@@ -129,16 +129,22 @@ miSyncDestroyFence(SyncFence * pFence)
 void
 miSyncTriggerFence(SyncFence * pFence)
 {
-    SyncTriggerList *ptl, *pNext;
+    SyncTriggerList *ptl;
+    Bool triggered;
 
     pFence->funcs.SetTriggered(pFence);
 
     /* run through triggers to see if any fired */
-    for (ptl = pFence->sync.pTriglist; ptl; ptl = pNext) {
-        pNext = ptl->next;
-        if ((*ptl->pTrigger->CheckTrigger) (ptl->pTrigger, 0))
-            (*ptl->pTrigger->TriggerFired) (ptl->pTrigger);
-    }
+    do {
+        triggered = FALSE;
+        for (ptl = pFence->sync.pTriglist; ptl; ptl = ptl->next) {
+            if ((*ptl->pTrigger->CheckTrigger) (ptl->pTrigger, 0)) {
+                (*ptl->pTrigger->TriggerFired) (ptl->pTrigger);
+                triggered = TRUE;
+                break;
+            }
+        }
+    } while (triggered);
 }
 
 SyncScreenFuncsPtr


### PR DESCRIPTION
As reported by valgrind:

  == Invalid read of size 8
  ==    at 0x568C14: miSyncTriggerFence (misync.c:140)
  ==    by 0x540688: ProcSyncTriggerFence (sync.c:1957)
  ==    by 0x540CCC: ProcSyncDispatch (sync.c:2152)
  ==    by 0x4A28C5: Dispatch (dispatch.c:553)
  ==    by 0x4B0B24: dix_main (main.c:274)
  ==    by 0x42915E: main (stubmain.c:34)
  ==  Address 0x17e35488 is 8 bytes inside a block of size 16 free'd
  ==    at 0x4843E43: free (vg_replace_malloc.c:990)
  ==    by 0x53D683: SyncDeleteTriggerFromSyncObject (sync.c:169)
  ==    by 0x53F14D: FreeAwait (sync.c:1208)
  ==    by 0x4DFB06: doFreeResource (resource.c:888)
  ==    by 0x4DFC59: FreeResource (resource.c:918)
  ==    by 0x53E349: SyncAwaitTriggerFired (sync.c:701)
  ==    by 0x568C52: miSyncTriggerFence (misync.c:142)
  ==    by 0x540688: ProcSyncTriggerFence (sync.c:1957)
  ==    by 0x540CCC: ProcSyncDispatch (sync.c:2152)
  ==    by 0x4A28C5: Dispatch (dispatch.c:553)
  ==    by 0x4B0B24: dix_main (main.c:274)
  ==    by 0x42915E: main (stubmain.c:34)
  ==  Block was alloc'd at
  ==    at 0x4840B26: malloc (vg_replace_malloc.c:447)
  ==    by 0x5E50E1: XNFalloc (utils.c:1129)
  ==    by 0x53D772: SyncAddTriggerToSyncObject (sync.c:206)
  ==    by 0x53DCA8: SyncInitTrigger (sync.c:414)
  ==    by 0x5409C7: ProcSyncAwaitFence (sync.c:2089)
  ==    by 0x540D04: ProcSyncDispatch (sync.c:2160)
  ==    by 0x4A28C5: Dispatch (dispatch.c:553)
  ==    by 0x4B0B24: dix_main (main.c:274)
  ==    by 0x42915E: main (stubmain.c:34)

When walking the list of fences to trigger, miSyncTriggerFence() may
call TriggerFence() for the current trigger, which end up calling the
function SyncAwaitTriggerFired().

SyncAwaitTriggerFired() frees the entire await resource, which removes
all triggers from that await - including pNext which may be another
trigger from the same await attached to the same fence.

On the next iteration, ptl = pNext points to freed memory...

To avoid the issue, we need to restart the iteration from the beginning
of the list each time a trigger fires, since the callback can modify the
list.

CVE-2026-34001, ZDI-CAN-28706

This vulnerability was discovered by:
Jan-Niklas Sohn working with TrendAI Zero Day Initiative

Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
Acked-by: Peter Hutterer <peter.hutterer@who-t.net>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2176>
