### PR TITLE
(master) Xext: saver: init reply struct at once in ProcScreenSaverQueryInfo()

### DIFF
--- a/Xext/saver.c
+++ b/Xext/saver.c
@@ -677,7 +677,9 @@ ProcScreenSaverQueryInfo(ClientPtr client)
     lastInput = GetTimeInMillis() - LastEventTime(XIAllDevices).milliseconds;
 
     xScreenSaverQueryInfoReply reply = {
-        .window = pSaver->wid
+        .window = pSaver->wid,
+        .idle = lastInput,
+        .eventMask = getEventMask(pDraw->pScreen, client),
     };
     if (screenIsSaved != SCREEN_SAVER_OFF) {
         reply.state = ScreenSaverOn;
@@ -694,8 +696,6 @@ ProcScreenSaverQueryInfo(ClientPtr client)
             reply.state = ScreenSaverDisabled;
         }
     }
-    reply.idle = lastInput;
-    reply.eventMask = getEventMask(pDraw->pScreen, client);
     if (pPriv && pPriv->attr) {
         reply.kind = ScreenSaverExternal;
     } else if (ScreenSaverBlanking != DontPreferBlanking) {


### PR DESCRIPTION
Initialize all the reply struct field in one shot.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
