### PR TITLE
(release/25.1) Add check for `pci_device_linux_sysfs_boot_display()`

### DIFF
--- a/hw/xfree86/common/xf86pciBus.c
+++ b/hw/xfree86/common/xf86pciBus.c
@@ -111,7 +111,8 @@ xf86PciProbe(void)
             xf86PciVideoInfo[num - 1] = info;
 
             pci_device_probe(info);
-            if (primaryBus.type == BUS_NONE && pci_device_is_boot_vga(info)) {
+            if (primaryBus.type == BUS_NONE && (pci_device_is_boot_vga(info) ||
+                                                pci_device_is_boot_display(info))) {
                 primaryBus.type = BUS_PCI;
                 primaryBus.id.pci = info;
             }

--- a/hw/xfree86/common/xf86platformBus.c
+++ b/hw/xfree86/common/xf86platformBus.c
@@ -378,7 +378,7 @@ xf86platformProbe(void)
         }
     }
 
-    /* Then check for pci_device_is_boot_vga() */
+    /* Then check for pci_device_is_boot_vga()/pci_device_is_boot_display() */
     for (i = 0; i < xf86_num_platform_devices; i++) {
         struct xf86_platform_device *dev = &xf86_platform_devices[i];
 
@@ -386,7 +386,8 @@ xf86platformProbe(void)
             continue;
 
         pci_device_probe(dev->pdev);
-        if (pci_device_is_boot_vga(dev->pdev)) {
+        if (pci_device_is_boot_display(dev->pdev) ||
+            pci_device_is_boot_vga(dev->pdev)) {
             primaryBus.type = BUS_PLATFORM;
             primaryBus.id.plat = dev;
         }


### PR DESCRIPTION
In the case of multiple display devices that are not VGA devices
the 'boot_display' attribute read by libpciaccess can disambiguate.

Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2038>
