### PR TITLE
(master) render: use X_REQUEST_*() macros in ProcRenderCreateAnimCursor()

### DIFF
--- a/Xext/render/render.c
+++ b/Xext/render/render.c
@@ -1616,13 +1616,9 @@ SingleRenderSetPictureFilter(ClientPtr client, xRenderSetPictureFilterReq *stuff
 static int
 ProcRenderCreateAnimCursor(ClientPtr client)
 {
-    REQUEST(xRenderCreateAnimCursorReq);
-    REQUEST_AT_LEAST_SIZE(xRenderCreateAnimCursorReq);
-
-    if (client->swapped) {
-        swapl(&stuff->cid);
-        SwapRestL(stuff);
-    }
+    X_REQUEST_HEAD_AT_LEAST(xRenderCreateAnimCursorReq);
+    X_REQUEST_FIELD_CARD32(cid);
+    X_REQUEST_REST_CARD32();
 
     CARD32 *deltas;
     CursorPtr pCursor;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
