### PR TITLE
(master) glamor: glamor_font.h: fix missing include of <X11/Xdefs.h>

### DIFF
--- a/glamor/glamor_font.h
+++ b/glamor/glamor_font.h
@@ -19,9 +19,10 @@
  * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
  * OF THIS SOFTWARE.
  */
-
 #ifndef _GLAMOR_FONT_H_
 #define _GLAMOR_FONT_H_
+
+#include <X11/Xdefs.h>
 
 typedef struct {
     Bool        realized;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
