### PR TITLE
(master) Xext: xv: use new X_REPLY_FIELD_* macros

### DIFF
--- a/Xext/xvdisp.c
+++ b/Xext/xvdisp.c
@@ -67,10 +67,8 @@ ProcXvQueryExtension(ClientPtr client)
         .revision = XvRevision
     };
 
-    if (client->swapped) {
-        swaps(&reply.version);
-        swaps(&reply.revision);
-    }
+    X_REPLY_FIELD_CARD16(version);
+    X_REPLY_FIELD_CARD16(revision);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }
@@ -131,9 +129,7 @@ ProcXvQueryAdaptors(ClientPtr client)
         .num_adaptors = numAdaptors,
     };
 
-    if (client->swapped) {
-        swaps(&reply.num_adaptors);
-    }
+    X_REPLY_FIELD_CARD16(num_adaptors);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
@@ -170,9 +166,7 @@ ProcXvQueryEncodings(ClientPtr client)
         .num_encodings = pPort->pAdaptor->nEncodings,
     };
 
-    if (client->swapped) {
-        swaps(&reply.num_encodings);
-    }
+    X_REPLY_FIELD_CARD16(num_encodings);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
@@ -544,9 +538,7 @@ ProcXvGetPortAttribute(ClientPtr client)
         .value = value
     };
 
-    if (client->swapped) {
-        swapl(&reply.value);
-    }
+    X_REPLY_FIELD_CARD32(value);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }
@@ -576,10 +568,8 @@ ProcXvQueryBestSize(ClientPtr client)
         .actual_height = actual_height
     };
 
-    if (client->swapped) {
-        swaps(&reply.actual_width);
-        swaps(&reply.actual_height);
-    }
+    X_REPLY_FIELD_CARD16(actual_width);
+    X_REPLY_FIELD_CARD16(actual_height);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }
@@ -614,10 +604,8 @@ ProcXvQueryPortAttributes(ClientPtr client)
         .text_size = textSize,
     };
 
-    if (client->swapped) {
-        swapl(&reply.num_attributes);
-        swapl(&reply.text_size);
-    }
+    X_REPLY_FIELD_CARD32(num_attributes);
+    X_REPLY_FIELD_CARD32(text_size);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
@@ -882,14 +870,15 @@ ProcXvQueryImageAttributes(ClientPtr client)
     };
 
     if (client->swapped) {
-        swapl(&reply.num_planes);
-        swapl(&reply.data_size);
-        swaps(&reply.width);
-        swaps(&reply.height);
         /* needed here, because ddQueryImageAttributes() directly wrote into
            our rpcbuf area */
         SwapLongs((CARD32 *) offsets, x_rpcbuf_wsize_units(&rpcbuf));
     }
+
+    X_REPLY_FIELD_CARD32(num_planes);
+    X_REPLY_FIELD_CARD32(data_size);
+    X_REPLY_FIELD_CARD16(width);
+    X_REPLY_FIELD_CARD16(height);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
@@ -950,9 +939,7 @@ ProcXvListImageFormats(ClientPtr client)
         .num_formats = pPort->pAdaptor->nImages,
     };
 
-    if (client->swapped) {
-        swapl(&reply.num_formats);
-    }
+    X_REPLY_FIELD_CARD32(num_formats);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }


### PR DESCRIPTION
Use the new X_REPLY_FIELD_* macros for reply byte-swapping.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
