### PR TITLE
(master) include: misyncfd.h: fix missing include of <X11/Xdefs.h>

### DIFF
--- a/include/misyncfd.h
+++ b/include/misyncfd.h
@@ -23,6 +23,8 @@
 #ifndef _MISYNCFD_H_
 #define _MISYNCFD_H_
 
+#include <X11/Xdefs.h>
+
 typedef int (*SyncScreenCreateFenceFromFdFunc) (ScreenPtr screen,
                                                 SyncFence *fence,
                                                 int fd,


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
