### PR TITLE
(master) render: use X_REQUEST_*() macros in ProcRenderTriangles()

### DIFF
--- a/Xext/render/render.c
+++ b/Xext/render/render.c
@@ -2683,17 +2683,13 @@ ProcRenderTrapezoids(ClientPtr client)
 static int
 ProcRenderTriangles(ClientPtr client)
 {
-    REQUEST(xRenderTrianglesReq);
-    REQUEST_AT_LEAST_SIZE(xRenderTrianglesReq);
-
-    if (client->swapped) {
-        swapl(&stuff->src);
-        swapl(&stuff->dst);
-        swapl(&stuff->maskFormat);
-        swaps(&stuff->xSrc);
-        swaps(&stuff->ySrc);
-        SwapRestL(stuff);
-    }
+    X_REQUEST_HEAD_AT_LEAST(xRenderTrianglesReq);
+    X_REQUEST_FIELD_CARD32(src);
+    X_REQUEST_FIELD_CARD32(dst);
+    X_REQUEST_FIELD_CARD32(maskFormat);
+    X_REQUEST_FIELD_CARD16(xSrc);
+    X_REQUEST_FIELD_CARD16(ySrc);
+    X_REQUEST_REST_CARD32();
 
 #ifdef XINERAMA
     return (usePanoramiX ? PanoramiXRenderTriangles(client, stuff)


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
