### PR TITLE
(master) render: use X_REQUEST_*() macros in ProcRenderFreeGlyphSet()

### DIFF
--- a/Xext/render/render.c
+++ b/Xext/render/render.c
@@ -783,14 +783,11 @@ ProcRenderReferenceGlyphSet(ClientPtr client)
 static int
 ProcRenderFreeGlyphSet(ClientPtr client)
 {
+    X_REQUEST_HEAD_STRUCT(xRenderFreeGlyphSetReq);
+    X_REQUEST_FIELD_CARD32(glyphset);
+
     GlyphSetPtr glyphSet;
     int rc;
-
-    REQUEST(xRenderFreeGlyphSetReq);
-    REQUEST_SIZE_MATCH(xRenderFreeGlyphSetReq);
-
-    if (client->swapped)
-        swapl(&stuff->glyphset);
 
     rc = dixLookupResourceByType((void **) &glyphSet, stuff->glyphset,
                                  GlyphSetType, client, DixDestroyAccess);


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
