### PR TITLE
(master) render: use X_REQUEST_*() macros in ProcRenderAddTraps()

### DIFF
--- a/Xext/render/render.c
+++ b/Xext/render/render.c
@@ -2905,15 +2905,11 @@ ProcRenderSetPictureFilter(ClientPtr client)
 static int
 ProcRenderAddTraps(ClientPtr client)
 {
-    REQUEST(xRenderAddTrapsReq);
-    REQUEST_AT_LEAST_SIZE(xRenderAddTrapsReq);
-
-    if (client->swapped) {
-        swapl(&stuff->picture);
-        swaps(&stuff->xOff);
-        swaps(&stuff->yOff);
-        SwapRestL(stuff);
-    }
+    X_REQUEST_HEAD_AT_LEAST(xRenderAddTrapsReq);
+    X_REQUEST_FIELD_CARD32(picture);
+    X_REQUEST_FIELD_CARD16(xOff);
+    X_REQUEST_FIELD_CARD16(yOff);
+    X_REQUEST_REST_CARD32();
 
 #ifdef XINERAMA
     return (usePanoramiX ? PanoramiXRenderAddTraps(client, stuff)


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
