### PR TITLE
(release/25.1) xfixes: region: fix duplicate reply field swapping

### DIFF
--- a/xfixes/region.c
+++ b/xfixes/region.c
@@ -487,8 +487,6 @@ ProcXFixesFetchRegion(ClientPtr client)
     };
 
     if (client->swapped) {
-        swaps(&reply.sequenceNumber);
-        swapl(&reply.length);
         swaps(&reply.x);
         swaps(&reply.y);
         swaps(&reply.width);


### PR DESCRIPTION
The sequenceNumber and length fields are already swapped behind the scenes
by X_SEND_REPLY*() macros, so we must not swap them here a second time.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
