### PR TITLE
(master) treewide: clean up includes of mipict.h

### DIFF
--- a/exa/exa_glyphs.c
+++ b/exa/exa_glyphs.c
@@ -44,9 +44,10 @@
 
 #include <stdlib.h>
 
+#include "include/mipict.h"
+
 #include "exa_priv.h"
 #include "glyphstr_priv.h"
-#include "mipict.h"
 
 #if DEBUG_GLYPH_CACHE
 #define DBG_GLYPH_CACHE(a) ErrorF a

--- a/exa/exa_render.c
+++ b/exa/exa_render.c
@@ -21,14 +21,13 @@
  * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  * PERFORMANCE OF THIS SOFTWARE.
  */
-
 #include <dix-config.h>
 
 #include <stdlib.h>
 
-#include "exa_priv.h"
+#include "include/mipict.h"
 
-#include "mipict.h"
+#include "exa_priv.h"
 
 #if DEBUG_TRACE_FALL
 static void

--- a/exa/exa_unaccel.c
+++ b/exa/exa_unaccel.c
@@ -22,9 +22,9 @@
  */
 #include <dix-config.h>
 
-#include "exa_priv.h"
+#include "include/mipict.h"
 
-#include "mipict.h"
+#include "exa_priv.h"
 
 /*
  * These functions wrap the low-level fb rendering functions and

--- a/fb/fbpict.c
+++ b/fb/fbpict.c
@@ -28,11 +28,11 @@
 #include <string.h>
 
 #include "fb/fbpict_priv.h"
+#include "include/mipict.h"
 
 #include "fb.h"
 #include "glyphstr_priv.h"
 #include "picturestr.h"
-#include "mipict.h"
 
 void
 fbComposite(CARD8 op,

--- a/fb/fbtrap.c
+++ b/fb/fbtrap.c
@@ -23,11 +23,11 @@
 #include <dix-config.h>
 
 #include "fb/fbpict_priv.h"
+#include "include/mipict.h"
 
 #include "fb.h"
 
 #include "picturestr.h"
-#include "mipict.h"
 #include "damage.h"
 
 void

--- a/glamor/glamor.c
+++ b/glamor/glamor.c
@@ -37,10 +37,10 @@
 #include <unistd.h>
 
 #include "dix/screen_hooks_priv.h"
+#include "include/mipict.h"
 #include "os/bug_priv.h"
 
 #include "glamor_priv.h"
-#include "mipict.h"
 
 DevPrivateKeyRec glamor_screen_private_key;
 DevPrivateKeyRec glamor_pixmap_private_key;

--- a/glamor/glamor_composite_glyphs.c
+++ b/glamor/glamor_composite_glyphs.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#include "include/mipict.h"
 #include "os/bug_priv.h"
 
 #include "Xprintf.h"
@@ -31,8 +32,6 @@
 #include "glamor_transform.h"
 #include "glamor_transfer.h"
 #include "glyphstr_priv.h"
-
-#include <mipict.h>
 
 #define DEFAULT_ATLAS_DIM       1024
 

--- a/glamor/glamor_compositerects.c
+++ b/glamor/glamor_compositerects.c
@@ -28,8 +28,9 @@
  */
 #include <dix-config.h>
 
+#include "include/mipict.h"
+
 #include "glamor_priv.h"
-#include "mipict.h"
 #include "damage.h"
 
 /** @file glamor_compositerects.

--- a/glamor/glamor_picture.c
+++ b/glamor/glamor_picture.c
@@ -40,8 +40,9 @@
 #include <assert.h>
 #include <stdlib.h>
 
+#include "include/mipict.h"
+
 #include "glamor_priv.h"
-#include "mipict.h"
 
 static void byte_swap_swizzle(GLenum *swizzle)
 {

--- a/glamor/glamor_render.c
+++ b/glamor/glamor_render.c
@@ -35,10 +35,10 @@
 
 #include <assert.h>
 
+#include "include/mipict.h"
 #include "os/bug_priv.h"
 
 #include "glamor_priv.h"
-#include "mipict.h"
 #include "fbpict.h"
 #if 0
 //#define DEBUGF(str, ...)  do {} while(0)

--- a/glamor/glamor_trapezoid.c
+++ b/glamor/glamor_trapezoid.c
@@ -31,9 +31,9 @@
  */
 #include <dix-config.h>
 
-#include "glamor_priv.h"
+#include "include/mipict.h"
 
