### PR TITLE
(master) dix: devices: declare variables where needed in CorePointerProc()

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -737,9 +737,7 @@ CorePointerProc(DeviceIntPtr pDev, int what)
 void
 InitCoreDevices(void)
 {
-    int result;
-
-    result = AllocDevicePair(serverClient, "Virtual core",
+    int result = AllocDevicePair(serverClient, "Virtual core",
                              &inputInfo.pointer, &inputInfo.keyboard,
                              CorePointerProc, CoreKeyboardProc, TRUE);
     if (result != Success) {


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
