### PR TITLE
(master) mi: Handle allocation failure in XYToWindow() spriteTrace realloc

### DIFF
--- a/mi/miwindow.c
+++ b/mi/miwindow.c
@@ -773,10 +773,16 @@ miSpriteTrace(SpritePtr pSprite, int x, int y)
              */
             && !pWin->unhittable) {
             if (pSprite->spriteTraceGood >= pSprite->spriteTraceSize) {
-                pSprite->spriteTraceSize += 10;
-                pSprite->spriteTrace = reallocarray(pSprite->spriteTrace,
-                                                    pSprite->spriteTraceSize,
-                                                    sizeof(WindowPtr));
+                WindowPtr *newTrace;
+                int newSize = pSprite->spriteTraceSize + 10;
+
+                newTrace = reallocarray(pSprite->spriteTrace,
+                                        newSize,
+                                        sizeof(WindowPtr));
+                if (!newTrace)
+                    return DeepestSpriteWin(pSprite);
+                pSprite->spriteTraceSize = newSize;
+                pSprite->spriteTrace = newTrace;
             }
             pSprite->spriteTrace[pSprite->spriteTraceGood++] = pWin;
             pWin = pWin->firstChild;


### PR DESCRIPTION
Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2184>
