### PR TITLE
(release/25.0) glx: fail if we can't init a screen

### DIFF
--- a/glx/glxscreens.c
+++ b/glx/glxscreens.c
@@ -317,7 +317,7 @@ __glXScreenInit(__GLXscreen * pGlxScreen, ScreenPtr pScreen)
         return;
 
     pGlxScreen->pScreen = pScreen;
-    pGlxScreen->GLextensions = strdup(GLServerExtensions);
+    pGlxScreen->GLextensions = XNFstrdup(GLServerExtensions);
     pGlxScreen->GLXextensions = NULL;
 
     dixScreenHookClose(pScreen, glxCloseScreen);
@@ -331,7 +331,7 @@ __glXScreenInit(__GLXscreen * pGlxScreen, ScreenPtr pScreen)
     pGlxScreen->numFBConfigs = i;
 
     pGlxScreen->visuals =
-        calloc(pGlxScreen->numFBConfigs, sizeof(__GLXconfig *));
+        XNFcallocarray(pGlxScreen->numFBConfigs, sizeof(__GLXconfig *));
 
     /* First, try to choose featureful FBconfigs for the existing X visuals.
      * Note that if multiple X visuals end up with the same FBconfig being


### PR DESCRIPTION
Not worth figuring out the perfect cleanup path here

Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2184>
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
