### PR TITLE
(master) Xi: xiquerydevice.h: fix missig include of Xdefs.h

### DIFF
--- a/Xi/xiquerydevice.h
+++ b/Xi/xiquerydevice.h
@@ -26,6 +26,7 @@
 #ifndef QUERYDEV_H
 #define QUERYDEV_H 1
 
+#include <X11/Xdefs.h>
 #include <X11/extensions/XI2proto.h>
 
 int SizeDeviceClasses(DeviceIntPtr dev);


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
