### PR TITLE
(release/25.0) Xext/shm: add missing reply byte-swap in ProcShmCreateSegment

### DIFF
--- a/Xext/shm.c
+++ b/Xext/shm.c
@@ -1335,6 +1335,10 @@ ProcShmCreateSegment(ClientPtr client)
         close(fd);
         return BadAlloc;
     }
+    if (client->swapped) {
+        swaps(&rep.sequenceNumber);
+        swapl(&rep.length);
+    }
     WriteToClient(client, sizeof (xShmCreateSegmentReply), &rep);
     return Success;
 }


### PR DESCRIPTION
ProcShmCreateSegment() sent the xShmCreateSegmentReply to the client
without byte-swapping the sequenceNumber field for byte-swapped clients.
Every other SHM Proc function that sends a reply (ProcShmQueryVersion,
ProcShmGetImage) correctly swaps the reply fields.

The sequenceNumber is a CARD16 that Xlib/XCB uses to match replies to
their corresponding requests. With a garbled sequence number, the client
library will mismatch the reply with the wrong request, causing the
client to hang waiting for the real reply, process stale data from a
different request's reply, or crash due to unexpected reply format.

Fix by adding byte-swap of sequenceNumber and length before
WriteToClient, consistent with the other SHM reply handlers.

Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2181>
