### PR TITLE
(master) Xext: damage: use new X_REPLY_FIELD_* macros

### DIFF
--- a/Xext/damage/damageext.c
+++ b/Xext/damage/damageext.c
@@ -231,12 +231,12 @@ ProcDamageQueryVersion(ClientPtr client)
         else
             reply.minorVersion = SERVER_DAMAGE_MINOR_VERSION;
     }
+
     pDamageClient->major_version = reply.majorVersion;
     pDamageClient->minor_version = reply.minorVersion;
-    if (client->swapped) {
-        swapl(&reply.majorVersion);
-        swapl(&reply.minorVersion);
-    }
+
+    X_REPLY_FIELD_CARD32(majorVersion);
+    X_REPLY_FIELD_CARD32(minorVersion);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }


### PR DESCRIPTION
Use the new X_REPLY_FIELD_* macros for reply byte-swapping.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
