### PR TITLE
(master) include: misyncshm.h: fix missing include of <X11/Xdefs.h>

### DIFF
--- a/include/misyncshm.h
+++ b/include/misyncshm.h
@@ -23,6 +23,8 @@
 #ifndef _MISYNCSHM_H_
 #define _MISYNCSHM_H_
 
+#include <X11/Xdefs.h>
+
 extern _X_EXPORT Bool miSyncShmScreenInit(ScreenPtr pScreen);
 
 #endif /* _MISYNCSHM_H_ */


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
