### PR TITLE
(release/25.1) render: fix swapping and additional length check in ProcRenderSetPictureFilter()

### DIFF
--- a/render/render.c
+++ b/render/render.c
@@ -2890,6 +2890,22 @@ ProcRenderSetPictureFilter(ClientPtr client)
         swaps(&stuff->nbytes);
     }
 
+    const size_t namelen = pad_to_int32(stuff->nbytes);
+    REQUEST_AT_LEAST_EXTRA_SIZE(xRenderSetPictureFilterReq, namelen);
+
+    const size_t packet_len = stuff->length * 4;
+    const size_t remaining =
+        (packet_len - sizeof(xRenderSetPictureFilterReq) - namelen);
+    const size_t nparams = remaining / 4;
+    if ((nparams * 4) != remaining) {
+        return BadLength;
+    }
+
+    if (client->swapped) {
+        CARD32 *params = (CARD32*)((char*)(stuff + 1) + namelen);
+        SwapLongs(params, nparams);
+    }
+
 #ifdef XINERAMA
     return (usePanoramiX ? PanoramiXRenderSetPictureFilter(client, stuff)
                          : SingleRenderSetPictureFilter(client, stuff));


### PR DESCRIPTION
* correctly swap the parameters, which are coming after the filter name block
  (those are treated as CARD32's)
* additional length checks for malicious packets (protect from buffer overflow)

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
