### PR TITLE
(release/25.0) damageext: fix wrong REQUEST_SIZE_MATCH type in SProcDamageAdd

### DIFF
--- a/damageext/damageext.c
+++ b/damageext/damageext.c
@@ -532,7 +532,7 @@ static int _X_COLD
 SProcDamageAdd(ClientPtr client)
 {
     REQUEST(xDamageAddReq);
-    REQUEST_SIZE_MATCH(xDamageSubtractReq);
+    REQUEST_SIZE_MATCH(xDamageAddReq);
     swapl(&stuff->drawable);
     swapl(&stuff->region);
     return ProcDamageAdd(client);


### PR DESCRIPTION
Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2183>
