### PR TITLE
(master) include: dri2.h: fix missing include of "dix.h"

### DIFF
--- a/include/dri2.h
+++ b/include/dri2.h
@@ -35,6 +35,8 @@
 
 #include <X11/extensions/dri2tokens.h>
 
+#include "dix.h"
+
 /* Version 2 structure (with format at the end) */
 typedef struct {
     unsigned int attachment;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
