### PR TITLE
(release/25.0) Zero out structs to avoid leaking information via padding

### DIFF
--- a/Xext/xvdisp.c
+++ b/Xext/xvdisp.c
@@ -319,7 +319,7 @@ static int
 ProcXvQueryAdaptors(ClientPtr client)
 {
     xvFormat format;
-    xvAdaptorInfo ainfo;
+    xvAdaptorInfo ainfo = { 0 };
     int totalSize, na, nf, rc;
     int nameSize;
     XvAdaptorPtr pa;
@@ -401,7 +401,7 @@ ProcXvQueryAdaptors(ClientPtr client)
 static int
 ProcXvQueryEncodings(ClientPtr client)
 {
-    xvEncodingInfo einfo;
+    xvEncodingInfo einfo = { 0 };
     int totalSize;
     int nameSize;
     XvPortPtr pPort;
@@ -1083,7 +1083,7 @@ ProcXvListImageFormats(ClientPtr client)
     XvPortPtr pPort;
     XvImagePtr pImage;
     int i;
-    xvImageFormatInfo info;
+    xvImageFormatInfo info = { 0 };
 
     REQUEST(xvListImageFormatsReq);
 

--- a/dbe/dbe.c
+++ b/dbe/dbe.c
@@ -659,7 +659,7 @@ ProcDbeGetVisualInfo(ClientPtr client)
 
         /* Now send off visual info items. */
         for (j = 0; j < pScrVisInfo[i].count; j++) {
-            xDbeVisInfo visInfo;
+            xDbeVisInfo visInfo = { 0 };
 
             /* Copy the data in the client data structure to a protocol
              * data structure.  We will send data to the client from the

--- a/os/connection.c
+++ b/os/connection.c
@@ -720,7 +720,7 @@ ConnMaxNotify(int fd, int events, void *data)
     /* try to read the byte-order of the connection */
     (void) _XSERVTransRead(trans_conn, &order, 1);
     if (order == 'l' || order == 'B' || order == 'r' || order == 'R') {
-        xConnSetupPrefix csp;
+        xConnSetupPrefix csp = { 0 };
         char pad[3] = { 0, 0, 0 };
         int whichbyte = 1;
         struct iovec iov[3];


### PR DESCRIPTION
Structs that are sent to the client may leak data via unititialized
padding bytes. Let's not do that.

Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2185>
