### PR TITLE
(release/25.1) xfree86: issue error if too many clocks entries are listed in config

### DIFF
--- a/hw/xfree86/parser/Configint.h
+++ b/hw/xfree86/parser/Configint.h
@@ -206,6 +206,8 @@ else\
 "The number \"%d\" given in this section must be in octal (0xxx) format."
 #define GPU_DEVICE_TOO_MANY \
 "More than %d GPU devices defined."
+#define CLOCKS_TOO_MANY \
+"More than %d Clocks defined."
 
 /* Warning messages */
 #define OBSOLETE_MSG \

--- a/hw/xfree86/parser/Device.c
+++ b/hw/xfree86/parser/Device.c
@@ -209,6 +209,8 @@ xf86parseDeviceSection(void)
                 ptr->dev_clock[i] = (int) (xf86_lex_val.realnum * 1000.0 + 0.5);
                 token = xf86getSubToken(&(ptr->dev_comment));
             }
+            if (token == NUMBER && i >= CONF_MAXCLOCKS)
+                Error(CLOCKS_TOO_MANY, CONF_MAXCLOCKS);
             ptr->dev_clocks = i;
             xf86unGetToken(token);
             break;


### PR DESCRIPTION
Changes message issued for too many clocks from the confusing:
    "29.0" is not a valid keyword in this section.
to the more obvious:
    More than 128 Clocks defined.

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2130>
