### PR TITLE
glamor: xfree86: Add `glamor_egl_init2` function

### DIFF
--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -1823,13 +1823,13 @@ glamor_egl_init_display(glamor_egl_priv_t *glamor_egl)
 }
 
 Bool
-glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, Bool *compat_ret)
+glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
 {
     const GLubyte *renderer;
     glamor_egl_priv_t* glamor_egl = NULL;
 
-    if (compat_ret) {
-        *compat_ret = TRUE;
+    if (caps) {
+        *caps = GLAMOR_EGL_CAP_NONE;
     }
 
     if (glamor_egl_conf->GLAMOR_EGL_PRIV_PROC) {
@@ -1861,9 +1861,6 @@ glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, Bool *compat_ret)
         if (glamor_egl->gbm == NULL) {
             ErrorF("couldn't create gbm device\n");
             glamor_egl->fd = -1;
-            if (compat_ret) {
-                *compat_ret = FALSE;
-            }
         }
 
         const char* gbm_backend = glamor_egl->gbm ?
@@ -1998,6 +1995,10 @@ glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, Bool *compat_ret)
         goto glamor_no_dri;
     }
 
+    if (caps) {
+        *caps |= GLAMOR_EGL_DEFAULT_CAPS;
+    }
+
     LogMessage(X_INFO, "glamor dri X acceleration enabled on %s\n",
                renderer);
     return TRUE;
@@ -2010,9 +2011,6 @@ error:
 glamor_no_dri:
     glamor_egl->fd = -1;
 
-    if (compat_ret) {
-        *compat_ret = FALSE;
-    }
     LogMessage(X_WARNING, "glamor X acceleration enabled without dri support on %s\n",
                renderer);
     return TRUE;

--- a/glamor/glamor_egl.h
+++ b/glamor/glamor_egl.h
@@ -69,10 +69,10 @@ typedef struct {
  *
  * glamor_egl_conf is a pointer to caller-allocated storage.
  *
- * If compat_ret is not NULL, it will be set to a return value
- * for compatibility with xf86 drivers.
+ * If caps is not NULL, it will be set to a bitmask containing
+ * information about glamor.
  */
-Bool glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, Bool *compat_ret);
+Bool glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps);
 
 /*
  * Create an EGLDisplay from a native display type. This is a little quirky

--- a/hw/xfree86/glamor_egl/glamor_xf86_egl.c
+++ b/hw/xfree86/glamor_egl/glamor_xf86_egl.c
@@ -53,8 +53,8 @@ glamor_xf86_egl_free_screen(ScrnInfoPtr scrn)
     }
 }
 
-Bool
-glamor_egl_init(ScrnInfoPtr scrn, int fd)
+static Bool
+_glamor_egl_init(ScrnInfoPtr scrn, int fd, int *caps)
 {
     glamor_egl_priv_t *glamor_egl;
     OptionInfoPtr options;
@@ -98,18 +98,35 @@ glamor_egl_init(ScrnInfoPtr scrn, int fd)
                                                    "dmabuf_capable");
     }
 
-    Bool compat_ret = TRUE;
-
     glamor_egl_conf.llvmpipe_allowed = !!scrn->confScreen->num_gpu_devices;
 
     glamor_egl_conf.server_private = scrn->FreeScreen;
-    if (glamor_egl_init_internal(&glamor_egl_conf, &compat_ret)) {
+
+    if (glamor_egl_init_internal(&glamor_egl_conf, caps)) {
         scrn->FreeScreen = glamor_xf86_egl_free_screen;
-        return compat_ret;
+        return TRUE;
     }
 
     free(glamor_egl);
     return FALSE;
+}
+
+Bool
+glamor_egl_init(ScrnInfoPtr scrn, int fd)
+{
+    int caps = GLAMOR_EGL_CAP_NONE;
+    if (_glamor_egl_init(scrn, fd, &caps)) {
+        return !!(caps & GLAMOR_EGL_DEFAULT_CAPS);
+    }
+
+    return FALSE;
+}
+
+Bool
+glamor_egl_init2(ScrnInfoPtr scrn, int fd, int *caps, int flags)
+{
+    (void)flags;
+    return _glamor_egl_init(scrn, fd, caps);
 }
 
 /** Stub to retain compatibility with pre-server-1.16 ABI. */

--- a/include/glamor.h
+++ b/include/glamor.h
@@ -342,6 +342,35 @@ extern _X_EXPORT void glamor_set_drawable_modifiers_func(ScreenPtr screen,
  * */
 extern _X_EXPORT Bool glamor_egl_init(ScrnInfoPtr scrn, int fd);
 
+enum {
+    GLAMOR_EGL_CAP_NONE = 0,
+    GLAMOR_EGL_CAP_DRI3 = 1 << 0,
+    GLAMOR_EGL_CAP_DRI3_IMPORT = 1 << 1,
+    GLAMOR_EGL_CAP_DRI3_EXPORT = 1 << 2,
+    GLAMOR_EGL_CAP_DRI3_SYNCOBJ = 1 << 3,
+    GLAMOR_EGL_CAP_TEXTURE_GBM_BO = 1 << 4,
+};
+
+#define GLAMOR_EGL_DEFAULT_CAPS (GLAMOR_EGL_CAP_DRI3 | GLAMOR_EGL_CAP_DRI3_IMPORT | GLAMOR_EGL_CAP_DRI3_EXPORT | GLAMOR_EGL_CAP_TEXTURE_GBM_BO)
+
+/* @glamor_egl_init2: Initialize EGL environment.
+ *
+ * @scrn:        Current screen info pointer.
+ * @fd:          Current drm fd.
+ * @caps:        Some capabilities that glamor can have
+ *
+ * This function creates and initializes EGL contexts.
+ * Should be called from DDX's preInit function.
+ * Return TRUE if success, otherwise return FALSE.
+ *
+ * Unlike glamor_egl_init, this function returns true
+ * even if some capabilities are missing.
+ *
+ * If caps is not NULL, it is set to a bitmask
+ * describing what glamor capabilites are available.
+ * */
+extern _X_EXPORT Bool glamor_egl_init2(ScrnInfoPtr scrn, int fd, int *caps, int flags);
+
 extern _X_EXPORT Bool glamor_egl_init_textured_pixmap(ScreenPtr screen);
 
 /*


### PR DESCRIPTION
`glamor_egl_init2` is now another function that can be used by xf86 drivers

Currently, all default glamor egl caps are either all set or all unset. In the future, I'm planning to make it so that systems where only some glamor egl caps can be enabled will have them enabled, even if more advanced caps are unavailable.