### PR TITLE
(master) randr: fix missing byte swaps

### DIFF
--- a/randr/rrlease.c
+++ b/randr/rrlease.c
@@ -221,6 +221,7 @@ ProcRRCreateLease(ClientPtr client)
         swapl(&stuff->window);
         swaps(&stuff->nCrtcs);
         swaps(&stuff->nOutputs);
+        swapl(&stuff->lid);
         SwapRestL(stuff);
     }
 

--- a/randr/rrmode.c
+++ b/randr/rrmode.c
@@ -300,6 +300,7 @@ ProcRRCreateMode(ClientPtr client)
         swaps(&modeinfo->hSyncStart);
         swaps(&modeinfo->hSyncEnd);
         swaps(&modeinfo->hTotal);
+        swaps(&modeinfo->hSkew);
         swaps(&modeinfo->vSyncStart);
         swaps(&modeinfo->vSyncEnd);
         swaps(&modeinfo->vTotal);

--- a/randr/rrprovider.c
+++ b/randr/rrprovider.c
@@ -227,6 +227,8 @@ ProcRRGetProviderInfo (ClientPtr client)
         swaps(&reply.nCrtcs);
         swaps(&reply.nOutputs);
         swaps(&reply.nameLength);
+        swapl(&reply.timestamp);
+        swaps(&reply.nAssociatedProviders);
     }
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);

--- a/randr/rrscreen.c
+++ b/randr/rrscreen.c
@@ -877,6 +877,7 @@ ProcRRSetScreenConfig(ClientPtr client)
         swapl(&stuff->timestamp);
         swaps(&stuff->sizeID);
         swaps(&stuff->rotation);
+        swapl(&stuff->configTimestamp);
     }
 
     DrawablePtr pDraw;


### PR DESCRIPTION
Some fields have been forgotten to be byte-swapped.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
