### PR TITLE
(master) dix: colormap: declare variables where needed in BigNumAdd()

### DIFF
--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -1228,9 +1228,8 @@ typedef struct _bignum {
 static void
 BigNumAdd(BigNumPtr x, BigNumPtr y, BigNumPtr r)
 {
-    BigNumLower lower, carry = 0;
-
-    lower = x->lower + y->lower;
+    BigNumLower carry = 0;
+    BigNumLower lower = x->lower + y->lower;
     if (lower >= BIGNUMLOWER) {
         lower -= BIGNUMLOWER;
         carry = 1;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
