### PR TITLE
(master) randr: ProcRRSetMonitor(): fix missing request field swaps

### DIFF
--- a/randr/rrmonitor.c
+++ b/randr/rrmonitor.c
@@ -670,6 +670,8 @@ ProcRRSetMonitor(ClientPtr client)
         swaps(&stuff->monitor.y);
         swaps(&stuff->monitor.width);
         swaps(&stuff->monitor.height);
+        swapl(&stuff->monitor.widthInMillimeters);
+        swapl(&stuff->monitor.heightInMillimeters);
         SwapRestL(stuff);
     }
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
