### PR TITLE
(release/25.0) Xi: add NULL checks to handle malloc failures

### DIFF
--- a/Xi/exevents.c
+++ b/Xi/exevents.c
@@ -1065,6 +1065,9 @@ TouchSendOwnershipEvent(DeviceIntPtr dev, TouchPointInfoPtr ti, int reason,
     int nev, i;
     InternalEvent *tel = InitEventList(GetMaximumEventsNum());
 
+    if (!tel)
+        return;
+
     nev = GetTouchOwnershipEvents(tel, dev, ti, reason, resource, 0);
     for (i = 0; i < nev; i++)
         mieqProcessDeviceEvent(dev, tel + i, NULL);


### PR DESCRIPTION
Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2184>
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
