### PR TITLE
dix/devices.c: Fix infinite loop when tearing down an X server

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -1050,9 +1050,11 @@ CloseDeviceList(DeviceIntPtr *listHead)
         return;
 
     DeviceIntPtr dev = *listHead;
+
+    /* Used to mark devices that we tried to free */
+    bool freedIds[MAXDEVICES] = { 0 };
+
     while (dev != NULL) {
-        /* Used to mark devices that we tried to free */
-        bool freedIds[MAXDEVICES] = { 0 };
         freedIds[dev->id] = TRUE;
         DeleteInputDeviceRequest(dev);
 


### PR DESCRIPTION
Fixes: https://github.com/X11Libre/xserver/commit/6d401a4d17477172a5fc72be73206690dcfe33af