### PR TITLE
(master) Xext: saver: extra NULL pointer protection in UninstallSaverColormap()

### DIFF
--- a/Xext/saver.c
+++ b/Xext/saver.c
@@ -466,7 +466,7 @@ UninstallSaverColormap(ScreenPtr pScreen)
         int rc = dixLookupResourceByType((void **) &pCmap, pPriv->installedMap,
                                      X11_RESTYPE_COLORMAP, serverClient,
                                      DixUninstallAccess);
-        if (rc == Success) {
+        if ((rc == Success) && (pCmap->pScreen) && (pCmap->pScreen->UninstallColormap)) {
             (*pCmap->pScreen->UninstallColormap) (pCmap);
         }
         pPriv->installedMap = None;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
