### PR TITLE
(release/25.1) mi: fail on reallocarray failure in miAppendSpans

### DIFF
--- a/mi/miwideline.c
+++ b/mi/miwideline.c
@@ -65,6 +65,7 @@ SOFTWARE.
 #include <X11/X.h>
 
 #include "mi/mi_priv.h"
+#include "os/osdep.h"
 
 #include "windowstr.h"
 #include "gcstruct.h"
@@ -227,8 +228,8 @@ miAppendSpans(SpanGroup * spanGroup, SpanGroup * otherGroup, Spans * spans)
     if (spansCount > 0) {
         if (spanGroup->size == spanGroup->count) {
             spanGroup->size = (spanGroup->size + 8) * 2;
-            spanGroup->group =
-                reallocarray(spanGroup->group, sizeof(Spans), spanGroup->size);
+            spanGroup->group = XNFreallocarray(spanGroup->group,
+                                               sizeof(Spans), spanGroup->size);
         }
 
         spanGroup->group[spanGroup->count] = *spans;


### PR DESCRIPTION
Use the XNF version for this and simply bail out if it fails. Clearly
this hasn't been a problem in over 20 years and I can't be bothered
finding the perfect cleanup path.

Co-Authored-by: Claude Code <noreply@anthropic.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2184>
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
