### PR TITLE
(release/25.1) hw/xwin: More adjustments to multiwindow mode focus handling

### DIFF
--- a/hw/xwin/winmultiwindowwndproc.c
+++ b/hw/xwin/winmultiwindowwndproc.c
@@ -802,6 +802,16 @@ winTopLevelWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
         /* Add the keyboard hook if possible */
         if (g_fKeyboardHookLL)
             g_fKeyboardHookLL = winInstallKeyboardHookLL();
+
+        /* Tell our Window Manager thread to activate the window */
+        if (fWMMsgInitialized)
+            {
+                wmMsg.msg = WM_WM_ACTIVATE;
+                /* don't focus override redirect windows (e.g. menus) */
+                if (!pWin || !pWin->overrideRedirect)
+                    winSendMessageToWM(s_pScreenPriv->pWMInfo, &wmMsg);
+            }
+
         return 0;
 
     case WM_KILLFOCUS:
@@ -897,21 +907,6 @@ winTopLevelWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
         /* Pass the message to the root window */
         SendMessage(hwndScreen, message, wParam, lParam);
 
-        if (LOWORD(wParam) != WA_INACTIVE) {
-            /* Raise the window to the top in Z order */
-            /* ago: Activate does not mean putting it to front! */
-            /*
-               wmMsg.msg = WM_WM_RAISE;
-               if (fWMMsgInitialized)
-               winSendMessageToWM (s_pScreenPriv->pWMInfo, &wmMsg);
-             */
-
-            /* Tell our Window Manager thread to activate the window */
-            wmMsg.msg = WM_WM_ACTIVATE;
-            if (fWMMsgInitialized)
-                if (!pWin || !pWin->overrideRedirect)   /* for OOo menus */
-                    winSendMessageToWM(s_pScreenPriv->pWMInfo, &wmMsg);
-        }
         /* Prevent the mouse wheel from stalling when another window is minimized */
         if (HIWORD(wParam) == 0 && LOWORD(wParam) == WA_ACTIVE &&
             (HWND) lParam != NULL && (HWND) lParam != GetParent(hwnd))


### PR DESCRIPTION
The previous change is not enough, as WM_KILLFOCUS can apparently be
sent to the window losing focus after WM_ACTIVATE has been sent to
the window gaining focus.

Try using WM_SETFOCUS instead, as that has the correct ordering and seems
more logical.

The test "!pWin || !pWin->overrideRedirect" is confusingly written: It's
true if:

(a) pWin is NULL (= X window doesn't exist, shouldn't happen), or
(b) pWin->overrideRedirect is FALSE

i.e. the intended effect is "don't give focus to override redirect windows"

There seem to be some cases where this still isn't quite correct: A
reproduction isn't known, but it seems to be related to minimizing a
maximized Windows window, and having window activation move to a
maximized X window beneath it.

Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/736>
