### PR TITLE
glamor: xfree86/glamor_egl: Update `glamor_egl_init_internal` interface

### DIFF
--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -1781,15 +1781,21 @@ glamor_egl_init_display(struct glamor_egl_screen_private *glamor_egl)
 }
 
 Bool
-glamor_egl_init_internal(glamor_egl_priv_t* glamor_egl, Bool *compat_ret)
+glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, Bool *compat_ret)
 {
     const GLubyte *renderer;
+    glamor_egl_priv_t* glamor_egl;
 
     if (compat_ret) {
         *compat_ret = TRUE;
     }
 
-    glamor_egl_get_screen_private = glamor_egl->GLAMOR_EGL_PRIV_PROC;
+    glamor_egl = glamor_egl_conf->glamor_egl_priv;
+
+    glamor_egl->glvnd_vendor = glamor_egl_conf->glvnd_vendor;
+    glamor_egl->fd = glamor_egl_conf->fd;
+
+    glamor_egl_get_screen_private = glamor_egl_conf->GLAMOR_EGL_PRIV_PROC;
 
 #ifdef GLAMOR_HAS_GBM
     if (glamor_egl->fd >= 0) {
@@ -1826,41 +1832,44 @@ glamor_egl_init_internal(glamor_egl_priv_t* glamor_egl, Bool *compat_ret)
 
     GLAMOR_CHECK_EGL_EXTENSION(KHR_surfaceless_context);
 
-    if (!glamor_egl->force_es) {
+    if (!glamor_egl_conf->force_es) {
         if(!glamor_egl_try_big_gl_api(glamor_egl))
             goto error;
     }
 
-    if (glamor_egl->context == EGL_NO_CONTEXT && !glamor_egl->es_disallowed) {
+    if (glamor_egl->context == EGL_NO_CONTEXT && !glamor_egl_conf->es_disallowed) {
         if(!glamor_egl_try_gles_api(glamor_egl))
             goto error;
     }
 
     if (glamor_egl->context == EGL_NO_CONTEXT) {
         LogMessage(X_ERROR,
-                    "glamor: Failed to create GL or GLES2 contexts\n");
+                   "glamor: Failed to create GL or GLES2 contexts\n");
         goto error;
     }
 
     renderer = glGetString(GL_RENDERER);
-    if (!renderer) {
-        LogMessage(X_ERROR,
-                   "glGetString() returned NULL, your GL is broken\n");
-        goto error;
-    }
-    if (strstr((const char *)renderer, "softpipe")) {
-        LogMessage(X_INFO,
-                   "Refusing to try glamor on softpipe\n");
-        goto error;
-    }
-    if (!strncmp("llvmpipe", (const char *)renderer, strlen("llvmpipe"))) {
-        if (glamor_egl->llvmpipe_allowed)
-            LogMessage(X_INFO,
-                       "Allowing glamor on llvmpipe for PRIME\n");
-        else {
-            LogMessage(X_INFO,
-                       "Refusing to try glamor on llvmpipe\n");
+
+    if (!glamor_egl_conf->force_glamor) {
+        if (!renderer) {
+            LogMessage(X_ERROR,
+                       "glGetString() returned NULL, your GL is broken\n");
             goto error;
+        }
+        if (strstr((const char *)renderer, "softpipe")) {
+            LogMessage(X_INFO,
+                       "Refusing to try glamor on softpipe\n");
+            goto error;
+        }
+        if (!strncmp("llvmpipe", (const char *)renderer, sizeof("llvmpipe") - 1)) {
+            if (glamor_egl_conf->llvmpipe_allowed)
+                LogMessage(X_INFO,
+                           "Allowing glamor on llvmpipe for PRIME\n");
+            else {
+                LogMessage(X_INFO,
+                           "Refusing to try glamor on llvmpipe\n");
+                 goto error;
+            }
         }
     }
 
@@ -1870,14 +1879,17 @@ glamor_egl_init_internal(glamor_egl_priv_t* glamor_egl, Bool *compat_ret)
      */
     lastGLContext = NULL;
 
-    if (!epoxy_has_gl_extension("GL_OES_EGL_image")) {
-        LogMessage(X_ERROR,
-                   "glamor acceleration requires GL_OES_EGL_image\n");
-        goto error;
+    /* XXX From here on, glamor initalization should not fail completely XXX */
+
+    if (glamor_egl->fd < 0) {
+        goto glamor_no_dri;
     }
 
-    LogMessage(X_INFO, "glamor X acceleration enabled on %s\n",
-               renderer);
+    if (!epoxy_has_gl_extension("GL_OES_EGL_image")) {
+        LogMessage(X_ERROR,
+                   "glamor dri acceleration requires GL_OES_EGL_image\n");
+        goto glamor_no_dri;
+    }
 
 #ifdef GBM_BO_WITH_MODIFIERS
     if (epoxy_has_egl_extension(glamor_egl->display,
@@ -1885,7 +1897,11 @@ glamor_egl_init_internal(glamor_egl_priv_t* glamor_egl, Bool *compat_ret)
         epoxy_has_egl_extension(glamor_egl->display,
                                 "EGL_EXT_image_dma_buf_import_modifiers")) {
 
-        if (strstr((const char *)renderer, "Intel"))
+        if (glamor_egl_conf->dmabuf_forced)
+            glamor_egl->dmabuf_capable = glamor_egl_conf->dmabuf_capable;
+        else if (!renderer)
+            glamor_egl->dmabuf_capable = FALSE;
+        else if (strstr((const char *)renderer, "Intel"))
             glamor_egl->dmabuf_capable = TRUE;
         else if (strstr((const char *)renderer, "zink"))
             glamor_egl->dmabuf_capable = TRUE;
@@ -1894,7 +1910,7 @@ glamor_egl_init_internal(glamor_egl_priv_t* glamor_egl, Bool *compat_ret)
         else if (strstr((const char *)renderer, "radeonsi"))
             glamor_egl->dmabuf_capable = TRUE;
         else
-            glamor_egl->dmabuf_capable = (glamor_egl->dmabuf_capable == TRUE);
+            glamor_egl->dmabuf_capable = FALSE;
     }
 #endif
 
@@ -1903,11 +1919,11 @@ glamor_egl_init_internal(glamor_egl_priv_t* glamor_egl, Bool *compat_ret)
     CARD32 num_formats = 0;
     Bool found = FALSE;
     if (!glamor_get_formats_internal(glamor_egl, &num_formats, &formats)) {
-        goto error;
+        goto glamor_no_dri;
     }
 
     if (num_formats == 0) {
-        return TRUE;
+        found = TRUE;
     }
 
     for (uint32_t i = 0; i < num_formats; i++) {
@@ -1925,12 +1941,25 @@ glamor_egl_init_internal(glamor_egl_priv_t* glamor_egl, Bool *compat_ret)
     if (!found) {
         LogMessage(X_ERROR,
                    "glamor: No combination of format + modifier is supported\n");
-        goto error;
+        goto glamor_no_dri;
     }
 
+    LogMessage(X_INFO, "glamor dri X acceleration enabled on %s\n",
+               renderer);
     return TRUE;
 
 error:
+    LogMessage(X_ERROR, "glamor X acceleration failed to initialize\n");
     glamor_egl_cleanup(glamor_egl);
     return FALSE;
+
+glamor_no_dri:
+    glamor_egl->fd = -1;
+
+    if (compat_ret) {
+        *compat_ret = FALSE;
+    }
+    LogMessage(X_WARNING, "glamor X acceleration enabled without dri support on %s\n",
+               renderer);
+    return TRUE;
 }

--- a/glamor/glamor_egl.h
+++ b/glamor/glamor_egl.h
@@ -27,6 +27,8 @@
 #ifndef GLAMOR_EGL_H
 #define GLAMOR_EGL_H
 
+#include <stdbool.h>
+
 #define MESA_EGL_NO_X11_HEADERS
 #define EGL_NO_X11
 #include <epoxy/gl.h>
@@ -42,31 +44,57 @@ typedef struct glamor_egl_screen_private {
     EGLDisplay display;
     EGLContext context;
     char *device_path;
-    char *glvnd_vendor; /* GLVND vendor if forced from options or NULL otherwise */
+    char *glvnd_vendor; /* glvnd vendor library name or driver name */
     int exact_glvnd_vendor; /* If the glvnd vendor should be assumed valid with no checks */
+    void* server_private;
 
 #ifdef GLAMOR_HAS_GBM
     struct gbm_device *gbm;
 #endif
     int fd;
     int dmabuf_capable;
-    int linear_only;
+    int linear_only; /* When using gbm, this means that only linear buffers can be created */
+} glamor_egl_priv_t;
+
+typedef struct {
+    void* server_private; /* Data the X server might want to map to a screen */
+
+    /* Pointer to a server-allocated glamor_egl_priv_t, that the server maps to a screen */
+    glamor_egl_priv_t *glamor_egl_priv;
+
+    /* Function that maps a glamor_egl_priv_t to each screen*/
+    glamor_egl_priv_t* (*GLAMOR_EGL_PRIV_PROC)(ScreenPtr screen);
+
+    char *glvnd_vendor; /* glvnd vendor library or driver name */
+    int fd; /* /dev/dri/cardxx */
+    int dmabuf_forced; /* If glamor should not use dynamic logic and only listen to the config below */
+    int dmabuf_capable; /* If glamor should use dmabufs when using direct rendering (dri) */
+
+    int llvmpipe_allowed; /* If glamor render accel should initialize on llvmpipe */
+    int force_glamor; /* If glamor should initialize even on softpipe/llvmpipe */
 
     int es_disallowed; /* If using GLES contexts is forbidden */
     int force_es; /* If glamor should only use GLES contexts */
+} glamor_egl_conf_t;
 
-    int llvmpipe_allowed; /* If glamor render accel should initialize on llvmpipe */
+/**
+ * Initialize an egl context suitable to be used by glamor.
+ *
+ * glamor_egl_conf is a pointer to caller-allocated storage.
+ *
+ * If compat_ret is not NULL, it will be set to a return value
+ * for compatibility with xf86 drivers.
+ */
+Bool glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, Bool *compat_ret);
 
-    void* saved_free_screen;
-
-    /* Function that maps each screen to a glamor_egl_priv_t */
-    struct glamor_egl_screen_private* (*GLAMOR_EGL_PRIV_PROC)(ScreenPtr screen);
-} glamor_egl_priv_t;
-
+/**
+ * Deinitialize an egl context created by glamor egl
+ * and free associated resources.
+ *
+ * glamor_egl is the pointer passed to glamor_egl_init2
+ * in glamor_egl_conf->glamor_egl_priv;
+ */
 void glamor_egl_cleanup(glamor_egl_priv_t *glamor_egl);
-
-/* Initialize an egl context suitable to be used by glamor. */
-Bool glamor_egl_init_internal(glamor_egl_priv_t* glamor_egl, Bool *compat_ret);
 
 /*
  * Create an EGLDisplay from a native display type. This is a little quirky
@@ -95,7 +123,7 @@ Bool glamor_egl_init_internal(glamor_egl_priv_t* glamor_egl, Bool *compat_ret);
  * like mesa will be able to adverise these (even though it can do EGL 1.5).
  */
 static inline EGLDisplay
-glamor_egl_get_display2(EGLint type, void *native, int platform_fallback)
+glamor_egl_get_display2(EGLint type, void *native, bool platform_fallback)
 {
     /* In practise any EGL 1.5 implementation would support the EXT extension */
     if (epoxy_has_egl_extension(NULL, "EGL_EXT_platform_base")) {
@@ -113,7 +141,7 @@ glamor_egl_get_display2(EGLint type, void *native, int platform_fallback)
 static inline EGLDisplay
 glamor_egl_get_display(EGLint type, void *native)
 {
-    return glamor_egl_get_display2(type, native, 1);
+    return glamor_egl_get_display2(type, native, true);
 }
 
 #endif

--- a/hw/xfree86/glamor_egl/glamor_xf86_egl.c
+++ b/hw/xfree86/glamor_egl/glamor_xf86_egl.c
@@ -10,7 +10,7 @@
 #include <xf86Priv.h>
 
 #include "glamor.h"
-#include "../../glamor/glamor_egl.h"
+#include "glamor_egl.h"
 
 enum {
     GLAMOREGLOPT_RENDERING_API,
@@ -45,7 +45,7 @@ glamor_xf86_egl_free_screen(ScrnInfoPtr scrn)
 
     glamor_egl = glamor_xf86_egl_get_scrn_private(scrn);
     if (glamor_egl != NULL) {
-        scrn->FreeScreen = glamor_egl->saved_free_screen;
+        scrn->FreeScreen = glamor_egl->server_private;
         glamor_egl_cleanup(glamor_egl);
         free(glamor_egl);
         scrn->FreeScreen(scrn);
@@ -59,10 +59,14 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
     OptionInfoPtr options;
     const char *api = NULL;
     const char *glvnd_vendor = NULL;
+    glamor_egl_conf_t glamor_egl_conf = {.fd = fd};
 
     glamor_egl = calloc(1, sizeof(*glamor_egl));
     if (glamor_egl == NULL)
         return FALSE;
+
+    glamor_egl_conf.glamor_egl_priv = glamor_egl;
+
     if (xf86GlamorEGLPrivateIndex == -1)
         xf86GlamorEGLPrivateIndex = xf86AllocateScrnInfoPrivateIndex();
 
@@ -71,34 +75,34 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
     xf86ProcessOptions(scrn->scrnIndex, scrn->options, options);
     glvnd_vendor = xf86GetOptValString(options, GLAMOREGLOPT_VENDOR_LIBRARY);
     if (glvnd_vendor) {
-        glamor_egl->glvnd_vendor = strdup(glvnd_vendor);
-        if (!glamor_egl->glvnd_vendor) {
+        glamor_egl_conf.glvnd_vendor = strdup(glvnd_vendor);
+        if (!glamor_egl_conf.glvnd_vendor) {
             LogMessage(X_WARNING, "Couldn't set gl vendor to: %s\n", glvnd_vendor);
-        } else {
-            glamor_egl->exact_glvnd_vendor = TRUE;
         }
     }
     api = xf86GetOptValString(options, GLAMOREGLOPT_RENDERING_API);
     if (api && !strncasecmp(api, "es", 2))
-        glamor_egl->force_es = TRUE;
+        glamor_egl_conf.force_es = TRUE;
     else if (api && !strncasecmp(api, "gl", 2))
-        glamor_egl->es_disallowed = TRUE;
+        glamor_egl_conf.es_disallowed = TRUE;
     free(options);
 
-    glamor_egl->GLAMOR_EGL_PRIV_PROC = glamor_xf86_egl_get_screen_private;
+    glamor_egl_conf.GLAMOR_EGL_PRIV_PROC = glamor_xf86_egl_get_screen_private;
 
     scrn->privates[xf86GlamorEGLPrivateIndex].ptr = glamor_egl;
 
-    glamor_egl->fd = fd;
-
-    if (xf86Info.debug != NULL)
-        glamor_egl->dmabuf_capable = !!strstr(xf86Info.debug,
-                                              "dmabuf_capable");
+    if (xf86Info.debug != NULL) {
+        glamor_egl_conf.dmabuf_forced = TRUE;
+        glamor_egl_conf.dmabuf_capable = !!strstr(xf86Info.debug,
+                                                   "dmabuf_capable");
+    }
 
     Bool compat_ret = TRUE;
 
-    if (glamor_egl_init_internal(glamor_egl, &compat_ret)) {
-        glamor_egl->saved_free_screen = scrn->FreeScreen;
+    glamor_egl_conf.llvmpipe_allowed = !!scrn->confScreen->num_gpu_devices;
+
+    glamor_egl_conf.server_private = scrn->FreeScreen;
+    if (glamor_egl_init_internal(&glamor_egl_conf, &compat_ret)) {
         scrn->FreeScreen = glamor_xf86_egl_free_screen;
         return compat_ret;
     }


### PR DESCRIPTION
to take a small config struct instead of the glamor private

Allows glamor egl to use regular dix screen privates in a further patch