### PR TITLE
(release/25.0) randr: fix missing byte swaps in ProcRRGetProviderInfo()

### DIFF
--- a/randr/rrprovider.c
+++ b/randr/rrprovider.c
@@ -253,6 +253,8 @@ ProcRRGetProviderInfo (ClientPtr client)
         swaps(&rep.nCrtcs);
         swaps(&rep.nOutputs);
         swaps(&rep.nameLength);
+        swapl(&rep.timestamp);
+        swaps(&rep.nAssociatedProviders);
     }
     WriteToClient(client, sizeof(xRRGetProviderInfoReply), (char *)&rep);
     if (extraLen)


### PR DESCRIPTION
Some fields have been forgotten to be byte-swapped.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
