### PR TITLE
(master) Xext: move some calls with return on error into macros

### DIFF
--- a/Xext/damage/damageext.c
+++ b/Xext/damage/damageext.c
@@ -291,10 +291,8 @@ static int doDamageCreate(ClientPtr client, DamageExtPtr *ext, xDamageCreateReq 
     DamageExtPtr pDamageExt;
     DamageReportLevel level;
 
-    int rc = dixLookupDrawable(&pDrawable, stuff->drawable, client, 0,
-                            DixGetAttrAccess | DixReadAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupDrawable(&pDrawable, stuff->drawable, client, 0,
+                            DixGetAttrAccess | DixReadAccess));
 
     switch (stuff->level) {
     case XDamageReportRawRectangles:
@@ -481,10 +479,8 @@ ProcDamageAdd(ClientPtr client)
     RegionPtr pRegion;
 
     VERIFY_REGION(pRegion, stuff->region, client, DixWriteAccess);
-    int rc = dixLookupDrawable(&pDrawable, stuff->drawable, client, 0,
-                           DixWriteAccess);
-    if (rc != Success)
-        return rc;
+
+    X_CALL_CHECK_ERR(dixLookupDrawable(&pDrawable, stuff->drawable, client, 0, DixWriteAccess));
 
     /* The region is relative to the drawable origin, so translate it out to
      * screen coordinates like damage expects.
@@ -590,10 +586,8 @@ PanoramiXDamageCreate(ClientPtr client, xDamageCreateReq *stuff)
     PanoramiXRes *draw;
 
     LEGAL_NEW_RESOURCE(stuff->damage, client);
-    int rc = dixLookupResourceByClass((void **)&draw, stuff->drawable, XRC_DRAWABLE,
-                                  client, DixGetAttrAccess | DixReadAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupResourceByClass((void **)&draw, stuff->drawable, XRC_DRAWABLE,
+                                  client, DixGetAttrAccess | DixReadAccess));
 
     if (!(damage = calloc(1, sizeof(PanoramiXDamageRes))))
         return BadAlloc;
@@ -601,7 +595,7 @@ PanoramiXDamageCreate(ClientPtr client, xDamageCreateReq *stuff)
     if (!AddResource(stuff->damage, XRT_DAMAGE, damage))
         return BadAlloc;
 
-    rc = doDamageCreate(client, &(damage->ext), stuff);
+    int rc = doDamageCreate(client, &(damage->ext), stuff);
     if (rc == Success && draw->type == XRT_WINDOW) {
         XINERAMA_FOR_EACH_SCREEN_FORWARD({
             DrawablePtr pDrawable;

--- a/Xext/dpms/dpms.c
+++ b/Xext/dpms/dpms.c
@@ -282,16 +282,10 @@ DPMSSet(ClientPtr client, int level)
 
     if (level != DPMSModeOn) {
         if (isUnblank(screenIsSaved)) {
-            int rc = dixSaveScreens(client, SCREEN_SAVER_FORCER, ScreenSaverActive);
-            if (rc != Success) {
-                return rc;
-            }
+            X_CALL_CHECK_ERR(dixSaveScreens(client, SCREEN_SAVER_FORCER, ScreenSaverActive));
         }
     } else if (!isUnblank(screenIsSaved)) {
-        int rc = dixSaveScreens(client, SCREEN_SAVER_OFF, ScreenSaverReset);
-        if (rc != Success) {
-            return rc;
-        }
+        X_CALL_CHECK_ERR(dixSaveScreens(client, SCREEN_SAVER_OFF, ScreenSaverReset));
     }
 
     DIX_FOR_EACH_SCREEN({

--- a/Xext/dri2/dri2.c
+++ b/Xext/dri2/dri2.c
@@ -35,6 +35,7 @@
 #include <errno.h>
 
 #include "dix/dix_priv.h"
+#include "dix/request_priv.h"
 #include "os/client_priv.h"
 
 #ifdef WITH_LIBDRM
@@ -353,9 +354,8 @@ DRI2CreateDrawable2(ClientPtr client, DrawablePtr pDraw, XID id,
     pPriv->prime_id = dri2_client->prime_id;
 
     XID dri2_id = FakeClientID(client->index);
-    int rc = DRI2AddDrawableRef(pPriv, id, dri2_id, invalidate, priv);
-    if (rc != Success)
-        return rc;
+
+    X_CALL_CHECK_ERR(DRI2AddDrawableRef(pPriv, id, dri2_id, invalidate, priv));
 
     if (dri2_id_out)
         *dri2_id_out = dri2_id;

--- a/Xext/panoramiX/panoramiX.c
+++ b/Xext/panoramiX/panoramiX.c
@@ -898,9 +898,7 @@ ProcPanoramiXGetState(ClientPtr client)
     X_REQUEST_FIELD_CARD32(window);
 
     WindowPtr pWin;
-    int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess));
 
     xPanoramiXGetStateReply reply = {
         .state = !noPanoramiXExtension,
@@ -919,9 +917,7 @@ ProcPanoramiXGetScreenCount(ClientPtr client)
     X_REQUEST_FIELD_CARD32(window);
 
     WindowPtr pWin;
-    int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess));
 
     xPanoramiXGetScreenCountReply reply = {
         .ScreenCount = PanoramiXNumScreens,
@@ -944,9 +940,7 @@ ProcPanoramiXGetScreenSize(ClientPtr client)
         return BadMatch;
 
     WindowPtr pWin;
-    int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess));
 
     ScreenPtr pScreen = dixGetScreenPtr(stuff->screen);
 

--- a/Xext/panoramiX/panoramiXprocs.c
+++ b/Xext/panoramiX/panoramiXprocs.c
@@ -573,9 +573,7 @@ PanoramiXGetGeometry(ClientPtr client)
     REQUEST(xResourceReq);
     REQUEST_SIZE_MATCH(xResourceReq);
 
-    int rc = dixLookupDrawable(&pDraw, stuff->id, client, M_ANY, DixGetAttrAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupDrawable(&pDraw, stuff->id, client, M_ANY, DixGetAttrAccess));
 
     ScreenPtr masterScreen = dixGetMasterScreen();
 
@@ -631,12 +629,8 @@ PanoramiXTranslateCoords(ClientPtr client)
 
     REQUEST_SIZE_MATCH(xTranslateCoordsReq);
 
-    int rc = dixLookupWindow(&pWin, stuff->srcWid, client, DixReadAccess);
-    if (rc != Success)
-        return rc;
-    rc = dixLookupWindow(&pDst, stuff->dstWid, client, DixReadAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupWindow(&pWin, stuff->srcWid, client, DixReadAccess));
+    X_CALL_CHECK_ERR(dixLookupWindow(&pDst, stuff->dstWid, client, DixReadAccess));
 
     ScreenPtr masterScreen = dixGetMasterScreen();
 
@@ -1125,13 +1119,11 @@ PanoramiXCopyArea(ClientPtr client)
         DrawablePtr pDst;
         GCPtr pGC = NULL;
         char *data;
-        int pitch, rc;
+        int pitch;
 
         XINERAMA_FOR_EACH_SCREEN_BACKWARD({
-            rc = dixLookupDrawable(drawables + walkScreenIdx, src->info[walkScreenIdx].id, client, 0,
-                                   DixGetAttrAccess);
-            if (rc != Success)
-                return rc;
+            X_CALL_CHECK_ERR(dixLookupDrawable(drawables + walkScreenIdx, src->info[walkScreenIdx].id, client, 0,
+                                   DixGetAttrAccess));
             drawables[walkScreenIdx]->pScreen->SourceValidate(drawables[walkScreenIdx], 0, 0,
                                                   drawables[walkScreenIdx]->width,
                                                   drawables[walkScreenIdx]->height,
@@ -1238,11 +1230,8 @@ PanoramiXCopyArea(ClientPtr client)
             VALIDATE_DRAWABLE_AND_GC(stuff->dstDrawable, pDst, DixWriteAccess);
 
             if (stuff->dstDrawable != stuff->srcDrawable) {
-                int rc = dixLookupDrawable(&pSrc, stuff->srcDrawable, client, 0,
-                                           DixReadAccess);
-                if (rc != Success)
-                    return rc;
-
+                X_CALL_CHECK_ERR(dixLookupDrawable(&pSrc, stuff->srcDrawable, client, 0,
+                                           DixReadAccess));
                 if ((pDst->pScreen != pSrc->pScreen) ||
                     (pDst->depth != pSrc->depth)) {
                     client->errorValue = stuff->dstDrawable;
@@ -1314,10 +1303,8 @@ PanoramiXCopyPlane(ClientPtr client)
     if (dstShared && srcShared)
         return (*SavedProcVector[X_CopyPlane]) (client);
 
-    rc = dixLookupResourceByType((void **) &gc, stuff->gc, XRT_GC,
-                                 client, DixReadAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupResourceByType((void **) &gc, stuff->gc, XRT_GC,
+                                 client, DixReadAccess));
 
     if ((dst->type == XRT_WINDOW) && dst->u.win.root)
         dstIsRoot = TRUE;
@@ -1348,11 +1335,8 @@ PanoramiXCopyPlane(ClientPtr client)
 
         VALIDATE_DRAWABLE_AND_GC(stuff->dstDrawable, pdstDraw, DixWriteAccess);
         if (stuff->dstDrawable != stuff->srcDrawable) {
-            rc = dixLookupDrawable(&psrcDraw, stuff->srcDrawable, client, 0,
-                                   DixReadAccess);
-            if (rc != Success)
-                return rc;
-
+            X_CALL_CHECK_ERR(dixLookupDrawable(&psrcDraw, stuff->srcDrawable, client, 0,
+                                   DixReadAccess));
             if (pdstDraw->pScreen != psrcDraw->pScreen) {
                 client->errorValue = stuff->dstDrawable;
                 return BadMatch;
@@ -2011,9 +1995,7 @@ PanoramiXGetImage(ClientPtr client)
     if (draw->type == XRT_PIXMAP)
         return (*SavedProcVector[X_GetImage]) (client);
 
-    rc = dixLookupDrawable(&pDraw, stuff->drawable, client, 0, DixReadAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupDrawable(&pDraw, stuff->drawable, client, 0, DixReadAccess));
 
     if (!((WindowPtr) pDraw)->realized)
         return BadMatch;
@@ -2050,12 +2032,10 @@ PanoramiXGetImage(ClientPtr client)
     drawables[0] = pDraw;
 
     XINERAMA_FOR_EACH_SCREEN_FORWARD_SKIP0({
-        rc = dixLookupDrawable(drawables + walkScreenIdx,
+        X_CALL_CHECK_ERR(dixLookupDrawable(drawables + walkScreenIdx,
                                draw->info[walkScreenIdx].id,
                                client, 0,
-                               DixGetAttrAccess);
-        if (rc != Success)
-            return rc;
+                               DixGetAttrAccess));
     });
 
     XINERAMA_FOR_EACH_SCREEN_FORWARD({

--- a/Xext/saver/saver.c
+++ b/Xext/saver/saver.c
@@ -645,15 +645,9 @@ ProcScreenSaverQueryInfo(ClientPtr client)
     X_REQUEST_FIELD_CARD32(drawable);
 
     DrawablePtr pDraw;
-    int rc = dixLookupDrawable(&pDraw, stuff->drawable, client, 0,
-                           DixGetAttrAccess);
-    if (rc != Success) {
-        return rc;
-    }
-    rc = dixCallScreensaverAccessCallback(client, pDraw->pScreen, DixGetAttrAccess);
-    if (rc != Success) {
-        return rc;
-    }
+    X_CALL_CHECK_ERR(dixLookupDrawable(&pDraw, stuff->drawable, client, 0,
+                           DixGetAttrAccess));
+    X_CALL_CHECK_ERR(dixCallScreensaverAccessCallback(client, pDraw->pScreen, DixGetAttrAccess));
 
     ScreenSaverStuffPtr pSaver = &pDraw->pScreen->screensaver;
     ScreenSaverScreenPrivatePtr pPriv = GetScreenPrivate(pDraw->pScreen);
@@ -706,16 +700,10 @@ ProcScreenSaverSelectInput(ClientPtr client)
     X_REQUEST_FIELD_CARD32(eventMask);
 
     DrawablePtr pDraw;
-    int rc = dixLookupDrawable(&pDraw, stuff->drawable, client, 0,
-                           DixGetAttrAccess);
-    if (rc != Success) {
-        return rc;
-    }
+    X_CALL_CHECK_ERR(dixLookupDrawable(&pDraw, stuff->drawable, client, 0,
+                           DixGetAttrAccess));
 
-    rc = dixCallScreensaverAccessCallback(client, pDraw->pScreen, DixSetAttrAccess);
-    if (rc != Success) {
-        return rc;
-    }
+    X_CALL_CHECK_ERR(dixCallScreensaverAccessCallback(client, pDraw->pScreen, DixSetAttrAccess));
 
     if (!setEventMask(pDraw->pScreen, client, stuff->eventMask)) {
         return BadAlloc;
@@ -1091,11 +1079,10 @@ static int
 ScreenSaverUnsetAttributes(ClientPtr client, Drawable drawable)
 {
     DrawablePtr pDraw;
-    int rc = dixLookupDrawable(&pDraw, drawable, client, 0, DixGetAttrAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupDrawable(&pDraw, drawable, client, 0, DixGetAttrAccess));
 
     ScreenSaverScreenPrivatePtr pPriv = GetScreenPrivate(pDraw->pScreen);
+
     if (pPriv && pPriv->attr && pPriv->attr->client == client) {
         FreeResource(pPriv->attr->resource, AttrType);
         FreeScreenAttr(pPriv->attr);

--- a/Xext/security/security.c
+++ b/Xext/security/security.c
@@ -580,11 +580,9 @@ ProcSecurityRevokeAuthorization(ClientPtr client)
 
     SecurityAuthorizationPtr pAuth;
 
-    int rc = dixLookupResourceByType((void **) &pAuth, stuff->authId,
+    X_CALL_CHECK_ERR(dixLookupResourceByType((void **) &pAuth, stuff->authId,
                                  SecurityAuthorizationResType, client,
-                                 DixDestroyAccess);
-    if (rc != Success)
-        return rc;
+                                 DixDestroyAccess));
 
     FreeResource(stuff->authId, X11_RESTYPE_NONE);
     return Success;

--- a/Xext/shape/shape.c
+++ b/Xext/shape/shape.c
@@ -243,15 +243,14 @@ ShapeRectangles(ClientPtr client, xShapeRectanglesReq *stuff)
 {
     WindowPtr pWin;
     xRectangle *prects;
-    int nrects, ctype, rc;
+    int nrects, ctype;
     RegionPtr srcRgn;
     RegionPtr *destRgn;
     CreateDftPtr createDefault;
 
     UpdateCurrentTime();
-    rc = dixLookupWindow(&pWin, stuff->dest, client, DixSetAttrAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupWindow(&pWin, stuff->dest, client, DixSetAttrAccess));
+
     switch (stuff->destKind) {
     case ShapeBounding:
         createDefault = CreateBoundingShape;
@@ -348,9 +347,9 @@ ShapeMask(ClientPtr client, xShapeMaskReq *stuff)
     CreateDftPtr createDefault;
 
     UpdateCurrentTime();
-    int rc = dixLookupWindow(&pWin, stuff->dest, client, DixSetAttrAccess);
-    if (rc != Success)
-        return rc;
+
+    X_CALL_CHECK_ERR(dixLookupWindow(&pWin, stuff->dest, client, DixSetAttrAccess));
+
     switch (stuff->destKind) {
     case ShapeBounding:
         createDefault = CreateBoundingShape;
@@ -369,10 +368,8 @@ ShapeMask(ClientPtr client, xShapeMaskReq *stuff)
     if (stuff->src == None)
         srcRgn = 0;
     else {
-        rc = dixLookupResourceByType((void **) &pPixmap, stuff->src,
-                                     X11_RESTYPE_PIXMAP, client, DixReadAccess);
-        if (rc != Success)
-            return rc;
+        X_CALL_CHECK_ERR(dixLookupResourceByType((void **) &pPixmap, stuff->src,
+                                     X11_RESTYPE_PIXMAP, client, DixReadAccess));
         if (pPixmap->drawable.pScreen != pScreen ||
             pPixmap->drawable.depth != 1)
             return BadMatch;
@@ -459,9 +456,9 @@ ShapeCombine(ClientPtr client, xShapeCombineReq *stuff)
     RegionPtr tmp;
 
     UpdateCurrentTime();
-    int rc = dixLookupWindow(&pDestWin, stuff->dest, client, DixSetAttrAccess);
-    if (rc != Success)
-        return rc;
+
+    X_CALL_CHECK_ERR(dixLookupWindow(&pDestWin, stuff->dest, client, DixSetAttrAccess));
+
     if (!MakeWindowOptional(pDestWin))
         return BadAlloc;
 
@@ -480,9 +477,8 @@ ShapeCombine(ClientPtr client, xShapeCombineReq *stuff)
         return BadValue;
     }
 
-    rc = dixLookupWindow(&pSrcWin, stuff->src, client, DixGetAttrAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupWindow(&pSrcWin, stuff->src, client, DixGetAttrAccess));
+
     switch (stuff->srcKind) {
     case ShapeBounding:
         srcRgn = wBoundingShape(pSrcWin);
@@ -581,9 +577,9 @@ ShapeOffset(ClientPtr client, xShapeOffsetReq *stuff)
     RegionPtr srcRgn;
 
     UpdateCurrentTime();
-    int rc = dixLookupWindow(&pWin, stuff->dest, client, DixSetAttrAccess);
-    if (rc != Success)
-        return rc;
+
+    X_CALL_CHECK_ERR(dixLookupWindow(&pWin, stuff->dest, client, DixSetAttrAccess));
+
     switch (stuff->destKind) {
     case ShapeBounding:
         srcRgn = wBoundingShape(pWin);
@@ -646,9 +642,7 @@ ProcShapeQueryExtents(ClientPtr client)
     X_REQUEST_FIELD_CARD32(window);
 
     WindowPtr pWin;
-    int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess));
 
     RegionPtr boundRegion;
     BoxRec boundBox;
@@ -716,9 +710,9 @@ ProcShapeSelectInput(ClientPtr client)
 
     if (client->swapped)
         swapl(&stuff->window);
-    int rc = dixLookupWindow(&pWin, stuff->window, client, DixReceiveAccess);
-    if (rc != Success)
-        return rc;
+
+    X_CALL_CHECK_ERR(dixLookupWindow(&pWin, stuff->window, client, DixReceiveAccess));
+
     ShapeEventPtr pShapeEvent, *pHead = SHAPE_WINDOW_PRIVADDR(pWin);
     switch (stuff->enable) {
     case xTrue:
@@ -836,9 +830,7 @@ ProcShapeInputSelected(ClientPtr client)
     WindowPtr pWin;
     int enabled;
 
-    int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess));
 
     ShapeEventPtr pShapeEvent, *pHead = SHAPE_WINDOW_PRIVADDR(pWin);
     enabled = xFalse;
@@ -868,9 +860,8 @@ ProcShapeGetRectangles(ClientPtr client)
     int nrects;
     RegionPtr region;
 
-    int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess));
+
     switch (stuff->kind) {
     case ShapeBounding:
         region = wBoundingShape(pWin);

--- a/Xext/shm/shm.c
+++ b/Xext/shm/shm.c
@@ -590,9 +590,8 @@ ShmGetImage(ClientPtr client, xShmGetImageReq *stuff)
         return BadValue;
     }
 
-    int rc = dixLookupDrawable(&pDraw, stuff->drawable, client, 0, DixReadAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupDrawable(&pDraw, stuff->drawable, client, 0, DixReadAccess));
+
     VERIFY_SHMPTR(stuff->shmseg, stuff->offset, TRUE, shmdesc, client);
     if (pDraw->type == DRAWABLE_WINDOW) {
         if (   /* check for being viewable */
@@ -788,9 +787,7 @@ ProcShmGetImage(ClientPtr client)
     if (draw->type == XRT_PIXMAP)
         return ShmGetImage(client, stuff);
 
-    rc = dixLookupDrawable(&pDraw, stuff->drawable, client, 0, DixReadAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupDrawable(&pDraw, stuff->drawable, client, 0, DixReadAccess));
 
     VERIFY_SHMPTR(stuff->shmseg, stuff->offset, TRUE, shmdesc, client);
 
@@ -917,7 +914,7 @@ ProcShmCreatePixmap(ClientPtr client)
     PixmapPtr pMap = NULL;
     DrawablePtr pDraw;
     DepthPtr pDepth;
-    int i, result, rc;
+    int i, result;
     ShmDescPtr shmdesc;
     unsigned int width, height, depth;
     unsigned long size;
@@ -927,10 +924,9 @@ ProcShmCreatePixmap(ClientPtr client)
     if (!sharedPixmaps)
         return BadImplementation;
     LEGAL_NEW_RESOURCE(stuff->pid, client);
-    rc = dixLookupDrawable(&pDraw, stuff->drawable, client, M_ANY,
-                           DixGetAttrAccess);
-    if (rc != Success)
-        return rc;
+
+    X_CALL_CHECK_ERR(dixLookupDrawable(&pDraw, stuff->drawable, client, M_ANY,
+                           DixGetAttrAccess));
 
     VERIFY_SHMPTR(stuff->shmseg, stuff->offset, TRUE, shmdesc, client);
 
@@ -1049,7 +1045,7 @@ ShmCreatePixmap(ClientPtr client, xShmCreatePixmapReq *stuff)
     PixmapPtr pMap;
     DrawablePtr pDraw;
     DepthPtr pDepth;
-    int i, rc;
+    int i;
     ShmDescPtr shmdesc;
     ShmScrPrivateRec *screen_priv;
     unsigned int width, height, depth;
@@ -1059,10 +1055,9 @@ ShmCreatePixmap(ClientPtr client, xShmCreatePixmapReq *stuff)
     if (!sharedPixmaps)
         return BadImplementation;
     LEGAL_NEW_RESOURCE(stuff->pid, client);
-    rc = dixLookupDrawable(&pDraw, stuff->drawable, client, M_ANY,
-                           DixGetAttrAccess);
-    if (rc != Success)
-        return rc;
+
+    X_CALL_CHECK_ERR(dixLookupDrawable(&pDraw, stuff->drawable, client, M_ANY,
+                           DixGetAttrAccess));
 
     VERIFY_SHMPTR(stuff->shmseg, stuff->offset, TRUE, shmdesc, client);
 
@@ -1102,7 +1097,7 @@ ShmCreatePixmap(ClientPtr client, xShmCreatePixmapReq *stuff)
                                                    shmdesc->addr +
                                                    stuff->offset);
     if (pMap) {
-        rc = XaceHookResourceAccess(client, stuff->pid, X11_RESTYPE_PIXMAP,
+        int rc = XaceHookResourceAccess(client, stuff->pid, X11_RESTYPE_PIXMAP,
                       pMap, X11_RESTYPE_NONE, NULL, DixCreateAccess);
         if (rc != Success) {
             dixDestroyPixmap(pMap, 0);

--- a/Xext/sync/sync.c
+++ b/Xext/sync/sync.c
@@ -350,12 +350,10 @@ SyncInitTrigger(ClientPtr client, SyncTrigger * pTrigger, XID syncObject,
         if (syncObject == None) {
             pSync = NULL;
         } else {
-            int rc = dixLookupResourceByType((void **) &pSync, syncObject,
-                                              resType, client, DixReadAccess);
-            if (rc != Success) {
-                client->errorValue = syncObject;
-                return rc;
-            }
+            X_CALL_CHECK_ERR_VAL(
+                dixLookupResourceByType((void **) &pSync, syncObject,
+                                        resType, client, DixReadAccess),
+                syncObject);
         }
     }
 
@@ -1377,10 +1375,8 @@ ProcSyncSetPriority(ClientPtr client)
     if (stuff->id == None)
         priorityclient = client;
     else {
-        int rc = dixLookupResourceOwner(&priorityclient, stuff->id, client,
-                             DixSetAttrAccess);
-        if (rc != Success)
-            return rc;
+        X_CALL_CHECK_ERR(dixLookupResourceOwner(&priorityclient, stuff->id, client,
+                             DixSetAttrAccess));
     }
 
     if (priorityclient->priority != stuff->priority) {
@@ -1411,10 +1407,8 @@ ProcSyncGetPriority(ClientPtr client)
     if (stuff->id == None)
         priorityclient = client;
     else {
-        int rc = dixLookupResourceOwner(&priorityclient, stuff->id, client,
-                             DixGetAttrAccess);
-        if (rc != Success)
-            return rc;
+        X_CALL_CHECK_ERR(dixLookupResourceOwner(&priorityclient, stuff->id, client,
+                             DixGetAttrAccess));
     }
 
     xSyncGetPriorityReply reply = {
@@ -1463,10 +1457,8 @@ ProcSyncSetCounter(ClientPtr client)
     SyncCounter *pCounter;
     int64_t newvalue;
 
-    int rc = dixLookupResourceByType((void **) &pCounter, stuff->cid, RTCounter,
-                                 client, DixWriteAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupResourceByType((void **) &pCounter, stuff->cid, RTCounter,
+                                 client, DixWriteAccess));
 
     if (IsSystemCounter(pCounter)) {
         client->errorValue = stuff->cid;
@@ -1493,10 +1485,8 @@ ProcSyncChangeCounter(ClientPtr client)
     int64_t newvalue;
     Bool overflow;
 
-    int rc = dixLookupResourceByType((void **) &pCounter, stuff->cid, RTCounter,
-                                 client, DixWriteAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupResourceByType((void **) &pCounter, stuff->cid, RTCounter,
+                                 client, DixWriteAccess));
 
     if (IsSystemCounter(pCounter)) {
         client->errorValue = stuff->cid;
@@ -1525,10 +1515,8 @@ ProcSyncDestroyCounter(ClientPtr client)
 
     SyncCounter *pCounter;
 
-    int rc = dixLookupResourceByType((void **) &pCounter, stuff->counter,
-                                 RTCounter, client, DixDestroyAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupResourceByType((void **) &pCounter, stuff->counter,
+                                 RTCounter, client, DixDestroyAccess));
 
     if (IsSystemCounter(pCounter)) {
         client->errorValue = stuff->counter;
@@ -1685,10 +1673,8 @@ ProcSyncQueryCounter(ClientPtr client)
 
     SyncCounter *pCounter;
 
-    int rc = dixLookupResourceByType((void **) &pCounter, stuff->counter,
-                                 RTCounter, client, DixReadAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupResourceByType((void **) &pCounter, stuff->counter,
+                                 RTCounter, client, DixReadAccess));
 
     /* if system counter, ask it what the current value is */
     if (IsSystemCounter(pCounter)) {
@@ -1847,10 +1833,8 @@ ProcSyncQueryAlarm(ClientPtr client)
     SyncAlarm *pAlarm;
     SyncTrigger *pTrigger;
 
-    int rc = dixLookupResourceByType((void **) &pAlarm, stuff->alarm, RTAlarm,
-                                 client, DixReadAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupResourceByType((void **) &pAlarm, stuff->alarm, RTAlarm,
+                                 client, DixReadAccess));
 
     pTrigger = &pAlarm->trigger;
 
@@ -1896,10 +1880,8 @@ ProcSyncDestroyAlarm(ClientPtr client)
 
     SyncAlarm *pAlarm;
 
-    int rc = dixLookupResourceByType((void **) &pAlarm, stuff->alarm, RTAlarm,
-                                 client, DixDestroyAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupResourceByType((void **) &pAlarm, stuff->alarm, RTAlarm,
+                                 client, DixDestroyAccess));
 
     FreeResource(stuff->alarm, X11_RESTYPE_NONE);
     return Success;
@@ -1915,9 +1897,7 @@ ProcSyncCreateFence(ClientPtr client)
     DrawablePtr pDraw;
     SyncFence *pFence;
 
-    int rc = dixLookupDrawable(&pDraw, stuff->d, client, M_ANY, DixGetAttrAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupDrawable(&pDraw, stuff->d, client, M_ANY, DixGetAttrAccess));
 
     LEGAL_NEW_RESOURCE(stuff->fid, client);
 
@@ -1959,10 +1939,8 @@ ProcSyncTriggerFence(ClientPtr client)
 
     SyncFence *pFence;
 
-    int rc = dixLookupResourceByType((void **) &pFence, stuff->fid, RTFence,
-                                 client, DixWriteAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupResourceByType((void **) &pFence, stuff->fid, RTFence,
+                                 client, DixWriteAccess));
 
     miSyncTriggerFence(pFence);
 
@@ -1977,10 +1955,8 @@ ProcSyncResetFence(ClientPtr client)
 
     SyncFence *pFence;
 
-    int rc = dixLookupResourceByType((void **) &pFence, stuff->fid, RTFence,
-                                 client, DixWriteAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupResourceByType((void **) &pFence, stuff->fid, RTFence,
+                                 client, DixWriteAccess));
 
     if (pFence->funcs.CheckTriggered(pFence) != TRUE)
         return BadMatch;
@@ -1998,10 +1974,8 @@ ProcSyncDestroyFence(ClientPtr client)
 
     SyncFence *pFence;
 
-    int rc = dixLookupResourceByType((void **) &pFence, stuff->fid, RTFence,
-                                 client, DixDestroyAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupResourceByType((void **) &pFence, stuff->fid, RTFence,
+                                 client, DixDestroyAccess));
 
     FreeResource(stuff->fid, X11_RESTYPE_NONE);
     return Success;
@@ -2015,10 +1989,8 @@ ProcSyncQueryFence(ClientPtr client)
 
     SyncFence *pFence;
 
-    int rc = dixLookupResourceByType((void **) &pFence, stuff->fid,
-                                 RTFence, client, DixReadAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupResourceByType((void **) &pFence, stuff->fid,
+                                 RTFence, client, DixReadAccess));
 
     xSyncQueryFenceReply reply = {
         .triggered = pFence->funcs.CheckTriggered(pFence)

--- a/Xext/xselinux/xselinux_ext.c
+++ b/Xext/xselinux/xselinux_ext.c
@@ -213,10 +213,7 @@ ProcSELinuxGetDeviceContext(ClientPtr client)
     DeviceIntPtr dev;
     SELinuxSubjectRec *subj;
 
-    int rc = dixLookupDevice(&dev, stuff->id, client, DixGetAttrAccess);
-    if (rc != Success) {
-        return rc;
-    }
+    X_CALL_CHECK_ERR(dixLookupDevice(&dev, stuff->id, client, DixGetAttrAccess));
 
     subj = dixLookupPrivate(&dev->devPrivates, subjectKey);
     return SELinuxSendContextReply(client, subj->sid);
@@ -232,10 +229,7 @@ ProcSELinuxGetDrawableContext(ClientPtr client)
     PrivateRec **privatePtr;
     SELinuxObjectRec *obj;
 
-    int rc = dixLookupDrawable(&pDraw, stuff->id, client, 0, DixGetAttrAccess);
-    if (rc != Success) {
-        return rc;
-    }
+    X_CALL_CHECK_ERR(dixLookupDrawable(&pDraw, stuff->id, client, 0, DixGetAttrAccess));
 
     if (pDraw->type == DRAWABLE_PIXMAP) {
         privatePtr = &((PixmapPtr) pDraw)->devPrivates;
@@ -258,16 +252,10 @@ ProcSELinuxGetPropertyContext(ClientPtr client, void *privKey)
     PropertyPtr pProp;
     SELinuxObjectRec *obj;
 
-    int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetPropAccess);
-    if (rc != Success) {
-        return rc;
-    }
+    X_CALL_CHECK_ERR(dixLookupWindow(&pWin, stuff->window, client, DixGetPropAccess));
 
-    rc = dixLookupProperty(&pProp, pWin, stuff->property, client,
-                           DixGetAttrAccess);
-    if (rc != Success) {
-        return rc;
-    }
+    X_CALL_CHECK_ERR(dixLookupProperty(&pProp, pWin, stuff->property, client,
+                           DixGetAttrAccess));
 
     obj = dixLookupPrivate(&pProp->devPrivates, privKey);
     return SELinuxSendContextReply(client, obj->sid);
@@ -282,10 +270,7 @@ ProcSELinuxGetSelectionContext(ClientPtr client, void *privKey)
     Selection *pSel;
     SELinuxObjectRec *obj;
 
-    int rc = dixLookupSelection(&pSel, stuff->id, client, DixGetAttrAccess);
-    if (rc != Success) {
-        return rc;
-    }
+    X_CALL_CHECK_ERR(dixLookupSelection(&pSel, stuff->id, client, DixGetAttrAccess));
 
     obj = dixLookupPrivate(&pSel->devPrivates, privKey);
     return SELinuxSendContextReply(client, obj->sid);
@@ -300,10 +285,7 @@ ProcSELinuxGetClientContext(ClientPtr client)
     ClientPtr target;
     SELinuxSubjectRec *subj;
 
-    int rc = dixLookupResourceOwner(&target, stuff->id, client, DixGetAttrAccess);
-    if (rc != Success) {
-        return rc;
-    }
+    X_CALL_CHECK_ERR(dixLookupResourceOwner(&target, stuff->id, client, DixGetAttrAccess));
 
     subj = dixLookupPrivate(&target->devPrivates, subjectKey);
     return SELinuxSendContextReply(client, subj->sid);
@@ -388,10 +370,7 @@ ProcSELinuxListProperties(ClientPtr client)
     int count, size, i;
     CARD32 id;
 
-    int rc = dixLookupWindow(&pWin, stuff->id, client, DixListPropAccess);
-    if (rc != Success) {
-        return rc;
-    }
+    X_CALL_CHECK_ERR(dixLookupWindow(&pWin, stuff->id, client, DixListPropAccess));
 
     /* Count the number of properties and allocate items */
     count = 0;
@@ -408,7 +387,7 @@ ProcSELinuxListProperties(ClientPtr client)
     size = 0;
     for (pProp = pWin->properties; pProp; pProp = pProp->next) {
         id = pProp->propertyName;
-        rc = SELinuxPopulateItem(items + i, &pProp->devPrivates, id, &size);
+        int rc = SELinuxPopulateItem(items + i, &pProp->devPrivates, id, &size);
         if (rc != Success) {
             SELinuxFreeItems(items, count);
             return rc;

--- a/Xext/xselinux/xselinux_label.c
+++ b/Xext/xselinux/xselinux_label.c
@@ -22,6 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <selinux/label.h>
 
 #include "dix/registry_priv.h"
+#include "dix/request_priv.h"
 
 #include "xselinuxint.h"
 
@@ -178,15 +179,11 @@ int
 SELinuxSelectionToSID(Atom selection, SELinuxSubjectRec * subj,
                       security_id_t * sid_rtn, int *poly_rtn)
 {
-    int rc;
     SELinuxObjectRec *obj;
     security_id_t tsid;
 
     /* Get the default context and polyinstantiation bit */
-    rc = SELinuxAtomToSID(selection, 0, &obj);
-    if (rc != Success) {
-        return rc;
-    }
+    X_CALL_CHECK_ERR(SELinuxAtomToSID(selection, 0, &obj));
 
     /* Check for an override context next */
     if (subj->sel_use_sid) {
@@ -217,15 +214,11 @@ int
 SELinuxPropertyToSID(Atom property, SELinuxSubjectRec * subj,
                      security_id_t * sid_rtn, int *poly_rtn)
 {
-    int rc;
     SELinuxObjectRec *obj;
     security_id_t tsid, tsid2;
 
     /* Get the default context and polyinstantiation bit */
-    rc = SELinuxAtomToSID(property, 1, &obj);
-    if (rc != Success) {
-        return rc;
-    }
+    X_CALL_CHECK_ERR(SELinuxAtomToSID(property, 1, &obj));
 
     /* Check for an override context next */
     if (subj->prp_use_sid) {

--- a/Xext/xtest/xtest.c
+++ b/Xext/xtest/xtest.c
@@ -116,10 +116,7 @@ ProcXTestCompareCursor(ClientPtr client)
     CursorPtr pCursor;
     DeviceIntPtr ptr = PickPointer(client);
 
-    int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
-    if (rc != Success) {
-        return rc;
-    }
+    X_CALL_CHECK_ERR(dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess));
 
     if (!ptr) {
         return BadAccess;
@@ -129,13 +126,12 @@ ProcXTestCompareCursor(ClientPtr client)
         pCursor = NullCursor;
     } else if (stuff->cursor == XTestCurrentCursor) {
         pCursor = InputDevGetSpriteCursor(ptr);
-    } else {
-        rc = dixLookupResourceByType((void **) &pCursor, stuff->cursor,
-                                     X11_RESTYPE_CURSOR, client, DixReadAccess);
-        if (rc != Success) {
-            client->errorValue = stuff->cursor;
-            return rc;
-        }
+    }
+    else {
+        X_CALL_CHECK_ERR_VAL(
+            dixLookupResourceByType((void **) &pCursor, stuff->cursor,
+                                     X11_RESTYPE_CURSOR, client, DixReadAccess),
+            stuff->cursor);
     }
 
     xXTestCompareCursorReply reply = {
@@ -211,12 +207,9 @@ ProcXTestFakeInput(ClientPtr client)
         extension = TRUE;
 
         /* check device */
-        int rc = dixLookupDevice(&dev, stuff->deviceid & 0177, client,
-                             DixWriteAccess);
-        if (rc != Success) {
-            client->errorValue = stuff->deviceid & 0177;
-            return rc;
-        }
+        X_CALL_CHECK_ERR_VAL(
+            dixLookupDevice(&dev, stuff->deviceid & 0177, client, DixWriteAccess),
+            stuff->deviceid & 0177);
 
         /* check type */
         type -= DeviceValuator;
@@ -410,11 +403,8 @@ ProcXTestFakeInput(ClientPtr client)
         }
 
         if (!(extension || ev->u.keyButtonPointer.root == None)) {
-            int rc = dixLookupWindow(&root, ev->u.keyButtonPointer.root,
-                                 client, DixGetAttrAccess);
-            if (rc != Success) {
-                return rc;
-            }
+            X_CALL_CHECK_ERR(dixLookupWindow(&root, ev->u.keyButtonPointer.root,
+                                 client, DixGetAttrAccess));
             if (root->parent) {
                 client->errorValue = ev->u.keyButtonPointer.root;
                 return BadValue;

--- a/Xext/xv/xvdisp.c
+++ b/Xext/xv/xvdisp.c
@@ -80,16 +80,14 @@ ProcXvQueryAdaptors(ClientPtr client)
     X_REQUEST_HEAD_STRUCT(xvQueryAdaptorsReq);
     X_REQUEST_FIELD_CARD32(window);
 
-    int na, nf, rc;
+    int na, nf;
     XvAdaptorPtr pa;
     XvFormatPtr pf;
     WindowPtr pWin;
     ScreenPtr pScreen;
     XvScreenPtr pxvs;
 
-    rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess));
 
     pScreen = pWin->drawable.pScreen;
     pxvs = (XvScreenPtr) dixLookupPrivate(&pScreen->devPrivates,
@@ -368,15 +366,12 @@ static int
 ProcXvSelectVideoNotify(ClientPtr client)
 {
     DrawablePtr pDraw;
-    int rc;
 
     X_REQUEST_HEAD_STRUCT(xvSelectVideoNotifyReq);
     X_REQUEST_FIELD_CARD32(drawable);
 
-    rc = dixLookupDrawable(&pDraw, stuff->drawable, client, 0,
-                           DixReceiveAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupDrawable(&pDraw, stuff->drawable, client, 0,
+                           DixReceiveAccess));
 
     return XvdiSelectVideoNotify(client, pDraw, stuff->onoff);
 }

--- a/Xext/xv/xvmc.c
+++ b/Xext/xv/xvmc.c
@@ -271,10 +271,8 @@ ProcXvMCDestroyContext(ClientPtr client)
 
     void *val;
 
-    int rc = dixLookupResourceByType(&val, stuff->context_id, XvMCRTContext,
-                                 client, DixDestroyAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupResourceByType(&val, stuff->context_id, XvMCRTContext,
+                                 client, DixDestroyAccess));
 
     FreeResource(stuff->context_id, X11_RESTYPE_NONE);
 
@@ -342,10 +340,8 @@ ProcXvMCDestroySurface(ClientPtr client)
 
     void *val;
 
-    int rc = dixLookupResourceByType(&val, stuff->surface_id, XvMCRTSurface,
-                                 client, DixDestroyAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupResourceByType(&val, stuff->surface_id, XvMCRTSurface,
+                                 client, DixDestroyAccess));
 
     FreeResource(stuff->surface_id, X11_RESTYPE_NONE);
 
@@ -472,10 +468,8 @@ ProcXvMCDestroySubpicture(ClientPtr client)
 
     void *val;
 
-    int rc = dixLookupResourceByType(&val, stuff->subpicture_id, XvMCRTSubpicture,
-                                 client, DixDestroyAccess);
-    if (rc != Success)
-        return rc;
+    X_CALL_CHECK_ERR(dixLookupResourceByType(&val, stuff->subpicture_id, XvMCRTSubpicture,
+                                 client, DixDestroyAccess));
 
     FreeResource(stuff->subpicture_id, X11_RESTYPE_NONE);
 

--- a/dix/request_priv.h
+++ b/dix/request_priv.h
@@ -175,4 +175,24 @@ static inline int __write_reply_hdr_simple(
 #define X_REPLY_FIELD_CARD64(field) \
     do { if (client->swapped) swapll(&reply.field); } while (0)
 
+/*
+ * do function call, check it's result and return when it's not Success
+ */
+#define X_CALL_CHECK_ERR(_FOO_) \
+    do { int _rc = _FOO_; \
+      if (_rc != Success) { return _rc; } \
+    } while (0)
+
+/*
+ * do function call, check it's result and return when it's not Success
+ * assign's client->errorValue on failure
+ */
+#define X_CALL_CHECK_ERR_VAL(_FOO_,_ERRVAL_) \
+    do { int _rc = _FOO_; \
+      if (_rc != Success) { \
+        client->errorValue = _ERRVAL_; \
+        return _rc; \
+      } \
+    } while (0)
+
 #endif /* _XSERVER_DIX_REQUEST_PRIV_H */


### PR DESCRIPTION
A frequent pattern inside request handlers looks like this:

   int rc = doSomething(...);
   if (rc != Success) {
       return rc;
   }

Making the code bit shorter & quicker to read my moving this
into a macro like this:

   X_CALL_CHECK_ERR(doSomething(...));

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
