### PR TITLE
(master) dix: devices: declare variables where needed in DeliverDeviceClassesChangedEvent()

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -2845,15 +2845,14 @@ void
 DeliverDeviceClassesChangedEvent(int sourceid, Time time)
 {
     DeviceIntPtr dev;
-    int num_events = 0;
-    InternalEvent dcce;
-
     dixLookupDevice(&dev, sourceid, serverClient, DixWriteAccess);
 
     if (!dev)
         return;
 
     /* UpdateFromMaster generates at most one event */
+    int num_events = 0;
+    InternalEvent dcce = { 0 };
     UpdateFromMaster(&dcce, dev, DEVCHANGE_POINTER_EVENT, &num_events);
     BUG_WARN(num_events > 1);
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
