### PR TITLE
(release/25.0) xkb: zero out structs and arrays

### DIFF
--- a/xkb/XKBMisc.c
+++ b/xkb/XKBMisc.c
@@ -51,7 +51,7 @@ XkbKeyTypesForCoreSymbols(XkbDescPtr xkb,
 {
     register int i;
     unsigned int empty;
-    int nSyms[XkbNumKbdGroups];
+    int nSyms[XkbNumKbdGroups] = { 0 };
     int nGroups, tmp, groupsWidth;
     BOOL replicated = FALSE;
 
@@ -376,7 +376,7 @@ XkbApplyCompatMapToKey(XkbDescPtr xkb, KeyCode key, XkbChangesPtr changes)
 {
     KeySym *syms;
     unsigned char explicit, mods;
-    XkbSymInterpretPtr *interps, ibuf[IBUF_SIZE];
+    XkbSymInterpretPtr *interps, ibuf[IBUF_SIZE] = { 0 };
     int n, nSyms, found;
     unsigned changed, tmp;
 
@@ -538,7 +538,7 @@ XkbChangeTypesOfKey(XkbDescPtr xkb,
 {
     XkbKeyTypePtr pOldType, pNewType;
     register int i;
-    int width, nOldGroups, oldWidth, newTypes[XkbNumKbdGroups];
+    int width, nOldGroups, oldWidth;
 
     if ((!xkb) || (!XkbKeycodeInRange(xkb, key)) || (!xkb->map) ||
         (!xkb->map->types) || (!newTypesIn) ||
@@ -559,6 +559,8 @@ XkbChangeTypesOfKey(XkbDescPtr xkb,
 
     nOldGroups = XkbKeyNumGroups(xkb, key);
     oldWidth = XkbKeyGroupsWidth(xkb, key);
+
+    int newTypes[XkbNumKbdGroups] = { 0 };
     for (width = i = 0; i < nGroups; i++) {
         if (groups & (1 << i))
             newTypes[i] = newTypesIn[i];

--- a/xkb/ddxLoad.c
+++ b/xkb/ddxLoad.c
@@ -112,7 +112,9 @@ static char *
 RunXkbComp(xkbcomp_buffer_callback callback, void *userdata)
 {
     FILE *out;
-    char *buf = NULL, keymap[PATH_MAX], xkm_output_dir[PATH_MAX];
+    char *buf = NULL;
+    char keymap[PATH_MAX] = { 0 };
+    char xkm_output_dir[PATH_MAX] = { 0 };
 
     const char *emptystring = "";
     char *xkbbasedirflag = NULL;
@@ -122,7 +124,7 @@ RunXkbComp(xkbcomp_buffer_callback callback, void *userdata)
 #ifdef WIN32
     /* WIN32 has no popen. The input must be stored in a file which is
        used as input for xkbcomp. xkbcomp does not read from stdin. */
-    char tmpname[PATH_MAX];
+    char tmpname[PATH_MAX] = { 0 };
     const char *xkmfile = tmpname;
 #else
     const char *xkmfile = "-";
@@ -309,7 +311,8 @@ XkbDDXLoadKeymapFromString(DeviceIntPtr keybd,
 static FILE *
 XkbDDXOpenConfigFile(const char *mapName, char *fileNameRtrn, int fileNameRtrnLen)
 {
-    char buf[PATH_MAX], xkm_output_dir[PATH_MAX];
+    char buf[PATH_MAX] = { 0 };
+    char xkm_output_dir[PATH_MAX] = { 0 };
     FILE *file;
 
     buf[0] = '\0';
@@ -346,7 +349,7 @@ static unsigned
 LoadXKM(unsigned want, unsigned need, const char *keymap, XkbDescPtr *xkbRtrn)
 {
     FILE *file;
-    char fileName[PATH_MAX];
+    char fileName[PATH_MAX] = { 0 };
     unsigned missing;
 
     file = XkbDDXOpenConfigFile(keymap, fileName, PATH_MAX);
@@ -407,7 +410,7 @@ XkbDDXNamesFromRules(DeviceIntPtr keybd,
                      const char *rules_name,
                      XkbRF_VarDefsPtr defs, XkbComponentNamesPtr names)
 {
-    char buf[PATH_MAX];
+    char buf[PATH_MAX] = { 0 };
     FILE *file;
     Bool complete;
     XkbRF_RulesPtr rules;
@@ -456,7 +459,7 @@ static Bool
 XkbRMLVOtoKcCGST(DeviceIntPtr dev, XkbRMLVOSet * rmlvo,
                  XkbComponentNamesPtr kccgst)
 {
-    XkbRF_VarDefsRec mlvo;
+    XkbRF_VarDefsRec mlvo = { 0 };
 
     mlvo.model = rmlvo->model;
     mlvo.layout = rmlvo->layout;
@@ -477,7 +480,7 @@ XkbCompileKeymapForDevice(DeviceIntPtr dev, XkbRMLVOSet * rmlvo, int need)
     XkbDescPtr xkb = NULL;
     unsigned int provided;
     XkbComponentNamesRec kccgst = { 0 };
-    char name[PATH_MAX];
+    char name[PATH_MAX] = { 0 };
 
     if (XkbRMLVOtoKcCGST(dev, rmlvo, &kccgst)) {
         provided =

--- a/xkb/maprules.c
+++ b/xkb/maprules.c
@@ -238,7 +238,7 @@ typedef struct {
 static char *
 get_index(char *str, int *ndx)
 {
-    char ndx_buf[NDX_BUFF_SIZE];
+    char ndx_buf[NDX_BUFF_SIZE] = { 0 };
     char *end;
 
     if (*str != '[') {
@@ -863,7 +863,7 @@ Bool
 XkbRF_GetComponents(XkbRF_RulesPtr rules,
                     XkbRF_VarDefsPtr defs, XkbComponentNamesPtr names)
 {
-    XkbRF_MultiDefsRec mdefs;
+    XkbRF_MultiDefsRec mdefs = { 0 };
 
     MakeMultiDefs(&mdefs, defs);
 
@@ -946,7 +946,7 @@ XkbRF_LoadRules(FILE * file, XkbRF_RulesPtr rules)
 {
     InputLine line;
     RemapSpec remap;
-    XkbRF_RuleRec trule, *rule;
+    XkbRF_RuleRec trule = { 0 }, *rule;
     XkbRF_GroupRec tgroup, *group;
 
     if (!(rules && file))

--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -623,10 +623,10 @@ ProcXkbLatchLockState(ClientPtr client)
 {
     int status;
     DeviceIntPtr dev, tmpd;
-    XkbStateRec oldState, *newState;
+    XkbStateRec oldState = { 0 }, *newState;
     CARD16 changed;
-    xkbStateNotify sn;
-    XkbEventCauseRec cause;
+    xkbStateNotify sn = { 0 };
+    XkbEventCauseRec cause = { 0 };
 
     REQUEST(xkbLatchLockStateReq);
     REQUEST_SIZE_MATCH(xkbLatchLockStateReq);
@@ -769,9 +769,10 @@ ProcXkbSetControls(ClientPtr client)
     DeviceIntPtr dev, tmpd;
     XkbSrvInfoPtr xkbi;
     XkbControlsPtr ctrl;
-    XkbControlsRec new, old;
-    xkbControlsNotify cn;
-    XkbEventCauseRec cause;
+    XkbControlsRec new = { 0 };
+    XkbControlsRec old = { 0 };
+    xkbControlsNotify cn = { 0 };
+    XkbEventCauseRec cause = { 0 };
     XkbSrvLedInfoPtr sli;
 
     REQUEST(xkbSetControlsReq);
@@ -2624,8 +2625,8 @@ _XkbSetMapChecks(ClientPtr client, DeviceIntPtr dev, xkbSetMapReq * req,
 static int
 _XkbSetMap(ClientPtr client, DeviceIntPtr dev, xkbSetMapReq * req, char *values)
 {
-    XkbEventCauseRec cause;
-    XkbChangesRec change;
+    XkbEventCauseRec cause = { 0 };
+    XkbChangesRec change = { 0 };
     Bool sentNKN;
     XkbSrvInfoPtr xkbi;
     XkbDescPtr xkb;
@@ -3091,7 +3092,7 @@ _XkbSetCompatMap(ClientPtr client, DeviceIntPtr dev,
     }
 
     if (dev->xkb_interest) {
-        xkbCompatMapNotify ev;
+        xkbCompatMapNotify ev = { 0 };
 
         ev.deviceID = dev->id;
         ev.changedGroups = req->groups;
@@ -3104,7 +3105,7 @@ _XkbSetCompatMap(ClientPtr client, DeviceIntPtr dev,
     if (req->recomputeActions) {
         XkbChangesRec change = { 0 };
         unsigned check;
-        XkbEventCauseRec cause;
+        XkbEventCauseRec cause = { 0 };
 
         XkbSetCauseXkbReq(&cause, X_kbSetCompatMap, client);
         XkbUpdateActions(dev, xkb->min_key_code, XkbNumKeys(xkb), &change,
@@ -3321,7 +3322,7 @@ _XkbSetIndicatorMap(ClientPtr client, DeviceIntPtr dev,
 {
     XkbSrvInfoPtr xkbi;
     XkbSrvLedInfoPtr sli;
-    XkbEventCauseRec cause;
+    XkbEventCauseRec cause = { 0 };
     int i, bit;
 
     xkbi = dev->key->xkbInfo;
@@ -3568,7 +3569,7 @@ _XkbSetNamedIndicator(ClientPtr client, DeviceIntPtr dev,
     int led = 0;
     XkbIndicatorMapPtr map;
     DeviceIntPtr kbd;
-    XkbEventCauseRec cause;
+    XkbEventCauseRec cause = { 0 };
     xkbExtensionDeviceNotify ed = { 0 };
     XkbChangesRec changes = { 0 };
     int rc;
@@ -4240,7 +4241,7 @@ _XkbSetNames(ClientPtr client, DeviceIntPtr dev, xkbSetNamesReq * stuff)
     XkbDescRec *xkb;
     XkbNamesRec *names;
     CARD32 *tmp;
-    xkbNamesNotify nn;
+    xkbNamesNotify nn = { 0 };
 
     tmp = (CARD32 *) &stuff[1];
     xkb = dev->key->xkbInfo->desc;
@@ -4366,7 +4367,7 @@ _XkbSetNames(ClientPtr client, DeviceIntPtr dev, xkbSetNamesReq * stuff)
         XkbSendNamesNotify(dev, &nn);
         if (needExtEvent) {
             XkbSrvLedInfoPtr sli;
-            xkbExtensionDeviceNotify edev;
+            xkbExtensionDeviceNotify edev = { 0 };
             register int i;
             register unsigned bit;
 
@@ -5882,7 +5883,7 @@ ProcXkbGetKbdByName(ClientPtr client)
     DeviceIntPtr tmpd;
     DeviceIntPtr master;
     XkbDescPtr xkb, new;
-    XkbEventCauseRec cause;
+    XkbEventCauseRec cause = { 0 };
     unsigned char *str;
     char mapFile[PATH_MAX] = { 0 };
     unsigned len;
@@ -6734,10 +6735,10 @@ SetDeviceIndicators(char *wire,
 {
     xkbDeviceLedsWireDesc *ledWire;
     int i;
-    XkbEventCauseRec cause;
+    XkbEventCauseRec cause = { 0 };
     unsigned namec, mapc, statec;
-    xkbExtensionDeviceNotify ed;
-    XkbChangesRec changes;
+    xkbExtensionDeviceNotify ed = { 0 };
+    XkbChangesRec changes = { 0 };
     DeviceIntPtr kbd;
 
     memset((char *) &ed, 0, sizeof(xkbExtensionDeviceNotify));

--- a/xkb/xkbAccessX.c
+++ b/xkb/xkbAccessX.c
@@ -161,8 +161,8 @@ AccessXKRGTurnOn(DeviceIntPtr dev, CARD16 KRGControl, xkbControlsNotify * pCN)
 {
     XkbSrvInfoPtr xkbi = dev->key->xkbInfo;
     XkbControlsPtr ctrls = xkbi->desc->ctrls;
-    XkbControlsRec old;
-    XkbEventCauseRec cause;
+    XkbControlsRec old = { 0 };
+    XkbEventCauseRec cause = { 0 };
     XkbSrvLedInfoPtr sli;
 
     old = *ctrls;
@@ -193,8 +193,8 @@ AccessXKRGTurnOff(DeviceIntPtr dev, xkbControlsNotify * pCN)
 {
     XkbSrvInfoPtr xkbi = dev->key->xkbInfo;
     XkbControlsPtr ctrls = xkbi->desc->ctrls;
-    XkbControlsRec old;
-    XkbEventCauseRec cause;
+    XkbControlsRec old = { 0 };
+    XkbEventCauseRec cause = { 0 };
     XkbSrvLedInfoPtr sli;
 
     old = *ctrls;
@@ -228,8 +228,8 @@ AccessXStickyKeysTurnOn(DeviceIntPtr dev, xkbControlsNotify * pCN)
 {
     XkbSrvInfoPtr xkbi = dev->key->xkbInfo;
     XkbControlsPtr ctrls = xkbi->desc->ctrls;
-    XkbControlsRec old;
-    XkbEventCauseRec cause;
+    XkbControlsRec old = { 0 };
+    XkbEventCauseRec cause = { 0 };
     XkbSrvLedInfoPtr sli;
 
     old = *ctrls;
@@ -262,8 +262,8 @@ AccessXStickyKeysTurnOff(DeviceIntPtr dev, xkbControlsNotify * pCN)
 {
     XkbSrvInfoPtr xkbi = dev->key->xkbInfo;
     XkbControlsPtr ctrls = xkbi->desc->ctrls;
-    XkbControlsRec old;
-    XkbEventCauseRec cause;
+    XkbControlsRec old = { 0 };
+    XkbEventCauseRec cause = { 0 };
     XkbSrvLedInfoPtr sli;
 
     old = *ctrls;
@@ -402,9 +402,9 @@ AccessXTimeoutExpire(OsTimerPtr timer, CARD32 now, void *arg)
     DeviceIntPtr dev = (DeviceIntPtr) arg;
     XkbSrvInfoPtr xkbi = dev->key->xkbInfo;
     XkbControlsPtr ctrls = xkbi->desc->ctrls;
-    XkbControlsRec old;
+    XkbControlsRec old = { 0 };
     xkbControlsNotify cn = { 0 };
-    XkbEventCauseRec cause;
+    XkbEventCauseRec cause = { 0 };
     XkbSrvLedInfoPtr sli;
 
     if (xkbi->lastPtrEventTime) {
@@ -772,7 +772,7 @@ ProcessPointerEvent(InternalEvent *ev, DeviceIntPtr mouse)
     /* clear any latched modifiers */
     if (xkbi->state.latched_mods && (event->type == ET_ButtonRelease)) {
         unsigned changed_leds;
-        XkbStateRec oldState;
+        XkbStateRec oldState = { 0 };
         XkbSrvLedInfoPtr sli;
 
         sli = XkbFindSrvLedInfo(dev, XkbDfltXIClass, XkbDfltXIId, 0);
@@ -784,8 +784,7 @@ ProcessPointerEvent(InternalEvent *ev, DeviceIntPtr mouse)
         if (changed & sli->usedComponents) {
             changed_leds = XkbIndicatorsToUpdate(dev, changed, FALSE);
             if (changed_leds) {
-                XkbEventCauseRec cause;
-
+                XkbEventCauseRec cause = { 0 };
                 XkbSetCauseKey(&cause, (event->detail.key & 0x7), event->type);
                 XkbUpdateIndicators(dev, changed_leds, TRUE, NULL, &cause);
             }
@@ -793,12 +792,11 @@ ProcessPointerEvent(InternalEvent *ev, DeviceIntPtr mouse)
     }
 
     if (((xkbi->flags & _XkbStateNotifyInProgress) == 0) && (changed != 0)) {
-        xkbStateNotify sn;
-
-        sn.keycode = event->detail.key;
-        sn.eventType = event->type;
-        sn.requestMajor = sn.requestMinor = 0;
-        sn.changed = changed;
+        xkbStateNotify sn = {
+            .keycode = event->detail.key,
+            .eventType = event->type,
+            .changed = changed,
+        };
         XkbSendStateNotify(dev, &sn);
     }
 

--- a/xkb/xkbActions.c
+++ b/xkb/xkbActions.c
@@ -610,7 +610,7 @@ _XkbFilterPointerBtn(XkbSrvInfoPtr xkbi,
         case XkbSA_SetPtrDflt:
         {
             XkbControlsPtr ctrls = xkbi->desc->ctrls;
-            XkbControlsRec old;
+            XkbControlsRec old = { 0 };
             xkbControlsNotify cn = { 0 };
 
             old = *ctrls;
@@ -680,11 +680,11 @@ static int
 _XkbFilterControls(XkbSrvInfoPtr xkbi,
                    XkbFilterPtr filter, unsigned keycode, XkbAction *pAction)
 {
-    XkbControlsRec old;
+    XkbControlsRec old = { 0 };
     XkbControlsPtr ctrls;
     DeviceIntPtr kbd;
     unsigned int change;
-    XkbEventCauseRec cause;
+    XkbEventCauseRec cause = { 0 };
 
     kbd = xkbi->device;
     ctrls = xkbi->desc->ctrls;
@@ -836,9 +836,10 @@ static int
 _XkbFilterRedirectKey(XkbSrvInfoPtr xkbi,
                       XkbFilterPtr filter, unsigned keycode, XkbAction *pAction)
 {
-    DeviceEvent ev;
+    DeviceEvent ev = { 0 };
     int x, y;
-    XkbStateRec old, old_prev;
+    XkbStateRec old = { 0 };
+    XkbStateRec old_prev = { 0 };
     unsigned mods, mask;
     xkbDeviceInfoPtr xkbPrivPtr = XKBDEVICEINFO(xkbi->device);
     ProcessInputProc backupproc;
@@ -1206,12 +1207,11 @@ _XkbApplyState(DeviceIntPtr dev, Bool genStateNotify, int evtype, int key)
     changed = XkbStateChangedFlags(&xkbi->prev_state, &xkbi->state);
     if (genStateNotify) {
         if (changed) {
-            xkbStateNotify sn;
-
-            sn.keycode = key;
-            sn.eventType = evtype;
-            sn.requestMajor = sn.requestMinor = 0;
-            sn.changed = changed;
+            xkbStateNotify sn = {
+                sn.keycode = key,
+                sn.eventType = evtype,
+                sn.changed = changed,
+            };
             XkbSendStateNotify(dev, &sn);
         }
         xkbi->flags &= ~_XkbStateNotifyInProgress;
@@ -1352,7 +1352,7 @@ XkbHandleActions(DeviceIntPtr dev, DeviceIntPtr kbd, DeviceEvent *event)
     KeyClassPtr keyc;
     int sendEvent;
     Bool genStateNotify;
-    XkbAction act;
+    XkbAction act = { 0 };
     Bool keyEvent;
     Bool pressEvent;
     ProcessInputProc backupproc;
@@ -1444,7 +1444,7 @@ XkbLatchModifiers(DeviceIntPtr pXDev, CARD8 mask, CARD8 latches)
 {
     XkbSrvInfoPtr xkbi;
     XkbFilterPtr filter;
-    XkbAction act;
+    XkbAction act = { 0 };
     unsigned clear;
 
     if (pXDev && pXDev->key && pXDev->key->xkbInfo) {
@@ -1472,7 +1472,7 @@ XkbLatchGroup(DeviceIntPtr pXDev, int group)
 {
     XkbSrvInfoPtr xkbi;
     XkbFilterPtr filter;
-    XkbAction act;
+    XkbAction act = { 0 };
 
     if (pXDev && pXDev->key && pXDev->key->xkbInfo) {
         xkbi = pXDev->key->xkbInfo;
@@ -1495,10 +1495,9 @@ XkbClearAllLatchesAndLocks(DeviceIntPtr dev,
                            XkbSrvInfoPtr xkbi,
                            Bool genEv, XkbEventCausePtr cause)
 {
-    XkbStateRec os;
-    xkbStateNotify sn;
+    XkbStateRec os = { 0 };
+    xkbStateNotify sn = { 0 };
 
-    sn.changed = 0;
     os = xkbi->state;
     if (os.latched_mods) {      /* clear all latches */
         XkbLatchModifiers(dev, ~0, 0);

--- a/xkb/xkbEvents.c
+++ b/xkb/xkbEvents.c
@@ -204,7 +204,7 @@ void
 XkbSendStateNotify(DeviceIntPtr kbd, xkbStateNotify * pSN)
 {
     XkbSrvInfoPtr xkbi;
-    XkbStatePtr state;
+    XkbStatePtr state = { 0 };
     XkbInterestPtr interest;
     Time time;
     register CARD16 changed, bState;
@@ -800,19 +800,18 @@ XkbSendNotification(DeviceIntPtr kbd,
 
     sli = NULL;
     if (pChanges->state_changes) {
-        xkbStateNotify sn;
-
-        sn.changed = pChanges->state_changes;
-        sn.keycode = cause->kc;
-        sn.eventType = cause->event;
-        sn.requestMajor = cause->mjr;
-        sn.requestMinor = cause->mnr;
+        xkbStateNotify sn = {
+            sn.changed = pChanges->state_changes,
+            sn.keycode = cause->kc,
+            sn.eventType = cause->event,
+            sn.requestMajor = cause->mjr,
+            sn.requestMinor = cause->mnr,
+        };
         XkbSendStateNotify(kbd, &sn);
     }
     if (pChanges->map.changed) {
-        xkbMapNotify mn;
+        xkbMapNotify mn = { 0 };
 
-        memset(&mn, 0, sizeof(xkbMapNotify));
         mn.changed = pChanges->map.changed;
         mn.firstType = pChanges->map.first_type;
         mn.nTypes = pChanges->map.num_types;
@@ -833,9 +832,8 @@ XkbSendNotification(DeviceIntPtr kbd,
     }
     if ((pChanges->ctrls.changed_ctrls) ||
         (pChanges->ctrls.enabled_ctrls_changes)) {
-        xkbControlsNotify cn;
+        xkbControlsNotify cn = { 0 };
 
-        memset(&cn, 0, sizeof(xkbControlsNotify));
         cn.changedControls = pChanges->ctrls.changed_ctrls;
         cn.enabledControlChanges = pChanges->ctrls.enabled_ctrls_changes;
         cn.keycode = cause->kc;
@@ -845,29 +843,26 @@ XkbSendNotification(DeviceIntPtr kbd,
         XkbSendControlsNotify(kbd, &cn);
     }
     if (pChanges->indicators.map_changes) {
-        xkbIndicatorNotify in;
+        xkbIndicatorNotify in = { 0 };
 
         if (sli == NULL)
             sli = XkbFindSrvLedInfo(kbd, XkbDfltXIClass, XkbDfltXIId, 0);
-        memset(&in, 0, sizeof(xkbIndicatorNotify));
         in.state = sli->effectiveState;
         in.changed = pChanges->indicators.map_changes;
         XkbSendIndicatorNotify(kbd, XkbIndicatorMapNotify, &in);
     }
     if (pChanges->indicators.state_changes) {
-        xkbIndicatorNotify in;
+        xkbIndicatorNotify in = { 0 };
 
         if (sli == NULL)
             sli = XkbFindSrvLedInfo(kbd, XkbDfltXIClass, XkbDfltXIId, 0);
-        memset(&in, 0, sizeof(xkbIndicatorNotify));
         in.state = sli->effectiveState;
         in.changed = pChanges->indicators.state_changes;
         XkbSendIndicatorNotify(kbd, XkbIndicatorStateNotify, &in);
     }
     if (pChanges->names.changed) {
-        xkbNamesNotify nn;
+        xkbNamesNotify nn = { 0 };
 
-        memset(&nn, 0, sizeof(xkbNamesNotify));
         nn.changed = pChanges->names.changed;
         nn.firstType = pChanges->names.first_type;
         nn.nTypes = pChanges->names.num_types;
@@ -879,9 +874,8 @@ XkbSendNotification(DeviceIntPtr kbd,
         XkbSendNamesNotify(kbd, &nn);
     }
     if ((pChanges->compat.changed_groups) || (pChanges->compat.num_si > 0)) {
-        xkbCompatMapNotify cmn;
+        xkbCompatMapNotify cmn = { 0 };
 
-        memset(&cmn, 0, sizeof(xkbCompatMapNotify));
         cmn.changedGroups = pChanges->compat.changed_groups;
         cmn.firstSI = pChanges->compat.first_si;
         cmn.nSI = pChanges->compat.num_si;
@@ -1077,7 +1071,7 @@ XkbRemoveResourceClient(DevicePtr inDev, XID id)
         }
     }
     if (found && autoCtrls && dev->key && dev->key->xkbInfo) {
-        XkbEventCauseRec cause;
+        XkbEventCauseRec cause = { 0 };
 
         xkbi = dev->key->xkbInfo;
         XkbSetCauseXkbReq(&cause, X_kbPerClientFlags, client);

--- a/xkb/xkbInit.c
+++ b/xkb/xkbInit.c
@@ -516,8 +516,8 @@ InitKeyboardDeviceStructInternal(DeviceIntPtr dev, XkbRMLVOSet * rmlvo,
     XkbSrvInfoPtr xkbi;
     XkbDescPtr xkb;
     XkbSrvLedInfoPtr sli;
-    XkbChangesRec changes;
-    XkbEventCauseRec cause;
+    XkbChangesRec changes = { 0 };
+    XkbEventCauseRec cause = { 0 };
     XkbRMLVOSet rmlvo_dflts = { NULL };
 
     BUG_RETURN_VAL(dev == NULL, FALSE);

--- a/xkb/xkbLEDs.c
+++ b/xkb/xkbLEDs.c
@@ -234,8 +234,8 @@ XkbUpdateLedAutoState(DeviceIntPtr dev,
     DeviceIntPtr kbd;
     XkbStatePtr state;
     XkbControlsPtr ctrls;
-    XkbChangesRec my_changes;
-    xkbExtensionDeviceNotify my_ed;
+    XkbChangesRec my_changes = { 0 };
+    xkbExtensionDeviceNotify my_ed = { 0 };
     register unsigned i, bit, affected;
     register XkbIndicatorMapPtr map;
     unsigned oldState;
@@ -365,8 +365,8 @@ XkbSetIndicators(DeviceIntPtr dev,
                  CARD32 affect, CARD32 values, XkbEventCausePtr cause)
 {
     XkbSrvLedInfoPtr sli;
-    XkbChangesRec changes;
-    xkbExtensionDeviceNotify ed;
+    XkbChangesRec changes = { 0 };
+    xkbExtensionDeviceNotify ed = { 0 };
     unsigned side_affected;
 
     memset((char *) &changes, 0, sizeof(XkbChangesRec));
@@ -821,8 +821,8 @@ XkbApplyLedNameChanges(DeviceIntPtr dev,
                        XkbChangesPtr changes, XkbEventCausePtr cause)
 {
     DeviceIntPtr kbd;
-    XkbChangesRec my_changes;
-    xkbExtensionDeviceNotify my_ed;
+    XkbChangesRec my_changes = { 0 };
+    xkbExtensionDeviceNotify my_ed = { 0 };
 
     if (changed_names == 0)
         return;
@@ -901,8 +901,8 @@ XkbApplyLedMapChanges(DeviceIntPtr dev,
                       XkbChangesPtr changes, XkbEventCausePtr cause)
 {
     DeviceIntPtr kbd;
-    XkbChangesRec my_changes;
-    xkbExtensionDeviceNotify my_ed;
+    XkbChangesRec my_changes = { 0 };
+    xkbExtensionDeviceNotify my_ed = { 0 };
 
     if (changed_maps == 0)
         return;
@@ -960,8 +960,8 @@ XkbApplyLedStateChanges(DeviceIntPtr dev,
 {
     XkbSrvInfoPtr xkbi;
     DeviceIntPtr kbd;
-    XkbChangesRec my_changes;
-    xkbExtensionDeviceNotify my_ed;
+    XkbChangesRec my_changes = { 0 };
+    xkbExtensionDeviceNotify my_ed = { 0 };
     register unsigned i, bit, affected;
     XkbIndicatorMapPtr map;
     unsigned oldState;

--- a/xkb/xkbPrKeyEv.c
+++ b/xkb/xkbPrKeyEv.c
@@ -49,7 +49,7 @@ XkbProcessKeyboardEvent(DeviceEvent *event, DeviceIntPtr keybd)
     KeyClassPtr keyc = keybd->key;
     XkbSrvInfoPtr xkbi;
     int key;
-    XkbBehavior behavior;
+    XkbBehavior behavior = { 0 };
     unsigned ndx;
 
     xkbi = keyc->xkbInfo;

--- a/xkb/xkbUtils.c
+++ b/xkb/xkbUtils.c
@@ -220,7 +220,7 @@ XkbUpdateKeyTypesFromCore(DeviceIntPtr pXDev,
 {
     XkbDescPtr xkb;
     unsigned key, nG, explicit;
-    int types[XkbNumKbdGroups];
+    int types[XkbNumKbdGroups] = { 0 };
     KeySym tsyms[XkbMaxSymsPerKey] = {NoSymbol}, *syms;
     XkbMapChangesPtr mc;
 
@@ -525,7 +525,7 @@ XkbSetRepeatKeys(DeviceIntPtr pXDev, int key, int onoff)
     if (pXDev && pXDev->key && pXDev->key->xkbInfo) {
         xkbControlsNotify cn = { 0 };
         XkbControlsPtr ctrls = pXDev->key->xkbInfo->desc->ctrls;
-        XkbControlsRec old;
+        XkbControlsRec old = { 0 };
 
         old = *ctrls;
 
@@ -552,12 +552,9 @@ XkbApplyMappingChange(DeviceIntPtr kbd, KeySymsPtr map, KeyCode first_key,
                       CARD8 num_keys, CARD8 *modmap, ClientPtr client)
 {
     XkbDescPtr xkb = kbd->key->xkbInfo->desc;
-    XkbEventCauseRec cause;
-    XkbChangesRec changes;
+    XkbEventCauseRec cause = { 0 };
+    XkbChangesRec changes = { 0 };
     unsigned int check;
-
-    memset(&changes, 0, sizeof(changes));
-    memset(&cause, 0, sizeof(cause));
 
     if (map && first_key && num_keys) {
         check = 0;
@@ -596,10 +593,9 @@ void
 XkbDisableComputedAutoRepeats(DeviceIntPtr dev, unsigned key)
 {
     XkbSrvInfoPtr xkbi = dev->key->xkbInfo;
-    xkbMapNotify mn;
+    xkbMapNotify mn = { 0 };
 
     xkbi->desc->server->explicit[key] |= XkbExplicitAutoRepeatMask;
-    memset(&mn, 0, sizeof(mn));
     mn.changed = XkbExplicitComponentsMask;
     mn.firstKeyExplicit = key;
     mn.nKeyExplicit = 1;
@@ -744,7 +740,7 @@ XkbCheckSecondaryEffects(XkbSrvInfoPtr xkbi,
                          XkbChangesPtr changes, XkbEventCausePtr cause)
 {
     if (which & XkbStateNotifyMask) {
-        XkbStateRec old;
+        XkbStateRec old = { 0 };
 
         old = xkbi->state;
         changes->state_changes |= XkbStateChangedFlags(&old, &xkbi->state);
@@ -2025,22 +2021,23 @@ XkbCopyKeymap(XkbDescPtr dst, XkbDescPtr src)
 Bool
 XkbDeviceApplyKeymap(DeviceIntPtr dst, XkbDescPtr desc)
 {
-    xkbNewKeyboardNotify nkn;
     Bool ret;
 
     if (!dst->key || !desc)
         return FALSE;
 
-    memset(&nkn, 0, sizeof(xkbNewKeyboardNotify));
-    nkn.oldMinKeyCode = dst->key->xkbInfo->desc->min_key_code;
-    nkn.oldMaxKeyCode = dst->key->xkbInfo->desc->max_key_code;
-    nkn.deviceID = dst->id;
-    nkn.oldDeviceID = dst->id;
-    nkn.minKeyCode = desc->min_key_code;
-    nkn.maxKeyCode = desc->max_key_code;
-    nkn.requestMajor = XkbReqCode;
-    nkn.requestMinor = X_kbSetMap;      /* Near enough's good enough. */
-    nkn.changed = XkbNKN_KeycodesMask;
+    xkbNewKeyboardNotify nkn = {
+        .oldMinKeyCode = dst->key->xkbInfo->desc->min_key_code,
+        .oldMaxKeyCode = dst->key->xkbInfo->desc->max_key_code,
+        .deviceID = dst->id,
+        .oldDeviceID = dst->id,
+        .minKeyCode = desc->min_key_code,
+        .maxKeyCode = desc->max_key_code,
+        .requestMajor = XkbReqCode,
+        .requestMinor = X_kbSetMap,      /* Near enough's good enough. */
+        .changed = XkbNKN_KeycodesMask,
+    };
+
     if (desc->geom)
         nkn.changed |= XkbNKN_GeometryMask;
 

--- a/xkb/xkbtext.c
+++ b/xkb/xkbtext.c
@@ -118,7 +118,7 @@ XkbVModIndexText(XkbDescPtr xkb, unsigned ndx, unsigned format)
     register Atom *vmodNames;
     char *rtrn;
     const char *tmp;
-    char numBuf[20];
+    char numBuf[20] = { 0 };
 
     if (xkb && xkb->names)
         vmodNames = xkb->names->vmods;
@@ -157,7 +157,7 @@ XkbVModMaskText(XkbDescPtr xkb,
     register int i, bit;
     int len;
     char *mm, *rtrn;
-    char *str, buf[VMOD_BUFFER_SIZE];
+    char *str, buf[VMOD_BUFFER_SIZE] = { 0 };
 
     if ((modMask == 0) && (mask == 0)) {
         const int rtrnsize = 5;
@@ -242,7 +242,7 @@ static const char *modNames[XkbNumModifiers] = {
 char *
 XkbModIndexText(unsigned ndx, unsigned format)
 {
-    char buf[100];
+    char buf[100] = { 0 };
 
     if (format == XkbCFile) {
         if (ndx < XkbNumModifiers)
@@ -267,7 +267,8 @@ char *
 XkbModMaskText(unsigned mask, unsigned format)
 {
     register int i, bit;
-    char buf[64], *rtrn;
+    char buf[64] = { 0 };
+    char *rtrn;
 
     if ((mask & 0xff) == 0xff) {
         if (format == XkbCFile)
@@ -359,7 +360,7 @@ XkbConfigText(unsigned config, unsigned format)
 char *
 XkbKeysymText(KeySym sym, unsigned format)
 {
-    static char buf[32];
+    static char buf[32] = { 0 };
 
     if (sym == NoSymbol)
         strcpy(buf, "NoSymbol");
@@ -401,7 +402,7 @@ static const char *siMatchText[5] = {
 const char *
 XkbSIMatchText(unsigned type, unsigned format)
 {
-    static char buf[40];
+    static char buf[40] = { 0 };
     const char *rtrn;
 
     switch (type & XkbSI_OpMask) {
@@ -711,7 +712,7 @@ static const char *actionTypeNames[XkbSA_NumActions] = {
 const char *
 XkbActionTypeText(unsigned type, unsigned format)
 {
-    static char buf[32];
+    static char buf[32] = { 0 };
     const char *rtrn;
 
     if (type <= XkbSA_LastAction) {
@@ -781,7 +782,7 @@ CopyModActionArgs(XkbDescPtr xkb, XkbAction *action, char *buf, int *sz)
 CopyGroupActionArgs(XkbDescPtr xkb, XkbAction *action, char *buf, int *sz)
 {
     XkbGroupAction *act;
-    char tbuf[32];
+    char tbuf[32] = { 0 };
 
     act = &action->group;
     TryCopyStr(buf, "group=", sz);
@@ -806,7 +807,7 @@ CopyMovePtrArgs(XkbDescPtr xkb, XkbAction *action, char *buf, int *sz)
 {
     XkbPtrAction *act;
     int x, y;
-    char tbuf[32];
+    char tbuf[32] = { 0 };
 
     act = &action->ptr;
     x = XkbPtrActionX(act);
@@ -831,7 +832,7 @@ CopyMovePtrArgs(XkbDescPtr xkb, XkbAction *action, char *buf, int *sz)
 CopyPtrBtnArgs(XkbDescPtr xkb, XkbAction *action, char *buf, int *sz)
 {
     XkbPtrBtnAction *act;
-    char tbuf[32];
+    char tbuf[32] = { 0 };
 
     act = &action->btn;
     TryCopyStr(buf, "button=", sz);
@@ -868,7 +869,7 @@ CopyPtrBtnArgs(XkbDescPtr xkb, XkbAction *action, char *buf, int *sz)
 CopySetPtrDfltArgs(XkbDescPtr xkb, XkbAction *action, char *buf, int *sz)
 {
     XkbPtrDfltAction *act;
-    char tbuf[32];
+    char tbuf[32] = { 0 };
 
     act = &action->dflt;
     if (act->affect == XkbSA_AffectDfltBtn) {
@@ -887,9 +888,8 @@ static Bool
 CopyISOLockArgs(XkbDescPtr xkb, XkbAction *action, char *buf, int *sz)
 {
     XkbISOAction *act;
-    char tbuf[64];
+    char tbuf[64] = { 0 };
 
-    memset(tbuf, 0, sizeof(tbuf));
     act = &action->iso;
     if (act->flags & XkbSA_ISODfltIsGroup) {
         TryCopyStr(tbuf, "group=", sz);
@@ -953,7 +953,7 @@ CopyISOLockArgs(XkbDescPtr xkb, XkbAction *action, char *buf, int *sz)
 CopySwitchScreenArgs(XkbDescPtr xkb, XkbAction *action, char *buf, int *sz)
 {
     XkbSwitchScreenAction *act;
-    char tbuf[32];
+    char tbuf[32] = { 0 };
 
     act = &action->screen;
     if ((act->flags & XkbSA_SwitchAbsolute) || (XkbSAScreen(act) < 0))
@@ -973,7 +973,7 @@ CopySetLockControlsArgs(XkbDescPtr xkb, XkbAction *action, char *buf, int *sz)
 {
     XkbCtrlsAction *act;
     unsigned tmp;
-    char tbuf[32];
+    char tbuf[32] = { 0 };
 
     act = &action->ctrls;
     tmp = XkbActionCtrls(act);
@@ -1064,7 +1064,7 @@ CopyActionMessageArgs(XkbDescPtr xkb, XkbAction *action, char *buf, int *sz)
 {
     XkbMessageAction *act;
     unsigned all;
-    char tbuf[32];
+    char tbuf[32] = { 0 };
 
     act = &action->msg;
     all = XkbSA_MessageOnPress | XkbSA_MessageOnRelease;
@@ -1096,7 +1096,8 @@ static Bool
 CopyRedirectKeyArgs(XkbDescPtr xkb, XkbAction *action, char *buf, int *sz)
 {
     XkbRedirectKeyAction *act;
-    char tbuf[32], *tmp;
+    char tbuf[32] = { 0 };
+    char *tmp;
     unsigned kc;
     unsigned vmods, vmods_mask;
 
@@ -1143,7 +1144,7 @@ CopyRedirectKeyArgs(XkbDescPtr xkb, XkbAction *action, char *buf, int *sz)
 CopyDeviceBtnArgs(XkbDescPtr xkb, XkbAction *action, char *buf, int *sz)
 {
     XkbDeviceBtnAction *act;
-    char tbuf[32];
+    char tbuf[32] = { 0 };
 
     act = &action->devbtn;
     snprintf(tbuf, sizeof(tbuf), "device= %d", act->device);
@@ -1178,7 +1179,7 @@ CopyDeviceBtnArgs(XkbDescPtr xkb, XkbAction *action, char *buf, int *sz)
 CopyOtherArgs(XkbDescPtr xkb, XkbAction *action, char *buf, int *sz)
 {
     XkbAnyAction *act;
-    char tbuf[32];
+    char tbuf[32] = { 0 };
 
     act = &action->any;
     snprintf(tbuf, sizeof(tbuf), "type=0x%02x", act->type);
@@ -1234,7 +1235,7 @@ static actionCopy copyActionArgs[XkbSA_NumActions] = {
 char *
 XkbActionText(XkbDescPtr xkb, XkbAction *action, unsigned format)
 {
-    char buf[ACTION_SZ];
+    char buf[ACTION_SZ] = { 0 };
     int sz;
 
     if (format == XkbCFile) {
@@ -1261,7 +1262,7 @@ XkbActionText(XkbDescPtr xkb, XkbAction *action, unsigned format)
 char *
 XkbBehaviorText(XkbDescPtr xkb, XkbBehavior * behavior, unsigned format)
 {
-    char buf[256];
+    char buf[256] = { 0 };
 
     if (format == XkbCFile) {
         if (behavior->type == XkbKB_Default)
@@ -1326,7 +1327,7 @@ XkbBehaviorText(XkbDescPtr xkb, XkbBehavior * behavior, unsigned format)
 char *
 XkbIndentText(unsigned size)
 {
-    static char buf[32];
+    static char buf[32] = { 0 };
     register int i;
 
     if (size > 31)

--- a/xkb/xkmread.c
+++ b/xkb/xkmread.c
@@ -208,7 +208,7 @@ ReadXkmKeycodes(FILE * file, XkbDescPtr xkb, XkbChangesPtr changes)
     register int i;
     unsigned minKC, maxKC, nAl;
     int nRead = 0;
-    char name[100];
+    char name[100] = { 0 };
     XkbKeyNamePtr pN;
 
     name[0] = '\0';
@@ -277,10 +277,10 @@ ReadXkmKeyTypes(FILE * file, XkbDescPtr xkb, XkbChangesPtr changes)
     int nRead = 0;
     int tmp;
     XkbKeyTypePtr type;
-    xkmKeyTypeDesc wire;
+    xkmKeyTypeDesc wire = { 0 };
     XkbKTMapEntryPtr entry;
-    xkmKTMapEntryDesc wire_entry;
-    char buf[100];
+    xkmKTMapEntryDesc wire_entry = { 0 };
+    char buf[100] = { 0 };
 
     if ((tmp = XkmGetCountedString(file, buf, 100)) < 1) {
         _XkbLibError(_XkbErrBadLength, "ReadXkmKeyTypes", 0);
@@ -416,9 +416,9 @@ ReadXkmCompatMap(FILE * file, XkbDescPtr xkb, XkbChangesPtr changes)
 {
     register int i;
     unsigned num_si, groups;
-    char name[100];
+    char name[100] = { 0 };
     XkbSymInterpretPtr interp;
-    xkmSymInterpretDesc wire;
+    xkmSymInterpretDesc wire = { 0 };
     unsigned tmp;
     int nRead = 0;
     XkbCompatMapPtr compat;
@@ -609,8 +609,8 @@ static int
 ReadXkmIndicators(FILE * file, XkbDescPtr xkb, XkbChangesPtr changes)
 {
     register unsigned nLEDs;
-    xkmIndicatorMapDesc wire;
-    char buf[100];
+    xkmIndicatorMapDesc wire = { 0 };
+    char buf[100] = { 0 };
     unsigned tmp;
     int nRead = 0;
 
@@ -693,8 +693,8 @@ static int
 ReadXkmSymbols(FILE * file, XkbDescPtr xkb)
 {
     register int i, g, s, totalVModMaps;
-    xkmKeySymMapDesc wireMap;
-    char buf[100];
+    xkmKeySymMapDesc wireMap = { 0 };
+    char buf[100] = { 0 };
     unsigned minKC, maxKC, groupNames, tmp;
     int nRead = 0;
 
@@ -861,8 +861,8 @@ static int
 ReadXkmGeomDoodad(FILE * file, XkbGeometryPtr geom, XkbSectionPtr section)
 {
     XkbDoodadPtr doodad;
-    xkmDoodadDesc doodadWire;
-    char buf[100];
+    xkmDoodadDesc doodadWire = { 0 };
+    char buf[100] = { 0 };
     unsigned tmp;
     int nRead = 0;
 
@@ -915,13 +915,13 @@ ReadXkmGeomDoodad(FILE * file, XkbGeometryPtr geom, XkbSectionPtr section)
 static int
 ReadXkmGeomOverlay(FILE * file, XkbGeometryPtr geom, XkbSectionPtr section)
 {
-    char buf[100];
+    char buf[100] = { 0 };
     unsigned tmp;
     int nRead = 0;
     XkbOverlayPtr ol;
     XkbOverlayRowPtr row;
-    xkmOverlayDesc olWire;
-    xkmOverlayRowDesc rowWire;
+    xkmOverlayDesc olWire = { 0 };
+    xkmOverlayRowDesc rowWire = { 0 };
     register int r;
 
     nRead += XkmGetCountedString(file, buf, 100);
@@ -957,10 +957,10 @@ ReadXkmGeomSection(FILE * file, XkbGeometryPtr geom)
 {
     register int i;
     XkbSectionPtr section;
-    xkmSectionDesc sectionWire;
+    xkmSectionDesc sectionWire = { 0 };
     unsigned tmp;
     int nRead = 0;
-    char buf[100];
+    char buf[100] = { 0 };
     Atom nameAtom;
 
     nRead += XkmGetCountedString(file, buf, 100);
@@ -983,9 +983,9 @@ ReadXkmGeomSection(FILE * file, XkbGeometryPtr geom)
     if (sectionWire.num_rows > 0) {
         register int k;
         XkbRowPtr row;
-        xkmRowDesc rowWire;
+        xkmRowDesc rowWire = { 0 };
         XkbKeyPtr key;
-        xkmKeyDesc keyWire;
+        xkmKeyDesc keyWire = { 0 };
 
         for (i = 0; i < sectionWire.num_rows; i++) {
             tmp = fread(&rowWire, SIZEOF(xkmRowDesc), 1, file);
@@ -1036,12 +1036,12 @@ static int
 ReadXkmGeometry(FILE * file, XkbDescPtr xkb)
 {
     register int i;
-    char buf[100];
+    char buf[100] = { 0 };
     unsigned tmp;
     int nRead = 0;
-    xkmGeometryDesc wireGeom;
+    xkmGeometryDesc wireGeom = { 0 };
     XkbGeometryPtr geom;
-    XkbGeometrySizesRec sizes;
+    XkbGeometrySizesRec sizes = { 0 };
 
     nRead += XkmGetCountedString(file, buf, 100);
     tmp = fread(&wireGeom, SIZEOF(xkmGeometryDesc), 1, file);
@@ -1211,7 +1211,7 @@ XkmReadFile(FILE * file, unsigned need, unsigned want, XkbDescPtr *xkb)
 {
     register unsigned i;
     xkmSectionInfo toc[MAX_TOC] = { 0 }, tmpTOC = { 0 };
-    xkmFileInfo fileInfo;
+    xkmFileInfo fileInfo = { 0 };
     unsigned tmp, nRead = 0;
     unsigned which = need | want;
 


### PR DESCRIPTION
Just to be on the safe side: prevent potential leaks.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
