### PR TITLE
(master) Xext: selinux: use new X_REPLY_FIELD_* macros

### DIFF
--- a/Xext/xselinux_ext.c
+++ b/Xext/xselinux_ext.c
@@ -73,10 +73,8 @@ ProcSELinuxQueryVersion(ClientPtr client)
         .server_minor = SELINUX_MINOR_VERSION
     };
 
-    if (client->swapped) {
-        swaps(&reply.server_major);
-        swaps(&reply.server_minor);
-    }
+    X_REPLY_FIELD_CARD16(server_major);
+    X_REPLY_FIELD_CARD16(server_minor);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }
@@ -100,9 +98,7 @@ SELinuxSendContextReply(ClientPtr client, security_id_t sid)
         .context_len = len
     };
 
-    if (client->swapped) {
-        swapl(&reply.context_len);
-    }
+    X_REPLY_FIELD_CARD32(context_len);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
@@ -361,9 +357,7 @@ SELinuxSendItemsToClient(ClientPtr client, SELinuxListItemRec * items,
         .count = count
     };
 
-    if (client->swapped) {
-        swapl(&reply.count);
-    }
+    X_REPLY_FIELD_CARD32(count);
 
     SELinuxFreeItems(items, count);
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);


### PR DESCRIPTION
Use the new X_REPLY_FIELD_* macros for reply byte-swapping.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
