### PR TITLE
(master) xquartz: make DarwinEQInit() return void

### DIFF
--- a/hw/xquartz/darwinEvents.c
+++ b/hw/xquartz/darwinEvents.c
@@ -356,8 +356,7 @@ DarwinProcessFDAdditionQueue_thread(void *args)
     return NULL;
 }
 
-Bool
-DarwinEQInit(void)
+void DarwinEQInit(void)
 {
     int *p;
 
@@ -377,8 +376,6 @@ DarwinEQInit(void)
         fd_add_tid = create_thread(DarwinProcessFDAdditionQueue_thread, NULL);
 
     signal_mieq_init();
-
-    return TRUE;
 }
 
 void

--- a/hw/xquartz/darwinEvents.h
+++ b/hw/xquartz/darwinEvents.h
@@ -31,8 +31,7 @@
 /* For extra precision of our cursor and other valuators */
 #define XQUARTZ_VALUATOR_LIMIT (1 << 16)
 
-Bool
-DarwinEQInit(void);
+void DarwinEQInit(void);
 void
 DarwinEQFini(void);
 void


### PR DESCRIPTION
It always returns TRUE, and the retval is never used, so no need
for returning anything in the first place.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
