### PR TITLE
(master) xfree86: loader: loader.h: fix missing include <X11/Xdefs.h>

### DIFF
--- a/hw/xfree86/loader/loader.h
+++ b/hw/xfree86/loader/loader.h
@@ -50,6 +50,7 @@
 
 #include <xorg-config.h>
 
+#include <X11/Xdefs.h>
 #include <X11/Xosdefs.h>
 #include <X11/Xfuncproto.h>
 #include <X11/Xmd.h>


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
