### PR TITLE
(master) randr: fix SetScreenSize transformation

### DIFF
--- a/randr/rrscreen.c
+++ b/randr/rrscreen.c
@@ -272,9 +272,9 @@ ProcRRSetScreenSize(ClientPtr client)
 
         if (!RRCrtcIsLeased(crtc) && mode) {
             struct pixman_box16 display_box = {
-                crtc->x, crtc->y,
-                crtc->x + mode->mode.width,
-                crtc->y + mode->mode.height
+                0, 0,
+                mode->mode.width,
+                mode->mode.height
             };
             pixman_f_transform_bounds(&crtc->f_transform, &display_box);
 


### PR DESCRIPTION
The fix in e2550d065b731f3f163725065d1db9522622e91c wrongly assumes crtc->f_transform only contain rotation and ignores translation part, which causes function to return erroneous BadMatch when it called. This commit fixes it.

This is correct fix for https://github.com/X11Libre/xserver/pull/2288
