### PR TITLE
(master) Xext: sync: ProcSyncGetPriority(): declare `rc` variable where needed

### DIFF
--- a/Xext/sync.c
+++ b/Xext/sync.c
@@ -1364,12 +1364,11 @@ ProcSyncGetPriority(ClientPtr client)
     X_REQUEST_FIELD_CARD32(id);
 
     ClientPtr priorityclient;
-    int rc;
 
     if (stuff->id == None)
         priorityclient = client;
     else {
-        rc = dixLookupResourceOwner(&priorityclient, stuff->id, client,
+        int rc = dixLookupResourceOwner(&priorityclient, stuff->id, client,
                              DixGetAttrAccess);
         if (rc != Success)
             return rc;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
