### PR TITLE
(master) Xext: xv: use REQUEST_HEAD_STRUCT and REQUEST_FIELD_* macros

### DIFF
--- a/Xext/xv/xvdisp.c
+++ b/Xext/xv/xvdisp.c
@@ -32,8 +32,8 @@ SOFTWARE.
 #include <X11/extensions/shmproto.h>
 
 #include "dix/dix_priv.h"
-#include "dix/rpcbuf_priv.h"
 #include "dix/request_priv.h"
+#include "dix/rpcbuf_priv.h"
 #include "dix/screenint_priv.h"
 #include "include/shmint.h"
 #include "include/misc.h"
@@ -178,7 +178,7 @@ SingleXvPutVideo(ClientPtr client)
     GCPtr pGC;
     int status;
 
-    REQUEST(xvPutVideoReq);
+    X_REQUEST_HEAD_STRUCT(xvPutVideoReq);
 
     VALIDATE_DRAWABLE_AND_GC(stuff->drawable, pDraw, DixWriteAccess);
     VALIDATE_XV_PORT(stuff->port, pPort, DixReadAccess);
@@ -229,12 +229,12 @@ ProcXvPutVideo(ClientPtr client)
 static int
 SingleXvPutStill(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xvPutStillReq);
+
     DrawablePtr pDraw;
     XvPortPtr pPort;
     GCPtr pGC;
     int status;
-
-    REQUEST(xvPutStillReq);
 
     VALIDATE_DRAWABLE_AND_GC(stuff->drawable, pDraw, DixWriteAccess);
     VALIDATE_XV_PORT(stuff->port, pPort, DixReadAccess);
@@ -428,11 +428,11 @@ ProcXvUngrabPort(ClientPtr client)
 static int
 SingleXvStopVideo(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xvStopVideoReq);
+
     int ret;
     DrawablePtr pDraw;
     XvPortPtr pPort;
-
-    REQUEST(xvStopVideoReq);
 
     VALIDATE_XV_PORT(stuff->port, pPort, DixReadAccess);
 
@@ -464,11 +464,10 @@ ProcXvStopVideo(ClientPtr client)
 static int
 SingleXvSetPortAttribute(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xvSetPortAttributeReq);
+
     int status;
     XvPortPtr pPort;
-
-    REQUEST(xvSetPortAttributeReq);
-
     VALIDATE_XV_PORT(stuff->port, pPort, DixSetAttrAccess);
 
     if (!ValidAtom(stuff->attribute)) {
@@ -609,14 +608,14 @@ ProcXvQueryPortAttributes(ClientPtr client)
 static int
 SingleXvPutImage(ClientPtr client)
 {
+    X_REQUEST_HEAD_AT_LEAST(xvPutImageReq);
+
     DrawablePtr pDraw;
     XvPortPtr pPort;
     XvImagePtr pImage = NULL;
     GCPtr pGC;
     int status, i, size;
     CARD16 width, height;
-
-    REQUEST(xvPutImageReq);
 
     VALIDATE_DRAWABLE_AND_GC(stuff->drawable, pDraw, DixWriteAccess);
     VALIDATE_XV_PORT(stuff->port, pPort, DixReadAccess);
@@ -698,6 +697,8 @@ ProcXvPutImage(ClientPtr client)
 static int
 SingleXvShmPutImage(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xvShmPutImageReq);
+
     ShmDescPtr shmdesc;
     DrawablePtr pDraw;
     XvPortPtr pPort;
@@ -705,8 +706,6 @@ SingleXvShmPutImage(ClientPtr client)
     GCPtr pGC;
     int status, size_needed, i;
     CARD16 width, height;
-
-    REQUEST(xvShmPutImageReq);
 
     VALIDATE_DRAWABLE_AND_GC(stuff->drawable, pDraw, DixWriteAccess);
     VALIDATE_XV_PORT(stuff->port, pPort, DixReadAccess);


### PR DESCRIPTION
Use the new macros to make request struct parsing / field swapping
much easier.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
