### PR TITLE
(master) glx: turn retval of xorgGlxCreateVendor() into void

### DIFF
--- a/glx/glxext.c
+++ b/glx/glxext.c
@@ -553,10 +553,9 @@ xorgGlxServerInit(CallbackListPtr *pcbl, void *param, void *ext)
     });
 }
 
-Bool
-xorgGlxCreateVendor(void)
+void xorgGlxCreateVendor(void)
 {
-    return AddCallback(glxServer.extensionInitCallback, xorgGlxServerInit, NULL);
+    AddCallback(glxServer.extensionInitCallback, xorgGlxServerInit, NULL);
 }
 
 /************************************************************************/

--- a/include/glx_extinit.h
+++ b/include/glx_extinit.h
@@ -42,10 +42,12 @@ struct __GLXprovider {
 extern __GLXprovider __glXDRISWRastProvider;
 
 void GlxPushProvider(__GLXprovider * provider);
-Bool xorgGlxCreateVendor(void);
-#else
-static inline Bool xorgGlxCreateVendor(void) { return TRUE; }
-#endif
+void xorgGlxCreateVendor(void);
 
+#else /* GLXEXT */
 
-#endif
+static inline void xorgGlxCreateVendor(void) {}
+
+#endif /* GLEXT */
+
+#endif /* GLX_EXT_INIT_H */


### PR DESCRIPTION
Nobody's using it's return value.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
