### PR TITLE
(master) Xext: bigreq: use new X_REPLY_FIELD_* macros

### DIFF
--- a/Xext/bigreq.c
+++ b/Xext/bigreq.c
@@ -56,9 +56,8 @@ ProcBigReqDispatch(ClientPtr client)
     xBigReqEnableReply reply = {
         .max_request_size = maxBigRequestSize
     };
-    if (client->swapped) {
-        swapl(&reply.max_request_size);
-    }
+
+    X_REPLY_FIELD_CARD32(max_request_size);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }


### PR DESCRIPTION
Use the new X_REPLY_FIELD_* macros for reply byte-swapping.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
