### PR TITLE
(release/25.1) Xi: Swap property data in ProcXChangeDeviceProperty/ProcXIChangeProperty

### DIFF
--- a/Xi/xiproperty.c
+++ b/Xi/xiproperty.c
@@ -876,6 +876,17 @@ ProcXChangeDeviceProperty(ClientPtr client)
         swapl(&stuff->nUnits);
     }
 
+    switch (stuff->format) {
+    case 8:
+        break;
+    case 16:
+        SwapRestS(stuff);
+        break;
+    case 32:
+        SwapRestL(stuff);
+        break;
+    }
+
     DeviceIntPtr dev;
     unsigned long len;
     uint64_t totalSize;
@@ -1054,6 +1065,17 @@ ProcXIChangeProperty(ClientPtr client)
         swapl(&stuff->property);
         swapl(&stuff->type);
         swapl(&stuff->num_items);
+    }
+
+    switch (stuff->format) {
+    case 8:
+        break;
+    case 16:
+        SwapRestS(stuff);
+        break;
+    case 32:
+        SwapRestL(stuff);
+        break;
     }
 
     int rc;


### PR DESCRIPTION
Property data (following the request header) also needs to be swapped.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
