### PR TITLE
(master) randr: ProcRRSetMonitor(): fix request size check

### DIFF
--- a/randr/rrmonitor.c
+++ b/randr/rrmonitor.c
@@ -660,7 +660,7 @@ int
 ProcRRSetMonitor(ClientPtr client)
 {
     REQUEST(xRRSetMonitorReq);
-    REQUEST_AT_LEAST_SIZE(xRRGetMonitorsReq);
+    REQUEST_AT_LEAST_SIZE(xRRSetMonitorReq);
 
     if (client->swapped) {
         swapl(&stuff->window);


### PR DESCRIPTION
We have to check against xRRSetMonitorsReq instead of xRRGetMonitorsReq.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
