### PR TITLE
(master) Xext: declare `rc` variables where needed

### DIFF
--- a/Xext/damage/damageext.c
+++ b/Xext/damage/damageext.c
@@ -479,10 +479,9 @@ ProcDamageAdd(ClientPtr client)
 
     DrawablePtr pDrawable;
     RegionPtr pRegion;
-    int rc;
 
     VERIFY_REGION(pRegion, stuff->region, client, DixWriteAccess);
-    rc = dixLookupDrawable(&pDrawable, stuff->drawable, client, 0,
+    int rc = dixLookupDrawable(&pDrawable, stuff->drawable, client, 0,
                            DixWriteAccess);
     if (rc != Success)
         return rc;
@@ -589,10 +588,9 @@ PanoramiXDamageCreate(ClientPtr client, xDamageCreateReq *stuff)
 {
     PanoramiXDamageRes *damage;
     PanoramiXRes *draw;
-    int rc;
 
     LEGAL_NEW_RESOURCE(stuff->damage, client);
-    rc = dixLookupResourceByClass((void **)&draw, stuff->drawable, XRC_DRAWABLE,
+    int rc = dixLookupResourceByClass((void **)&draw, stuff->drawable, XRC_DRAWABLE,
                                   client, DixGetAttrAccess | DixReadAccess);
     if (rc != Success)
         return rc;

--- a/Xext/panoramiX.c
+++ b/Xext/panoramiX.c
@@ -901,9 +901,8 @@ ProcPanoramiXGetState(ClientPtr client)
         swapl(&stuff->window);
 
     WindowPtr pWin;
-    int rc;
 
-    rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
+    int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 
@@ -927,9 +926,8 @@ ProcPanoramiXGetScreenCount(ClientPtr client)
         swapl(&stuff->window);
 
     WindowPtr pWin;
-    int rc;
 
-    rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
+    int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 
@@ -955,12 +953,11 @@ ProcPanoramiXGetScreenSize(ClientPtr client)
     }
 
     WindowPtr pWin;
-    int rc;
 
     if (stuff->screen >= PanoramiXNumScreens)
         return BadMatch;
 
-    rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
+    int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 

--- a/Xext/panoramiXprocs.c
+++ b/Xext/panoramiXprocs.c
@@ -569,12 +569,11 @@ int
 PanoramiXGetGeometry(ClientPtr client)
 {
     DrawablePtr pDraw;
-    int rc;
 
     REQUEST(xResourceReq);
-
     REQUEST_SIZE_MATCH(xResourceReq);
-    rc = dixLookupDrawable(&pDraw, stuff->id, client, M_ANY, DixGetAttrAccess);
+
+    int rc = dixLookupDrawable(&pDraw, stuff->id, client, M_ANY, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 
@@ -628,11 +627,11 @@ PanoramiXTranslateCoords(ClientPtr client)
     INT16 x, y;
 
     REQUEST(xTranslateCoordsReq);
-    int rc;
     WindowPtr pWin, pDst;
 
     REQUEST_SIZE_MATCH(xTranslateCoordsReq);
-    rc = dixLookupWindow(&pWin, stuff->srcWid, client, DixReadAccess);
+
+    int rc = dixLookupWindow(&pWin, stuff->srcWid, client, DixReadAccess);
     if (rc != Success)
         return rc;
     rc = dixLookupWindow(&pDst, stuff->dstWid, client, DixReadAccess);
@@ -1218,7 +1217,6 @@ PanoramiXCopyArea(ClientPtr client)
         DrawablePtr pDst = NULL, pSrc = NULL;
         GCPtr pGC = NULL;
         RegionRec totalReg;
-        int rc;
 
         RegionNull(&totalReg);
 
@@ -1240,8 +1238,8 @@ PanoramiXCopyArea(ClientPtr client)
             VALIDATE_DRAWABLE_AND_GC(stuff->dstDrawable, pDst, DixWriteAccess);
 
             if (stuff->dstDrawable != stuff->srcDrawable) {
-                rc = dixLookupDrawable(&pSrc, stuff->srcDrawable, client, 0,
-                                       DixReadAccess);
+                int rc = dixLookupDrawable(&pSrc, stuff->srcDrawable, client, 0,
+                                           DixReadAccess);
                 if (rc != Success)
                     return rc;
 
@@ -1286,7 +1284,7 @@ PanoramiXCopyArea(ClientPtr client)
 int
 PanoramiXCopyPlane(ClientPtr client)
 {
-    int srcx, srcy, dstx, dsty, rc;
+    int srcx, srcy, dstx, dsty;
     PanoramiXRes *gc, *src, *dst;
     Bool srcIsRoot = FALSE;
     Bool dstIsRoot = FALSE;
@@ -1299,8 +1297,8 @@ PanoramiXCopyPlane(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xCopyPlaneReq);
 
-    rc = dixLookupResourceByClass((void **) &src, stuff->srcDrawable,
-                                  XRC_DRAWABLE, client, DixReadAccess);
+    int rc = dixLookupResourceByClass((void **) &src, stuff->srcDrawable,
+                                      XRC_DRAWABLE, client, DixReadAccess);
     if (rc != Success)
         return (rc == BadValue) ? BadDrawable : rc;
 
@@ -1991,7 +1989,7 @@ PanoramiXGetImage(ClientPtr client)
     DrawablePtr pDraw;
     PanoramiXRes *draw;
     Bool isRoot;
-    int x, y, w, h, format, rc;
+    int x, y, w, h, format;
     Mask plane = 0, planemask;
     int linesDone, nlines, linesPerBuf;
     long widthBytesLine;
@@ -2005,8 +2003,8 @@ PanoramiXGetImage(ClientPtr client)
         return BadValue;
     }
 
-    rc = dixLookupResourceByClass((void **) &draw, stuff->drawable,
-                                  XRC_DRAWABLE, client, DixReadAccess);
+    int rc = dixLookupResourceByClass((void **) &draw, stuff->drawable,
+                                      XRC_DRAWABLE, client, DixReadAccess);
     if (rc != Success)
         return (rc == BadValue) ? BadDrawable : rc;
 

--- a/Xext/saver.c
+++ b/Xext/saver.c
@@ -461,10 +461,9 @@ UninstallSaverColormap(ScreenPtr pScreen)
 {
     SetupScreen(pScreen);
     ColormapPtr pCmap;
-    int rc;
 
     if (pPriv && pPriv->installedMap != None) {
-        rc = dixLookupResourceByType((void **) &pCmap, pPriv->installedMap,
+        int rc = dixLookupResourceByType((void **) &pCmap, pPriv->installedMap,
                                      X11_RESTYPE_COLORMAP, serverClient,
                                      DixUninstallAccess);
         if (rc == Success) {
@@ -656,13 +655,12 @@ ProcScreenSaverQueryInfo(ClientPtr client)
     X_REQUEST_HEAD_STRUCT(xScreenSaverQueryInfoReq);
     X_REQUEST_FIELD_CARD32(drawable);
 
-    int rc;
     ScreenSaverStuffPtr pSaver;
     DrawablePtr pDraw;
     CARD32 lastInput;
     ScreenSaverScreenPrivatePtr pPriv;
 
-    rc = dixLookupDrawable(&pDraw, stuff->drawable, client, 0,
+    int rc = dixLookupDrawable(&pDraw, stuff->drawable, client, 0,
                            DixGetAttrAccess);
     if (rc != Success) {
         return rc;
@@ -722,8 +720,7 @@ ProcScreenSaverSelectInput(ClientPtr client)
     X_REQUEST_FIELD_CARD32(eventMask);
 
     DrawablePtr pDraw;
-    int rc;
-    rc = dixLookupDrawable(&pDraw, stuff->drawable, client, 0,
+    int rc = dixLookupDrawable(&pDraw, stuff->drawable, client, 0,
                            DixGetAttrAccess);
     if (rc != Success) {
         return rc;
@@ -1100,9 +1097,8 @@ ScreenSaverUnsetAttributes(ClientPtr client, Drawable drawable)
 {
     DrawablePtr pDraw;
     ScreenSaverScreenPrivatePtr pPriv;
-    int rc;
 
-    rc = dixLookupDrawable(&pDraw, drawable, client, 0, DixGetAttrAccess);
+    int rc = dixLookupDrawable(&pDraw, drawable, client, 0, DixGetAttrAccess);
     if (rc != Success)
         return rc;
     pPriv = GetScreenPrivate(pDraw->pScreen);
@@ -1221,10 +1217,9 @@ ProcScreenSaverUnsetAttributes(ClientPtr client)
 #ifdef XINERAMA
     if (!noPanoramiXExtension) {
         PanoramiXRes *draw;
-        int rc, i;
+        int i;
 
-
-        rc = dixLookupResourceByClass((void **) &draw, stuff->drawable,
+        int rc = dixLookupResourceByClass((void **) &draw, stuff->drawable,
                                       XRC_DRAWABLE, client, DixWriteAccess);
         if (rc != Success)
             return (rc == BadValue) ? BadDrawable : rc;

--- a/Xext/security.c
+++ b/Xext/security.c
@@ -579,9 +579,8 @@ ProcSecurityRevokeAuthorization(ClientPtr client)
     X_REQUEST_FIELD_CARD32(authId);
 
     SecurityAuthorizationPtr pAuth;
-    int rc;
 
-    rc = dixLookupResourceByType((void **) &pAuth, stuff->authId,
+    int rc = dixLookupResourceByType((void **) &pAuth, stuff->authId,
                                  SecurityAuthorizationResType, client,
                                  DixDestroyAccess);
     if (rc != Success)
@@ -891,7 +890,6 @@ SecurityClientState(CallbackListPtr *pcbl, void *unused, void *calldata)
     NewClientInfoRec *pci = calldata;
     SecurityStateRec *state;
     SecurityAuthorizationPtr pAuth;
-    int rc;
 
     state = dixLookupPrivate(&pci->client->devPrivates, stateKey);
 
@@ -904,8 +902,9 @@ SecurityClientState(CallbackListPtr *pcbl, void *unused, void *calldata)
         break;
 
     case ClientStateRunning:
+    {
         state->authId = AuthorizationIDOfClient(pci->client);
-        rc = dixLookupResourceByType((void **) &pAuth, state->authId,
+        int rc = dixLookupResourceByType((void **) &pAuth, state->authId,
                                      SecurityAuthorizationResType, serverClient,
                                      DixGetAttrAccess);
         if (rc == Success) {
@@ -918,10 +917,11 @@ SecurityClientState(CallbackListPtr *pcbl, void *unused, void *calldata)
             state->trustLevel = pAuth->trustLevel;
         }
         break;
-
+    }
     case ClientStateGone:
     case ClientStateRetained:
-        rc = dixLookupResourceByType((void **) &pAuth, state->authId,
+    {
+        int rc = dixLookupResourceByType((void **) &pAuth, state->authId,
                                      SecurityAuthorizationResType, serverClient,
                                      DixGetAttrAccess);
         if (rc == Success && state->live) {
@@ -932,7 +932,7 @@ SecurityClientState(CallbackListPtr *pcbl, void *unused, void *calldata)
                 SecurityStartAuthorizationTimer(pAuth);
         }
         break;
-
+    }
     default:
         break;
     }

--- a/Xext/shape.c
+++ b/Xext/shape.c
@@ -346,10 +346,9 @@ ShapeMask(ClientPtr client, xShapeMaskReq *stuff)
     RegionPtr *destRgn;
     PixmapPtr pPixmap;
     CreateDftPtr createDefault;
-    int rc;
 
     UpdateCurrentTime();
-    rc = dixLookupWindow(&pWin, stuff->dest, client, DixSetAttrAccess);
+    int rc = dixLookupWindow(&pWin, stuff->dest, client, DixSetAttrAccess);
     if (rc != Success)
         return rc;
     switch (stuff->destKind) {
@@ -458,10 +457,9 @@ ShapeCombine(ClientPtr client, xShapeCombineReq *stuff)
     CreateDftPtr createDefault;
     CreateDftPtr createSrc;
     RegionPtr tmp;
-    int rc;
 
     UpdateCurrentTime();
-    rc = dixLookupWindow(&pDestWin, stuff->dest, client, DixSetAttrAccess);
+    int rc = dixLookupWindow(&pDestWin, stuff->dest, client, DixSetAttrAccess);
     if (rc != Success)
         return rc;
     if (!MakeWindowOptional(pDestWin))
@@ -581,10 +579,9 @@ ShapeOffset(ClientPtr client, xShapeOffsetReq *stuff)
 {
     WindowPtr pWin;
     RegionPtr srcRgn;
-    int rc;
 
     UpdateCurrentTime();
-    rc = dixLookupWindow(&pWin, stuff->dest, client, DixSetAttrAccess);
+    int rc = dixLookupWindow(&pWin, stuff->dest, client, DixSetAttrAccess);
     if (rc != Success)
         return rc;
     switch (stuff->destKind) {
@@ -714,13 +711,12 @@ ProcShapeSelectInput(ClientPtr client)
 
     WindowPtr pWin;
     ShapeEventPtr pNewShapeEvent;
-    int rc;
 
     REQUEST_SIZE_MATCH(xShapeSelectInputReq);
 
     if (client->swapped)
         swapl(&stuff->window);
-    rc = dixLookupWindow(&pWin, stuff->window, client, DixReceiveAccess);
+    int rc = dixLookupWindow(&pWin, stuff->window, client, DixReceiveAccess);
     if (rc != Success)
         return rc;
     ShapeEventPtr pShapeEvent, *pHead = SHAPE_WINDOW_PRIVADDR(pWin);
@@ -838,9 +834,9 @@ ProcShapeInputSelected(ClientPtr client)
     X_REQUEST_FIELD_CARD32(window);
 
     WindowPtr pWin;
-    int enabled, rc;
+    int enabled;
 
-    rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
+    int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 
@@ -869,10 +865,10 @@ ProcShapeGetRectangles(ClientPtr client)
     X_REQUEST_FIELD_CARD32(window);
 
     WindowPtr pWin;
-    int nrects, rc;
+    int nrects;
     RegionPtr region;
 
-    rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
+    int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
     if (rc != Success)
         return rc;
     switch (stuff->kind) {

--- a/Xext/shm.c
+++ b/Xext/shm.c
@@ -583,13 +583,13 @@ ShmGetImage(ClientPtr client, xShmGetImageReq *stuff)
     ShmDescPtr shmdesc;
     VisualID visual = None;
     RegionPtr pVisibleRegion = NULL;
-    int rc;
 
     if ((stuff->format != XYPixmap) && (stuff->format != ZPixmap)) {
         client->errorValue = stuff->format;
         return BadValue;
     }
-    rc = dixLookupDrawable(&pDraw, stuff->drawable, client, 0, DixReadAccess);
+
+    int rc = dixLookupDrawable(&pDraw, stuff->drawable, client, 0, DixReadAccess);
     if (rc != Success)
         return rc;
     VERIFY_SHMPTR(stuff->shmseg, stuff->offset, TRUE, shmdesc, client);

--- a/Xext/sync.c
+++ b/Xext/sync.c
@@ -344,18 +344,18 @@ SyncInitTrigger(ClientPtr client, SyncTrigger * pTrigger, XID syncObject,
 {
     SyncObject *pSync = pTrigger->pSync;
     SyncCounter *pCounter = NULL;
-    int rc;
     Bool newSyncObject = FALSE;
 
     if (changes & XSyncCACounter) {
-        if (syncObject == None)
+        if (syncObject == None) {
             pSync = NULL;
-        else if (Success != (rc = dixLookupResourceByType((void **) &pSync,
-                                                          syncObject, resType,
-                                                          client,
-                                                          DixReadAccess))) {
-            client->errorValue = syncObject;
-            return rc;
+        } else {
+            int rc = dixLookupResourceByType((void **) &pSync, syncObject,
+                                              resType, client, DixReadAccess);
+            if (rc != Success) {
+                client->errorValue = syncObject;
+                return rc;
+            }
         }
     }
 
@@ -1329,12 +1329,11 @@ ProcSyncSetPriority(ClientPtr client)
     X_REQUEST_FIELD_CARD32(priority);
 
     ClientPtr priorityclient;
-    int rc;
 
     if (stuff->id == None)
         priorityclient = client;
     else {
-        rc = dixLookupResourceOwner(&priorityclient, stuff->id, client,
+        int rc = dixLookupResourceOwner(&priorityclient, stuff->id, client,
                              DixSetAttrAccess);
         if (rc != Success)
             return rc;
@@ -1420,9 +1419,8 @@ ProcSyncSetCounter(ClientPtr client)
 
     SyncCounter *pCounter;
     int64_t newvalue;
-    int rc;
 
-    rc = dixLookupResourceByType((void **) &pCounter, stuff->cid, RTCounter,
+    int rc = dixLookupResourceByType((void **) &pCounter, stuff->cid, RTCounter,
                                  client, DixWriteAccess);
     if (rc != Success)
         return rc;
@@ -1451,9 +1449,8 @@ ProcSyncChangeCounter(ClientPtr client)
     SyncCounter *pCounter;
     int64_t newvalue;
     Bool overflow;
-    int rc;
 
-    rc = dixLookupResourceByType((void **) &pCounter, stuff->cid, RTCounter,
+    int rc = dixLookupResourceByType((void **) &pCounter, stuff->cid, RTCounter,
                                  client, DixWriteAccess);
     if (rc != Success)
         return rc;
@@ -1484,9 +1481,8 @@ ProcSyncDestroyCounter(ClientPtr client)
     X_REQUEST_FIELD_CARD32(counter);
 
     SyncCounter *pCounter;
-    int rc;
 
-    rc = dixLookupResourceByType((void **) &pCounter, stuff->counter,
+    int rc = dixLookupResourceByType((void **) &pCounter, stuff->counter,
                                  RTCounter, client, DixDestroyAccess);
     if (rc != Success)
         return rc;
@@ -1645,9 +1641,8 @@ ProcSyncQueryCounter(ClientPtr client)
     X_REQUEST_FIELD_CARD32(counter);
 
     SyncCounter *pCounter;
-    int rc;
 
-    rc = dixLookupResourceByType((void **) &pCounter, stuff->counter,
+    int rc = dixLookupResourceByType((void **) &pCounter, stuff->counter,
                                  RTCounter, client, DixReadAccess);
     if (rc != Success)
         return rc;
@@ -1808,9 +1803,8 @@ ProcSyncQueryAlarm(ClientPtr client)
 
     SyncAlarm *pAlarm;
     SyncTrigger *pTrigger;
-    int rc;
 
-    rc = dixLookupResourceByType((void **) &pAlarm, stuff->alarm, RTAlarm,
+    int rc = dixLookupResourceByType((void **) &pAlarm, stuff->alarm, RTAlarm,
                                  client, DixReadAccess);
     if (rc != Success)
         return rc;
@@ -1858,9 +1852,8 @@ ProcSyncDestroyAlarm(ClientPtr client)
     X_REQUEST_FIELD_CARD32(alarm);
 
     SyncAlarm *pAlarm;
-    int rc;
 
-    rc = dixLookupResourceByType((void **) &pAlarm, stuff->alarm, RTAlarm,
+    int rc = dixLookupResourceByType((void **) &pAlarm, stuff->alarm, RTAlarm,
                                  client, DixDestroyAccess);
     if (rc != Success)
         return rc;
@@ -1878,9 +1871,8 @@ ProcSyncCreateFence(ClientPtr client)
 
     DrawablePtr pDraw;
     SyncFence *pFence;
-    int rc;
 
-    rc = dixLookupDrawable(&pDraw, stuff->d, client, M_ANY, DixGetAttrAccess);
+    int rc = dixLookupDrawable(&pDraw, stuff->d, client, M_ANY, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 
@@ -1923,9 +1915,8 @@ ProcSyncTriggerFence(ClientPtr client)
     X_REQUEST_FIELD_CARD32(fid);
 
     SyncFence *pFence;
-    int rc;
 
-    rc = dixLookupResourceByType((void **) &pFence, stuff->fid, RTFence,
+    int rc = dixLookupResourceByType((void **) &pFence, stuff->fid, RTFence,
                                  client, DixWriteAccess);
     if (rc != Success)
         return rc;
@@ -1942,9 +1933,8 @@ ProcSyncResetFence(ClientPtr client)
     X_REQUEST_FIELD_CARD32(fid);
 
     SyncFence *pFence;
-    int rc;
 
-    rc = dixLookupResourceByType((void **) &pFence, stuff->fid, RTFence,
+    int rc = dixLookupResourceByType((void **) &pFence, stuff->fid, RTFence,
                                  client, DixWriteAccess);
     if (rc != Success)
         return rc;
@@ -1964,9 +1954,8 @@ ProcSyncDestroyFence(ClientPtr client)
     X_REQUEST_FIELD_CARD32(fid);
 
     SyncFence *pFence;
-    int rc;
 
-    rc = dixLookupResourceByType((void **) &pFence, stuff->fid, RTFence,
+    int rc = dixLookupResourceByType((void **) &pFence, stuff->fid, RTFence,
                                  client, DixDestroyAccess);
     if (rc != Success)
         return rc;
@@ -1982,9 +1971,8 @@ ProcSyncQueryFence(ClientPtr client)
     X_REQUEST_FIELD_CARD32(fid);
 
     SyncFence *pFence;
-    int rc;
 
-    rc = dixLookupResourceByType((void **) &pFence, stuff->fid,
+    int rc = dixLookupResourceByType((void **) &pFence, stuff->fid,
                                  RTFence, client, DixReadAccess);
     if (rc != Success)
         return rc;

--- a/Xext/xf86bigfont.c
+++ b/Xext/xf86bigfont.c
@@ -567,8 +567,6 @@ ProcXF86BigfontQueryFont(ClientPtr client)
             swapCharInfo(&reply.maxBounds);
         }
 
-        int rc = Success;
-
         x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
         for (int i = 0; i < nfontprops; i++) {
@@ -582,7 +580,7 @@ ProcXF86BigfontQueryFont(ClientPtr client)
             x_rpcbuf_write_CARD16s(&rpcbuf, pIndex2UniqIndex, nCharInfos);
         }
 
-        rc = X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
+        int rc = X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 
         if (nCharInfos > 0) {
             if (shmid == -1)

--- a/Xext/xselinux_ext.c
+++ b/Xext/xselinux_ext.c
@@ -114,7 +114,6 @@ ProcSELinuxSetCreateContext(ClientPtr client, unsigned offset)
     security_id_t *pSid;
     char *ctx = NULL;
     char *ptr;
-    int rc;
 
     if (stuff->context_len > 0) {
         ctx = SELinuxCopyContext((char *) (stuff + 1), stuff->context_len);
@@ -126,7 +125,7 @@ ProcSELinuxSetCreateContext(ClientPtr client, unsigned offset)
     pSid = (security_id_t *) (ptr + offset);
     *pSid = NULL;
 
-    rc = Success;
+    int rc = Success;
     if (stuff->context_len > 0) {
         if (security_check_context_raw(ctx) < 0 ||
             avc_context_to_sid_raw(ctx, pSid) < 0)
@@ -168,7 +167,6 @@ ProcSELinuxSetDeviceContext(ClientPtr client)
     DeviceIntPtr dev;
     SELinuxSubjectRec *subj;
     SELinuxObjectRec *obj;
-    int rc;
 
     if (stuff->context_len < 1)
         return BadLength;
@@ -176,7 +174,7 @@ ProcSELinuxSetDeviceContext(ClientPtr client)
     if (!ctx)
         return BadAlloc;
 
-    rc = dixLookupDevice(&dev, stuff->id, client, DixManageAccess);
+    int rc = dixLookupDevice(&dev, stuff->id, client, DixManageAccess);
     if (rc != Success)
         goto out;
 
@@ -205,9 +203,8 @@ ProcSELinuxGetDeviceContext(ClientPtr client)
 
     DeviceIntPtr dev;
     SELinuxSubjectRec *subj;
-    int rc;
 
-    rc = dixLookupDevice(&dev, stuff->id, client, DixGetAttrAccess);
+    int rc = dixLookupDevice(&dev, stuff->id, client, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 
@@ -224,9 +221,8 @@ ProcSELinuxGetDrawableContext(ClientPtr client)
     DrawablePtr pDraw;
     PrivateRec **privatePtr;
     SELinuxObjectRec *obj;
-    int rc;
 
-    rc = dixLookupDrawable(&pDraw, stuff->id, client, 0, DixGetAttrAccess);
+    int rc = dixLookupDrawable(&pDraw, stuff->id, client, 0, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 
@@ -249,9 +245,8 @@ ProcSELinuxGetPropertyContext(ClientPtr client, void *privKey)
     WindowPtr pWin;
     PropertyPtr pProp;
     SELinuxObjectRec *obj;
-    int rc;
 
-    rc = dixLookupWindow(&pWin, stuff->window, client, DixGetPropAccess);
+    int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetPropAccess);
     if (rc != Success)
         return rc;
 
@@ -272,9 +267,8 @@ ProcSELinuxGetSelectionContext(ClientPtr client, void *privKey)
 
     Selection *pSel;
     SELinuxObjectRec *obj;
-    int rc;
 
-    rc = dixLookupSelection(&pSel, stuff->id, client, DixGetAttrAccess);
+    int rc = dixLookupSelection(&pSel, stuff->id, client, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 
@@ -290,9 +284,8 @@ ProcSELinuxGetClientContext(ClientPtr client)
 
     ClientPtr target;
     SELinuxSubjectRec *subj;
-    int rc;
 
-    rc = dixLookupResourceOwner(&target, stuff->id, client, DixGetAttrAccess);
+    int rc = dixLookupResourceOwner(&target, stuff->id, client, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 
@@ -372,10 +365,10 @@ ProcSELinuxListProperties(ClientPtr client)
     WindowPtr pWin;
     PropertyPtr pProp;
     SELinuxListItemRec *items;
-    int rc, count, size, i;
+    int count, size, i;
     CARD32 id;
 
-    rc = dixLookupWindow(&pWin, stuff->id, client, DixListPropAccess);
+    int rc = dixLookupWindow(&pWin, stuff->id, client, DixListPropAccess);
     if (rc != Success)
         return rc;
 
@@ -410,7 +403,7 @@ ProcSELinuxListSelections(ClientPtr client)
 
     Selection *pSel;
     SELinuxListItemRec *items;
-    int rc, count, size, i;
+    int count, size, i;
     CARD32 id;
 
     /* Count the number of selections and allocate items */
@@ -428,7 +421,7 @@ ProcSELinuxListSelections(ClientPtr client)
     size = 0;
     for (pSel = CurrentSelections; pSel; pSel = pSel->next) {
         id = pSel->selection;
-        rc = SELinuxPopulateItem(items + i, &pSel->devPrivates, id, &size);
+        int rc = SELinuxPopulateItem(items + i, &pSel->devPrivates, id, &size);
         if (rc != Success) {
             SELinuxFreeItems(items, count);
             return rc;

--- a/Xext/xselinux_hooks.c
+++ b/Xext/xselinux_hooks.c
@@ -362,7 +362,6 @@ SELinuxDevice(CallbackListPtr *pcbl, void *unused, void *calldata)
     SELinuxObjectRec *obj;
     SELinuxAuditRec auditdata = {.client = rec->client,.dev = rec->dev };
     security_class_t cls;
-    int rc;
 
     subj = dixLookupPrivate(&rec->client->devPrivates, subjectKey);
     obj = dixLookupPrivate(&rec->dev->devPrivates, objectKey);
@@ -386,7 +385,7 @@ SELinuxDevice(CallbackListPtr *pcbl, void *unused, void *calldata)
     }
 
     cls = IsPointerDevice(rec->dev) ? SECCLASS_X_POINTER : SECCLASS_X_KEYBOARD;
-    rc = SELinuxDoCheck(subj, obj, cls, rec->access_mode, &auditdata);
+    int rc = SELinuxDoCheck(subj, obj, cls, rec->access_mode, &auditdata);
     if (rc != Success)
         rec->status = rc;
 }
@@ -399,7 +398,7 @@ SELinuxSend(CallbackListPtr *pcbl, void *unused, void *calldata)
     SELinuxObjectRec *obj, ev_sid;
     SELinuxAuditRec auditdata = {.client = rec->client,.dev = rec->dev };
     security_class_t class;
-    int rc, i, type;
+    int i, type;
 
     if (rec->dev)
         subj = dixLookupPrivate(&rec->dev->devPrivates, subjectKey);
@@ -409,7 +408,7 @@ SELinuxSend(CallbackListPtr *pcbl, void *unused, void *calldata)
     obj = dixLookupPrivate(&rec->pWin->devPrivates, objectKey);
 
     /* Check send permission on window */
-    rc = SELinuxDoCheck(subj, obj, SECCLASS_X_DRAWABLE, DixSendAccess,
+    int rc = SELinuxDoCheck(subj, obj, SECCLASS_X_DRAWABLE, DixSendAccess,
                         &auditdata);
     if (rc != Success)
         goto err;
@@ -441,13 +440,13 @@ SELinuxReceive(CallbackListPtr *pcbl, void *unused, void *calldata)
     SELinuxObjectRec *obj, ev_sid;
     SELinuxAuditRec auditdata = {.client = NULL };
     security_class_t class;
-    int rc, i, type;
+    int i, type;
 
     subj = dixLookupPrivate(&rec->client->devPrivates, subjectKey);
     obj = dixLookupPrivate(&rec->pWin->devPrivates, objectKey);
 
     /* Check receive permission on window */
-    rc = SELinuxDoCheck(subj, obj, SECCLASS_X_DRAWABLE, DixReceiveAccess,
+    int rc = SELinuxDoCheck(subj, obj, SECCLASS_X_DRAWABLE, DixReceiveAccess,
                         &auditdata);
     if (rc != Success)
         goto err;
@@ -478,7 +477,6 @@ SELinuxExtension(CallbackListPtr *pcbl, void *unused, void *calldata)
     SELinuxSubjectRec *subj, *serv;
     SELinuxObjectRec *obj;
     SELinuxAuditRec auditdata = {.client = rec->client };
-    int rc;
 
     subj = dixLookupPrivate(&rec->client->devPrivates, subjectKey);
     obj = dixLookupPrivate(&rec->ext->devPrivates, objectKey);
@@ -489,7 +487,7 @@ SELinuxExtension(CallbackListPtr *pcbl, void *unused, void *calldata)
         security_id_t sid;
 
         serv = dixLookupPrivate(&serverClient->devPrivates, subjectKey);
-        rc = SELinuxExtensionToSID(rec->ext->name, &sid);
+        int rc = SELinuxExtensionToSID(rec->ext->name, &sid);
         if (rc != Success) {
             rec->status = rc;
             return;
@@ -506,7 +504,7 @@ SELinuxExtension(CallbackListPtr *pcbl, void *unused, void *calldata)
 
     /* Perform the security check */
     auditdata.extension = (char *) rec->ext->name;
-    rc = SELinuxDoCheck(subj, obj, SECCLASS_X_EXTENSION, rec->access_mode,
+    int rc = SELinuxDoCheck(subj, obj, SECCLASS_X_EXTENSION, rec->access_mode,
                         &auditdata);
     if (rc != Success)
         rec->status = rc;
@@ -523,21 +521,20 @@ SELinuxSelection(CallbackListPtr *pcbl, void *unused, void *calldata)
     Mask access_mode = rec->access_mode;
     SELinuxAuditRec auditdata = {.client = rec->client,.selection = name };
     security_id_t tsid;
-    int rc;
 
     subj = dixLookupPrivate(&rec->client->devPrivates, subjectKey);
     obj = dixLookupPrivate(&pSel->devPrivates, objectKey);
 
     /* If this is a new object that needs labeling, do it now */
     if (access_mode & DixCreateAccess) {
-        rc = SELinuxSelectionToSID(name, subj, &obj->sid, &obj->poly);
+        int rc = SELinuxSelectionToSID(name, subj, &obj->sid, &obj->poly);
         if (rc != Success)
             obj->sid = unlabeled_sid;
         access_mode = DixSetAttrAccess;
     }
     /* If this is a polyinstantiated object, find the right instance */
     else if (obj->poly) {
-        rc = SELinuxSelectionToSID(name, subj, &tsid, NULL);
+        int rc = SELinuxSelectionToSID(name, subj, &tsid, NULL);
         if (rc != Success) {
             rec->status = rc;
             return;
@@ -557,7 +554,7 @@ SELinuxSelection(CallbackListPtr *pcbl, void *unused, void *calldata)
     }
 
     /* Perform the security check */
-    rc = SELinuxDoCheck(subj, obj, SECCLASS_X_SELECTION, access_mode,
+    int rc = SELinuxDoCheck(subj, obj, SECCLASS_X_SELECTION, access_mode,
                         &auditdata);
     if (rc != Success)
         rec->status = rc;
@@ -582,7 +579,6 @@ SELinuxProperty(CallbackListPtr *pcbl, void *unused, void *calldata)
     Atom name = pProp->propertyName;
     SELinuxAuditRec auditdata = {.client = rec->client,.property = name };
     security_id_t tsid;
-    int rc;
 
     /* Don't care about the new content check */
     if (rec->access_mode & DixPostAccess)
@@ -593,7 +589,7 @@ SELinuxProperty(CallbackListPtr *pcbl, void *unused, void *calldata)
 
     /* If this is a new object that needs labeling, do it now */
     if (rec->access_mode & DixCreateAccess) {
-        rc = SELinuxPropertyToSID(name, subj, &obj->sid, &obj->poly);
+        int rc = SELinuxPropertyToSID(name, subj, &obj->sid, &obj->poly);
         if (rc != Success) {
             rec->status = rc;
             return;
@@ -601,7 +597,7 @@ SELinuxProperty(CallbackListPtr *pcbl, void *unused, void *calldata)
     }
     /* If this is a polyinstantiated object, find the right instance */
     else if (obj->poly) {
-        rc = SELinuxPropertyToSID(name, subj, &tsid, NULL);
+        int rc = SELinuxPropertyToSID(name, subj, &tsid, NULL);
         if (rc != Success) {
             rec->status = rc;
             return;
@@ -621,7 +617,7 @@ SELinuxProperty(CallbackListPtr *pcbl, void *unused, void *calldata)
     }
 
     /* Perform the security check */
-    rc = SELinuxDoCheck(subj, obj, SECCLASS_X_PROPERTY, rec->access_mode,
+    int rc = SELinuxDoCheck(subj, obj, SECCLASS_X_PROPERTY, rec->access_mode,
                         &auditdata);
     if (rc != Success)
         rec->status = rc;
@@ -646,7 +642,7 @@ SELinuxResource(CallbackListPtr *pcbl, void *unused, void *calldata)
     Mask access_mode = rec->access_mode;
     PrivateRec **privatePtr;
     security_class_t class;
-    int rc, offset;
+    int offset;
 
     subj = dixLookupPrivate(&rec->client->devPrivates, subjectKey);
 
@@ -670,7 +666,7 @@ SELinuxResource(CallbackListPtr *pcbl, void *unused, void *calldata)
 
     /* If this is a new object that needs labeling, do it now */
     if (access_mode & DixCreateAccess && offset >= 0) {
-        rc = SELinuxLabelResource(rec, subj, obj, class);
+        int rc = SELinuxLabelResource(rec, subj, obj, class);
         if (rc != Success) {
             rec->status = rc;
             return;
@@ -686,7 +682,7 @@ SELinuxResource(CallbackListPtr *pcbl, void *unused, void *calldata)
     /* Perform the security check */
     auditdata.restype = rec->rtype;
     auditdata.id = rec->id;
-    rc = SELinuxDoCheck(subj, obj, class, access_mode, &auditdata);
+    int rc = SELinuxDoCheck(subj, obj, class, access_mode, &auditdata);
     if (rc != Success)
         rec->status = rc;
 
@@ -706,7 +702,6 @@ SELinuxScreen(CallbackListPtr *pcbl, void *is_saver, void *calldata)
     SELinuxObjectRec *obj;
     SELinuxAuditRec auditdata = {.client = rec->client };
     Mask access_mode = rec->access_mode;
-    int rc;
 
     subj = dixLookupPrivate(&rec->client->devPrivates, subjectKey);
     obj = dixLookupPrivate(&rec->screen->devPrivates, objectKey);
@@ -725,7 +720,7 @@ SELinuxScreen(CallbackListPtr *pcbl, void *is_saver, void *calldata)
     if (is_saver)
         access_mode <<= 2;
 
-    rc = SELinuxDoCheck(subj, obj, SECCLASS_X_SCREEN, access_mode, &auditdata);
+    int rc = SELinuxDoCheck(subj, obj, SECCLASS_X_SCREEN, access_mode, &auditdata);
     if (rc != Success)
         rec->status = rc;
 }
@@ -737,12 +732,11 @@ SELinuxClient(CallbackListPtr *pcbl, void *unused, void *calldata)
     SELinuxSubjectRec *subj;
     SELinuxObjectRec *obj;
     SELinuxAuditRec auditdata = {.client = rec->client };
-    int rc;
 
     subj = dixLookupPrivate(&rec->client->devPrivates, subjectKey);
     obj = dixLookupPrivate(&rec->target->devPrivates, objectKey);
 
-    rc = SELinuxDoCheck(subj, obj, SECCLASS_X_CLIENT, rec->access_mode,
+    int rc = SELinuxDoCheck(subj, obj, SECCLASS_X_CLIENT, rec->access_mode,
                         &auditdata);
     if (rc != Success)
         rec->status = rc;
@@ -755,12 +749,11 @@ SELinuxServer(CallbackListPtr *pcbl, void *unused, void *calldata)
     SELinuxSubjectRec *subj;
     SELinuxObjectRec *obj;
     SELinuxAuditRec auditdata = {.client = rec->client };
-    int rc;
 
     subj = dixLookupPrivate(&rec->client->devPrivates, subjectKey);
     obj = dixLookupPrivate(&serverClient->devPrivates, objectKey);
 
-    rc = SELinuxDoCheck(subj, obj, SECCLASS_X_SERVER, rec->access_mode,
+    int rc = SELinuxDoCheck(subj, obj, SECCLASS_X_SERVER, rec->access_mode,
                         &auditdata);
     if (rc != Success)
         rec->status = rc;

--- a/Xext/xtest.c
+++ b/Xext/xtest.c
@@ -114,10 +114,9 @@ ProcXTestCompareCursor(ClientPtr client)
 
     WindowPtr pWin;
     CursorPtr pCursor;
-    int rc;
     DeviceIntPtr ptr = PickPointer(client);
 
-    rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
+    int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 
@@ -184,7 +183,7 @@ ProcXTestFakeInput(ClientPtr client)
             return n;
     }
 
-    int nev, n, type, rc;
+    int nev, n, type;
     xEvent *ev;
     DeviceIntPtr dev = NULL;
     WindowPtr root;
@@ -209,7 +208,7 @@ ProcXTestFakeInput(ClientPtr client)
         extension = TRUE;
 
         /* check device */
-        rc = dixLookupDevice(&dev, stuff->deviceid & 0177, client,
+        int rc = dixLookupDevice(&dev, stuff->deviceid & 0177, client,
                              DixWriteAccess);
         if (rc != Success) {
             client->errorValue = stuff->deviceid & 0177;
@@ -402,7 +401,7 @@ ProcXTestFakeInput(ClientPtr client)
             return BadDevice;
 
         if (!(extension || ev->u.keyButtonPointer.root == None)) {
-            rc = dixLookupWindow(&root, ev->u.keyButtonPointer.root,
+            int rc = dixLookupWindow(&root, ev->u.keyButtonPointer.root,
                                  client, DixGetAttrAccess);
             if (rc != Success)
                 return rc;

--- a/Xext/xvmain.c
+++ b/Xext/xvmain.c
@@ -733,11 +733,10 @@ int
 XvdiSelectVideoNotify(ClientPtr client, DrawablePtr pDraw, BOOL onoff)
 {
     XvVideoNotifyPtr pn, tpn, fpn;
-    int rc;
 
     /* FIND VideoNotify LIST */
 
-    rc = dixLookupResourceByType((void **) &pn, pDraw->id,
+    int rc = dixLookupResourceByType((void **) &pn, pDraw->id,
                                  XvRTVideoNotifyList, client, DixWriteAccess);
     if (rc != Success && rc != BadValue)
         return rc;

--- a/Xext/xvmc.c
+++ b/Xext/xvmc.c
@@ -270,9 +270,8 @@ ProcXvMCDestroyContext(ClientPtr client)
     X_REQUEST_FIELD_CARD32(context_id);
 
     void *val;
-    int rc;
 
-    rc = dixLookupResourceByType(&val, stuff->context_id, XvMCRTContext,
+    int rc = dixLookupResourceByType(&val, stuff->context_id, XvMCRTContext,
                                  client, DixDestroyAccess);
     if (rc != Success)
         return rc;
@@ -342,9 +341,8 @@ ProcXvMCDestroySurface(ClientPtr client)
     X_REQUEST_FIELD_CARD32(surface_id);
 
     void *val;
-    int rc;
 
-    rc = dixLookupResourceByType(&val, stuff->surface_id, XvMCRTSurface,
+    int rc = dixLookupResourceByType(&val, stuff->surface_id, XvMCRTSurface,
                                  client, DixDestroyAccess);
     if (rc != Success)
         return rc;
@@ -473,9 +471,8 @@ ProcXvMCDestroySubpicture(ClientPtr client)
     X_REQUEST_FIELD_CARD32(subpicture_id);
 
     void *val;
-    int rc;
 
-    rc = dixLookupResourceByType(&val, stuff->subpicture_id, XvMCRTSubpicture,
+    int rc = dixLookupResourceByType(&val, stuff->subpicture_id, XvMCRTSubpicture,
                                  client, DixDestroyAccess);
     if (rc != Success)
         return rc;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
