### PR TITLE
(release/25.0) Xi: Swap property data in SProcXChangeDeviceProperty/SProcXIChangeProperty

### DIFF
--- a/Xi/xiproperty.c
+++ b/Xi/xiproperty.c
@@ -1031,6 +1031,16 @@ SProcXChangeDeviceProperty(ClientPtr client)
     swapl(&stuff->property);
     swapl(&stuff->type);
     swapl(&stuff->nUnits);
+    switch (stuff->format) {
+    case 8:
+        break;
+    case 16:
+        SwapRestS(stuff);
+        break;
+    case 32:
+        SwapRestL(stuff);
+        break;
+    }
     return (ProcXChangeDeviceProperty(client));
 }
 
@@ -1255,6 +1265,16 @@ SProcXIChangeProperty(ClientPtr client)
     swapl(&stuff->property);
     swapl(&stuff->type);
     swapl(&stuff->num_items);
+    switch (stuff->format) {
+    case 8:
+        break;
+    case 16:
+        SwapRestS(stuff);
+        break;
+    case 32:
+        SwapRestL(stuff);
+        break;
+    }
     return (ProcXIChangeProperty(client));
 }
 


### PR DESCRIPTION
Both SProcXChangeDeviceProperty() and SProcXIChangeProperty() swap the
fixed header fields (property, type, nUnits/num_items) but fail to
byte-swap the variable-length property data (CARD16 or CARD32, depending
on format) that follows the header.

Assisted-by: Claude:claude-claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2202>
