### PR TITLE
(master) Xext: xtest: use new X_REPLY_FIELD_* macros

### DIFF
--- a/Xext/xtest.c
+++ b/Xext/xtest.c
@@ -100,8 +100,7 @@ ProcXTestGetVersion(ClientPtr client)
         .minorVersion = XTestMinorVersion
     };
 
-    if (client->swapped)
-        swaps(&reply.minorVersion);
+    X_REPLY_FIELD_CARD16(minorVersion);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }


### PR DESCRIPTION
Use the new X_REPLY_FIELD_* macros for reply byte-swapping.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
