### PR TITLE
(master) dix: colormap: declare variables where needed in FreePixels()

### DIFF
--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -1431,11 +1431,8 @@ QueryColors(ColormapPtr pmap, int count, Pixel * ppixIn, xrgb * prgbList,
 static void
 FreePixels(ColormapPtr pmap, int client)
 {
-    Pixel *ppixStart;
-    int class;
-
-    class = pmap->class;
-    ppixStart = pmap->clientPixelsRed[client];
+    int class = pmap->class;
+    Pixel *ppixStart = pmap->clientPixelsRed[client];
     if (class & DynamicClass) {
         int n = pmap->numPixelsRed[client];
         for (Pixel *ppix = ppixStart; --n >= 0;) {


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
