### PR TITLE
(master) dix: and NULL protect FreeCursor()

### DIFF
--- a/Xext/saver.c
+++ b/Xext/saver.c
@@ -146,8 +146,6 @@ typedef struct _ScreenSaverAttr {
 
 static int ScreenSaverFreeAttr(void *value, XID id);
 
-static void FreeAttrs(ScreenSaverAttrPtr pAttr);
-
 static void FreeScreenAttr(ScreenSaverAttrPtr pAttr);
 
 static void
@@ -283,13 +281,9 @@ setEventMask(ScreenPtr pScreen, ClientPtr client, unsigned long mask)
 static void
 FreeAttrs(ScreenSaverAttrPtr pAttr)
 {
-    CursorPtr pCursor;
-
     dixDestroyPixmap(pAttr->pBackgroundPixmap, 0);
     dixDestroyPixmap(pAttr->pBorderPixmap, 0);
-    if ((pCursor = pAttr->pCursor) != 0) {
-        FreeCursor(pCursor, (Cursor) 0);
-    }
+    FreeCursor(pAttr->pCursor, (Cursor) 0);
 }
 
 static void
@@ -531,9 +525,7 @@ CreateSaverWindow(ScreenPtr pScreen)
             return FALSE;
         }
         CursorPtr cursor = RefCursor(pAttr->pCursor);
-        if (pWin->optional->cursor) {
-            FreeCursor(pWin->optional->cursor, (Cursor) 0);
-        }
+        FreeCursor(pWin->optional->cursor, (Cursor) 0);
         pWin->optional->cursor = cursor;
         pWin->cursorIsNone = FALSE;
         CheckWindowOptionalNeed(pWin);

--- a/dix/cursor.c
+++ b/dix/cursor.c
@@ -106,6 +106,9 @@ FreeCursorBits(CursorBitsPtr bits)
 int
 FreeCursor(void *value, XID cid)
 {
+    if (!value)
+        return Success;
+
     CursorPtr pCurs = (CursorPtr) value;
     DeviceIntPtr pDev = NULL;   /* unused anyway */
 

--- a/dix/events.c
+++ b/dix/events.c
@@ -3357,8 +3357,7 @@ InitializeSprite(DeviceIntPtr pDev, WindowPtr pWin)
         pSprite->pDequeueScreen = pSprite->pEnqueueScreen;
     }
     pCursor = RefCursor(pCursor);
