### PR TITLE
(master) Xext: saver.c: declare variables where needed in ScreenSaverUnsetAttributes()

### DIFF
--- a/Xext/saver.c
+++ b/Xext/saver.c
@@ -1103,12 +1103,11 @@ static int
 ScreenSaverUnsetAttributes(ClientPtr client, Drawable drawable)
 {
     DrawablePtr pDraw;
-    ScreenSaverScreenPrivatePtr pPriv;
-
     int rc = dixLookupDrawable(&pDraw, drawable, client, 0, DixGetAttrAccess);
     if (rc != Success)
         return rc;
-    pPriv = GetScreenPrivate(pDraw->pScreen);
+
+    ScreenSaverScreenPrivatePtr pPriv = GetScreenPrivate(pDraw->pScreen);
     if (pPriv && pPriv->attr && pPriv->attr->client == client) {
         FreeResource(pPriv->attr->resource, AttrType);
         FreeScreenAttr(pPriv->attr);


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
