### PR TITLE
(release/25.0) modesetting: add NULL check for drmModeObjectGetProperties in VRR check

### DIFF
--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
@@ -3374,6 +3374,8 @@ drmmode_connector_check_vrr_capable(uint32_t drm_fd, int connector_id)
 
     props = drmModeObjectGetProperties(drm_fd, connector_id,
                                     DRM_MODE_OBJECT_CONNECTOR);
+    if (!props)
+        return FALSE;
 
     for (i = 0; !found && i < props->count_props; ++i) {
         drmModePropertyPtr drm_prop = drmModeGetProperty(drm_fd, props->props[i]);


### PR DESCRIPTION
Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2184>
