### PR TITLE
(master) Xext: xres: ProcXResQueryClientIds() fix request field wapping

### DIFF
--- a/Xext/xres.c
+++ b/Xext/xres.c
@@ -476,6 +476,11 @@ ProcXResQueryClientIds (ClientPtr client)
 
     xXResClientIdSpec        *specs = (void*) ((char*) stuff + sizeof(xXResQueryClientIdsReq));
 
+    if (client->swapped) {
+        /* each spec is made of two CARD32's */
+        SwapLongs((CARD32*)specs, stuff->numSpecs * 2);
+    }
+
     ConstructClientIdCtx      ctx = {
         .rpcbuf.swapped = client->swapped,
         .rpcbuf.err_clear = TRUE


### PR DESCRIPTION
The individual spec entries' fields also need to be swapped.
Each is made of two CARD32's.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
