### PR TITLE
(master) xfixes: use new X_REPLY_FIELD_* macros

### DIFF
--- a/xfixes/cursor.c
+++ b/xfixes/cursor.c
@@ -384,15 +384,13 @@ ProcXFixesGetCursorImage(ClientPtr client)
         .cursorSerial = pCursor->serialNumber,
     };
 
-    if (client->swapped) {
-        swaps(&reply.x);
-        swaps(&reply.y);
-        swaps(&reply.width);
-        swaps(&reply.height);
-        swaps(&reply.xhot);
-        swaps(&reply.yhot);
-        swapl(&reply.cursorSerial);
-    }
+    X_REPLY_FIELD_CARD16(x);
+    X_REPLY_FIELD_CARD16(y);
+    X_REPLY_FIELD_CARD16(width);
+    X_REPLY_FIELD_CARD16(height);
+    X_REPLY_FIELD_CARD16(xhot);
+    X_REPLY_FIELD_CARD16(yhot);
+    X_REPLY_FIELD_CARD32(cursorSerial);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
@@ -441,10 +439,9 @@ ProcXFixesGetCursorName(ClientPtr client)
         .atom = pCursor->name,
         .nbytes = strlen(str)
     };
-    if (client->swapped) {
-        swapl(&reply.atom);
-        swaps(&reply.nbytes);
-    }
+
+    X_REPLY_FIELD_CARD32(atom);
+    X_REPLY_FIELD_CARD16(nbytes);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
@@ -500,17 +497,15 @@ ProcXFixesGetCursorImageAndName(ClientPtr client)
         .nbytes = strlen(name),
     };
 
-    if (client->swapped) {
-        swaps(&reply.x);
-        swaps(&reply.y);
-        swaps(&reply.width);
-        swaps(&reply.height);
-        swaps(&reply.xhot);
-        swaps(&reply.yhot);
-        swapl(&reply.cursorSerial);
-        swapl(&reply.cursorName);
-        swaps(&reply.nbytes);
-    }
+    X_REPLY_FIELD_CARD16(x);
+    X_REPLY_FIELD_CARD16(y);
+    X_REPLY_FIELD_CARD16(width);
+    X_REPLY_FIELD_CARD16(height);
+    X_REPLY_FIELD_CARD16(xhot);
+    X_REPLY_FIELD_CARD16(yhot);
+    X_REPLY_FIELD_CARD32(cursorSerial);
+    X_REPLY_FIELD_CARD32(cursorName);
+    X_REPLY_FIELD_CARD16(nbytes);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }

--- a/xfixes/disconnect.c
+++ b/xfixes/disconnect.c
@@ -84,9 +84,7 @@ ProcXFixesGetClientDisconnectMode(ClientPtr client)
         .disconnect_mode = pDisconnect->disconnect_mode,
     };
 
-    if (client->swapped) {
-        swapl(&reply.disconnect_mode);
-    }
+    X_REPLY_FIELD_CARD32(disconnect_mode);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }

--- a/xfixes/region.c
+++ b/xfixes/region.c
@@ -435,12 +435,10 @@ ProcXFixesFetchRegion(ClientPtr client)
         .height = pExtent->y2 - pExtent->y1,
     };
 
-    if (client->swapped) {
-        swaps(&reply.x);
-        swaps(&reply.y);
-        swaps(&reply.width);
-        swaps(&reply.height);
-    }
+    X_REPLY_FIELD_CARD16(x);
+    X_REPLY_FIELD_CARD16(y);
+    X_REPLY_FIELD_CARD16(width);
+    X_REPLY_FIELD_CARD16(height);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }

--- a/xfixes/xfixes.c
+++ b/xfixes/xfixes.c
@@ -89,10 +89,8 @@ ProcXFixesQueryVersion(ClientPtr client)
         .minorVersion = minor
     };
 
-    if (client->swapped) {
-        swapl(&reply.majorVersion);
-        swapl(&reply.minorVersion);
-    }
+    X_REPLY_FIELD_CARD32(majorVersion);
+    X_REPLY_FIELD_CARD32(minorVersion);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }


### PR DESCRIPTION
Use the new X_REPLY_FIELD_* macros for reply byte-swapping.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
