### PR TITLE
(master) mi: mifillarc.h: fix missing include of <X11/Xdefs.h>

### DIFF
--- a/mi/mifillarc.h
+++ b/mi/mifillarc.h
@@ -27,6 +27,8 @@ in this Software without prior written authorization from The Open Group.
 #ifndef __MIFILLARC_H__
 #define __MIFILLARC_H__
 
+#include <X11/Xdefs.h>
+
 #define FULLCIRCLE (360 * 64)
 
 typedef struct _miFillArc {


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
