### PR TITLE
(master) dix: devices: declare variables where needed in ProcBell()

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -2220,11 +2220,6 @@ ProcGetKeyboardControl(ClientPtr client)
 int
 ProcBell(ClientPtr client)
 {
-    DeviceIntPtr keybd = PickKeyboard(client);
-    int base = keybd->kbdfeed->ctrl.bell;
-    int newpercent;
-    int rc;
-
     REQUEST(xBellReq);
     REQUEST_SIZE_MATCH(xBellReq);
 
@@ -2233,7 +2228,9 @@ ProcBell(ClientPtr client)
         return BadValue;
     }
 
-    newpercent = (base * stuff->percent) / 100;
+    DeviceIntPtr keybd = PickKeyboard(client);
+    int base = keybd->kbdfeed->ctrl.bell;
+    int newpercent = (base * stuff->percent) / 100;
     if (stuff->percent < 0)
         newpercent = base + newpercent;
     else
@@ -2244,7 +2241,7 @@ ProcBell(ClientPtr client)
              (!InputDevIsMaster(dev) && GetMaster(dev, MASTER_KEYBOARD) == keybd)) &&
             ((dev->kbdfeed && dev->kbdfeed->BellProc) || dev->xkb_interest)) {
 
-            rc = dixCallDeviceAccessCallback(client, dev, DixBellAccess);
+            int rc = dixCallDeviceAccessCallback(client, dev, DixBellAccess);
             if (rc != Success)
                 return rc;
             XkbHandleBell(FALSE, FALSE, dev, newpercent,


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
