### PR TITLE
(release/25.1) glx: __glXDispSwap_CopyContext(): fix missing byte swap

### DIFF
--- a/glx/glxcmdsswap.c
+++ b/glx/glxcmdsswap.c
@@ -185,6 +185,7 @@ __glXDispSwap_CopyContext(__GLXclientState * cl, GLbyte * pc)
     swapl(&req->source);
     swapl(&req->dest);
     swapl(&req->mask);
+    swapl(&req->contextTag);
 
     return __glXDisp_CopyContext(cl, pc);
 }


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
