### PR TITLE
(release/25.1) modesetting: Don't recursively force present to unflip

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -1725,7 +1725,7 @@ static void drmmmode_prepare_modeset(ScrnInfoPtr scrn)
     ScreenPtr pScreen = scrn->pScreen;
     modesettingPtr ms = modesettingPTR(scrn);
 
-    if (ms->drmmode.pending_modeset)
+    if (!ms->drmmode.present_flipping || ms->drmmode.pending_modeset)
         return;
 
     /*

--- a/hw/xfree86/drivers/video/modesetting/present.c
+++ b/hw/xfree86/drivers/video/modesetting/present.c
@@ -459,6 +459,8 @@ ms_present_unflip(ScreenPtr screen, uint64_t event_id)
         }
     }
 
+    ms->drmmode.present_flipping = FALSE;
+
     for (i = 0; i < config->num_crtc; i++) {
         xf86CrtcPtr crtc = config->crtc[i];
         drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
@@ -482,7 +484,6 @@ ms_present_unflip(ScreenPtr screen, uint64_t event_id)
     }
 
     present_event_notify(event_id, 0, 0);
-    ms->drmmode.present_flipping = FALSE;
 }
 #endif
 


### PR DESCRIPTION
Present calls drmmode_set_mode_major() as part of ms_present_unflip(),
which leads to a crash due to the recursive attempt to force present to
unflip when it already is.

Fix it by simply skipping the forced present unflip when present itself is
unflipping. This also speeds up drmmmode_prepare_modeset() when present
isn't even flipping to begin with.

Closes: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1791
Fixes: 899c87af1 ("modesetting: unflip before any setcrtc() calls")
Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1793>
