### PR TITLE
(release/25.1) glamor: export some glamor APIs used by xorgxrdp.

### DIFF
--- a/glamor/glamor.h
+++ b/glamor/glamor.h
@@ -152,6 +152,27 @@ extern _X_EXPORT struct gbm_device *glamor_egl_get_gbm_device(ScreenPtr screen);
  * */
 extern _X_EXPORT Bool glamor_supports_pixmap_import_export(ScreenPtr screen);
 
+/* @glamor_fds_from_pixmap: Get a dma-buf fd from a pixmap.
+ *
+ * @screen:   Current screen pointer.
+ * @pixmap:   The pixmap from which we want the fd.
+ * @fds, @strides, @offsets: Pointers to fill info of each plane.
+ * @modifier: Pointer to fill the modifier of the buffer.
+ *
+ * the pixmap and the buffer associated by the fds will share the same
+ * content. The caller is responsible to close the returned file descriptors.
+ * Returns the number of planes, -1 on error.
+ *
+ * Currently just exported for Xrdp's virtual driver - real HW drivers
+ * usually shouldn't need this.
+ * */
+_X_EXPORT int glamor_fds_from_pixmap(ScreenPtr screen,
+                                     PixmapPtr pixmap,
+                                     int *fds,
+                                     uint32_t *strides,
+                                     uint32_t *offsets,
+                                     uint64_t *modifier);
+
 /* @glamor_fd_from_pixmap: Get a dma-buf fd from a pixmap.
  *
  * @screen: Current screen pointer.
@@ -217,6 +238,34 @@ extern _X_EXPORT int glamor_name_from_pixmap(PixmapPtr pixmap,
 extern _X_EXPORT struct gbm_bo *glamor_gbm_bo_from_pixmap(ScreenPtr screen,
                                                           PixmapPtr pixmap);
 
+/* @glamor_pixmap_from_fds: Creates a pixmap to wrap a dma-buf fds.
+ *
+ * @screen:   Current screen pointer.
+ * @num_fds:  Number of fds to import
+ * @fds:      The dma-buf fds to import.
+ * @width:    The width of the buffers.
+ * @height:   The height of the buffers.
+ * @stride:   The stride of the buffers.
+ * @depth:    The depth of the buffers.
+ * @bpp:      The bpp of the buffers.
+ * @modifier: The modifier of the buffers.
+ *
+ * Returns a valid pixmap if the import succeeded, else NULL.
+ *
+ * Currently just exported for Xrdp's virtual driver - real HW drivers
+ * usually shouldn't need this.
+ * */
+_X_EXPORT PixmapPtr glamor_pixmap_from_fds(ScreenPtr screen,
+                                           CARD8 num_fds,
+                                           const int *fds,
+                                           CARD16 width,
+                                           CARD16 height,
+                                           const CARD32 *strides,
+                                           const CARD32 *offsets,
+                                           CARD8 depth,
+                                           CARD8 bpp,
+                                           uint64_t modifier);
+
 /* @glamor_pixmap_from_fd: Creates a pixmap to wrap a dma-buf fd.
  *
  * @screen: Current screen pointer.
@@ -256,6 +305,23 @@ extern _X_EXPORT Bool glamor_back_pixmap_from_fd(PixmapPtr pixmap,
                                                  CARD16 stride,
                                                  CARD8 depth,
                                                  CARD8 bpp);
+
+/* for xorgrdp */
+_X_EXPORT Bool glamor_get_formats(ScreenPtr screen,
+                                  CARD32 *num_formats,
+                                  CARD32 **formats);
+
+/* for xorgrdp */
+_X_EXPORT Bool glamor_get_modifiers(ScreenPtr screen,
+                                    uint32_t format,
+                                    uint32_t *num_modifiers,
+                                    uint64_t **modifiers);
+
+/* for xorgrdp */
+_X_EXPORT Bool glamor_get_drawable_modifiers(DrawablePtr draw,
+                                             uint32_t format,
+                                             uint32_t *num_modifiers,
+                                             uint64_t **modifiers);
 
 extern _X_EXPORT void glamor_set_drawable_modifiers_func(ScreenPtr screen,
                                                          GetDrawableModifiersFuncPtr func);

--- a/glamor/glamor_priv.h
+++ b/glamor/glamor_priv.h
@@ -1007,57 +1007,6 @@ int glamor_egl_fd_name_from_pixmap(ScreenPtr pScreen, PixmapPtr pPixmap,
 
 int glamor_egl_fd_from_pixmap(ScreenPtr, PixmapPtr, CARD16 *, CARD32 *);
 
-/* @glamor_fds_from_pixmap: Get a dma-buf fd from a pixmap.
- *
- * @screen: Current screen pointer.
- * @pixmap: The pixmap from which we want the fd.
- * @fds, @strides, @offsets: Pointers to fill info of each plane.
- * @modifier: Pointer to fill the modifier of the buffer.
- *
- * the pixmap and the buffer associated by the fds will share the same
- * content. The caller is responsible to close the returned file descriptors.
- * Returns the number of planes, -1 on error.
- * */
-int glamor_fds_from_pixmap(ScreenPtr screen,  PixmapPtr pixmap, int *fds,
-                           uint32_t *strides, uint32_t *offsets,
-                           uint64_t *modifier);
-
-/* @glamor_pixmap_from_fds: Creates a pixmap to wrap a dma-buf fds.
- *
- * @screen: Current screen pointer.
- * @num_fds: Number of fds to import
- * @fds: The dma-buf fds to import.
- * @width: The width of the buffers.
- * @height: The height of the buffers.
- * @stride: The stride of the buffers.
- * @depth: The depth of the buffers.
- * @bpp: The bpp of the buffers.
- * @modifier: The modifier of the buffers.
- *
- * Returns a valid pixmap if the import succeeded, else NULL.
- * */
-PixmapPtr glamor_pixmap_from_fds(ScreenPtr screen,
-                                 CARD8 num_fds,
-                                 const int *fds,
-                                 CARD16 width,
-                                 CARD16 height,
-                                 const CARD32 *strides,
-                                 const CARD32 *offsets,
-                                 CARD8 depth,
-                                 CARD8 bpp,
-                                 uint64_t modifier);
-
-Bool glamor_get_formats(ScreenPtr screen, CARD32 *num_formats, CARD32 **formats);
-
-Bool glamor_get_modifiers(ScreenPtr screen,
-                          uint32_t format,
-                          uint32_t *num_modifiers,
-                          uint64_t **modifiers);
-
-Bool glamor_get_drawable_modifiers(DrawablePtr draw,
-                                   uint32_t format,
-                                   uint32_t *num_modifiers,
-                                   uint64_t **modifiers);
 
 void glamor_egl_screen_init(ScreenPtr screen,
                             struct glamor_context *glamor_ctx);


### PR DESCRIPTION
The recent development versions of xorgxrdp require these 5 glamor_*
functions that were made private in the past:

glamor_fds_from_pixmap:        Made private in ea232c7
glamor_pixmap_from_fds:        Made private in 81c1479
glamor_get_formats:            Made private in 6f6aab8
glamor_get_modifiers:          Made private in 0644764
glamor_get_drawable_modifiers: Made private in 800ab10

Exporting them again to make xorgxrdp compilable with XLibre.

Signed-off-by: b-aaz <b-aazbsd@proton.me>
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
