### PR TITLE
(master) dix: devices: declare variables where needed in InitValuatorClassDeviceStruct()

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -1342,8 +1342,6 @@ Bool
 InitValuatorClassDeviceStruct(DeviceIntPtr dev, int numAxes, Atom *labels,
                               int numMotionEvents, int mode)
 {
-    ValuatorClassPtr valc;
-
     BUG_RETURN_VAL(dev == NULL, FALSE);
     BUG_RETURN_VAL(numAxes == 0, FALSE);
 
@@ -1354,7 +1352,7 @@ InitValuatorClassDeviceStruct(DeviceIntPtr dev, int numAxes, Atom *labels,
         numAxes = MAX_VALUATORS;
     }
 
-    valc = AllocValuatorClass(NULL, numAxes);
+    ValuatorClassPtr valc = AllocValuatorClass(NULL, numAxes);
     if (!valc)
         return FALSE;
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
