### PR TITLE
(release/25.1) Add compatibility define for `pci_device_is_boot_display()`

### DIFF
--- a/hw/xfree86/common/xf86platformBus.h
+++ b/hw/xfree86/common/xf86platformBus.h
@@ -94,4 +94,11 @@ xf86PlatformDeviceCheckBusID(struct xf86_platform_device *device, const char *bu
 
 #endif
 
+#ifndef HAVE_PCI_DEVICE_IS_BOOT_DISPLAY
+static inline Bool pci_device_is_boot_display(struct pci_device *dev)
+{
+    return FALSE;
+}
+#endif
+
 #endif

--- a/include/meson.build
+++ b/include/meson.build
@@ -331,6 +331,11 @@ conf_data.set('PCVT_SUPPORT', supports_pcvt ? '1' : false)
 conf_data.set('SYSCONS_SUPPORT', supports_syscons ? '1' : false)
 conf_data.set('WSCONS_SUPPORT', supports_wscons ? '1' : false)
 conf_data.set('XSERVER_LIBPCIACCESS', get_option('pciaccess') ? '1' : false)
+if get_option('pciaccess')
+    pciaccess_dep = dependency('pciaccess', required: build_xorg)
+    conf_data.set('HAVE_PCI_DEVICE_IS_BOOT_DISPLAY',
+                  cc.has_function('pci_device_is_boot_display', dependencies: pciaccess_dep) ? '1' : false)
+endif
 conf_data.set('XSERVER_PLATFORM_BUS', build_udev_kms ? '1' : false)
 conf_data.set('XSERVER_SCREEN_VRR', '1')
 


### PR DESCRIPTION
It will take some time for a new libpciaccess to be released and
even then bumping the dependency for libpciaccess isn't attractive.
If an older libpciaccess is used just add a static inline define.

Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2038>
