### PR TITLE
(release/25.0) Xext/xres: fix undefined behavior in ConstructClientIdValue

### DIFF
--- a/Xext/xres.c
+++ b/Xext/xres.c
@@ -468,11 +468,13 @@ ConstructClientIdValue(ClientPtr sendClient, ClientPtr client, CARD32 mask,
         if (pid != -1) {
             void *ptr = AddFragment(&ctx->response,
                                     sizeof(rep) + sizeof(CARD32));
-            CARD32 *value = (void*) ((char*) ptr + sizeof(rep));
+            CARD32 *value;
 
             if (!ptr) {
                 return FALSE;
             }
+
+            value = (void*) ((char*) ptr + sizeof(rep));
 
             rep.spec.mask = X_XResLocalClientPIDMask;
             rep.length = 4;


### PR DESCRIPTION
The CARD32 *value pointer was computed as (ptr + sizeof(rep))
BEFORE the NULL check for ptr. If AddFragment returns NULL, this
performs pointer arithmetic on a null pointer, which is undefined
behavior per C11 section 6.5.6 paragraph 8. With aggressive compiler
optimizations (e.g., GCC -O2 with LTO), the compiler could reason
that since ptr was used in arithmetic, it must be non-NULL, and
optimize away the NULL check entirely. This would then cause a
write to an invalid address on OOM.

Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2181>
