### PR TITLE
(release/25.1) xf86: check return value of XF86_CRTC_CONFIG_PTR in xf86CompatOutput()

### DIFF
--- a/hw/xfree86/modes/xf86Crtc.h
+++ b/hw/xfree86/modes/xf86Crtc.h
@@ -842,7 +842,7 @@ xf86CompatOutput(ScrnInfoPtr pScrn)
     if (xf86CrtcConfigPrivateIndex == -1)
         return NULL;
     config = XF86_CRTC_CONFIG_PTR(pScrn);
-    if (config->compat_output < 0)
+    if ((config == NULL) || (config->compat_output < 0))
         return NULL;
     return config->output[config->compat_output];
 }


### PR DESCRIPTION
If privates[xf86CrtcConfigPrivateIndex].ptr is NULL, this will cause
a segfault.

Possible fix for !1241

Signed-off-by: Benjamin Valentin <benjamin.valentin@ml-pa.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/835>
