### PR TITLE
(release/25.1) Xext: xres: ProcXResQueryClientIds() fix request field wapping

### DIFF
--- a/Xext/xres.c
+++ b/Xext/xres.c
@@ -519,6 +519,11 @@ ProcXResQueryClientIds (ClientPtr client)
     xXResClientIdSpec        *specs = (void*) ((char*) stuff + sizeof(xXResQueryClientIdsReq));
     ConstructClientIdCtx      ctx;
 
+    if (client->swapped) {
+        /* each spec is made of two CARD32's */
+        SwapLongs((CARD32*)specs, stuff->numSpecs * 2);
+    }
+
     InitConstructClientIdCtx(&ctx);
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };


### PR DESCRIPTION
The individual spec entries' fields also need to be swapped.
Each is made of two CARD32's.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
