### PR TITLE
(release/25.1) xf86pciBus.c: use Intel ddx only for pre-gen3 hardware

### DIFF
--- a/hw/xfree86/common/xf86pciBus.c
+++ b/hw/xfree86/common/xf86pciBus.c
@@ -1155,7 +1155,16 @@ xf86VideoPtrToDriverList(struct pci_device *dev, XF86MatchedDrivers *md)
 		case 0x0bef:
 			/* Use fbdev/vesa driver on Oaktrail, Medfield, CDV */
 			break;
-		default:
+		/* Default to intel only on pre-gen3 chips */
+		case 0x7121:
+		case 0x7123:
+		case 0x7125:
+		case 0x1132:
+		case 0x3577:
+		case 0x2562:
+		case 0x3582:
+		case 0x358e:
+		case 0x2572:
 			driverList[0] = "intel";
 			break;
         }


### PR DESCRIPTION
### Backport dashboard

Master: #2119 ✅ merged

| Branch | PR | Status |
|---|---|---|
| release/25.0 | #2244 | ✅ merged |
| release/25.1 | #2280 | ⬜ open ← this PR |

<sub>Auto-generated backport dashboard — links the source master PR and sibling backports with their merge status.</sub>

---

Use intel ddx only on pre-gen4 hw, newer ones will fall back to modesetting.

Instead of defaulting to the Intel driver for all Intel hardware, only
default it for older hardware for which it has shown to be better for.

Note that Debian/Fedora and their derivatives, as well as the yocto project
have been carrying this patch for many years:
https://salsa.debian.org/xorg-team/xserver/xorg-server/-/commit/192254841ab79e102c18fc299f18af0e27d5b517
https://src.fedoraproject.org/rpms/xorg-x11-server/c/ee515e44b07e37689abf48cf2fffb41578f3bc1d

so this simply aligns xserver upstream with Linux distributions.

Signed-off-by: California Sullivan <california.l.sullivan@intel.com>
Signed-off-by: Alexander Kanavin <alex@linutronix.de>
Co-authored-by: Balló György <ballogyor@gmail.com>
Reviewed-by: Emma Anholt <emma@anholt.net>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/1887>
