### PR TITLE
(master) include: mizerarc.h: fix missing include of <X11/Xdefs.h>

### DIFF
--- a/include/mizerarc.h
+++ b/include/mizerarc.h
@@ -27,6 +27,8 @@ in this Software without prior written authorization from The Open Group.
 #ifndef XSERVER_MIZERARC_H
 #define XSERVER_MIZERARC_H
 
+#include <X11/Xdefs.h>
+
 typedef struct {
     int x;
     int y;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
