### PR TITLE
glamor: xfree86/glamor_egl: Add default dixprivate storage for glamor_egl's private data

### DIFF
--- a/glamor/glamor.c
+++ b/glamor/glamor.c
@@ -41,6 +41,7 @@
 #include "os/bug_priv.h"
 
 #include "glamor_priv.h"
+#include "glamor_egl_priv.h"
 
 DevPrivateKeyRec glamor_screen_private_key;
 DevPrivateKeyRec glamor_pixmap_private_key;
@@ -650,11 +651,18 @@ glamor_init(ScreenPtr screen, unsigned int flags)
 
     if (flags & ~GLAMOR_VALID_FLAGS) {
         ErrorF("glamor_init: Invalid flags %x\n", flags);
+        if (flags & GLAMOR_USE_EGL_SCREEN) {
+            glamor_egl_cleanup_screen(screen);
+        }
         return FALSE;
     }
     glamor_priv = calloc(1, sizeof(*glamor_priv));
-    if (glamor_priv == NULL)
+    if (glamor_priv == NULL) {
+        if (flags & GLAMOR_USE_EGL_SCREEN) {
+            glamor_egl_cleanup_screen(screen);
+        }
         return FALSE;
+    }
 
     glamor_priv->flags = flags;
 
@@ -662,6 +670,9 @@ glamor_init(ScreenPtr screen, unsigned int flags)
         LogMessage(X_WARNING,
                    "glamor%d: Failed to allocate screen private\n",
                    screen->myNum);
+        if (flags & GLAMOR_USE_EGL_SCREEN) {
+            glamor_egl_cleanup_screen(screen);
+        }
         goto fail;
     }
 
@@ -672,6 +683,9 @@ glamor_init(ScreenPtr screen, unsigned int flags)
         LogMessage(X_WARNING,
                    "glamor%d: Failed to allocate pixmap private\n",
                    screen->myNum);
+        if (flags & GLAMOR_USE_EGL_SCREEN) {
+            glamor_egl_cleanup_screen(screen);
+        }
         goto fail;
     }
 
@@ -680,8 +694,15 @@ glamor_init(ScreenPtr screen, unsigned int flags)
         LogMessage(X_WARNING,
                    "glamor%d: Failed to allocate gc private\n",
                    screen->myNum);
+        if (flags & GLAMOR_USE_EGL_SCREEN) {
+            glamor_egl_cleanup_screen(screen);
+        }
         goto fail;
     }
+
+    /**
+     * glamor_egl_screen_init2 adds any needed cleanup to CloseScreen
+     */
 
     /* If we are using egl screen, call egl screen init to
      * register correct close screen function. */

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -53,8 +53,27 @@
 #include "glamor.h"
 #include "glamor_egl.h"
 #include "glamor_egl_ext.h"
+#include "glamor_egl_priv.h"
 #include "glamor_glx_provider.h"
 #include "dri3.h"
+
+static DevPrivateKeyRec glamor_egl_screen_private_key;
+static inline Bool
+glamor_egl_init_screen_private(ScreenPtr screen)
+{
+    if (!dixRegisterPrivateKey(&glamor_egl_screen_private_key, PRIVATE_SCREEN, sizeof(glamor_egl_priv_t))) {
+        LogMessage(X_ERROR,
+                   "glamor%d: Failed to allocate screen private\n",
+                   screen->myNum);
+        return FALSE;
+    }
+    return TRUE;
+}
+static glamor_egl_priv_t*
+_glamor_egl_get_screen_private(ScreenPtr screen)
+{
+    return dixLookupPrivate(&screen->devPrivates, &glamor_egl_screen_private_key);
+}
 
 /**
  * Hack to not break xf86 drivers.
@@ -68,7 +87,7 @@
  */
 
 static glamor_egl_priv_t*
-(*glamor_egl_get_screen_private)(ScreenPtr screen) = NULL;
+(*glamor_egl_get_screen_private)(ScreenPtr screen) = _glamor_egl_get_screen_private;
 
 static void
 glamor_egl_make_current(struct glamor_context *glamor_ctx)
