### PR TITLE
(release/25.0) glx: fix wrong pointer passed to non-swap handlers in TexImage/CopySubBuffer

### DIFF
--- a/glx/glxcmdsswap.c
+++ b/glx/glxcmdsswap.c
@@ -637,7 +637,7 @@ __glXDispSwap_BindTexImageEXT(__GLXclientState * cl, GLbyte * pc)
     __GLX_SWAP_INT(buffer);
     __GLX_SWAP_INT(num_attribs);
 
-    return __glXDisp_BindTexImageEXT(cl, (GLbyte *) pc);
+    return __glXDisp_BindTexImageEXT(cl, (GLbyte *) req);
 }
 
 int
@@ -662,7 +662,7 @@ __glXDispSwap_ReleaseTexImageEXT(__GLXclientState * cl, GLbyte * pc)
     __GLX_SWAP_INT(drawId);
     __GLX_SWAP_INT(buffer);
 
-    return __glXDisp_ReleaseTexImageEXT(cl, (GLbyte *) pc);
+    return __glXDisp_ReleaseTexImageEXT(cl, (GLbyte *) req);
 }
 
 int
@@ -690,7 +690,7 @@ __glXDispSwap_CopySubBufferMESA(__GLXclientState * cl, GLbyte * pc)
     __GLX_SWAP_INT(pc + 12);
     __GLX_SWAP_INT(pc + 16);
 
-    return __glXDisp_CopySubBufferMESA(cl, pc);
+    return __glXDisp_CopySubBufferMESA(cl, (GLbyte *) req);
 
 }
 


### PR DESCRIPTION
Three GLX byte-swap dispatch functions advance the pc pointer past the
vendor private header (pc += __GLX_VENDPRIV_HDR_SIZE) for local field
swapping, then pass the ADVANCED pc to the non-swap handler. But the
non-swap handlers expect pc to point to the start of the
xGLXVendorPrivateReq — they cast pc to xGLXVendorPrivateReq* to access
req->contextTag, then do their own pc += __GLX_VENDPRIV_HDR_SIZE.

Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2181>
