### PR TITLE
(master) render: fix swapping and additional length check in ProcRenderSetPictureFilter()

### DIFF
--- a/Xext/render/render.c
+++ b/Xext/render/render.c
@@ -2884,6 +2884,22 @@ ProcRenderSetPictureFilter(ClientPtr client)
         swaps(&stuff->nbytes);
     }
 
+    const size_t namelen = pad_to_int32(stuff->nbytes);
+    REQUEST_AT_LEAST_EXTRA_SIZE(xRenderSetPictureFilterReq, namelen);
+
+    const size_t packet_len = stuff->length * 4;
+    const size_t remaining =
+        (packet_len - sizeof(xRenderSetPictureFilterReq) - namelen);
+    const size_t nparams = remaining / 4;
+    if ((nparams * 4) != remaining) {
+        return BadLength;
+    }
+
+    if (client->swapped) {
+        CARD32 *params = (CARD32*)((char*)(stuff + 1) + namelen);
+        SwapLongs(params, nparams);
+    }
+
 #ifdef XINERAMA
     return (usePanoramiX ? PanoramiXRenderSetPictureFilter(client, stuff)
                          : SingleRenderSetPictureFilter(client, stuff));


### PR DESCRIPTION
* correctly swap the parameters, which are coming after the filter name block
  (those are treated as CARD32's)
* additional length checks for malicious packets (protect from buffer overflow)

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>

---

### Backport dashboard

| Target branch | Backport PR | Status |
|----------------|-------------|--------|
| `release/25.2` | #3096 | 🔄 Open |
| `release/25.1` | — | ✅ Already contained |
| `release/25.0` | — | ✅ N/A (not vulnerable) |

<sub>🤖 Backport assessment by Claude Code on behalf of @metux. **25.1** already carries the identical fix in `render/render.c`. **25.0** predates the regression: its pre-refactor `SProcRenderSetPictureFilter` already swaps the trailing params (`SwapLongs`) and bounds-checks them via `nparams < 0`, so the bug this PR fixes was never present there.</sub>
