### PR TITLE
(master) dix: colormap: change return type to `bool`

### DIFF
--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -2469,11 +2469,10 @@ StoreColors(ColormapPtr pmap, int count, xColorItem * defs, ClientPtr client)
     return errVal;
 }
 
-int
-IsMapInstalled(Colormap map, WindowPtr pWin)
+bool IsMapInstalled(Colormap map, WindowPtr pWin)
 {
     Colormap *pmaps;
-    int nummaps, found;
+    int nummaps;
 
     pmaps = calloc(pWin->drawable.pScreen->maxInstalledCmaps,
                    sizeof(Colormap));
@@ -2481,7 +2480,8 @@ IsMapInstalled(Colormap map, WindowPtr pWin)
         return FALSE;
     nummaps = (*pWin->drawable.pScreen->ListInstalledColormaps)
         (pWin->drawable.pScreen, pmaps);
-    found = FALSE;
+
+    bool found = FALSE;
     for (int imap = 0; imap < nummaps; imap++) {
         if (pmaps[imap] == map) {
             found = TRUE;

--- a/dix/colormap_priv.h
+++ b/dix/colormap_priv.h
@@ -5,6 +5,7 @@
 #ifndef _XSERVER_DIX_COLORMAP_PRIV_H
 #define _XSERVER_DIX_COLORMAP_PRIV_H
 
+#include <stdbool.h>
 #include <X11/Xdefs.h>
 #include <X11/Xproto.h>
 
@@ -107,7 +108,7 @@ int FreeColors(ColormapPtr pmap, int client, int count, Pixel *pixels, Pixel mas
 
 int StoreColors(ColormapPtr pmap, int count, xColorItem * defs, ClientPtr client);
 
-int IsMapInstalled(Colormap map, WindowPtr pWin);
+bool IsMapInstalled(Colormap map, WindowPtr pWin);
 
 /* only exported for glx, but should not be used by external drivers */
 _X_EXPORT Bool ResizeVisualArray(ScreenPtr pScreen, int new_vis_count, DepthPtr depth);

--- a/dix/window.c
+++ b/dix/window.c
@@ -1443,7 +1443,7 @@ ChangeWindowAttributes(WindowPtr pWin, Mask vmask, XID *vlist, ClientPtr client)
                     .u.colormap.window = pWin->drawable.id,
                     .u.colormap.colormap = cmap,
                     .u.colormap.new = xTrue,
-                    .u.colormap.state = IsMapInstalled(cmap, pWin)
+                    .u.colormap.state = (!!IsMapInstalled(cmap, pWin))
                 };
                 xE.u.u.type = ColormapNotify;
                 DeliverEvents(pWin, &xE, 1, NullWindow);
@@ -1586,7 +1586,7 @@ ProcGetWindowAttributes(ClientPtr client)
                      (pWin->realized ? IsViewable : IsUnviewable)),
         .colormap = wColormap(pWin),
         .mapInstalled = (wColormap(pWin) == None) ? xFalse
-            : IsMapInstalled(wColormap(pWin), pWin),
+            : (!!IsMapInstalled(wColormap(pWin), pWin)),
         .yourEventMask = EventMaskForClient(pWin, client),
         .allEventMasks = pWin->eventMask | wOtherEventMasks(pWin),
         .doNotPropagateMask = wDontPropagateMask(pWin),


### PR DESCRIPTION
`bool` is the natural boolean type, instead of int.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
