### PR TITLE
(master) Xext: shm: don't abuse `length` variable in ProcShmGetImage()

### DIFF
--- a/Xext/shm.c
+++ b/Xext/shm.c
@@ -879,14 +879,13 @@ ProcShmGetImage(ClientPtr client)
                              widthBytesLine, isRoot);
     }
     else {
-
-        length = stuff->offset;
+        long len2 = stuff->offset;
         for (; plane; plane >>= 1) {
             if (planemask & plane) {
                 XineramaGetImageData(drawables, x, y, w, h,
-                                     format, plane, shmdesc->addr + length,
+                                     format, plane, shmdesc->addr + len2,
                                      widthBytesLine, isRoot);
-                length += lenPer;
+                len2 += lenPer;
             }
         }
     }


### PR DESCRIPTION
It's originally used for the reply's `size` field, but later abused
for entirely different purpose. Such things can cause subtle bugs
on later changes, so let's keep them cleanly separated.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
