### PR TITLE
(release/25.0) Xext: sync: fix missing byte swap in ProcSyncQueryAlarm()

### DIFF
--- a/Xext/sync.c
+++ b/Xext/sync.c
@@ -1890,6 +1890,7 @@ ProcSyncQueryAlarm(ClientPtr client)
         swaps(&rep.sequenceNumber);
         swapl(&rep.length);
         swapl(&rep.counter);
+        swapl(&rep.value_type);
         swapl(&rep.wait_value_hi);
         swapl(&rep.wait_value_lo);
         swapl(&rep.test_type);


### PR DESCRIPTION
The reply's `value_type` field had been forgotten.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
