### PR TITLE
(release/25.1) xkb: Fix key type without level names in XkbCopyKeymap

### DIFF
--- a/xkb/xkbUtils.c
+++ b/xkb/xkbUtils.c
@@ -1046,7 +1046,7 @@ _XkbCopyClientMap(XkbDescPtr src, XkbDescPtr dst)
                     if (dtype->num_levels && dtype->level_names &&
                         i < dst->map->num_types)
                         free(dtype->level_names);
-                    dtype->num_levels = 0;
+                    dtype->num_levels = stype->num_levels;
                     dtype->level_names = NULL;
                 }
 


### PR DESCRIPTION
A key type that has no level names is legit. Before this commit,
`XkbCopyKeymap` would make such level inconsistent by setting its
number of levels to 0 while keeping its map entries. It suffices
to clear the names array.

Fixed by copying the level count from the source type.

WARNING: this will trigger an error in `XkbGetNames`, which worked
before this commit only by chance. This is fixed in the next commit.

Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2082>
