### PR TITLE
(master) dix: add dixScreenRaiseDisplayCursor()

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -1139,8 +1139,9 @@ UndisplayDevices(void)
 {
     ScreenPtr masterScreen = dixGetMasterScreen();
 
-    for (DeviceIntPtr dev = inputInfo.devices; dev; dev = dev->next)
-        masterScreen->DisplayCursor(dev, masterScreen, NullCursor);
+    for (DeviceIntPtr dev = inputInfo.devices; dev; dev = dev->next) {
+        dixScreenRaiseDisplayCursor(masterScreen, dev, NullCursor);
+    }
 }
 
 static int
@@ -1190,7 +1191,7 @@ RemoveDevice(DeviceIntPtr dev, BOOL sendevent)
     if (initialized) {
         if (DevHasCursor(dev)) {
             ScreenPtr masterScreen = dixGetMasterScreen();
-            masterScreen->DisplayCursor(dev, masterScreen, NullCursor);
+            dixScreenRaiseDisplayCursor(masterScreen, dev, NullCursor);
         }
 
         DisableDevice(dev, sendevent);

--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -380,6 +380,15 @@ void dixScreenRaisePixmapDestroy(PixmapPtr pPixmap);
 Bool dixScreenRaiseCreateResources(ScreenPtr pScreen);
 
 /*
+ * @brief call screen's DisplayCursor chain
+ * @param pScreen the screen to operate on
+ * @param pDev    device whose cursor to show/hide
+ * @param pCursor cursor object (NullCursor = hide the cursor)
+ * @return TRUE if the cursor was displayed, FALSE otherwise
+ */
+Bool dixScreenRaiseDisplayCursor(ScreenPtr pScreen, DeviceIntPtr pDev, CursorPtr pCursor);
+
+/*
  * @brief mark event ID as critical
  * @param event the event to add to the critical events bitmap
  */

--- a/dix/events.c
+++ b/dix/events.c
@@ -970,7 +970,7 @@ ChangeToCursor(DeviceIntPtr pDev, CursorPtr cursor)
 #endif /* XINERAMA */
             pScreen = pSprite->hotPhys.pScreen;
 
-        (*pScreen->DisplayCursor) (pDev, pScreen, cursor);
+        dixScreenRaiseDisplayCursor(pScreen, pDev, cursor);
         FreeCursor(pSprite->current, (Cursor) 0);
         pSprite->current = RefCursor(cursor);
     }
@@ -3370,7 +3370,7 @@ InitializeSprite(DeviceIntPtr pDev, WindowPtr pWin)
         (*pScreen->ConstrainCursor) (pDev, pScreen, &pSprite->physLimits);
         (*pScreen->SetCursorPosition) (pDev, pScreen, pSprite->hot.x,
                                        pSprite->hot.y, FALSE);
-        (*pScreen->DisplayCursor) (pDev, pScreen, pSprite->current);
+        dixScreenRaiseDisplayCursor(pScreen, pDev, pSprite->current);
     }
 #ifdef XINERAMA
     if (!noPanoramiXExtension) {
@@ -3449,7 +3449,7 @@ UpdateSpriteForScreen(DeviceIntPtr pDev, ScreenPtr pScreen)
                               &pSprite->hotLimits, &pSprite->physLimits);
     pSprite->confined = FALSE;
     (*pScreen->ConstrainCursor) (pDev, pScreen, &pSprite->physLimits);
-    (*pScreen->DisplayCursor) (pDev, pScreen, pSprite->current);
+    dixScreenRaiseDisplayCursor(pScreen, pDev, pSprite->current);
 
 #ifdef XINERAMA
     if (!noPanoramiXExtension) {

--- a/dix/screen_hooks.c
+++ b/dix/screen_hooks.c
@@ -110,3 +110,12 @@ void dixScreenRaiseUnrealizeWindow(WindowPtr pWin)
     if (pWin->drawable.pScreen->UnrealizeWindow)
         pWin->drawable.pScreen->UnrealizeWindow(pWin);
 }
+
+Bool dixScreenRaiseDisplayCursor(ScreenPtr pScreen, DeviceIntPtr pDev, CursorPtr pCursor)
+{
+    /* for now just calling the screen proc, but in the future we'll also handle hide
+       counters and animations here, so we don't need fragile proc wrapping anymore */
+    if (pScreen && pScreen->DisplayCursor)
+        return pScreen->DisplayCursor(pDev, pScreen, pCursor);
+    return FALSE;
+}

--- a/mi/mipointer.c
+++ b/mi/mipointer.c
@@ -310,7 +310,7 @@ miRecolorCursor(DeviceIntPtr pDev, ScreenPtr pScr,
     pScr->UnrealizeCursor(pDev, pScr, pCurs);
     pScr->RealizeCursor(pDev, pScr, pCurs);
     if (displayed)
-        pScr->DisplayCursor(pDev, pScr, pCurs);
+        dixScreenRaiseDisplayCursor(pScr, pDev, pCurs);
 }
 
 /**


### PR DESCRIPTION
Add new function for calling into screen's DisplayCursor() chain.
This is a preparational step for moving hide cursor counters (xfixes)
and animations (randr) into DIX, in order to get rid of ugly wrapping.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
