### PR TITLE
(release/25.1) present: Fix missing byte swaps in sproc_present_pixmap()

### DIFF
--- a/present/present_request.c
+++ b/present/present_request.c
@@ -364,6 +364,7 @@ sproc_present_pixmap(ClientPtr client)
     swapll(&stuff->divisor);
     swapll(&stuff->remainder);
     swapl(&stuff->idle_fence);
+    SwapRestL(stuff);
     return proc_present_pixmap(client);
 }
 


### PR DESCRIPTION
sproc_present_pixmap() was missing byte swaps the variable-length
xPresentNotify array after the fixed header was not
byte-swapped at all (each entry has window and serial CARD32 fields).

Fixes: a5ac3c871219 ("present: add missing byte swapping for various fields")

Assisted-by: Claude:claude-claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2202>