-    if (pSprite->current)
-        FreeCursor(pSprite->current, None);
+    FreeCursor(pSprite->current, None);
     pSprite->current = pCursor;
 
     if (pScreen) {
@@ -3393,8 +3392,7 @@ InitializeSprite(DeviceIntPtr pDev, WindowPtr pWin)
 void FreeSprite(DeviceIntPtr dev)
 {
     if (DevHasCursor(dev) && dev->spriteInfo->sprite) {
-        if (dev->spriteInfo->sprite->current)
-            FreeCursor(dev->spriteInfo->sprite->current, None);
+        FreeCursor(dev->spriteInfo->sprite->current, None);
         free(dev->spriteInfo->sprite->spriteTrace);
         free(dev->spriteInfo->sprite);
     }
@@ -3440,8 +3438,7 @@ UpdateSpriteForScreen(DeviceIntPtr pDev, ScreenPtr pScreen)
     pSprite->hotLimits.y2 = pScreen->height;
     pSprite->win = win;
     pCursor = RefCursor(wCursor(win));
-    if (pSprite->current)
-        FreeCursor(pSprite->current, 0);
+    FreeCursor(pSprite->current, 0);
     pSprite->current = pCursor;
     pSprite->spriteTraceGood = 1;
     pSprite->spriteTrace[0] = win;
@@ -5109,8 +5106,7 @@ ProcChangeActivePointerGrab(ClientPtr client)
     oldCursor = grab->cursor;
     grab->cursor = RefCursor(newCursor);
     PostNewCursor(device);
-    if (oldCursor)
-        FreeCursor(oldCursor, (Cursor) 0);
+    FreeCursor(oldCursor, (Cursor) 0);
     grab->eventMask = stuff->eventMask;
     return Success;
 }

--- a/dix/grabs.c
+++ b/dix/grabs.c
@@ -262,9 +262,7 @@ FreeGrab(GrabPtr pGrab)
 
     free(pGrab->modifiersDetail.pMask);
     free(pGrab->detail.pMask);
-
-    if (pGrab->cursor)
-        FreeCursor(pGrab->cursor, (Cursor) 0);
+    FreeCursor(pGrab->cursor, (Cursor) 0);
 
     xi2mask_free(&pGrab->xi2mask);
     free(pGrab);

--- a/dix/window.c
+++ b/dix/window.c
@@ -953,8 +953,7 @@ DisposeWindowOptional(WindowPtr pWin)
 
         pList = pWin->optional->deviceCursors;
         while (pList) {
-            if (pList->cursor)
-                FreeCursor(pList->cursor, (XID) 0);
+            FreeCursor(pList->cursor, (XID) 0);
             pPrev = pList;
             pList = pList->next;
             free(pPrev);
@@ -1527,8 +1526,7 @@ ChangeWindowAttributes(WindowPtr pWin, Mask vmask, XID *vlist, ClientPtr client)
                 /* Can't free cursor until here - old cursor
                  * is needed in WindowHasNewCursor
                  */
-                if (pOldCursor)
-                    FreeCursor(pOldCursor, (Cursor) 0);
+                FreeCursor(pOldCursor, (Cursor) 0);
             }
             break;
         default:
@@ -3494,8 +3492,7 @@ ChangeWindowDeviceCursor(WindowPtr pWin, DeviceIntPtr pDev, CursorPtr pCursor)
     if (pWin->realized)
         WindowHasNewCursor(pWin);
 
-    if (pOldCursor)
-        FreeCursor(pOldCursor, (Cursor) 0);
+    FreeCursor(pOldCursor, (Cursor) 0);
 
     /* FIXME: We SHOULD check for an error value here XXX
        (comment taken from ChangeWindowAttributes) */

--- a/hw/xfree86/ramdac/xf86CursorRD.c
+++ b/hw/xfree86/ramdac/xf86CursorRD.c
@@ -140,8 +140,7 @@ static void xf86CursorCloseScreen(CallbackListPtr *pcbl,
     if (ScreenPriv->isUp && pScrn->vtSema)
         xf86SetCursor(pScreen, NullCursor, ScreenPriv->x, ScreenPriv->y);
 
-    if (ScreenPriv->CurrentCursor)
-        FreeCursor(ScreenPriv->CurrentCursor, None);
+    FreeCursor(ScreenPriv->CurrentCursor, None);
 
     pScreen->QueryBestSize = ScreenPriv->QueryBestSize;
     pScreen->RecolorCursor = ScreenPriv->RecolorCursor;
@@ -322,8 +321,7 @@ xf86CursorSetCursor(DeviceIntPtr pDev, ScreenPtr pScreen, CursorPtr pCurs,
             xf86SetCursor(pScreen, NullCursor, x, y);
             ScreenPriv->isUp = FALSE;
         }
-        if (ScreenPriv->CurrentCursor)
-            FreeCursor(ScreenPriv->CurrentCursor, None);
+        FreeCursor(ScreenPriv->CurrentCursor, None);
         ScreenPriv->CurrentCursor = NullCursor;
         return;
     }
@@ -332,8 +330,7 @@ xf86CursorSetCursor(DeviceIntPtr pDev, ScreenPtr pScreen, CursorPtr pCurs,
        sprite. The second cursor is never HW rendered anyway. */
     if (GetMaster(pDev, MASTER_POINTER) == inputInfo.pointer) {
         CursorPtr cursor = RefCursor(pCurs);
-        if (ScreenPriv->CurrentCursor)
-            FreeCursor(ScreenPriv->CurrentCursor, None);
+        FreeCursor(ScreenPriv->CurrentCursor, None);
         ScreenPriv->CurrentCursor = cursor;
         ScreenPriv->x = x;
         ScreenPriv->y = y;
@@ -343,8 +340,7 @@ xf86CursorSetCursor(DeviceIntPtr pDev, ScreenPtr pScreen, CursorPtr pCurs,
 
         if (!infoPtr->pScrn->vtSema) {
             cursor = RefCursor(cursor);
-            if (ScreenPriv->SavedCursor)
-                FreeCursor(ScreenPriv->SavedCursor, None);
+            FreeCursor(ScreenPriv->SavedCursor, None);
             ScreenPriv->SavedCursor = cursor;
             return;
         }


### PR DESCRIPTION
Adding NULL protection in FreeCursor(), so we don't need extra
checks at caller sites anymore.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
