### PR TITLE
(master) Xext: saver: cleanup UninstallSaverColormap()

### DIFF
--- a/Xext/saver.c
+++ b/Xext/saver.c
@@ -71,7 +71,6 @@ static int ScreenSaverEventBase = 0;
 static Bool ScreenSaverHandle(ScreenPtr pScreen, int xstate, Bool force);
 static Bool CreateSaverWindow(ScreenPtr pScreen);
 static Bool DestroySaverWindow(ScreenPtr pScreen);
-static void UninstallSaverColormap(ScreenPtr pScreen);
 static void CheckScreenPrivate(ScreenPtr pScreen);
 static void SScreenSaverNotifyEvent(xScreenSaverNotifyEvent *from,
                                     xScreenSaverNotifyEvent *to);
@@ -460,9 +459,9 @@ static void
 UninstallSaverColormap(ScreenPtr pScreen)
 {
     SetupScreen(pScreen);
-    ColormapPtr pCmap;
 
     if (pPriv && pPriv->installedMap != None) {
+        ColormapPtr pCmap;
         int rc = dixLookupResourceByType((void **) &pCmap, pPriv->installedMap,
                                      X11_RESTYPE_COLORMAP, serverClient,
                                      DixUninstallAccess);


### PR DESCRIPTION
* drop the extra prototype
* scope the pCmap variable

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
