### PR TITLE
(master) xfixes: cursor: declare variables where needed in ProcXFixesGetCursorImage()

### DIFF
--- a/xfixes/cursor.c
+++ b/xfixes/cursor.c
@@ -349,20 +349,20 @@ ProcXFixesGetCursorImage(ClientPtr client)
 {
     X_REQUEST_HEAD_STRUCT(xXFixesGetCursorImageReq);
 
-    CursorPtr pCursor;
-    int npixels, width, height, rc, x, y;
-
-    pCursor = CursorForClient(client);
+    CursorPtr pCursor = CursorForClient(client);
     if (!pCursor)
         return BadCursor;
-    rc = XaceHookResourceAccess(client, pCursor->id, X11_RESTYPE_CURSOR,
+    int rc = XaceHookResourceAccess(client, pCursor->id, X11_RESTYPE_CURSOR,
                   pCursor, X11_RESTYPE_NONE, NULL, DixReadAccess);
     if (rc != Success)
         return rc;
+
+    int x, y;
     GetSpritePosition(PickPointer(client), &x, &y);
-    width = pCursor->bits->width;
-    height = pCursor->bits->height;
-    npixels = width * height;
+
+    int width = pCursor->bits->width;
+    int height = pCursor->bits->height;
+    int npixels = width * height;
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