-#include "mipict.h"
+#include "glamor_priv.h"
 #include "fbpict.h"
 
 /**

--- a/glamor/glamor_utils.h
+++ b/glamor/glamor_utils.h
@@ -32,10 +32,10 @@
 #error This file can only be included by glamor_priv.h
 #endif
 
+#include "include/mipict.h"
 #include "os/bug_priv.h"
 
 #include "glamor_prepare.h"
-#include "mipict.h"
 
 #define v_from_x_coord_x(_xscale_, _x_)          ( 2 * (_x_) * (_xscale_) - 1.0)
 #define v_from_x_coord_y(_yscale_, _y_)          (2 * (_y_) * (_yscale_) - 1.0)

--- a/hw/xfree86/sdksyms.sh
+++ b/hw/xfree86/sdksyms.sh
@@ -14,7 +14,7 @@ cat > sdksyms.c << EOF
 
 /* render/Makefile.am */
 #include "picture.h"
-#include "mipict.h"
+#include "include/mipict.h"
 #include "glyphstr.h"
 #include "picturestr.h"
 

--- a/hw/xwin/win.h
+++ b/hw/xwin/win.h
@@ -140,6 +140,7 @@
 
 #include "dix/colormap_priv.h"
 #include "dix/dix_priv.h"
+#include "include/mipict.h"
 
 #include "scrnintstr.h"
 #include "pixmapstr.h"
@@ -161,7 +162,6 @@
 #include "shadow.h"
 #include "fb.h"
 
-#include "mipict.h"
 #include "picturestr.h"
 
 #ifdef RANDR

--- a/miext/damage/damage.c
+++ b/miext/damage/damage.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 
 #include "dix/screen_hooks_priv.h"
+#include "include/mipict.h"
 #include "os/osdep.h"
 
 #include    <X11/X.h>
@@ -35,7 +36,6 @@
 #include    <X11/fonts/fontstruct.h>
 #include    <X11/fonts/libxfont2.h>
 #include    "mi.h"
-#include    "mipict.h"
 #include    "regionstr.h"
 #include    "globals.h"
 #include    "gcstruct.h"

--- a/render/glyph.c
+++ b/render/glyph.c
@@ -25,6 +25,7 @@
 #include <dix-config.h>
 
 #include "dix/screenint_priv.h"
+#include "include/mipict.h"
 #include "os/bug_priv.h"
 #include "os/xsha1.h"
 
@@ -42,7 +43,6 @@
 #include "servermd.h"
 #include "picturestr.h"
 #include "glyphstr_priv.h"
-#include "mipict.h"
 
 /*
  * From Knuth -- a good choice for hash/rehash values is p, p-2 where

--- a/render/miindex.c
+++ b/render/miindex.c
@@ -24,6 +24,7 @@
 #include <dix-config.h>
 
 #include "dix/colormap_priv.h"
+#include "include/mipict.h"
 
 #include "scrnintstr.h"
 #include "gcstruct.h"
@@ -31,7 +32,6 @@
 #include "windowstr.h"
 #include "mi.h"
 #include "picturestr.h"
-#include "mipict.h"
 
 #define NUM_CUBE_LEVELS	4
 #define NUM_GRAY_LEVELS	13

--- a/render/mipict.c
+++ b/render/mipict.c
@@ -23,6 +23,7 @@
 
 #include <dix-config.h>
 
+#include "include/mipict.h"
 #include "os/osdep.h"
 
 #include "scrnintstr.h"
@@ -31,7 +32,6 @@
 #include "windowstr.h"
 #include "mi.h"
 #include "picturestr.h"
-#include "mipict.h"
 
 int
 miCreatePicture(PicturePtr pPicture)

--- a/render/mirect.c
+++ b/render/mirect.c
@@ -23,13 +23,14 @@
 
 #include <dix-config.h>
 
+#include "include/mipict.h"
+
 #include "scrnintstr.h"
 #include "gcstruct.h"
 #include "pixmapstr.h"
 #include "windowstr.h"
 #include "mi.h"
 #include "picturestr.h"
-#include "mipict.h"
 
 static void
 miColorRects(PicturePtr pDst,

--- a/render/mitrap.c
+++ b/render/mitrap.c
@@ -23,6 +23,8 @@
 
 #include <dix-config.h>
 
+#include "include/mipict.h"
+
 #include "scrnintstr.h"
 #include "gcstruct.h"
 #include "pixmapstr.h"
@@ -30,7 +32,6 @@
 #include "servermd.h"
 #include "mi.h"
 #include "picturestr.h"
-#include "mipict.h"
 
 static xFixed
 miLineFixedX(xLineFixed * l, xFixed y, Bool ceil)

--- a/render/mitri.c
+++ b/render/mitri.c
@@ -23,13 +23,14 @@
 
 #include <dix-config.h>
 
+#include "include/mipict.h"
+
 #include "scrnintstr.h"
 #include "gcstruct.h"
 #include "pixmapstr.h"
 #include "windowstr.h"
 #include "mi.h"
 #include "picturestr.h"
-#include "mipict.h"
 
 void
 miPointFixedBounds(int npoint, xPointFixed * points, BoxPtr bounds)


### PR DESCRIPTION
This header is part of SDK and thus located under ./include

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
