### PR TITLE
(master) xnest: use bool instead of Bool for xnest_upstream_setup()

### DIFF
--- a/hw/xnest/xcb.c
+++ b/hw/xnest/xcb.c
@@ -4,6 +4,7 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <xcb/xcb.h>
 #include <xcb/xcb_aux.h>
 #include <xcb/xcb_icccm.h>
@@ -25,7 +26,7 @@ struct xnest_upstream_info xnestUpstreamInfo = { 0 };
 xnest_visual_t *xnestVisualMap;
 int xnestNumVisualMap;
 
-Bool xnest_upstream_setup(const char* displayName)
+bool xnest_upstream_setup(const char* displayName)
 {
     xnestUpstreamInfo.conn = xcb_connect(displayName, &xnestUpstreamInfo.screenId);
     if (!xnestUpstreamInfo.conn)

--- a/hw/xnest/xnest-xcb.h
+++ b/hw/xnest/xnest-xcb.h
@@ -5,6 +5,7 @@
 #ifndef __XNEST__XCB_H
 #define __XNEST__XCB_H
 
+#include <stdbool.h>
 #include <xcb/xcb.h>
 
 #include "include/list.h"
@@ -25,7 +26,7 @@ struct xnest_upstream_info {
 extern struct xnest_upstream_info xnestUpstreamInfo;
 
 /* connect to upstream X server */
-Bool xnest_upstream_setup(const char* displayName);
+bool xnest_upstream_setup(const char* displayName);
 
 /* retrieve upstream GC XID for our xserver GC */
 uint32_t xnest_upstream_gc(GCPtr pGC);


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
