### PR TITLE
(master) Xext: panoramiXh.h: fix missing include of "dix.h"

### DIFF
--- a/Xext/panoramiXh.h
+++ b/Xext/panoramiXh.h
@@ -5,6 +5,8 @@
 #ifndef XSERVER_PANORAMIXH_H
 #define XSERVER_PANORAMIXH_H
 
+#include "dix.h"
+
 int PanoramiXCreateWindow(ClientPtr client);
 int PanoramiXChangeWindowAttributes(ClientPtr client);
 int PanoramiXDestroyWindow(ClientPtr client);


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
