### PR TITLE
(release/25.1) glx: fix wrong pointer passed to non-swap handlers in TexImage/CopySubBuffer

### DIFF
--- a/glx/glxcmdsswap.c
+++ b/glx/glxcmdsswap.c
@@ -575,7 +575,7 @@ __glXDispSwap_BindTexImageEXT(__GLXclientState * cl, GLbyte * pc)
     swapl(buffer);
     swapl(num_attribs);
 
-    return __glXDisp_BindTexImageEXT(cl, (GLbyte *) pc);
+    return __glXDisp_BindTexImageEXT(cl, (GLbyte *) req);
 }
 
 int
@@ -598,7 +598,7 @@ __glXDispSwap_ReleaseTexImageEXT(__GLXclientState * cl, GLbyte * pc)
     swapl(drawId);
     swapl(buffer);
 
-    return __glXDisp_ReleaseTexImageEXT(cl, (GLbyte *) pc);
+    return __glXDisp_ReleaseTexImageEXT(cl, (GLbyte *) req);
 }
 
 int
@@ -624,7 +624,7 @@ __glXDispSwap_CopySubBufferMESA(__GLXclientState * cl, GLbyte * pc)
     swapl((CARD32*)(pc + 12));
     swapl((CARD32*)(pc + 16));
 
-    return __glXDisp_CopySubBufferMESA(cl, pc);
+    return __glXDisp_CopySubBufferMESA(cl, (GLbyte *) req);
 
 }
 


### PR DESCRIPTION
Three GLX byte-swap dispatch functions advance the pc pointer past the
vendor private header (pc += __GLX_VENDPRIV_HDR_SIZE) for local field
swapping, then pass the ADVANCED pc to the non-swap handler. But the
non-swap handlers expect pc to point to the start of the
xGLXVendorPrivateReq — they cast pc to xGLXVendorPrivateReq* to access
req->contextTag, then do their own pc += __GLX_VENDPRIV_HDR_SIZE.

Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2181>
