### PR TITLE
(master) render: use X_REQUEST_HEAD*() macros in ProcRenderReferenceGlyphSet()

### DIFF
--- a/Xext/render/render.c
+++ b/Xext/render/render.c
@@ -752,16 +752,12 @@ ProcRenderCreateGlyphSet(ClientPtr client)
 static int
 ProcRenderReferenceGlyphSet(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xRenderReferenceGlyphSetReq);
+    X_REQUEST_FIELD_CARD32(gsid);
+    X_REQUEST_FIELD_CARD32(existing);
+
     GlyphSetPtr glyphSet;
     int rc;
-
-    REQUEST(xRenderReferenceGlyphSetReq);
-    REQUEST_SIZE_MATCH(xRenderReferenceGlyphSetReq);
-
-    if (client->swapped) {
-        swapl(&stuff->gsid);
-        swapl(&stuff->existing);
-    }
 
     LEGAL_NEW_RESOURCE(stuff->gsid, client);
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
