### PR TITLE
(master) include: scrnintstr.h: mark private area of ScreenRec

### DIFF
--- a/include/scrnintstr.h
+++ b/include/scrnintstr.h
@@ -681,6 +681,8 @@ typedef struct _Screen {
     XYToWindowProcPtr XYToWindow;
     DPMSProcPtr DPMS;
 
+    /* ===== below here is PRIVATE ==== drivers MUST NEVER touch it ===== */
+
     /* additional window destructors (replaces wrapping DestroyWindow).
        should NOT be touched outside of DIX core */
     CallbackListPtr hookWindowDestroy;


### PR DESCRIPTION
Add a clear marker telling the border line of which fields drivers
are allowed to touch (except for in-tree drivers) - anything below
is NOT part of ABI anymore and can change anytime.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
