### PR TITLE
(master) xkb: use new X_REPLY_FIELD_* macros

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -203,10 +203,9 @@ ProcXkbUseExtension(ClientPtr client)
         .serverMajor = SERVER_XKB_MAJOR_VERSION,
         .serverMinor = SERVER_XKB_MINOR_VERSION
     };
-    if (client->swapped) {
-        swaps(&reply.serverMajor);
-        swaps(&reply.serverMinor);
-    }
+
+    X_REPLY_FIELD_CARD16(serverMajor);
+    X_REPLY_FIELD_CARD16(serverMinor);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }
@@ -675,9 +674,8 @@ ProcXkbGetState(ClientPtr client)
         .compatState = xkb->compat_state,
         .ptrBtnState = xkb->ptr_buttons
     };
-    if (client->swapped) {
-        swaps(&reply.ptrBtnState);
-    }
+
+    X_REPLY_FIELD_CARD16(ptrBtnState);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }
@@ -793,26 +791,25 @@ ProcXkbGetControls(ClientPtr client)
         .enabledCtrls = xkb->enabled_ctrls,
     };
     memcpy(reply.perKeyRepeat, xkb->per_key_repeat, XkbPerKeyBitArraySize);
-    if (client->swapped) {
-        swaps(&reply.internalVMods);
-        swaps(&reply.ignoreLockVMods);
-        swapl(&reply.enabledCtrls);
-        swaps(&reply.repeatDelay);
-        swaps(&reply.repeatInterval);
-        swaps(&reply.slowKeysDelay);
-        swaps(&reply.debounceDelay);
-        swaps(&reply.mkDelay);
-        swaps(&reply.mkInterval);
-        swaps(&reply.mkTimeToMax);
-        swaps(&reply.mkMaxSpeed);
-        swaps(&reply.mkCurve);
-        swaps(&reply.axTimeout);
-        swapl(&reply.axtCtrlsMask);
-        swapl(&reply.axtCtrlsValues);
-        swaps(&reply.axtOptsMask);
-        swaps(&reply.axtOptsValues);
-        swaps(&reply.axOptions);
-    }
+
+    X_REPLY_FIELD_CARD16(internalVMods);
+    X_REPLY_FIELD_CARD16(ignoreLockVMods);
+    X_REPLY_FIELD_CARD32(enabledCtrls);
+    X_REPLY_FIELD_CARD16(repeatDelay);
+    X_REPLY_FIELD_CARD16(repeatInterval);
+    X_REPLY_FIELD_CARD16(slowKeysDelay);
+    X_REPLY_FIELD_CARD16(debounceDelay);
+    X_REPLY_FIELD_CARD16(mkDelay);
+    X_REPLY_FIELD_CARD16(mkInterval);
+    X_REPLY_FIELD_CARD16(mkTimeToMax);
+    X_REPLY_FIELD_CARD16(mkMaxSpeed);
+    X_REPLY_FIELD_CARD16(mkCurve);
+    X_REPLY_FIELD_CARD16(axTimeout);
+    X_REPLY_FIELD_CARD32(axtCtrlsMask);
+    X_REPLY_FIELD_CARD32(axtCtrlsValues);
+    X_REPLY_FIELD_CARD16(axtOptsMask);
+    X_REPLY_FIELD_CARD16(axtOptsValues);
+    X_REPLY_FIELD_CARD16(axOptions);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }
@@ -1574,11 +1571,9 @@ ProcXkbGetMap(ClientPtr client)
     if (rpcbuf.error)
         return BadAlloc;
 
-    if (client->swapped) {
-        swaps(&reply.present);
-        swaps(&reply.totalSyms);
-        swaps(&reply.totalActs);
-    }
+    X_REPLY_FIELD_CARD16(present);
+    X_REPLY_FIELD_CARD16(totalSyms);
+    X_REPLY_FIELD_CARD16(totalActs);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
@@ -2952,11 +2947,9 @@ ProcXkbGetCompatMap(ClientPtr client)
     if (rpcbuf.error)
         return BadAlloc;
 
-    if (client->swapped) {
-        swaps(&reply.firstSI);
-        swaps(&reply.nSI);
-        swaps(&reply.nTotalSI);
-    }
+    X_REPLY_FIELD_CARD16(firstSI);
+    X_REPLY_FIELD_CARD16(nSI);
+    X_REPLY_FIELD_CARD16(nTotalSI);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
@@ -3205,9 +3198,7 @@ ProcXkbGetIndicatorState(ClientPtr client)
         .state = sli->effectiveState
     };
 
-    if (client->swapped) {
-        swapl(&reply.state);
-    }
+    X_REPLY_FIELD_CARD32(state);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }
@@ -3285,10 +3276,8 @@ ProcXkbGetIndicatorMap(ClientPtr client)
     if (rpcbuf.error)
         return BadAlloc;
 
