### PR TITLE
(release/25.0) Xi: add missing byte-swap of resolution values in SProcXChangeDeviceControl

### DIFF
--- a/Xi/chgdctl.c
+++ b/Xi/chgdctl.c
@@ -87,10 +87,16 @@ SProcXChangeDeviceControl(ClientPtr client)
     case DEVICE_ABS_AREA:
     case DEVICE_CORE:
     case DEVICE_ENABLE:
-    case DEVICE_RESOLUTION:
-        /* hmm. beer. *drool* */
         break;
-
+    case DEVICE_RESOLUTION:
+    {
+        xDeviceResolutionCtl *r = (xDeviceResolutionCtl *) &stuff[1];
+        if (client->req_len - bytes_to_int32(sizeof(xChangeDeviceControlReq))
+            < bytes_to_int32(sizeof(xDeviceResolutionCtl)))
+            return BadLength;
+        SwapLongs((CARD32 *) (r + 1), r->num_valuators);
+        break;
+    }
     }
     return (ProcXChangeDeviceControl(client));
 }


### PR DESCRIPTION
Clearly no-one has needed this since at least 2008, that's the earliest
mention of this comment.

Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2181>
