### PR TITLE
(master) glamor: glamor_transform.h: fix missing include of <X11/Xdefs.h>

### DIFF
--- a/glamor/glamor_transform.h
+++ b/glamor/glamor_transform.h
@@ -19,9 +19,10 @@
  * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
  * OF THIS SOFTWARE.
  */
-
 #ifndef _GLAMOR_TRANSFORM_H_
 #define _GLAMOR_TRANSFORM_H_
+
+#include <X11/Xdefs.h>
 
 Bool
 glamor_set_destination_drawable(DrawablePtr     drawable,


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
