### PR TITLE
(master) Xext: xcmisc: brackets around if

### DIFF
--- a/Xext/xcmisc.c
+++ b/Xext/xcmisc.c
@@ -88,8 +88,9 @@ ProcXCMiscGetXIDList(ClientPtr client)
     X_REQUEST_HEAD_STRUCT(xXCMiscGetXIDListReq);
     X_REQUEST_FIELD_CARD32(count);
 
-    if (stuff->count > UINT32_MAX / sizeof(XID))
+    if (stuff->count > UINT32_MAX / sizeof(XID)) {
         return BadAlloc;
+    }
 
     XID *pids = calloc(stuff->count, sizeof(XID));
     if (!pids) {


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
