### PR TITLE
(master) Xext: sleepuntil: rename list walk variables

### DIFF
--- a/Xext/sleepuntil.c
+++ b/Xext/sleepuntil.c
@@ -71,8 +71,6 @@ ClientSleepUntil(ClientPtr client,
                  TimeStamp *revive,
                  void (*notifyFunc) (ClientPtr, void *), void *closure)
 {
-    SertafiedPtr pReq, pPrev;
-
     SertafiedResType = CreateNewResourceType(SertafiedDelete,
                                              "ClientSleep");
     if (!SertafiedResType)
@@ -102,17 +100,18 @@ ClientSleepUntil(ClientPtr client,
         notifyFunc = ClientAwaken;
     pRequest->notifyFunc = notifyFunc;
     /* Insert into time-ordered queue, with earliest activation time coming first. */
-    pPrev = 0;
-    for (pReq = pending; pReq; pReq = pReq->next) {
-        if (CompareTimeStamps(pReq->revive, *revive) == LATER)
+
+    SertafiedPtr walk, pPrev = NULL;
+    for (walk = pending; walk; walk = walk->next) {
+        if (CompareTimeStamps(walk->revive, *revive) == LATER)
             break;
-        pPrev = pReq;
+        pPrev = walk;
     }
     if (pPrev)
         pPrev->next = pRequest;
     else
         pending = pRequest;
-    pRequest->next = pReq;
+    pRequest->next = walk;
     IgnoreClient(client);
     return TRUE;
 }
@@ -127,15 +126,14 @@ static int
 SertafiedDelete(void *value, XID id)
 {
     SertafiedPtr pRequest = (SertafiedPtr) value;
-    SertafiedPtr pReq, pPrev;
 
-    pPrev = 0;
-    for (pReq = pending; pReq; pPrev = pReq, pReq = pReq->next)
-        if (pReq == pRequest) {
+    SertafiedPtr walk, pPrev = NULL;
+    for (walk = pending; walk; pPrev = walk, walk = walk->next)
+        if (walk == pRequest) {
             if (pPrev)
-                pPrev->next = pReq->next;
+                pPrev->next = walk->next;
             else
-                pending = pReq->next;
+                pending = walk->next;
             break;
         }
     if (pRequest->notifyFunc)
@@ -147,7 +145,6 @@ SertafiedDelete(void *value, XID id)
 static void
 SertafiedBlockHandler(void *data, void *wt)
 {
-    SertafiedPtr pReq, pNext;
     unsigned long delay;
     TimeStamp now;
 
@@ -157,11 +154,13 @@ SertafiedBlockHandler(void *data, void *wt)
     now.months = currentTime.months;
     if ((int) (now.milliseconds - currentTime.milliseconds) < 0)
         now.months++;
-    for (pReq = pending; pReq; pReq = pNext) {
-        pNext = pReq->next;
-        if (CompareTimeStamps(pReq->revive, now) == LATER)
+
+    SertafiedPtr walk, pNext;
+    for (walk = pending; walk; walk = pNext) {
+        pNext = walk->next;
+        if (CompareTimeStamps(walk->revive, now) == LATER)
             break;
-        FreeResource(pReq->id, X11_RESTYPE_NONE);
+        FreeResource(walk->id, X11_RESTYPE_NONE);
 
         /* AttendClient() may have been called via the resource delete
          * function so a client may have input to be processed and so
@@ -169,28 +168,29 @@ SertafiedBlockHandler(void *data, void *wt)
          */
         AdjustWaitForDelay(wt, 0);
     }
-    pReq = pending;
-    if (!pReq)
-        return;
-    delay = pReq->revive.milliseconds - now.milliseconds;
-    AdjustWaitForDelay(wt, delay);
+
+    if (pending) {
+        delay = pending->revive.milliseconds - now.milliseconds;
+        AdjustWaitForDelay(wt, delay);
+    }
 }
 
 static void
 SertafiedWakeupHandler(void *data, int i)
 {
-    SertafiedPtr pReq, pNext;
     TimeStamp now;
 
     now.milliseconds = GetTimeInMillis();
     now.months = currentTime.months;
     if ((int) (now.milliseconds - currentTime.milliseconds) < 0)
         now.months++;
-    for (pReq = pending; pReq; pReq = pNext) {
-        pNext = pReq->next;
-        if (CompareTimeStamps(pReq->revive, now) == LATER)
+
+    SertafiedPtr walk, pNext;
+    for (walk = pending; walk; walk = pNext) {
+        pNext = walk->next;
+        if (CompareTimeStamps(walk->revive, now) == LATER)
             break;
-        FreeResource(pReq->id, X11_RESTYPE_NONE);
+        FreeResource(walk->id, X11_RESTYPE_NONE);
     }
     if (!pending) {
         RemoveBlockAndWakeupHandlers(SertafiedBlockHandler,


### PR DESCRIPTION
For carirty, rename the list walk variables `pReq` to `walk`.
Also reducing diff size on follow-up commits.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
