### PR TITLE
(master) Xext: xcmisc: use new X_REPLY_FIELD_* macros

### DIFF
--- a/Xext/xcmisc.c
+++ b/Xext/xcmisc.c
@@ -57,10 +57,8 @@ ProcXCMiscGetVersion(ClientPtr client)
         .minorVersion = XCMiscMinorVersion
     };
 
-    if (client->swapped) {
-        swaps(&reply.majorVersion);
-        swaps(&reply.minorVersion);
-    }
+    X_REPLY_FIELD_CARD16(majorVersion);
+    X_REPLY_FIELD_CARD16(minorVersion);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }
@@ -77,10 +75,9 @@ ProcXCMiscGetXIDRange(ClientPtr client)
         .start_id = min_id,
         .count = max_id - min_id + 1
     };
-    if (client->swapped) {
-        swapl(&reply.start_id);
-        swapl(&reply.count);
-    }
+
+    X_REPLY_FIELD_CARD32(start_id);
+    X_REPLY_FIELD_CARD32(count);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }
@@ -109,9 +106,8 @@ ProcXCMiscGetXIDList(ClientPtr client)
     xXCMiscGetXIDListReply reply = {
         .count = count
     };
-    if (client->swapped) {
-        swapl(&reply.count);
-    }
+
+    X_REPLY_FIELD_CARD32(count);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }


### PR DESCRIPTION
Use the new X_REPLY_FIELD_* macros for reply byte-swapping.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
