### PR TITLE
(master) dix: devices: declare variables where needed in ProcGetKeyboardMapping()

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -1894,19 +1894,15 @@ ProcSetPointerMapping(ClientPtr client)
 int
 ProcGetKeyboardMapping(ClientPtr client)
 {
-    DeviceIntPtr kbd = PickKeyboard(client);
-    XkbDescPtr xkb;
-    KeySymsPtr syms;
-    int rc;
-
     REQUEST(xGetKeyboardMappingReq);
     REQUEST_SIZE_MATCH(xGetKeyboardMappingReq);
 
-    rc = dixCallDeviceAccessCallback(client, kbd, DixGetAttrAccess);
+    DeviceIntPtr kbd = PickKeyboard(client);
+    int rc = dixCallDeviceAccessCallback(client, kbd, DixGetAttrAccess);
     if (rc != Success)
         return rc;
 
-    xkb = kbd->key->xkbInfo->desc;
+    XkbDescPtr xkb = kbd->key->xkbInfo->desc;
 
     if ((stuff->firstKeyCode < xkb->min_key_code) ||
         (stuff->firstKeyCode > xkb->max_key_code)) {
@@ -1918,7 +1914,7 @@ ProcGetKeyboardMapping(ClientPtr client)
         return BadValue;
     }
 
-    syms = XkbGetCoreMap(kbd);
+    KeySymsPtr syms = XkbGetCoreMap(kbd);
     if (!syms)
         return BadAlloc;
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
