### PR TITLE
glx: indirect_reqsize.h: move include inside the guards

### DIFF
--- a/glx/indirect_reqsize.h
+++ b/glx/indirect_reqsize.h
@@ -24,11 +24,11 @@
  * OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include <X11/Xdefs.h>
 
 #if !defined( _INDIRECT_REQSIZE_H_ )
 #define _INDIRECT_REQSIZE_H_
 
+#include <X11/Xdefs.h>
 #include <X11/Xfuncproto.h>
 
 #if defined(__GNUC__)


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
