### PR TITLE
(master) include: mioverlay.h: fix missing include of <X11/Xdefs.h>

### DIFF
--- a/include/mioverlay.h
+++ b/include/mioverlay.h
@@ -1,6 +1,8 @@
 #ifndef __MIOVERLAY_H
 #define __MIOVERLAY_H
 
+#include <X11/Xdefs.h>
+
 typedef void (*miOverlayTransFunc) (ScreenPtr, int, BoxPtr);
 typedef Bool (*miOverlayInOverlayFunc) (WindowPtr);
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
