### PR TITLE
(master) xwin: winmultiwindowwm: use bool parameter in winShowWindowOnTaskbar()

### DIFF
--- a/hw/xwin/wintaskbar.c
+++ b/hw/xwin/wintaskbar.c
@@ -63,7 +63,7 @@ DECLARE_INTERFACE_(ITaskbarList, IUnknown)
    seem to be the case
 */
 
-void winShowWindowOnTaskbar(HWND hWnd, Bool show)
+void winShowWindowOnTaskbar(HWND hWnd, bool show)
 {
   ITaskbarList* pTaskbarList = NULL;
 

--- a/hw/xwin/winwindow.h
+++ b/hw/xwin/winwindow.h
@@ -154,7 +154,6 @@ void
 void
  winSetAppUserModelID(HWND hWnd, const char *AppID);
 
-void
- winShowWindowOnTaskbar(HWND hWnd, Bool show);
+void winShowWindowOnTaskbar(HWND hWnd, bool show);
 
 #endif


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
