### PR TITLE
(release/25.1) xserver: config: split 10-nvidia.conf file

### DIFF
--- a/config/10-nvidia-modules.conf.debian.in
+++ b/config/10-nvidia-modules.conf.debian.in
@@ -1,0 +1,16 @@
+# This xorg.conf.d configuration snippet is a Debian version of a supplement to
+# /etc/X11/xorg.conf.d/10-nvidia.conf that sets module paths for nvidia GLX libraries
+# when it detects a device driven by the nvidia-drm kernel driver.
+# Please note that this works on Linux kernels version 6.12 or higher
+# with CONFIG_DRM enabled, and only if the nvidia-drm.ko kernel module
+# for the versions 390 and later of the nvidia driver or the nvidia.ko
+# kernel module for the version 340 is loaded before the X server is started.
+
+Section "OutputClass"
+        Identifier "NVidia-modules"
+        MatchDriver "nvidia-drm"
+        Module "glx"
+        Module "glxserver_nvidia"
+        # Debian specific directories
+        ModulePath "/usr/lib/x86_64-linux-gnu/nvidia/xorg,/usr/lib/nvidia/nvidia"
+EndSection

--- a/config/10-nvidia-modules.conf.in
+++ b/config/10-nvidia-modules.conf.in
@@ -1,15 +1,15 @@
-# This xorg.conf.d configuration snippet configures the X server to
-# automatically load the nvidia X driver when it detects a device
-# driven by the nvidia-drm kernel driver.
+# This xorg.conf.d configuration snippet is a supplement to
+# 10-nvidia.conf that sets module paths for nvidia GLX libraries
+# when it detects a device driven by the nvidia-drm kernel driver.
 # Please note that this works on Linux kernels version 6.12 or higher
 # with CONFIG_DRM enabled, and only if the nvidia-drm.ko kernel module
 # for the versions 390 and later of the nvidia driver or the nvidia.ko
 # kernel module for the version 340 is loaded before the X server is started.
 
 Section "OutputClass"
-        Identifier "NVidia"
+        Identifier "NVidia-modules"
         MatchDriver "nvidia-drm"
-        Driver "nvidia"
-        Option "AllowEmptyInitialConfiguration"
+        Module "glx"
+        Module "glxserver_nvidia"
         ModulePath "@libdir@/nvidia/xorg"
 EndSection

--- a/config/10-nvidia.conf.debian.in
+++ b/config/10-nvidia.conf.debian.in
@@ -1,4 +1,4 @@
-# This xorg.conf.d configuration snippet configures the X server to
+# This xorg.conf.d configuration snippet for Debian configures the X server to
 # automatically load the nvidia X driver when it detects a device
 # driven by the nvidia-drm kernel driver.
 # Please note that this works on Linux kernels version 6.12 or higher
@@ -11,5 +11,6 @@ Section "OutputClass"
         MatchDriver "nvidia-drm"
         Driver "nvidia"
         Option "AllowEmptyInitialConfiguration"
-        ModulePath "@libdir@/nvidia/xorg"
+        # Debian specific directories
+        ModulePath "/usr/lib/x86_64-linux-gnu/nvidia/xorg,/usr/lib/nvidia/nvidia"
 EndSection

--- a/config/meson.build
+++ b/config/meson.build
@@ -34,6 +34,24 @@ if build_xorg
         configuration: nvidia_conf,
         install_dir: join_paths(get_option('datadir'), 'X11/xorg.conf.d'),
     )
+    configure_file(
+        input: '10-nvidia-modules.conf.in',
+        output: '10-nvidia-modules.conf',
+        configuration: nvidia_conf,
+        install_dir: join_paths(get_option('datadir'), 'X11/xorg.conf.d'),
+    )
+    configure_file(
+        input: '10-nvidia.conf.debian.in',
+        output: '10-nvidia.conf.debian',
+        configuration: nvidia_conf,
+        install_dir: join_paths(get_option('sysconfdir'), 'X11/xorg.conf.d'),
+    )
+    configure_file(
+        input: '10-nvidia-modules.conf.debian.in',
+        output: '10-nvidia-modules.conf.debian',
+        configuration: nvidia_conf,
+        install_dir: join_paths(get_option('sysconfdir'), 'X11/xorg.conf.d'),
+    )
 endif
 
 libxserver_config = static_library('xserver_config',


### PR DESCRIPTION
This PR is https://github.com/X11Libre/xserver/pull/2569 modified for xserver-stable.

XLibre 10-nvidia.conf is extended w.r.t. XOrg version and can be overwritten by NVidia installers or packages, hence it is safer to split it into 10-nvidia.conf (a common part) and 10-nvidia-modules.conf (an extra part).

This patch also provides /etc/X11/xorg.conf.d/10-nvidia.conf.debian and /etc/X11/xorg.conf.d/10-nvidia-modules.conf.debian files that, when .debian suffix is removed, shadow the respective files in /usr/share/X11/xorg.conf.d and set Debian specific search directories for drivers and modules.

Closes: https://github.com/X11Libre/xserver/issues/2166