### PR TITLE
(master) xfree86: modesetting: drmmode_display.h: fix missing include of <X11/Xdefs.h>

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.h
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.h
@@ -29,6 +29,8 @@
 #ifndef DRMMODE_DISPLAY_H
 #define DRMMODE_DISPLAY_H
 
+#include <X11/Xdefs.h>
+
 #include "xf86drmMode.h"
 #ifdef CONFIG_UDEV_KMS
 #include "libudev.h"


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
