### PR TITLE
(master) Xi: use new X_REPLY_FIELD_* macros

### DIFF
--- a/Xi/getfctl.c
+++ b/Xi/getfctl.c
@@ -311,8 +311,7 @@ ProcXGetFeedbackControl(ClientPtr client)
     for (b = dev->bell; b; b = b->next)
         CopySwapBellFeedback(client, b, &buf);
 
-    if (client->swapped) {
-        swaps(&reply.num_feedbacks);
-    }
+    X_REPLY_FIELD_CARD16(num_feedbacks);
+
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }

--- a/Xi/getfocus.c
+++ b/Xi/getfocus.c
@@ -101,10 +101,8 @@ ProcXGetDeviceFocus(ClientPtr client)
     else
         reply.focus = focus->win->drawable.id;
 
-    if (client->swapped) {
-        swapl(&reply.focus);
-        swapl(&reply.time);
-    }
+    X_REPLY_FIELD_CARD32(focus);
+    X_REPLY_FIELD_CARD32(time);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }

--- a/Xi/getprop.c
+++ b/Xi/getprop.c
@@ -119,9 +119,7 @@ ProcXGetDeviceDontPropagateList(ClientPtr client)
         }
     }
 
-    if (client->swapped) {
-        swaps(&reply.count);
-    }
+    X_REPLY_FIELD_CARD16(count);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }

--- a/Xi/getselev.c
+++ b/Xi/getselev.c
@@ -137,10 +137,8 @@ ProcXGetSelectedExtensionEvents(ClientPtr client)
         free(buf);
     }
 
-    if (client->swapped) {
-        swaps(&reply.this_client_count);
-        swaps(&reply.all_clients_count);
-    }
+    X_REPLY_FIELD_CARD16(this_client_count);
+    X_REPLY_FIELD_CARD16(all_clients_count);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }

--- a/Xi/getvers.c
+++ b/Xi/getvers.c
@@ -87,10 +87,8 @@ ProcXGetExtensionVersion(ClientPtr client)
         .present = TRUE
     };
 
-    if (client->swapped) {
-        swaps(&reply.major_version);
-        swaps(&reply.minor_version);
-    }
+    X_REPLY_FIELD_CARD16(major_version);
+    X_REPLY_FIELD_CARD16(minor_version);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }

--- a/Xi/gtmotion.c
+++ b/Xi/gtmotion.c
@@ -114,9 +114,7 @@ ProcXGetDeviceMotionEvents(ClientPtr client)
         }
     }
 
-    if (client->swapped) {
-        swapl(&reply.nEvents);
-    }
+    X_REPLY_FIELD_CARD32(nEvents);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }

--- a/Xi/xigetclientpointer.c
+++ b/Xi/xigetclientpointer.c
@@ -70,9 +70,7 @@ ProcXIGetClientPointer(ClientPtr client)
         .deviceid = (winclient->clientPtr) ? winclient->clientPtr->id : 0
     };
 
-    if (client->swapped) {
-        swaps(&reply.deviceid);
-    }
+    X_REPLY_FIELD_CARD16(deviceid);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }

--- a/Xi/xipassivegrab.c
+++ b/Xi/xipassivegrab.c
@@ -222,9 +222,7 @@ ProcXIPassiveGrabDevice(ClientPtr client)
 
     xi2mask_free(&mask.xi2mask);
 
-    if (client->swapped) {
-        swaps(&reply.num_modifiers);
-    }
+    X_REPLY_FIELD_CARD16(num_modifiers);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 

--- a/Xi/xiproperty.c
+++ b/Xi/xiproperty.c
@@ -856,9 +856,7 @@ ProcXListDeviceProperties(ClientPtr client)
         .nAtoms = natoms
     };
 
-    if (client->swapped) {
-        swaps(&reply.nAtoms);
-    }
+    X_REPLY_FIELD_CARD16(nAtoms);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
@@ -963,12 +961,6 @@ ProcXGetDeviceProperty(ClientPtr client)
     if (stuff->delete && (reply.bytesAfter == 0))
         send_property_event(dev, stuff->property, XIPropertyDeleted);
 
