### PR TITLE
(master) dix: devices: declare variables where needed in InitButtonClassDeviceStruct()

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -1279,13 +1279,11 @@ Bool
 InitButtonClassDeviceStruct(DeviceIntPtr dev, int numButtons, Atom *labels,
                             CARD8 *map)
 {
-    ButtonClassPtr butc;
-
     BUG_RETURN_VAL(dev == NULL, FALSE);
     BUG_RETURN_VAL(dev->button != NULL, FALSE);
     BUG_RETURN_VAL(numButtons >= MAX_BUTTONS, FALSE);
 
-    butc = calloc(1, sizeof(ButtonClassRec));
+    ButtonClassPtr butc = calloc(1, sizeof(ButtonClassRec));
     if (!butc)
         return FALSE;
     butc->numButtons = numButtons;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
