### PR TITLE
(master) render: use X_REQUEST_*() macros in ProcRenderSetPictureClipRectangles()

### DIFF
--- a/Xext/render/render.c
+++ b/Xext/render/render.c
@@ -2594,15 +2594,11 @@ ProcRenderChangePicture(ClientPtr client)
 static int
 ProcRenderSetPictureClipRectangles(ClientPtr client)
 {
-    REQUEST(xRenderSetPictureClipRectanglesReq);
-    REQUEST_AT_LEAST_SIZE(xRenderSetPictureClipRectanglesReq);
-
-    if (client->swapped) {
-        swapl(&stuff->picture);
-        swaps(&stuff->xOrigin);
-        swaps(&stuff->yOrigin);
-        SwapRestS(stuff);
-    }
+    X_REQUEST_HEAD_AT_LEAST(xRenderSetPictureClipRectanglesReq);
+    X_REQUEST_FIELD_CARD32(picture);
+    X_REQUEST_FIELD_CARD16(xOrigin);
+    X_REQUEST_FIELD_CARD16(yOrigin);
+    X_REQUEST_REST_CARD16();
 
 #ifdef XINERAMA
     return (usePanoramiX ? PanoramiXRenderSetPictureClipRectangles(client, stuff, stuff->picture)


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
