### PR TITLE
(master) dix: devices: declare variables where needed in ProcSetModifierMapping()

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -1733,8 +1733,6 @@ BadDeviceMap(BYTE * buff, int length, unsigned low, unsigned high, XID *errval)
 int
 ProcSetModifierMapping(ClientPtr client)
 {
-    int rc;
-
     REQUEST(xSetModifierMappingReq);
     REQUEST_AT_LEAST_SIZE(xSetModifierMappingReq);
 
@@ -1743,7 +1741,7 @@ ProcSetModifierMapping(ClientPtr client)
         return BadLength;
 
 
-    rc = change_modmap(client, PickKeyboard(client), (KeyCode *) &stuff[1],
+    int rc = change_modmap(client, PickKeyboard(client), (KeyCode *) &stuff[1],
                        stuff->numKeyPerModifier);
     if (rc == MappingFailed)
         return BadValue;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
