### PR TITLE
(release/25.0) xfree86/linux: Enable all I/O ports

### DIFF
--- a/hw/xfree86/os-support/linux/lnx_video.c
+++ b/hw/xfree86/os-support/linux/lnx_video.c
@@ -123,10 +123,20 @@ hwEnableIO(void)
     char *buf=NULL, target[5];
     FILE *fp;
 
-    if (ioperm(0, 1024, 1)) {
-        ErrorF("xf86EnableIO: failed to enable I/O ports 0000-03ff (%s)\n",
+    /* xf86-video-vesa and others (at least mach64) need access to all I/O ports */
+    if (iopl(3)) {
+        ErrorF("xf86EnableIO: failed to set I/O privilege level to 3 (%s)\n",
+           strerror(errno));
+        /* Since Linux 2.6.8, 65,536 I/O ports can be specified */
+        if (ioperm(0, 65536, 1)) {
+            ErrorF("xf86EnableIO: failed to enable I/O ports 0000-ffff (%s)\n",
                strerror(errno));
-        return FALSE;
+            if (ioperm(0, 1024, 1)) {
+                ErrorF("xf86EnableIO: failed to enable I/O ports 0000-03ff (%s)\n",
+                   strerror(errno));
+                return FALSE;
+            }
+        }
     }
 
 #if !defined(__alpha__)


### PR DESCRIPTION
When switching vt to an X server using the vesa driver,
the driver needs access to a high io port, which segfaults
if only the first 1024 io ports are enabled.

Signed-off-by: stefan11111 <stefan11111@shitposting.expert>

-----------------------------------------------------------

Fix mach64 driver crash
Due to lack of iopl(3), mach64 driver crashes when ior(BUS_CNTL) is
called. Since BUS_CNTL is out of the range 0x0000-0x03ff, ioperm(0,
1024, 1) is not sufficient and the ior() causes access violation.
This patch reintroduce iopl(3) call in the function hwEnableIO().

Addresses: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1110521

Fixes: https://github.com/X11Libre/xserver/commit/a0f738a67327ca1315bacdf543c28cc3046989dc ("Fixed ioperm calls in hwEnableIO")
Signed-off-by: Takashi Yano <takashi.yano@nifty.ne.jp>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2052>
