### PR TITLE
(release/25.1) dix: Silent static analyzer warning

### DIFF
--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -826,7 +826,7 @@ doListFontsWithInfo(ClientPtr client, LFWIclosurePtr c)
     FontPathElementPtr fpe;
     int err = Successful;
     char *name;
-    int namelen;
+    int namelen = 0;
     int numFonts;
     FontInfoRec fontInfo, *pFontInfo;
     int length;


### PR DESCRIPTION
 | dix/dixfonts.c:849:5: var_decl: Declaring variable "namelen" without initializer.
 | dix/dixfonts.c:932:17: uninit_use: Using uninitialized value "namelen".
 |    930|                   c->savedNumFonts = numFonts;
 |    931|                   free(c->savedName);
 |    932|->                 c->savedName = XNFalloc(namelen + 1);
 |    933|                   memcpy(c->savedName

Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2195>
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
