### PR TITLE
(master) xquartz: darwinEvents.h: drop some obsolete prototypes

### DIFF
--- a/hw/xquartz/darwinEvents.h
+++ b/hw/xquartz/darwinEvents.h
@@ -36,12 +36,6 @@ DarwinEQInit(void);
 void
 DarwinEQFini(void);
 void
-DarwinEQEnqueue(const xEventPtr e);
-void
-DarwinEQPointerPost(DeviceIntPtr pDev, xEventPtr e);
-void
-DarwinEQSwitchScreen(ScreenPtr pScreen, Bool fromDIX);
-void
 DarwinInputReleaseButtonsAndKeys(DeviceIntPtr pDev);
 void
 DarwinSendTabletEvents(DeviceIntPtr pDev, int ev_type, int ev_button,


### PR DESCRIPTION
Those functions don't exist anymore, so the prototypes aren't needed.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
