### PR TITLE
(master) dix: devices: declare variables where needed in InitPointerAccelerationScheme()

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -1413,10 +1413,7 @@ ValuatorAccelerationRec pointerAccelerationScheme[] = {
 Bool
 InitPointerAccelerationScheme(DeviceIntPtr dev, int scheme)
 {
-    int i = -1;
-    ValuatorClassPtr val;
-
-    val = dev->valuator;
+    ValuatorClassPtr val = dev->valuator;
 
     if (!val)
         return FALSE;
@@ -1424,6 +1421,7 @@ InitPointerAccelerationScheme(DeviceIntPtr dev, int scheme)
     if (InputDevIsMaster(dev) && scheme != PtrAccelNoOp)
         return FALSE;
 
+    int i = -1;
     for (int x = 0; pointerAccelerationScheme[x].number >= 0; x++) {
         if (pointerAccelerationScheme[x].number == scheme) {
             i = x;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