-    if (client->swapped) {
-        swapl(&reply.which);
-        swapl(&reply.realIndicators);
-    }
+    X_REPLY_FIELD_CARD32(which);
+    X_REPLY_FIELD_CARD32(realIndicators);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
@@ -3459,11 +3448,10 @@ ProcXkbGetNamedIndicator(ClientPtr client)
         reply.virtualMods = map->mods.vmods;
         reply.ctrls = map->ctrls;
     }
-    if (client->swapped) {
-        swapl(&reply.indicator);
-        swaps(&reply.virtualMods);
-        swapl(&reply.ctrls);
-    }
+
+    X_REPLY_FIELD_CARD32(indicator);
+    X_REPLY_FIELD_CARD16(virtualMods);
+    X_REPLY_FIELD_CARD32(ctrls);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }
@@ -3927,11 +3915,9 @@ ProcXkbGetNames(ClientPtr client)
     if (rpcbuf.error)
         return BadAlloc;
 
-    if (client->swapped) {
-        swapl(&reply.which);
-        swaps(&reply.virtualMods);
-        swapl(&reply.indicators);
-    }
+    X_REPLY_FIELD_CARD32(which);
+    X_REPLY_FIELD_CARD16(virtualMods);
+    X_REPLY_FIELD_CARD32(indicators);
 
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
@@ -4918,17 +4904,15 @@ ProcXkbGetGeometry(ClientPtr client)
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
     XkbAssembleGeometry(client, geom, reply, &rpcbuf);
 
-    if (client->swapped) {
-        swapl(&reply.name);
-        swaps(&reply.widthMM);
-        swaps(&reply.heightMM);
-        swaps(&reply.nProperties);
-        swaps(&reply.nColors);
-        swaps(&reply.nShapes);
-        swaps(&reply.nSections);
-        swaps(&reply.nDoodads);
-        swaps(&reply.nKeyAliases);
-    }
+    X_REPLY_FIELD_CARD32(name);
+    X_REPLY_FIELD_CARD16(widthMM);
+    X_REPLY_FIELD_CARD16(heightMM);
+    X_REPLY_FIELD_CARD16(nProperties);
+    X_REPLY_FIELD_CARD16(nColors);
+    X_REPLY_FIELD_CARD16(nShapes);
+    X_REPLY_FIELD_CARD16(nSections);
+    X_REPLY_FIELD_CARD16(nDoodads);
+    X_REPLY_FIELD_CARD16(nKeyAliases);
 
     status = X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 
@@ -5586,12 +5570,11 @@ ProcXkbPerClientFlags(ClientPtr client)
         .autoCtrls = interest ? interest->autoCtrls : 0,
         .autoCtrlValues =  interest ? interest->autoCtrlValues : 0,
     };
-    if (client->swapped) {
-        swapl(&reply.supported);
-        swapl(&reply.value);
-        swapl(&reply.autoCtrls);
-        swapl(&reply.autoCtrlValues);
-    }
+
+    X_REPLY_FIELD_CARD32(supported);
+    X_REPLY_FIELD_CARD32(value);
+    X_REPLY_FIELD_CARD32(autoCtrls);
+    X_REPLY_FIELD_CARD32(autoCtrlValues);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }
@@ -6084,6 +6067,9 @@ ProcXkbGetKbdByName(ClientPtr client)
         x_rpcbuf_write_rpcbuf_pad(&rpcbuf, &childbuf);
     }
 
+    X_REPLY_FIELD_CARD16(found);
+    X_REPLY_FIELD_CARD16(reported);
+
     status = X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 
     if (loaded) {
@@ -6488,6 +6474,14 @@ ProcXkbGetDeviceInfo(ClientPtr client)
         return BadLength;
     }
 
+    X_REPLY_FIELD_CARD16(present);
+    X_REPLY_FIELD_CARD16(supported);
+    X_REPLY_FIELD_CARD16(unsupported);
+    X_REPLY_FIELD_CARD16(nDeviceLedFBs);
+    X_REPLY_FIELD_CARD16(dfltKbdFB);
+    X_REPLY_FIELD_CARD16(dfltLedFB);
+    X_REPLY_FIELD_CARD32(devType);
+
     return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
@@ -6891,12 +6885,11 @@ ProcXkbSetDebuggingFlags(ClientPtr client)
         .supportedFlags = ~0,
         .supportedCtrls = ~0
     };
-    if (client->swapped) {
-        swapl(&reply.currentFlags);
-        swapl(&reply.currentCtrls);
-        swapl(&reply.supportedFlags);
-        swapl(&reply.supportedCtrls);
-    }
+
+    X_REPLY_FIELD_CARD32(currentFlags);
+    X_REPLY_FIELD_CARD32(currentCtrls);
+    X_REPLY_FIELD_CARD32(supportedFlags);
+    X_REPLY_FIELD_CARD32(supportedCtrls);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }


### PR DESCRIPTION
Use the new X_REPLY_FIELD_* macros for reply byte-swapping.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
