### PR TITLE
(release/25.0) render: add missing byte-swap of filter params in SProcRenderSetPictureFilter

### DIFF
--- a/render/render.c
+++ b/render/render.c
@@ -2402,11 +2402,24 @@ SProcRenderQueryFilters(ClientPtr client)
 static int _X_COLD
 SProcRenderSetPictureFilter(ClientPtr client)
 {
+    int nparams;
+    char *name;
+    xFixed *params;
+
     REQUEST(xRenderSetPictureFilterReq);
     REQUEST_AT_LEAST_SIZE(xRenderSetPictureFilterReq);
 
     swapl(&stuff->picture);
     swaps(&stuff->nbytes);
+
+    name = (char *) (stuff + 1);
+    params = (xFixed *) (name + pad_to_int32(stuff->nbytes));
+    nparams = ((xFixed *) stuff + client->req_len) - params;
+    if (nparams < 0)
+        return BadLength;
+
+    SwapLongs((CARD32*)params, nparams);
+
     return (*ProcRenderVector[stuff->renderReqType]) (client);
 }
 


### PR DESCRIPTION
SProcRenderSetPictureFilter() swapped the picture and nbytes fields but
did not swap the xFixed (CARD32) filter parameter values that follow the
filter name string in the request body.

Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2181>
