### PR TITLE
(master) include: vbeModes.h: fix missing include of <X11/Xdefs.h>

### DIFF
--- a/include/vbeModes.h
+++ b/include/vbeModes.h
@@ -27,9 +27,10 @@
  * Authors: David Dawes <dawes@xfree86.org>
  *
  */
-
 #ifndef _VBE_MODES_H
 #define _VBE_MODES_H
+
+#include <X11/Xdefs.h>
 
 /*
  * This is intended to be stored in the DisplayModeRec's private area.


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
