### PR TITLE
(release/25.1) Xi: fix ProcXIGrabDevice returning AlreadyGrabbed as X error code

### DIFF
--- a/Xi/xigrabdev.c
+++ b/Xi/xigrabdev.c
@@ -73,8 +73,10 @@ ProcXIGrabDevice(ClientPtr client)
     if (ret != Success)
         return ret;
 
-    if (!dev->enabled)
-        return AlreadyGrabbed;
+    if (!dev->enabled) {
+        status = XIAlreadyGrabbed;
+        goto reply;
+    }
 
     if (!InputDevIsMaster(dev))
         stuff->paired_device_mode = GrabModeAsync;
@@ -114,6 +116,7 @@ ProcXIGrabDevice(ClientPtr client)
     if (ret != Success)
         return ret;
 
+reply:
     xXIGrabDeviceReply reply = {
         .RepType = X_XIGrabDevice,
         .status = status


### PR DESCRIPTION
When the target device is disabled, ProcXIGrabDevice returns
AlreadyGrabbed directly as the request handler return value.
AlreadyGrabbed (1) is a grab status code, not an X error code. The
server dispatch loop interprets any non-zero return value as an X
protocol error, so the client receives BadRequest (error code 1)
instead of a proper XIGrabDevice reply with status=AlreadyGrabbed.

And use XIAlreadyGrabbed since this is an XI2 request. It's the same
value anyway.

This is the same class of bug that was fixed in ProcXIPassiveGrabDevice
by commit 'Xi: Fix XIPassiveGrab handling of keycodes > 255'

Fix by jumping to the reply path with status=AlreadyGrabbed instead of
returning the status code directly.

Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2186>
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
