### PR TITLE
(release/25.1) selinux: only generate audit events for avc and error messages

### DIFF
--- a/Xext/xselinux_hooks.c
+++ b/Xext/xselinux_hooks.c
@@ -310,25 +310,27 @@ SELinuxLog(int type, const char *fmt, ...)
 {
     va_list ap;
     char buf[MAX_AUDIT_MESSAGE_LENGTH];
-    int rc, aut;
+    int aut;
 
     switch (type) {
-    case SELINUX_INFO:
-        aut = AUDIT_USER_MAC_POLICY_LOAD;
+    case SELINUX_ERROR:
+        aut = AUDIT_USER_SELINUX_ERR;
         break;
     case SELINUX_AVC:
         aut = AUDIT_USER_AVC;
         break;
     default:
-        aut = AUDIT_USER_SELINUX_ERR;
+        /* Do not generate an audit event, just log normally. */
+        aut = -1;
         break;
     }
 
     va_start(ap, fmt);
     vsnprintf(buf, MAX_AUDIT_MESSAGE_LENGTH, fmt, ap);
-    rc = audit_log_user_avc_message(audit_fd, aut, buf, NULL, NULL, NULL, 0);
-    (void) rc;
     va_end(ap);
+
+    if (aut != -1)
+        (void) audit_log_user_avc_message(audit_fd, aut, buf, NULL, NULL, NULL, 0);
     LogMessageVerb(X_WARNING, 0, "%s", buf);
     return 0;
 }


### PR DESCRIPTION
Only generate audit events for messages of the type avc (permission
denied) and error (e.g. invalid context).
For example avoid USER_SELINUX_ERR for policy load events:
    audit[980]: USER_SELINUX_ERR pid=980 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:xorg_t:s0 msg='avc:  op=load_policy lsm=selinux seqno=8 res=1 exe="/usr/lib/xorg/Xorg" sauid=0 hostname=? addr=? terminal=?'

Signed-off-by: Christian Göttsche <cgzones@googlemail.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/801>