-    if (client->swapped) {
-        swapl(&reply.propertyType);
-        swapl(&reply.bytesAfter);
-        swapl(&reply.nItems);
-    }
-
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
     if (length) {
@@ -999,6 +991,10 @@ ProcXGetDeviceProperty(ClientPtr client)
         }
     }
 
+    X_REPLY_FIELD_CARD32(propertyType);
+    X_REPLY_FIELD_CARD32(bytesAfter);
+    X_REPLY_FIELD_CARD32(nItems);
+
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
@@ -1021,9 +1017,7 @@ ProcXIListProperties(ClientPtr client)
         .num_properties = natoms
     };
 
-    if (client->swapped) {
-        swaps(&reply.num_properties);
-    }
+    X_REPLY_FIELD_CARD16(num_properties);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
@@ -1130,12 +1124,6 @@ ProcXIGetProperty(ClientPtr client)
     if (length && stuff->delete && (reply.bytes_after == 0))
         send_property_event(dev, stuff->property, XIPropertyDeleted);
 
-    if (client->swapped) {
-        swapl(&reply.type);
-        swapl(&reply.bytes_after);
-        swapl(&reply.num_items);
-    }
-
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
     if (length) {
@@ -1151,6 +1139,10 @@ ProcXIGetProperty(ClientPtr client)
             break;
         }
     }
+
+    X_REPLY_FIELD_CARD32(type);
+    X_REPLY_FIELD_CARD32(bytes_after);
+    X_REPLY_FIELD_CARD32(num_items);
 
     rc = X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     if (rc != Success)

--- a/Xi/xiquerydevice.c
+++ b/Xi/xiquerydevice.c
@@ -141,9 +141,7 @@ ProcXIQueryDevice(ClientPtr client)
 
     free(skip);
 
-    if (client->swapped) {
-        swaps(&reply.num_devices);
-    }
+    X_REPLY_FIELD_CARD16(num_devices);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }

--- a/Xi/xiquerypointer.c
+++ b/Xi/xiquerypointer.c
@@ -174,15 +174,13 @@ ProcXIQueryPointer(ClientPtr client)
     }
 #endif /* XINERAMA */
 
-    if (client->swapped) {
-        swapl(&reply.root);
-        swapl(&reply.child);
-        swapl(&reply.root_x);
-        swapl(&reply.root_y);
-        swapl(&reply.win_x);
-        swapl(&reply.win_y);
-        swaps(&reply.buttons_len);
-    }
+    X_REPLY_FIELD_CARD32(root);
+    X_REPLY_FIELD_CARD32(child);
+    X_REPLY_FIELD_CARD32(root_x);
+    X_REPLY_FIELD_CARD32(root_y);
+    X_REPLY_FIELD_CARD32(win_x);
+    X_REPLY_FIELD_CARD32(win_y);
+    X_REPLY_FIELD_CARD16(buttons_len);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }

--- a/Xi/xiqueryversion.c
+++ b/Xi/xiqueryversion.c
@@ -120,10 +120,8 @@ ProcXIQueryVersion(ClientPtr client)
         .minor_version = minor
     };
 
-    if (client->swapped) {
-        swaps(&reply.major_version);
-        swaps(&reply.minor_version);
-    }
+    X_REPLY_FIELD_CARD16(major_version);
+    X_REPLY_FIELD_CARD16(minor_version);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }

--- a/Xi/xiselectev.c
+++ b/Xi/xiselectev.c
@@ -386,9 +386,7 @@ ProcXIGetSelectedEvents(ClientPtr client)
 
 finish: ;
 
-    if (client->swapped) {
-        swaps(&reply.num_masks);
-    }
+    X_REPLY_FIELD_CARD16(num_masks);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }

--- a/Xi/xisetdevfocus.c
+++ b/Xi/xisetdevfocus.c
@@ -90,9 +90,7 @@ ProcXIGetFocus(ClientPtr client)
     else
         reply.focus = dev->focus->win->drawable.id;
 
-    if (client->swapped) {
-        swapl(&reply.focus);
-    }
+    X_REPLY_FIELD_CARD32(focus);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }


### PR DESCRIPTION
Use the new X_REPLY_FIELD_* macros for reply byte-swapping.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
