### PR TITLE
(release/25.0) Xext/xres: add missing byte-swap of spec entries in SProcXResQueryClientIds

### DIFF
--- a/Xext/xres.c
+++ b/Xext/xres.c
@@ -1036,10 +1036,22 @@ SProcXResQueryClientPixmapBytes(ClientPtr client)
 static int _X_COLD
 SProcXResQueryClientIds (ClientPtr client)
 {
+    int i;
+    xXResClientIdSpec *specs;
+
     REQUEST(xXResQueryClientIdsReq);
 
     REQUEST_AT_LEAST_SIZE (xXResQueryClientIdsReq);
     swapl(&stuff->numSpecs);
+    REQUEST_FIXED_SIZE(xXResQueryClientIdsReq,
+                       stuff->numSpecs * sizeof(xXResClientIdSpec));
+
+    specs = (xXResClientIdSpec *) (stuff + 1);
+    for (i = 0; i < stuff->numSpecs; i++) {
+        swapl(&specs[i].client);
+        swapl(&specs[i].mask);
+    }
+
     return ProcXResQueryClientIds(client);
 }
 


### PR DESCRIPTION
SProcXResQueryClientIds() swapped the numSpecs field but did not swap
the individual xXResClientIdSpec entries that follow the request header.
Each spec contains two CARD32 fields: client (an XID) and mask (a
bitmask selecting which client ID types to query).

Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2181>
