### PR TITLE
(master) include: xlibre_ptrtypes: protect from double declaration of ClientPtr

### DIFF
--- a/include/xlibre_ptrtypes.h
+++ b/include/xlibre_ptrtypes.h
@@ -12,7 +12,10 @@
 #define _XLIBRE_SDK_PTRTYPES_H
 
 struct _Client;
+#ifndef _XTYPEDEF_CLIENTPTR
 typedef struct _Client *ClientPtr;
+#  define _XTYPEDEF_CLIENTPTR
+#endif
 typedef struct _Client ClientRec;
 
 struct _ClientId;


### PR DESCRIPTION
On MacOS we're getting tons of warnings, because Xdefs.h also defining
this type. In the longer run we should check whether to include
Xdefs.h at all, but for the time being just doing a quick workaround.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
