### PR TITLE
(master) Xext: saver: scope variables in ScreenSaverSetAttributes()

### DIFF
--- a/Xext/saver.c
+++ b/Xext/saver.c
@@ -28,6 +28,7 @@ in this Software without prior written authorization from the X Consortium.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>
@@ -747,20 +748,10 @@ ScreenSaverSetAttributes(ClientPtr client, xScreenSaverSetAttributesReq *stuff)
     ScreenSaverAttrPtr pAttr = 0;
     int ret, len, class, bw, depth;
     unsigned long visual;
-    int idepth, ivisual;
-    Bool fOK;
-    DepthPtr pDepth;
     WindowOptPtr ancwopt;
     unsigned int *pVlist;
     unsigned long *values = 0;
-    unsigned long tmask, imask;
-    unsigned long val;
-    Pixmap pixID;
-    PixmapPtr pPixmap;
-    Cursor cursorID;
-    CursorPtr pCursor;
-    Colormap cmap;
-    ColormapPtr pCmap;
+    unsigned long tmask;
 
     ret = dixLookupDrawable(&pDraw, stuff->drawable, client, 0,
                             DixGetAttrAccess);
@@ -828,11 +819,11 @@ ScreenSaverSetAttributes(ClientPtr client, xScreenSaverSetAttributesReq *stuff)
 
     /* Find out if the depth and visual are acceptable for this Screen */
     if ((visual != ancwopt->visual) || (depth != pParent->drawable.depth)) {
-        fOK = FALSE;
-        for (idepth = 0; idepth < pScreen->numDepths; idepth++) {
-            pDepth = (DepthPtr) &pScreen->allowedDepths[idepth];
+        bool fOK = FALSE;
+        for (int idepth = 0; idepth < pScreen->numDepths; idepth++) {
+            DepthPtr pDepth = (DepthPtr) &pScreen->allowedDepths[idepth];
             if ((depth == pDepth->depth) || (depth == 0)) {
-                for (ivisual = 0; ivisual < pDepth->numVids; ivisual++) {
+                for (int ivisual = 0; ivisual < pDepth->numVids; ivisual++) {
                     if (visual == pDepth->vids[ivisual]) {
                         fOK = TRUE;
                         break;
@@ -903,11 +894,12 @@ ScreenSaverSetAttributes(ClientPtr client, xScreenSaverSetAttributesReq *stuff)
     pAttr->mask = tmask = stuff->mask | CWOverrideRedirect;
     pVlist = (unsigned int *) (stuff + 1);
     while (tmask) {
-        imask = lowbit(tmask);
+        unsigned long imask = lowbit(tmask);
         tmask &= ~imask;
         switch (imask) {
         case CWBackPixmap:
-            pixID = (Pixmap) * pVlist;
+        {
+            Pixmap pixID = (Pixmap) * pVlist;
             if (pixID == None) {
                 *values++ = None;
             }
@@ -919,6 +911,7 @@ ScreenSaverSetAttributes(ClientPtr client, xScreenSaverSetAttributesReq *stuff)
                 *values++ = ParentRelative;
             }
             else {
+                PixmapPtr pPixmap;
                 ret =
                     dixLookupResourceByType((void **) &pPixmap, pixID,
                                             X11_RESTYPE_PIXMAP, client, DixReadAccess);
@@ -938,11 +931,13 @@ ScreenSaverSetAttributes(ClientPtr client, xScreenSaverSetAttributesReq *stuff)
                 }
             }
             break;
+        }
         case CWBackPixel:
             *values++ = (CARD32) *pVlist;
             break;
         case CWBorderPixmap:
-            pixID = (Pixmap) * pVlist;
+        {
+            Pixmap pixID = (Pixmap) * pVlist;
             if (pixID == CopyFromParent) {
                 if (depth != pParent->drawable.depth) {
                     ret = BadMatch;
@@ -951,6 +946,7 @@ ScreenSaverSetAttributes(ClientPtr client, xScreenSaverSetAttributesReq *stuff)
                 *values++ = CopyFromParent;
             }
             else {
+                PixmapPtr pPixmap;
                 ret =
                     dixLookupResourceByType((void **) &pPixmap, pixID,
                                             X11_RESTYPE_PIXMAP, client, DixReadAccess);
@@ -970,11 +966,13 @@ ScreenSaverSetAttributes(ClientPtr client, xScreenSaverSetAttributesReq *stuff)
                 }
             }
             break;
+        }
         case CWBorderPixel:
             *values++ = (CARD32) *pVlist;
             break;
         case CWBitGravity:
-            val = (CARD8) *pVlist;
+        {
+            unsigned long val = (CARD8) *pVlist;
             if (val > StaticGravity) {
                 ret = BadValue;
                 client->errorValue = val;
@@ -982,8 +980,10 @@ ScreenSaverSetAttributes(ClientPtr client, xScreenSaverSetAttributesReq *stuff)
             }
             *values++ = val;
             break;
+        }
         case CWWinGravity:
-            val = (CARD8) *pVlist;
+        {
+            unsigned long val = (CARD8) *pVlist;
             if (val > StaticGravity) {
                 ret = BadValue;
                 client->errorValue = val;
@@ -991,8 +991,10 @@ ScreenSaverSetAttributes(ClientPtr client, xScreenSaverSetAttributesReq *stuff)
             }
             *values++ = val;
             break;
+        }
         case CWBackingStore:
-            val = (CARD8) *pVlist;
+        {
+            unsigned long val = (CARD8) *pVlist;
             if ((val != NotUseful) && (val != WhenMapped) && (val != Always)) {
                 ret = BadValue;
                 client->errorValue = val;
@@ -1000,6 +1002,7 @@ ScreenSaverSetAttributes(ClientPtr client, xScreenSaverSetAttributesReq *stuff)
             }
             *values++ = val;
             break;
+        }
         case CWBackingPlanes:
             *values++ = (CARD32) *pVlist;
             break;
@@ -1007,7 +1010,8 @@ ScreenSaverSetAttributes(ClientPtr client, xScreenSaverSetAttributesReq *stuff)
             *values++ = (CARD32) *pVlist;
             break;
         case CWSaveUnder:
-            val = (BOOL) * pVlist;
+        {
+            unsigned long val = (BOOL) * pVlist;
             if ((val != xTrue) && (val != xFalse)) {
                 ret = BadValue;
                 client->errorValue = val;
@@ -1015,6 +1019,7 @@ ScreenSaverSetAttributes(ClientPtr client, xScreenSaverSetAttributesReq *stuff)
             }
             *values++ = val;
             break;
+        }
         case CWEventMask:
             *values++ = (CARD32) *pVlist;
             break;
@@ -1025,7 +1030,7 @@ ScreenSaverSetAttributes(ClientPtr client, xScreenSaverSetAttributesReq *stuff)
             if (!(stuff->mask & CWOverrideRedirect))
                 pVlist--;
             else {
-                val = (BOOL) * pVlist;
+                unsigned long val = (BOOL) * pVlist;
                 if ((val != xTrue) && (val != xFalse)) {
                     ret = BadValue;
                     client->errorValue = val;
@@ -1035,7 +1040,9 @@ ScreenSaverSetAttributes(ClientPtr client, xScreenSaverSetAttributesReq *stuff)
             *values++ = xTrue;
             break;
         case CWColormap:
-            cmap = (Colormap) * pVlist;
+        {
+            Colormap cmap = (Colormap) * pVlist;
+            ColormapPtr pCmap;
             ret = dixLookupResourceByType((void **) &pCmap, cmap, X11_RESTYPE_COLORMAP,
                                           client, DixUseAccess);
             if (ret != Success) {
@@ -1049,12 +1056,15 @@ ScreenSaverSetAttributes(ClientPtr client, xScreenSaverSetAttributesReq *stuff)
             pAttr->colormap = cmap;
             pAttr->mask &= ~CWColormap;
             break;
+        }
         case CWCursor:
-            cursorID = (Cursor) * pVlist;
+        {
+            Cursor cursorID = (Cursor) * pVlist;
             if (cursorID == None) {
                 *values++ = None;
             }
             else {
+                CursorPtr pCursor;
                 ret = dixLookupResourceByType((void **) &pCursor, cursorID,
                                               X11_RESTYPE_CURSOR, client, DixUseAccess);
                 if (ret != Success) {
@@ -1065,6 +1075,7 @@ ScreenSaverSetAttributes(ClientPtr client, xScreenSaverSetAttributesReq *stuff)
                 pAttr->mask &= ~CWCursor;
             }
             break;
+        }
         default:
             ret = BadValue;
             client->errorValue = stuff->mask;


### PR DESCRIPTION
Properly scoping variables to where they're actually used reduces the
risk of abusing them for multiple different things and thus the risk
of introducing bugs on refactoring.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
