### PR TITLE
(master) xfree86: common: xf86Bus.h: fix missing include of <X11/Xdefs.h>

### DIFF
--- a/hw/xfree86/common/xf86Bus.h
+++ b/hw/xfree86/common/xf86Bus.h
@@ -33,6 +33,8 @@
 #ifndef _XF86_BUS_H
 #define _XF86_BUS_H
 
+#include <X11/Xdefs.h>
+
 #include "xf86pciBus.h"
 #if defined(__sparc__) || defined(__sparc)
 #include "xf86sbusBus.h"


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
