### PR TITLE
Fix #1482

### DIFF
--- a/.github/scripts/ubuntu/install-pkg.sh
+++ b/.github/scripts/ubuntu/install-pkg.sh
@@ -43,6 +43,7 @@ apt-get install -y \
 	libpixman-1-dev \
 	libspice-protocol-dev \
 	libsystemd-dev \
+	libtool \
 	libudev-dev \
 	libunwind-dev \
 	libx11-dev \


### PR DESCRIPTION
This PR addresses https://github.com/X11Libre/xserver/issues/1482 by adding `libtool` as a dependency for Ubuntu. It seems like the GitHub Actions automatically does have this installed, but not normal systems, so let's make it work on all Ubuntu systems.