@@ -1035,7 +1054,8 @@ glamor_egl_exchange_buffers(PixmapPtr front, PixmapPtr back)
 
 static void glamor_egl_pre_close_screen_cleanup(glamor_egl_priv_t *glamor_egl);
 
-static void glamor_egl_close_screen(CallbackListPtr *pcbl, ScreenPtr screen, void *unused)
+static void
+glamor_egl_close_screen(CallbackListPtr *pcbl, ScreenPtr screen, void *unused)
 {
     glamor_egl_priv_t *glamor_egl;
 #ifdef GLAMOR_HAS_GBM
@@ -1485,6 +1505,10 @@ glamor_egl_pre_close_screen_cleanup(glamor_egl_priv_t *glamor_egl)
 
 void glamor_egl_cleanup(glamor_egl_priv_t *glamor_egl)
 {
+    if (!glamor_egl) {
+        return;
+    }
+
     glamor_egl_pre_close_screen_cleanup(glamor_egl);
 
 #ifdef GLAMOR_HAS_GBM
@@ -1493,6 +1517,14 @@ void glamor_egl_cleanup(glamor_egl_priv_t *glamor_egl)
 #endif
 }
 
+
+void glamor_egl_cleanup_screen(ScreenPtr screen)
+{
+    /* Only clean up stuff if we set it up to begin with */
+    if (screen && (glamor_egl_screen_init2 == glamor_egl_screen_init)) {
+        glamor_egl_cleanup(glamor_egl_get_screen_private(screen));
+    }
+}
 
 static void
 glamor_egl_chose_configs(EGLDisplay display, const EGLint *attrib_list,
@@ -1687,7 +1719,7 @@ gbm_create_device_by_name(int fd, const char* name)
 #endif
 
 static Bool
-glamor_egl_init_display(struct glamor_egl_screen_private *glamor_egl)
+glamor_egl_init_display(glamor_egl_priv_t *glamor_egl)
 {
     EGLDeviceEXT *devices = NULL;
     EGLint num_devices = 0;
@@ -1789,18 +1821,30 @@ Bool
 glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, Bool *compat_ret)
 {
     const GLubyte *renderer;
-    glamor_egl_priv_t* glamor_egl;
+    glamor_egl_priv_t* glamor_egl = NULL;
 
     if (compat_ret) {
         *compat_ret = TRUE;
     }
 
-    glamor_egl = glamor_egl_conf->glamor_egl_priv;
+    if (glamor_egl_conf->GLAMOR_EGL_PRIV_PROC) {
+        glamor_egl_get_screen_private = glamor_egl_conf->GLAMOR_EGL_PRIV_PROC;
+        glamor_egl = glamor_egl_conf->glamor_egl_priv;
+    } else {
+        if (!glamor_egl_conf->screen ||
+            !glamor_egl_init_screen_private(glamor_egl_conf->screen)) {
+            goto error;
+        }
+        glamor_egl = glamor_egl_get_screen_private(glamor_egl_conf->screen);
+    }
 
-    glamor_egl->glvnd_vendor = glamor_egl_conf->glvnd_vendor;
+    memset(glamor_egl, 0, sizeof(*glamor_egl));
+
+    if (glamor_egl_conf->glvnd_vendor) {
+        glamor_egl->glvnd_vendor = glamor_egl_conf->glvnd_vendor;
+        glamor_egl->exact_glvnd_vendor = TRUE;
+    }
     glamor_egl->fd = glamor_egl_conf->fd;
-
-    glamor_egl_get_screen_private = glamor_egl_conf->GLAMOR_EGL_PRIV_PROC;
 
 #ifdef GLAMOR_HAS_GBM
     if (glamor_egl->fd >= 0) {

--- a/glamor/glamor_egl.h
+++ b/glamor/glamor_egl.h
@@ -36,33 +36,20 @@
 
 #include "scrnintstr.h"
 
-#ifdef GLAMOR_HAS_GBM
-#include <gbm.h>
-#endif
-
-typedef struct glamor_egl_screen_private {
-    EGLDisplay display;
-    EGLContext context;
-    char *device_path;
-    char *glvnd_vendor; /* glvnd vendor library name or driver name */
-    int exact_glvnd_vendor; /* If the glvnd vendor should be assumed valid with no checks */
-    void* server_private;
-
-#ifdef GLAMOR_HAS_GBM
-    struct gbm_device *gbm;
-#endif
-    int fd;
-    int dmabuf_capable;
-    int linear_only; /* When using gbm, this means that only linear buffers can be created */
-} glamor_egl_priv_t;
+typedef struct glamor_egl_screen_private glamor_egl_priv_t;
 
 typedef struct {
     void* server_private; /* Data the X server might want to map to a screen */
 
-    /* Pointer to a server-allocated glamor_egl_priv_t, that the server maps to a screen */
+    /* Either Optional 1 or 2 must be non-NULL */
+
+    /* Optional 1 pointer to a screen */
+    ScreenPtr screen;
+
+    /* Optional 2 pointer to a server-allocated glamor_egl_priv_t, that the server maps to a screen */
     glamor_egl_priv_t *glamor_egl_priv;
 
-    /* Function that maps a glamor_egl_priv_t to each screen*/
+    /* Optional 2 function that maps a glamor_egl_priv_t to each screen*/
     glamor_egl_priv_t* (*GLAMOR_EGL_PRIV_PROC)(ScreenPtr screen);
 
     char *glvnd_vendor; /* glvnd vendor library or driver name */
@@ -86,15 +73,6 @@ typedef struct {
  * for compatibility with xf86 drivers.
  */
 Bool glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, Bool *compat_ret);
-
-/**
- * Deinitialize an egl context created by glamor egl
- * and free associated resources.
- *
- * glamor_egl is the pointer passed to glamor_egl_init2
- * in glamor_egl_conf->glamor_egl_priv;
- */
-void glamor_egl_cleanup(glamor_egl_priv_t *glamor_egl);
 
 /*
  * Create an EGLDisplay from a native display type. This is a little quirky

--- a/glamor/glamor_egl_priv.h
+++ b/glamor/glamor_egl_priv.h
@@ -1,0 +1,54 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Copyright © 2026 stefan11111 <stefan11111@shitposting.expert>
+ */
+
+/**
+ * Private definitions to be used by glamor and the xf86 server
+ */
+
+#ifndef GLAMOR_EGL_PRIV_H
+#define GLAMOR_EGL_PRIV_H
+
+#define MESA_EGL_NO_X11_HEADERS
+#define EGL_NO_X11
+#include <epoxy/gl.h>
+#include <epoxy/egl.h>
+
+#include "scrnintstr.h"
+#include "glamor_egl_ext.h"
+
+#ifdef GLAMOR_HAS_GBM
+#include <gbm.h>
+#endif
+
+typedef struct glamor_egl_screen_private {
+    EGLDisplay display;
+    EGLContext context;
+    char *device_path;
+    char *glvnd_vendor; /* glvnd vendor library name or driver name */
+    int exact_glvnd_vendor; /* If the glvnd vendor should be assumed valid with no checks */
+    void* server_private;
+
+#ifdef GLAMOR_HAS_GBM
+    struct gbm_device *gbm;
+#endif
+    int fd;
+    int dmabuf_capable;
+    int linear_only; /* When using gbm, this means that only linear buffers can be created */
+} glamor_egl_priv_t;
+
+/**
+ * Deinitialize an egl context created by glamor egl
+ * and free associated resources.
+ */
+void glamor_egl_cleanup(glamor_egl_priv_t *glamor_egl);
+
+/**
+ * Deinitialize an egl context created by glamor egl
+ * and free associated resources.
+ */
+void glamor_egl_cleanup_screen(ScreenPtr screen);
+
+
+#endif /* GLAMOR_EGL_PRIV_H */

--- a/hw/xfree86/glamor_egl/glamor_xf86_egl.c
+++ b/hw/xfree86/glamor_egl/glamor_xf86_egl.c
@@ -11,6 +11,7 @@
 
 #include "glamor.h"
 #include "glamor_egl.h"
+#include "glamor_egl_priv.h"
 
 enum {
     GLAMOREGLOPT_RENDERING_API,


### PR DESCRIPTION
This allows glamor to fully manage it's resources and not leak or use-after-free.

Users of glamor_egl now just need to pass a ScreenPtr, without having to manage glamor_egl's memory