### PR TITLE
(release/25.0) dix: devices: fix missing free in AddInputDevice()

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -304,6 +304,7 @@ AddInputDevice(ClientPtr client, DeviceProc deviceProc, Bool autoStart)
      */
     if (XaceHookDeviceAccess(client, dev, DixCreateAccess)) {
         dixFreePrivates(dev->devPrivates, PRIVATE_DEVICE);
+        free(dev->deviceGrab.sync.event);
         free(dev);
         return NULL;
     }


### PR DESCRIPTION
When dixCallDeviceAccessCallback() rejects, we need to really clean up.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
