### PR TITLE
(master) glamor: glamor_prepare.h: fix missing include of <X11/Xdefs.h>

### DIFF
--- a/glamor/glamor_prepare.h
+++ b/glamor/glamor_prepare.h
@@ -19,9 +19,10 @@
  * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
  * OF THIS SOFTWARE.
  */
-
 #ifndef _GLAMOR_PREPARE_H_
 #define _GLAMOR_PREPARE_H_
+
+#include <X11/Xdefs.h>
 
 Bool
 glamor_prepare_access(DrawablePtr drawable, glamor_access_t access);


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
