### PR TITLE
(release/25.1) dix: InitTouchClassDeviceStruct(): clear `touch` pointer in device on error

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -1678,6 +1678,8 @@ InitTouchClassDeviceStruct(DeviceIntPtr device, unsigned int max_touches,
     free(touch->touches);
     free(touch);
 
+    device->touch = NULL;
+
     return FALSE;
 }
 


### PR DESCRIPTION
Clear the pointer to touch structure on error path

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
