### PR TITLE
(master) xfixes: declare variables where needed in ProcXFixesSelectCursorInput()

### DIFF
--- a/xfixes/cursor.c
+++ b/xfixes/cursor.c
@@ -264,11 +264,10 @@ ProcXFixesSelectCursorInput(ClientPtr client)
     X_REQUEST_FIELD_CARD32(eventMask);
 
     WindowPtr pWin;
-    int rc;
-
-    rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
+    int rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
     if (rc != Success)
         return rc;
+
     if (stuff->eventMask & ~CursorAllEvents) {
         client->errorValue = stuff->eventMask;
         return BadValue;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
