### PR TITLE
(master) dix: colormap: declare variables where needed in FreeClientPixels()

### DIFF
--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -1482,9 +1482,8 @@ FreeClientPixels(void *value, XID fakeid)
     (void) fakeid;
     void *pmap;
     colorResource *pcr = value;
-    int rc;
 
-    rc = dixLookupResourceByType(&pmap, pcr->mid, X11_RESTYPE_COLORMAP, serverClient,
+    int rc = dixLookupResourceByType(&pmap, pcr->mid, X11_RESTYPE_COLORMAP, serverClient,
                                  DixRemoveAccess);
     if (rc == Success)
         FreePixels((ColormapPtr) pmap, pcr->client);


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
