### PR TITLE
(master) include: fix missing includes of <X11/Xfuncproto.h>

### DIFF
--- a/Xext/geext_priv.h
+++ b/Xext/geext_priv.h
@@ -7,6 +7,7 @@
 #define _XORG_GEEXT_PRIV_H
 
 #include <X11/Xproto.h>
+#include <X11/Xfuncproto.h>
 
 typedef void (*XorgGESwapProcPtr) (xGenericEvent *from, xGenericEvent *to);
 

--- a/include/damage.h
+++ b/include/damage.h
@@ -22,6 +22,8 @@
 #ifndef _DAMAGE_H_
 #define _DAMAGE_H_
 
+#include <X11/Xfuncproto.h>
+
 typedef struct _damage *DamagePtr;
 
 typedef enum _damageReportLevel {

--- a/include/fbrop.h
+++ b/include/fbrop.h
@@ -23,6 +23,8 @@
 #ifndef _FBROP_H_
 #define _FBROP_H_
 
+#include <X11/Xfuncproto.h>
+
 typedef struct _mergeRopBits {
     FbBits ca1, cx1, ca2, cx2;
 } FbMergeRopRec, *FbMergeRopPtr;

--- a/include/mioverlay.h
+++ b/include/mioverlay.h
@@ -2,6 +2,7 @@
 #define __MIOVERLAY_H
 
 #include <X11/Xdefs.h>
+#include <X11/Xfuncproto.h>
 
 typedef void (*miOverlayTransFunc) (ScreenPtr, int, BoxPtr);
 typedef Bool (*miOverlayInOverlayFunc) (WindowPtr);

--- a/include/misyncfd.h
+++ b/include/misyncfd.h
@@ -24,6 +24,7 @@
 #define _MISYNCFD_H_
 
 #include <X11/Xdefs.h>
+#include <X11/Xfuncproto.h>
 
 typedef int (*SyncScreenCreateFenceFromFdFunc) (ScreenPtr screen,
                                                 SyncFence *fence,

--- a/include/misyncshm.h
+++ b/include/misyncshm.h
@@ -24,6 +24,7 @@
 #define _MISYNCSHM_H_
 
 #include <X11/Xdefs.h>
+#include <X11/Xfuncproto.h>
 
 extern _X_EXPORT Bool miSyncShmScreenInit(ScreenPtr pScreen);
 

--- a/include/mizerarc.h
+++ b/include/mizerarc.h
@@ -28,6 +28,7 @@ in this Software without prior written authorization from The Open Group.
 #define XSERVER_MIZERARC_H
 
 #include <X11/Xdefs.h>
+#include <X11/Xfuncproto.h>
 
 typedef struct {
     int x;

--- a/include/vbeModes.h
+++ b/include/vbeModes.h
@@ -31,6 +31,7 @@
 #define _VBE_MODES_H
 
 #include <X11/Xdefs.h>
+#include <X11/Xfuncproto.h>
 
 /*
  * This is intended to be stored in the DisplayModeRec's private area.

--- a/include/xf86Opt.h
+++ b/include/xf86Opt.h
@@ -31,6 +31,7 @@
 #define _XF86_OPT_H_
 
 #include <X11/Xdefs.h>
+#include <X11/Xfuncproto.h>
 
 #include "xf86Optionstr.h"
 

--- a/include/xisb.h
+++ b/include/xisb.h
@@ -29,6 +29,7 @@
 #define _xisb_H_
 
 #include <unistd.h>
+#include <X11/Xfuncproto.h>
 
 /******************************************************************************
  *		Definitions


### PR DESCRIPTION
Needed for _X_EXPORT.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
