### PR TITLE
(master) include: window.h: drop duplicate typedef of WindowPtr

### DIFF
--- a/include/window.h
+++ b/include/window.h
@@ -72,7 +72,6 @@ struct _DeviceIntRec;
 struct _Cursor;
 
 typedef struct _BackingStore *BackingStorePtr;
-typedef struct _Window *WindowPtr;
 typedef struct _Property *PropertyPtr;
 
 enum RootClipMode {


### PR DESCRIPTION
this typedef is already in include/xlibre_ptrtypes.h

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
