### PR TITLE
(master) render: use X_REQUEST_*() macros in ProcRenderFreePicture()

### DIFF
--- a/Xext/render/render.c
+++ b/Xext/render/render.c
@@ -2615,11 +2615,8 @@ ProcRenderSetPictureClipRectangles(ClientPtr client)
 static int
 ProcRenderFreePicture(ClientPtr client)
 {
-    REQUEST(xRenderFreePictureReq);
-    REQUEST_SIZE_MATCH(xRenderFreePictureReq);
-
-    if (client->swapped)
-        swapl(&stuff->picture);
+    X_REQUEST_HEAD_STRUCT(xRenderFreePictureReq);
+    X_REQUEST_FIELD_CARD32(picture);
 
 #ifdef XINERAMA
     return (usePanoramiX ? PanoramiXRenderFreePicture(client)


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
