### PR TITLE
(master) Xext: dri2: dri2int.h: fix missing include

### DIFF
--- a/Xext/dri2/dri2int.h
+++ b/Xext/dri2/dri2int.h
@@ -26,6 +26,8 @@
 #ifndef XSERVER_XFREE86_DRI2INT_H
 #define XSERVER_XFREE86_DRI2INT_H
 
+#include <X11/Xdefs.h>
+
 extern Bool DRI2ModuleSetup(void);
 
 #endif /* XSERVER_XFREE86_DRI2INT_H */


### PR DESCRIPTION
`Bool` is defined in <X11/Xdefs.h>

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
