### PR TITLE
(release/25.1) panoramiX: fail if we can't allocate our visual arrays

### DIFF
--- a/Xext/panoramiX.c
+++ b/Xext/panoramiX.c
@@ -756,16 +756,16 @@ PanoramiXMaybeAddVisual(VisualPtr pVisual)
     /* found a matching visual on all screens, add it to the subset list */
     int j = PanoramiXNumVisuals;
     PanoramiXNumVisuals++;
-    PanoramiXVisuals = reallocarray(PanoramiXVisuals,
-                                    PanoramiXNumVisuals, sizeof(VisualRec));
+    PanoramiXVisuals = XNFreallocarray(PanoramiXVisuals,
+                                       PanoramiXNumVisuals, sizeof(VisualRec));
 
     memcpy(&PanoramiXVisuals[j], pVisual, sizeof(VisualRec));
 
     for (k = 0; k < PanoramiXNumDepths; k++) {
         if (PanoramiXDepths[k].depth == pVisual->nplanes) {
-            PanoramiXDepths[k].vids = reallocarray(PanoramiXDepths[k].vids,
-                                                   PanoramiXDepths[k].numVids + 1,
-                                                   sizeof(VisualID));
+            PanoramiXDepths[k].vids = XNFreallocarray(PanoramiXDepths[k].vids,
+                                                      PanoramiXDepths[k].numVids + 1,
+                                                      sizeof(VisualID));
             PanoramiXDepths[k].vids[PanoramiXDepths[k].numVids] = pVisual->vid;
             PanoramiXDepths[k].numVids++;
             break;


### PR DESCRIPTION
This code has failed for decades by triggering a segfault, let's not
bother figuring out the perfect cleanup path.

Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2184>
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
