### PR TITLE
(master) dbe: use new X_REPLY_FIELD_* macros

### DIFF
--- a/dbe/dbe.c
+++ b/dbe/dbe.c
@@ -625,9 +625,7 @@ ProcDbeGetVisualInfo(ClientPtr client)
         .m = count
     };
 
-    if (client->swapped) {
-        swapl(&reply.m);
-    }
+    X_REPLY_FIELD_CARD32(m);
 
     rc = X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 
@@ -675,9 +673,7 @@ ProcDbeGetBackBufferAttributes(ClientPtr client)
         reply.attributes = None;
     }
 
-    if (client->swapped) {
-        swapl(&reply.attributes);
-    }
+    X_REPLY_FIELD_CARD32(attributes);
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }


### PR DESCRIPTION
Use the new X_REPLY_FIELD_* macros for reply byte-swapping.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
