### PR TITLE
(release/25.1) Xext: sync: fix missing byte swap in ProcSyncQueryAlarm()

### DIFF
--- a/Xext/sync.c
+++ b/Xext/sync.c
@@ -1887,6 +1887,7 @@ ProcSyncQueryAlarm(ClientPtr client)
 
     if (client->swapped) {
         swapl(&reply.counter);
+        swapl(&reply.value_type);
         swapl(&reply.wait_value_hi);
         swapl(&reply.wait_value_lo);
         swapl(&reply.test_type);


### PR DESCRIPTION
The reply's `value_type` field had been forgotten.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
