### PR TITLE
glamor/glamor_egl: Don't blindly set the gl vendor to mesa

### DIFF
--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -1140,6 +1140,9 @@ static const dri3_screen_info_rec glamor_dri3_info = {
 static inline void
 glamor_egl_set_glvnd_vendor(ScreenPtr screen)
 {
+    const char *vendor;
+    const char *renderer;
+
     glamor_egl_priv_t *glamor_egl =
         glamor_egl_get_screen_private(screen);
 
@@ -1156,16 +1159,18 @@ glamor_egl_set_glvnd_vendor(ScreenPtr screen)
         if (gbm_backend_name) {
             if (!strncmp(gbm_backend_name, "nvidia", sizeof("nvidia") - 1)) {
                  glamor_set_glvnd_vendor(screen, "nvidia");
-            } else {
+                 return;
+            } else if (!strcmp(gbm_backend_name, "drm")) {
+                 /* Mesa uses "drm" as the gbm backend name */
                  glamor_set_glvnd_vendor(screen, "mesa");
+                 return;
             }
-            return;
         }
     }
 #endif
 
-    const char *vendor = (const char*)glGetString(GL_VENDOR);
-    const char *renderer = (const char*)glGetString(GL_RENDERER);
+    vendor = (const char*)glGetString(GL_VENDOR);
+    renderer = (const char*)glGetString(GL_RENDERER);
 
     if (!glamor_egl->glvnd_vendor) {
         if (renderer && strstr(renderer, "NVIDIA")) {


### PR DESCRIPTION
When using libgbm without nvidia's backend, we were assuming we were using mesa's backend.

With this, we actually check to see if we are using mesa's backend.

If not, we use the same fallback logic as if we didn't have a gbm backend at all.