### PR TITLE
(master) xfree86: common: seatd-libseat.h: fix missing include of <X11/Xdefs.h>

### DIFF
--- a/hw/xfree86/common/seatd-libseat.h
+++ b/hw/xfree86/common/seatd-libseat.h
@@ -27,6 +27,8 @@
 #ifndef SEATD_LIBSEAT_H
 #define SEATD_LIBSEAT_H
 
+#include <X11/Xdefs.h>
+
 #ifdef SEATD_LIBSEAT
 #include <xf86Xinput.h>
 extern int seatd_libseat_init(Bool KeepTty_state);


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
