### PR TITLE
(master) dix: dispatch: CreateConnectionBlock() drop extra memcpy()

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -599,7 +599,6 @@ Bool
 CreateConnectionBlock(void)
 {
     xConnSetup setup;
-    xWindowRoot root;
     xDepth depth;
     xVisualType visual;
     xPixmapFormat format;
@@ -667,23 +666,24 @@ CreateConnectionBlock(void)
         DepthPtr pDepth;
         VisualPtr pVisual;
 
-        root.windowId = walkScreen->root->drawable.id;
-        root.defaultColormap = walkScreen->defColormap;
-        root.whitePixel = walkScreen->whitePixel;
-        root.blackPixel = walkScreen->blackPixel;
-        root.currentInputMask = 0;      /* filled in when sent */
-        root.pixWidth = walkScreen->width;
-        root.pixHeight = walkScreen->height;
-        root.mmWidth = walkScreen->mmWidth;
-        root.mmHeight = walkScreen->mmHeight;
-        root.minInstalledMaps = walkScreen->minInstalledCmaps;
-        root.maxInstalledMaps = walkScreen->maxInstalledCmaps;
-        root.rootVisualID = walkScreen->rootVisual;
-        root.backingStore = walkScreen->backingStoreSupport;
-        root.saveUnders = FALSE;
-        root.rootDepth = walkScreen->rootDepth;
-        root.nDepths = walkScreen->numDepths;
-        memcpy(pBuf, &root, sizeof(xWindowRoot));
+        xWindowRoot *root = (xWindowRoot*)pBuf;
+        root->windowId = walkScreen->root->drawable.id;
+        root->defaultColormap = walkScreen->defColormap;
+        root->whitePixel = walkScreen->whitePixel;
+        root->blackPixel = walkScreen->blackPixel;
+        root->currentInputMask = 0;      /* filled in when sent */
+        root->pixWidth = walkScreen->width;
+        root->pixHeight = walkScreen->height;
+        root->mmWidth = walkScreen->mmWidth;
+        root->mmHeight = walkScreen->mmHeight;
+        root->minInstalledMaps = walkScreen->minInstalledCmaps;
+        root->maxInstalledMaps = walkScreen->maxInstalledCmaps;
+        root->rootVisualID = walkScreen->rootVisual;
+        root->backingStore = walkScreen->backingStoreSupport;
+        root->saveUnders = FALSE;
+        root->rootDepth = walkScreen->rootDepth;
+        root->nDepths = walkScreen->numDepths;
+
         sizesofar += sizeof(xWindowRoot);
         pBuf += sizeof(xWindowRoot);
 


### PR DESCRIPTION
Let's directly write into the target buffer, instead of first writing
to temporary struct and then memcpy() it into the target buffer.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
