### PR TITLE
(release/25.1) Xi: fail if we can't assign device names

### DIFF
--- a/Xi/extinit.c
+++ b/Xi/extinit.c
@@ -1037,7 +1037,7 @@ void
 AssignTypeAndName(DeviceIntPtr dev, Atom type, const char *name)
 {
     dev->xinput_type = type;
-    dev->name = strdup(name);
+    dev->name = XNFstrdup(name);
 }
 
 /***********************************************************************
@@ -1185,9 +1185,9 @@ XInputExtensionInit(void)
         memset(&xi_all_devices, 0, sizeof(xi_all_devices));
         memset(&xi_all_master_devices, 0, sizeof(xi_all_master_devices));
         xi_all_devices.id = XIAllDevices;
-        xi_all_devices.name = strdup("XIAllDevices");
+        xi_all_devices.name = XNFstrdup("XIAllDevices");
         xi_all_master_devices.id = XIAllMasterDevices;
-        xi_all_master_devices.name = strdup("XIAllMasterDevices");
+        xi_all_master_devices.name = XNFstrdup("XIAllMasterDevices");
 
         inputInfo.all_devices = &xi_all_devices;
         inputInfo.all_master_devices = &xi_all_master_devices;


### PR DESCRIPTION
During extension init this makes sense, failing to assign a name to a
new device is more controversial but none of the paths handle
this situation correctly right now so we're just as likely to introduce
an exploit if the name remains NULL.

Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2184>
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
