### PR TITLE
(master) Zero out structs to avoid leaking information via padding

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -2657,7 +2657,7 @@ _XkbSetMap(ClientPtr client, DeviceIntPtr dev, xkbSetMapReq * req, char *values)
     if ((xkb->min_key_code != req->minKeyCode) ||
         (xkb->max_key_code != req->maxKeyCode)) {
         Status status;
-        xkbNewKeyboardNotify nkn;
+        xkbNewKeyboardNotify nkn = { 0 };
 
         nkn.deviceID = nkn.oldDeviceID = dev->id;
         nkn.oldMinKeyCode = xkb->min_key_code;

--- a/xkb/xkbAccessX.c
+++ b/xkb/xkbAccessX.c
@@ -289,7 +289,7 @@ AccessXStickyKeysTurnOff(DeviceIntPtr dev, xkbControlsNotify * pCN)
 static CARD32
 AccessXKRGExpire(OsTimerPtr timer, CARD32 now, void *arg)
 {
-    xkbControlsNotify cn;
+    xkbControlsNotify cn = { 0 };
     DeviceIntPtr dev = arg;
     XkbSrvInfoPtr xkbi = dev->key->xkbInfo;
 
@@ -352,7 +352,7 @@ AccessXSlowKeyExpire(OsTimerPtr timer, CARD32 now, void *arg)
     xkb = xkbi->desc;
     ctrls = xkb->ctrls;
     if (xkbi->slowKey != 0) {
-        xkbAccessXNotify ev;
+        xkbAccessXNotify ev = { 0 };
         KeySym *sym = XkbKeySymsPtr(xkb, xkbi->slowKey);
 
         ev.detail = XkbAXN_SKAccept;
@@ -402,7 +402,7 @@ AccessXTimeoutExpire(OsTimerPtr timer, CARD32 now, void *arg)
     XkbSrvInfoPtr xkbi = dev->key->xkbInfo;
     XkbControlsPtr ctrls = xkbi->desc->ctrls;
     XkbControlsRec old;
-    xkbControlsNotify cn;
+    xkbControlsNotify cn = { 0 };
     XkbEventCauseRec cause;
     XkbSrvLedInfoPtr sli;
 
@@ -506,7 +506,7 @@ AccessXFilterPressEvent(DeviceEvent *event, DeviceIntPtr keybd)
      * has held the key long enough.
      */
     if (ctrls->enabled_ctrls & XkbSlowKeysMask) {
-        xkbAccessXNotify ev;
+        xkbAccessXNotify ev = { 0 };
 
         /* If key was already pressed, ignore subsequent press events
          * from the server's autorepeat
@@ -572,7 +572,7 @@ AccessXFilterPressEvent(DeviceEvent *event, DeviceIntPtr keybd)
     if ((ctrls->enabled_ctrls & XkbStickyKeysMask) &&
         (xkbi->state.base_mods != 0) &&
         (XkbAX_NeedOption(ctrls, XkbAX_TwoKeysMask))) {
-        xkbControlsNotify cn;
+        xkbControlsNotify cn = { 0 };
 
         cn.keycode = key;
         cn.eventType = KeyPress;
@@ -625,7 +625,7 @@ AccessXFilterReleaseEvent(DeviceEvent *event, DeviceIntPtr keybd)
      * the key if the down bit was set by CoreProcessKeyboardEvent.
      */
     if (ctrls->enabled_ctrls & XkbSlowKeysMask) {
-        xkbAccessXNotify ev;
+        xkbAccessXNotify ev = { 0 };
         unsigned beep_type;
         unsigned mask;
 
@@ -682,7 +682,7 @@ AccessXFilterReleaseEvent(DeviceEvent *event, DeviceIntPtr keybd)
             xkbi->shiftKeyCount = 0;
         }
         else if (xkbi->shiftKeyCount >= 5) {
-            xkbControlsNotify cn;
+            xkbControlsNotify cn = { 0 };
 
             cn.keycode = key;
             cn.eventType = KeyPress;

--- a/xkb/xkbActions.c
+++ b/xkb/xkbActions.c
@@ -612,7 +612,7 @@ _XkbFilterPointerBtn(XkbSrvInfoPtr xkbi,
         {
             XkbControlsPtr ctrls = xkbi->desc->ctrls;
             XkbControlsRec old;
-            xkbControlsNotify cn;
+            xkbControlsNotify cn = { 0 };
 
             old = *ctrls;
             AccessXCancelRepeatKey(xkbi, keycode);
@@ -706,7 +706,7 @@ _XkbFilterControls(XkbSrvInfoPtr xkbi,
         }
 
         if (change) {
-            xkbControlsNotify cn;
+            xkbControlsNotify cn = { 0 };
             XkbSrvLedInfoPtr sli;
 
             ctrls->enabled_ctrls |= change;
@@ -735,7 +735,7 @@ _XkbFilterControls(XkbSrvInfoPtr xkbi,
     else if (filter->keycode == keycode) {
         change = filter->priv;
         if (change) {
-            xkbControlsNotify cn;
+            xkbControlsNotify cn = { 0 };
             XkbSrvLedInfoPtr sli;
 
             ctrls->enabled_ctrls &= ~change;
@@ -794,7 +794,7 @@ _XkbFilterActionMessage(XkbSrvInfoPtr xkbi,
             filter->upAction = *pAction;
         }
         if (pMsg->flags & XkbSA_MessageOnPress) {
-            xkbActionMessage msg;
+            xkbActionMessage msg = { 0 };
 
             msg.keycode = keycode;
             msg.press = 1;

--- a/xkb/xkbEvents.c
+++ b/xkb/xkbEvents.c
@@ -474,7 +474,7 @@ XkbHandleBell(BOOL force,
               void *pCtrl,
               CARD8 class, Atom name, WindowPtr pWin, ClientPtr pClient)
 {
-    xkbBellNotify bn;
+    xkbBellNotify bn = { 0 };
     int initialized;
     XkbSrvInfoPtr xkbi;
     XkbInterestPtr interest;

--- a/xkb/xkbUtils.c
+++ b/xkb/xkbUtils.c
@@ -523,7 +523,7 @@ void
 XkbSetRepeatKeys(DeviceIntPtr pXDev, int key, int onoff)
 {
     if (pXDev && pXDev->key && pXDev->key->xkbInfo) {
-        xkbControlsNotify cn;
+        xkbControlsNotify cn = { 0 };
         XkbControlsPtr ctrls = pXDev->key->xkbInfo->desc->ctrls;
         XkbControlsRec old;
 
@@ -775,7 +775,7 @@ XkbEnableDisableControls(XkbSrvInfoPtr xkbi,
     if (old == ctrls->enabled_ctrls)
         return FALSE;
     if (cause != NULL) {
-        xkbControlsNotify cn;
+        xkbControlsNotify cn = { 0 };
 
         cn.numGroups = ctrls->num_groups;
         cn.changedControls = XkbControlsEnabledMask;


### PR DESCRIPTION
Structs that are sent to the client may leak data via unititialized
padding bytes. Let's not do that.

Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2185>
