### PR TITLE
modesetting: perform null check before pointer is dereferenced

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/vblank.c
+++ b/hw/xfree86/drivers/video/modesetting/vblank.c
@@ -440,12 +440,12 @@ ms_get_crtc_ust_msc(xf86CrtcPtr crtc, CARD64 *ust, CARD64 *msc)
 static void
 ms_drm_socket_handler(int fd, int ready, void *data)
 {
+    if (data == NULL)
+        return;
+
     ScreenPtr screen = data;
     ScrnInfoPtr scrn = xf86ScreenToScrn(screen);
     modesettingPtr ms = modesettingPTR(scrn);
-
-    if (data == NULL)
-        return;
 
     drmHandleEvent(fd, &ms->event_context);
 }


### PR DESCRIPTION
Reported here  https://gitlab.freedesktop.org/xorg/xserver/-/work_items/1874

The pointer is dereferenced in `xf86ScreenToScrn` before the null check

https://github.com/X11Libre/xserver/blob/a088b1629dafd2977073eaf10fb01819ec2570cb/hw/xfree86/common/xf86Helper.c#L1618-L1621