### PR TITLE
(release/25.0) randr, Xext: remove stale length swaps

### DIFF
--- a/randr/rrsdispatch.c
+++ b/randr/rrsdispatch.c
@@ -116,7 +116,6 @@ SProcRRGetScreenResourcesCurrent(ClientPtr client)
     REQUEST(xRRGetScreenResourcesCurrentReq);
 
     REQUEST_SIZE_MATCH(xRRGetScreenResourcesCurrentReq);
-    swaps(&stuff->length);
     swapl(&stuff->window);
     return ProcRRGetScreenResourcesCurrent(client);
 }


### PR DESCRIPTION
The dispatch infrastructure already handles request length byte-swapping via
get_req_len() / client->req_len, so let's not double-swap the length
field back to the wrong byte order.

Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2181>
