### PR TITLE
(master) xfree86: common: xf86pciBus.h: fix missing include of <X11/Xdefs.h>

### DIFF
--- a/hw/xfree86/common/xf86pciBus.h
+++ b/hw/xfree86/common/xf86pciBus.h
@@ -27,6 +27,8 @@
 #ifndef _XF86_PCI_BUS_H
 #define _XF86_PCI_BUS_H
 
+#include <X11/Xdefs.h>
+
 #include "xf86MatchDrivers.h"
 
 void xf86PciProbe(void);


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
