### PR TITLE
(master) Xext: dpms: use new X_REPLY_FIELD_* macros

### DIFF
--- a/Xext/dpms.c
+++ b/Xext/dpms.c
@@ -325,10 +325,8 @@ ProcDPMSGetVersion(ClientPtr client)
         .minorVersion = SERVER_DPMS_MINOR_VERSION
     };
 
-    if (client->swapped) {
-        swaps(&reply.majorVersion);
-        swaps(&reply.minorVersion);
-    }
+    X_REPLY_FIELD_CARD16(majorVersion);
+    X_REPLY_FIELD_CARD16(minorVersion);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }
@@ -356,11 +354,9 @@ ProcDPMSGetTimeouts(ClientPtr client)
         .off = DPMSOffTime / MILLI_PER_SECOND
     };
 
-    if (client->swapped) {
-        swaps(&reply.standby);
-        swaps(&reply.suspend);
-        swaps(&reply.off);
-    }
+    X_REPLY_FIELD_CARD16(standby);
+    X_REPLY_FIELD_CARD16(suspend);
+    X_REPLY_FIELD_CARD16(off);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }
@@ -455,9 +451,7 @@ ProcDPMSInfo(ClientPtr client)
         .state = DPMSEnabled
     };
 
-    if (client->swapped) {
-        swaps(&reply.power_level);
-    }
+    X_REPLY_FIELD_CARD16(power_level);
     return X_SEND_REPLY_SIMPLE(client, reply);
 }
 


### PR DESCRIPTION
Use the new X_REPLY_FIELD_* macros for reply byte-swapping.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
