### PR TITLE
(master) Xi: XProcXChangeDeviceControl(): fix missing request parameter bytewap

### DIFF
--- a/Xi/chgdctl.c
+++ b/Xi/chgdctl.c
@@ -132,6 +132,9 @@ ProcXChangeDeviceControl(ClientPtr client)
             ret = BadValue;
             goto out;
         }
+        if (client->swapped) {
+            SwapLongs((CARD32 *) (r + 1), r->num_valuators);
+        }
         status = ChangeDeviceControl(client, dev, (xDeviceCtl *) r);
         if (status == Success) {
             a = &dev->valuator->axes[r->first_valuator];


### PR DESCRIPTION
Unlikely that those operations ever coming from a remote client,
let alone one with different endianess, but nevertheless let's be
correct here :)

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
