### PR TITLE
(master) dix: devices: fix missing free in AddInputDevice()

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -302,6 +302,7 @@ AddInputDevice(ClientPtr client, DeviceProc deviceProc, Bool autoStart)
      */
     if (dixCallDeviceAccessCallback(client, dev, DixCreateAccess)) {
         dixFreePrivates(dev->devPrivates, PRIVATE_DEVICE);
+        free(dev->deviceGrab.sync.event);
         free(dev);
         return NULL;
     }


### PR DESCRIPTION
When dixCallDeviceAccessCallback() rejects, we need to really clean up.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
