### PR TITLE
(master) dix: devices: declare variables where needed in ProcGetKeyboardControl()

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -2190,15 +2190,14 @@ ProcChangeKeyboardControl(ClientPtr client)
 int
 ProcGetKeyboardControl(ClientPtr client)
 {
-    DeviceIntPtr kbd = PickKeyboard(client);
-    KeybdCtrl *ctrl = &kbd->kbdfeed->ctrl;
-
     REQUEST_SIZE_MATCH(xReq);
 
+    DeviceIntPtr kbd = PickKeyboard(client);
     int rc = dixCallDeviceAccessCallback(client, kbd, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 
+    KeybdCtrl *ctrl = &kbd->kbdfeed->ctrl;
     xGetKeyboardControlReply reply = {
         .globalAutoRepeat = ctrl->autoRepeat,
         .ledMask = ctrl->leds,


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
