### PR TITLE
kdrive/fbdev: Add multi-screen support

### DIFF
--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -1961,7 +1961,9 @@ glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
         dri_fd = &glamor_egl->fd;
     }
 
-    if (!glamor_egl_init_display(glamor_egl, dri_fd)) {
+    if (glamor_egl_conf->display) {
+        glamor_egl->display = glamor_egl_conf->display;
+    } else if (!glamor_egl_init_display(glamor_egl, dri_fd)) {
         goto error;
     }
 

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -1567,7 +1567,9 @@ glamor_egl_pre_close_screen_cleanup(glamor_egl_priv_t *glamor_egl)
          * (on hot unplug another GPU may still be using glamor)
          */
         lastGLContext = NULL;
-        eglTerminate(glamor_egl->display);
+        if (!glamor_egl->no_display_terminate) {
+            eglTerminate(glamor_egl->display);
+        }
         glamor_egl->display = EGL_NO_DISPLAY;
     }
 
@@ -1897,6 +1899,12 @@ glamor_egl_get_fd(ScreenPtr screen)
     return glamor_egl_get_screen_private(screen)->fd;
 }
 
+void*
+glamor_egl_get_screen_display(ScreenPtr screen)
+{
+    return glamor_egl_get_screen_private(screen)->display;
+}
+
 Bool
 glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
 {
@@ -1920,6 +1928,8 @@ glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
     }
 
     memset(glamor_egl, 0, sizeof(*glamor_egl));
+
+    glamor_egl->no_display_terminate = glamor_egl_conf->no_display_terminate;
 
     if (glamor_egl_conf->glvnd_vendor) {
         glamor_egl->glvnd_vendor = glamor_egl_conf->glvnd_vendor;

--- a/glamor/glamor_egl.h
+++ b/glamor/glamor_egl.h
@@ -66,6 +66,7 @@ typedef struct {
     int es_disallowed; /* If using GLES contexts is forbidden */
     int force_es; /* If glamor should only use GLES contexts */
 
+    void* display; /* An optional initialized EGLDisplay for glamor to use */
     int no_display_terminate; /* If glamor should not terminate the EGLDisplay */
 } glamor_egl_conf_t;
 

--- a/glamor/glamor_egl.h
+++ b/glamor/glamor_egl.h
@@ -65,6 +65,8 @@ typedef struct {
 
     int es_disallowed; /* If using GLES contexts is forbidden */
     int force_es; /* If glamor should only use GLES contexts */
+
+    int no_display_terminate; /* If glamor should not terminate the EGLDisplay */
 } glamor_egl_conf_t;
 
 /**
@@ -126,5 +128,7 @@ glamor_egl_get_display(EGLint type, void *native)
 }
 
 int glamor_egl_get_fd(ScreenPtr screen);
+
+void* glamor_egl_get_screen_display(ScreenPtr screen);
 
 #endif

--- a/glamor/glamor_egl_priv.h
+++ b/glamor/glamor_egl_priv.h
@@ -37,6 +37,7 @@ typedef struct glamor_egl_screen_private {
     int fd;
     int dmabuf_capable;
     int linear_only; /* When using gbm, this means that only linear buffers can be created */
+    int no_display_terminate;
 } glamor_egl_priv_t;
 
 /**

--- a/hw/kdrive/ephyr/ephyrinit.c
+++ b/hw/kdrive/ephyr/ephyrinit.c
@@ -63,6 +63,12 @@ InitCard(char *name)
     KdCardInfoAdd(&ephyrFuncs, 0);
 }
 
+KdScreenInfo*
+NewScreen(KdCardInfo * ci)
+{
+    return KdScreenInfoAdd(ci, NULL);
+}
+
 void
 InitOutput(int argc, char **argv)
 {
@@ -155,7 +161,7 @@ processScreenOrOutputArg(const char *screen_size, const char *output, char *pare
         unsigned long p_id = 0;
         Bool use_geometry;
 
-        screen = KdScreenInfoAdd(card);
+        screen = NewScreen(card);
         KdParseScreen(screen, screen_size);
         screen->driver = calloc(1, sizeof(EphyrScrPriv));
         if (!screen->driver)

--- a/hw/kdrive/fbdev/Xfbdev.man
+++ b/hw/kdrive/fbdev/Xfbdev.man
@@ -21,6 +21,9 @@ see Xkdrive(1).
 .B Xfbdev
 also accepts the following additional options:
 .TP 8
+.B -card
+Declares a new physical device for the X server to use.
+.TP 8
 .B -fb "</dev/fbxx>"
 sets the framebuffer device path the X server will use.
 .TP 8

--- a/hw/kdrive/fbdev/fb_glamor.c
+++ b/hw/kdrive/fbdev/fb_glamor.c
@@ -24,70 +24,60 @@
 
 #include <errno.h>
 
-char *fbdev_glvnd_provider = NULL;
-char *fbdev_dri_path = NULL;
-
-bool fbdev_auto_dri3 = FALSE;
-bool fbdev_drm_master = FALSE;
-bool es_allowed = TRUE;
-bool force_es = FALSE;
-bool fbGlamorAllowed = TRUE;
-bool fbForceGlamor = FALSE;
-bool fbXVAllowed = TRUE;
-
 Bool
 fbdevInitAccel(ScreenPtr pScreen)
 {
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     FbdevScrPriv *scrpriv = screen->driver;
+    FbScreenConf *config = screen->card->closure;
 
-    if (fbdev_dri_path) {
-        scrpriv->dri_fd = open(fbdev_dri_path, O_RDWR);
+    if (config->fbdev_dri_path) {
+        scrpriv->dri_fd = open(config->fbdev_dri_path, O_RDWR);
         if (scrpriv->dri_fd >= 0) {
 #ifdef WITH_LIBDRM
-            if (fbdev_drm_master) {
+            if (config->fbdev_drm_master) {
                 drmSetMaster(scrpriv->dri_fd);
             } else {
                 drmDropMaster(scrpriv->dri_fd);
             }
 #endif
         } else {
-            LogMessage(X_WARNING, "Could not open %s: %s\n", fbdev_dri_path, strerror(errno));
+            LogMessage(X_WARNING, "Could not open %s: %s\n", config->fbdev_dri_path, strerror(errno));
         }
     } else {
         scrpriv->dri_fd = -1;
     }
 
     if (scrpriv->dri_fd >= 0) {
-        fbdev_auto_dri3 = FALSE;
+        config->fbdev_auto_dri3 = FALSE;
     }
 
     glamor_egl_conf_t glamor_egl_conf = {
                                          .screen = pScreen,
-                                         .glvnd_vendor = fbdev_glvnd_provider,
+                                         .glvnd_vendor = config->fbdev_glvnd_provider,
                                          .fd = scrpriv->dri_fd,
-                                         .auto_dri = fbdev_auto_dri3,
+                                         .auto_dri = config->fbdev_auto_dri3,
                                          .llvmpipe_allowed = TRUE,
                                          .force_glamor = TRUE,
-                                         .es_disallowed = !es_allowed,
-                                         .force_es = force_es,
+                                         .es_disallowed = !config->es_allowed,
+                                         .force_es = config->force_es,
                                         };
 
     if (!glamor_egl_init_internal(&glamor_egl_conf, NULL)) {
         return FALSE;
     }
 
-    if (fbdev_auto_dri3) {
+    if (config->fbdev_auto_dri3) {
         scrpriv->dri_fd = glamor_egl_get_fd(pScreen);
     }
 
     const char *renderer = (const char*)glGetString(GL_RENDERER);
 
     int flags = GLAMOR_USE_EGL_SCREEN;
-    if (!fbGlamorAllowed) {
+    if (!config->fbGlamorAllowed) {
         flags |= GLAMOR_NO_RENDER_ACCEL;
-    } else if (!fbForceGlamor){
+    } else if (!config->fbForceGlamor){
         if (!renderer ||
             strstr(renderer, "softpipe") ||
             strstr(renderer, "llvmpipe")) {
@@ -106,7 +96,7 @@ fbdevInitAccel(ScreenPtr pScreen)
 
 #ifdef XV
     /* X-Video needs glamor render accel */
-    if (fbXVAllowed && !(flags & GLAMOR_NO_RENDER_ACCEL)) {
+    if (config->fbXVAllowed && !(flags & GLAMOR_NO_RENDER_ACCEL)) {
         kd_glamor_xv_init(pScreen);
     }
 #endif
@@ -121,8 +111,9 @@ fbdevEnableAccel(ScreenPtr pScreen)
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     FbdevScrPriv *scrpriv = screen->driver;
+    FbScreenConf *config = screen->card->closure;
 
-    if (fbdev_drm_master && scrpriv->dri_fd >= 0) {
+    if (config->fbdev_drm_master && scrpriv->dri_fd >= 0) {
         drmSetMaster(scrpriv->dri_fd);
     }
 #endif
@@ -135,8 +126,9 @@ fbdevDisableAccel(ScreenPtr pScreen)
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     FbdevScrPriv *scrpriv = screen->driver;
+    FbScreenConf *config = screen->card->closure;
 
-    if (fbdev_drm_master && scrpriv->dri_fd >= 0) {
+    if (config->fbdev_drm_master && scrpriv->dri_fd >= 0) {
         drmDropMaster(scrpriv->dri_fd);
     }
 #endif

--- a/hw/kdrive/fbdev/fb_glamor.c
+++ b/hw/kdrive/fbdev/fb_glamor.c
@@ -63,6 +63,7 @@ fbdevInitAccel(ScreenPtr pScreen)
                                          .force_glamor = TRUE,
                                          .es_disallowed = !config->es_allowed,
                                          .force_es = config->force_es,
+                                         .display = priv->display,
                                          .no_display_terminate = TRUE,
                                         };
 
@@ -103,7 +104,9 @@ fbdevInitAccel(ScreenPtr pScreen)
     }
 #endif
 
-    priv->display = glamor_egl_get_screen_display(pScreen);
+    if (!priv->display) {
+        priv->display = glamor_egl_get_screen_display(pScreen);
+    }
 
     return TRUE;
 }

--- a/hw/kdrive/fbdev/fb_glamor.c
+++ b/hw/kdrive/fbdev/fb_glamor.c
@@ -31,6 +31,7 @@ fbdevInitAccel(ScreenPtr pScreen)
     KdScreenInfo *screen = pScreenPriv->screen;
     FbdevScrPriv *scrpriv = screen->driver;
     FbCardConf *config = screen->card->closure;
+    FbdevPriv *priv = screen->card->driver;
 
     if (config->fbdev_dri_path) {
         scrpriv->dri_fd = open(config->fbdev_dri_path, O_RDWR);
@@ -62,6 +63,7 @@ fbdevInitAccel(ScreenPtr pScreen)
                                          .force_glamor = TRUE,
                                          .es_disallowed = !config->es_allowed,
                                          .force_es = config->force_es,
+                                         .no_display_terminate = TRUE,
                                         };
 
     if (!glamor_egl_init_internal(&glamor_egl_conf, NULL)) {
@@ -100,6 +102,8 @@ fbdevInitAccel(ScreenPtr pScreen)
         kd_glamor_xv_init(pScreen);
     }
 #endif
+
+    priv->display = glamor_egl_get_screen_display(pScreen);
 
     return TRUE;
 }
@@ -143,5 +147,19 @@ fbdevFiniAccel(ScreenPtr pScreen)
 
     if (scrpriv->dri_fd >= 0) {
         close(scrpriv->dri_fd);
+    }
+}
+
+void
+fbdevFiniCardAccel(KdCardInfo * card)
+{
+    /**
+     * Due to global state tracking in egl,
+     * we need to terminate the display for a card exactly once
+     */
+    FbdevPriv *priv = card->driver;
+    if (priv->display != EGL_NO_DISPLAY) {
+        eglTerminate(priv->display);
+        priv->display = EGL_NO_DISPLAY;
     }
 }

--- a/hw/kdrive/fbdev/fb_glamor.c
+++ b/hw/kdrive/fbdev/fb_glamor.c
@@ -30,7 +30,7 @@ fbdevInitAccel(ScreenPtr pScreen)
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     FbdevScrPriv *scrpriv = screen->driver;
-    FbCardConf *config = screen->card->closure;
+    FbScreenConf *config = screen->closure;
     FbdevPriv *priv = screen->card->driver;
 
     if (config->fbdev_dri_path) {
@@ -115,7 +115,7 @@ fbdevEnableAccel(ScreenPtr pScreen)
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     FbdevScrPriv *scrpriv = screen->driver;
-    FbCardConf *config = screen->card->closure;
+    FbScreenConf *config = screen->closure;
 
     if (config->fbdev_drm_master && scrpriv->dri_fd >= 0) {
         drmSetMaster(scrpriv->dri_fd);
@@ -130,7 +130,7 @@ fbdevDisableAccel(ScreenPtr pScreen)
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     FbdevScrPriv *scrpriv = screen->driver;
-    FbCardConf *config = screen->card->closure;
+    FbScreenConf *config = screen->closure;
 
     if (config->fbdev_drm_master && scrpriv->dri_fd >= 0) {
         drmDropMaster(scrpriv->dri_fd);

--- a/hw/kdrive/fbdev/fb_glamor.c
+++ b/hw/kdrive/fbdev/fb_glamor.c
@@ -30,7 +30,7 @@ fbdevInitAccel(ScreenPtr pScreen)
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     FbdevScrPriv *scrpriv = screen->driver;
-    FbScreenConf *config = screen->card->closure;
+    FbCardConf *config = screen->card->closure;
 
     if (config->fbdev_dri_path) {
         scrpriv->dri_fd = open(config->fbdev_dri_path, O_RDWR);
@@ -111,7 +111,7 @@ fbdevEnableAccel(ScreenPtr pScreen)
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     FbdevScrPriv *scrpriv = screen->driver;
-    FbScreenConf *config = screen->card->closure;
+    FbCardConf *config = screen->card->closure;
 
     if (config->fbdev_drm_master && scrpriv->dri_fd >= 0) {
         drmSetMaster(scrpriv->dri_fd);
@@ -126,7 +126,7 @@ fbdevDisableAccel(ScreenPtr pScreen)
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     FbdevScrPriv *scrpriv = screen->driver;
-    FbScreenConf *config = screen->card->closure;
+    FbCardConf *config = screen->card->closure;
 
     if (config->fbdev_drm_master && scrpriv->dri_fd >= 0) {
         drmDropMaster(scrpriv->dri_fd);

--- a/hw/kdrive/fbdev/fbdev.c
+++ b/hw/kdrive/fbdev/fbdev.c
@@ -364,7 +364,7 @@ fbdevMapFramebuffer(KdScreenInfo * screen)
     FbdevScrPriv *scrpriv = screen->driver;
     KdPointerMatrix m;
     FbdevPriv *priv = screen->card->driver;
-    FbCardConf *config = screen->card->closure;
+    FbScreenConf *config = screen->closure;
 
     if (!config->fbDisableShadow) {
         scrpriv->shadow = TRUE;

--- a/hw/kdrive/fbdev/fbdev.c
+++ b/hw/kdrive/fbdev/fbdev.c
@@ -34,7 +34,7 @@ static Bool
 fbdevInitialize(KdCardInfo * card, FbdevPriv * priv)
 {
     unsigned long off;
-    FbScreenConf *config = card->closure;
+    FbCardConf *config = card->closure;
 
     if (config->fbdevDevicePath) {
         priv->fd = open(config->fbdevDevicePath, O_RDWR);
@@ -364,7 +364,7 @@ fbdevMapFramebuffer(KdScreenInfo * screen)
     FbdevScrPriv *scrpriv = screen->driver;
     KdPointerMatrix m;
     FbdevPriv *priv = screen->card->driver;
-    FbScreenConf *config = screen->card->closure;
+    FbCardConf *config = screen->card->closure;
 
     if (!config->fbDisableShadow) {
         scrpriv->shadow = TRUE;

--- a/hw/kdrive/fbdev/fbdev.c
+++ b/hw/kdrive/fbdev/fbdev.c
@@ -30,19 +30,17 @@
 
 #include "fbdev.h"
 
-const char *fbdevDevicePath = NULL;
-Bool fbDisableShadow = FALSE;
-
 static Bool
 fbdevInitialize(KdCardInfo * card, FbdevPriv * priv)
 {
     unsigned long off;
+    FbScreenConf *config = card->closure;
 
-    if (fbdevDevicePath) {
-        priv->fd = open(fbdevDevicePath, O_RDWR);
+    if (config->fbdevDevicePath) {
+        priv->fd = open(config->fbdevDevicePath, O_RDWR);
         if (priv->fd < 0) {
             ErrorF("Error opening framebuffer %s: %s\n",
-                   fbdevDevicePath, strerror(errno));
+                   config->fbdevDevicePath, strerror(errno));
             return FALSE;
         }
     } else {
@@ -366,8 +364,9 @@ fbdevMapFramebuffer(KdScreenInfo * screen)
     FbdevScrPriv *scrpriv = screen->driver;
     KdPointerMatrix m;
     FbdevPriv *priv = screen->card->driver;
+    FbScreenConf *config = screen->card->closure;
 
-    if (!fbDisableShadow) {
+    if (!config->fbDisableShadow) {
         scrpriv->shadow = TRUE;
     } else if (scrpriv->randr != RR_Rotate_0 ||
         priv->fix.type != FB_TYPE_PACKED_PIXELS) {
@@ -852,6 +851,10 @@ fbdevCardFini(KdCardInfo * card)
     munmap(priv->fb_base, priv->fix.smem_len);
     close(priv->fd);
     free(priv);
+    card->driver = NULL;
+
+    free(card->closure);
+    card->closure = NULL;
 }
 
 /*

--- a/hw/kdrive/fbdev/fbdev.c
+++ b/hw/kdrive/fbdev/fbdev.c
@@ -846,6 +846,10 @@ fbdevScreenFini(KdScreenInfo * screen)
 void
 fbdevCardFini(KdCardInfo * card)
 {
+#ifdef GLAMOR
+    fbdevFiniCardAccel(card);
+#endif
+
     FbdevPriv *priv = card->driver;
 
     munmap(priv->fb_base, priv->fix.smem_len);

--- a/hw/kdrive/fbdev/fbdev.h
+++ b/hw/kdrive/fbdev/fbdev.h
@@ -52,7 +52,7 @@ typedef struct _fbdevScrPriv {
 #endif
 } FbdevScrPriv;
 
-typedef struct _fbScreenConf {
+typedef struct _fbCardConf {
 const char *fbdevDevicePath;
 Bool fbDisableShadow;
 
@@ -72,7 +72,7 @@ bool fbForceGlamor;
 bool fbXVAllowed;
 #endif
 #endif
-} FbScreenConf;
+} FbCardConf;
 
 extern KdCardFuncs fbdevFuncs;
 

--- a/hw/kdrive/fbdev/fbdev.h
+++ b/hw/kdrive/fbdev/fbdev.h
@@ -42,6 +42,9 @@ typedef struct _fbdevPriv {
     int fd;
     char *fb;
     char *fb_base;
+#ifdef GLAMOR
+    void* display;
+#endif
 } FbdevPriv;
 
 typedef struct _fbdevScrPriv {
@@ -114,6 +117,8 @@ void fbdevEnableAccel(ScreenPtr screen);
 void fbdevDisableAccel(ScreenPtr screen);
 
 void fbdevFiniAccel(ScreenPtr screen);
+
+void fbdevFiniCardAccel(KdCardInfo * card);
 #endif
 
 #endif                          /* _KDRIVE_FBDEV_H_ */

--- a/hw/kdrive/fbdev/fbdev.h
+++ b/hw/kdrive/fbdev/fbdev.h
@@ -52,23 +52,29 @@ typedef struct _fbdevScrPriv {
 #endif
 } FbdevScrPriv;
 
-extern KdCardFuncs fbdevFuncs;
-extern const char *fbdevDevicePath;
-extern Bool fbDisableShadow;
+typedef struct _fbScreenConf {
+const char *fbdevDevicePath;
+Bool fbDisableShadow;
 
 #ifdef GLAMOR
-extern char *fbdev_glvnd_provider;
-extern char *fbdev_dri_path;
-extern bool fbdev_auto_dri3;
-extern bool fbdev_drm_master;
-extern bool es_allowed;
-extern bool force_es;
-extern bool fbGlamorAllowed;
-extern bool fbForceGlamor;
+char *fbdev_glvnd_provider;
+
+char *fbdev_dri_path;
+bool fbdev_auto_dri3;
+bool fbdev_drm_master;
+
+bool es_allowed;
+bool force_es;
+
+bool fbGlamorAllowed;
+bool fbForceGlamor;
 #ifdef XV
-extern bool fbXVAllowed;
+bool fbXVAllowed;
 #endif
 #endif
+} FbScreenConf;
+
+extern KdCardFuncs fbdevFuncs;
 
 Bool fbdevCardInit(KdCardInfo * card);
 

--- a/hw/kdrive/fbdev/fbdev.h
+++ b/hw/kdrive/fbdev/fbdev.h
@@ -56,26 +56,29 @@ typedef struct _fbdevScrPriv {
 } FbdevScrPriv;
 
 typedef struct _fbCardConf {
-const char *fbdevDevicePath;
-Bool fbDisableShadow;
+    const char *fbdevDevicePath;
+} FbCardConf;
+
+typedef struct _fbScreenConf {
+    Bool fbDisableShadow;
 
 #ifdef GLAMOR
-char *fbdev_glvnd_provider;
+    char *fbdev_glvnd_provider;
 
-char *fbdev_dri_path;
-bool fbdev_auto_dri3;
-bool fbdev_drm_master;
+    char *fbdev_dri_path;
+    bool fbdev_auto_dri3;
+    bool fbdev_drm_master;
 
-bool es_allowed;
-bool force_es;
+    bool es_allowed;
+    bool force_es;
 
-bool fbGlamorAllowed;
-bool fbForceGlamor;
+    bool fbGlamorAllowed;
+    bool fbForceGlamor;
 #ifdef XV
-bool fbXVAllowed;
+    bool fbXVAllowed;
 #endif
 #endif
-} FbCardConf;
+} FbScreenConf;
 
 extern KdCardFuncs fbdevFuncs;
 

--- a/hw/kdrive/fbdev/fbinit.c
+++ b/hw/kdrive/fbdev/fbinit.c
@@ -28,13 +28,13 @@
 
 #include <string.h>
 
-static FbScreenConf *fbCurrScreen = NULL;
+static FbCardConf *fbCurrCard = NULL;
 
 void
 InitCard(char *name)
 {
-    fbCurrScreen = XNFalloc(sizeof(*fbCurrScreen));
-    *fbCurrScreen = (FbScreenConf) {
+    fbCurrCard = XNFalloc(sizeof(*fbCurrCard));
+    *fbCurrCard = (FbCardConf) {
                                     .fbdevDevicePath = NULL,
                                     .fbDisableShadow = FALSE,
 #ifdef GLAMOR
@@ -55,7 +55,7 @@ InitCard(char *name)
 #endif
                                    };
 
-    KdCardInfoAdd(&fbdevFuncs, fbCurrScreen);
+    KdCardInfoAdd(&fbdevFuncs, fbCurrCard);
 }
 
 #if INPUTTHREAD
@@ -93,6 +93,8 @@ ddxUseMsg(void)
     KdUseMsg();
     ErrorF("\nXfbdev Device Usage:\n");
     ErrorF
+        ("-card                Declare a new card for the X server to parse\n");
+    ErrorF
         ("-fb <path>           Framebuffer device to use. Defaults to /dev/fb0\n");
     ErrorF
         ("-dri [path|auto]     Optional drm device path to use\n");
@@ -118,21 +120,24 @@ ddxUseMsg(void)
 int
 ddxProcessArgument(int argc, char **argv, int i)
 {
-    if (!fbCurrScreen || !strcmp(argv[i], "-screen")) {
-        /* Put each screen on a separate card */
-        int implicit_first_screen = !fbCurrScreen;
+    if (!fbCurrCard && argv[i][0] == '-' &&
+        strcmp(argv[i], "-card")) {
         InitCard(NULL);
-        if (implicit_first_screen) {
-            /* This is what KdInitOutput would have done */
-            KdCardInfo *card = KdCardInfoLast();
-            KdScreenInfo *screen = KdScreenInfoAdd(card);
-            KdParseScreen(screen, NULL);
-        }
+
+        /* This is what KdInitOutput would have done */
+        KdCardInfo *card = KdCardInfoLast();
+        KdScreenInfo *screen = KdScreenInfoAdd(card);
+        KdParseScreen(screen, NULL);
+    } else if (!strcmp(argv[i], "-card")) {
+        InitCard(NULL);
+
+        /* a -screen option must follow before the next -card option */
+        return 1;
     }
 
     if (!strcmp(argv[i], "-fb")) {
         if (i + 1 < argc) {
-            fbCurrScreen->fbdevDevicePath = argv[i + 1];
+            fbCurrCard->fbdevDevicePath = argv[i + 1];
             return 2;
         }
         UseMsg();
@@ -140,24 +145,24 @@ ddxProcessArgument(int argc, char **argv, int i)
     }
 
     if (!strcmp(argv[i], "-noshadow")) {
-        fbCurrScreen->fbDisableShadow = TRUE;
+        fbCurrCard->fbDisableShadow = TRUE;
         return 1;
     }
 
 #ifdef GLAMOR
     if (!strcmp(argv[i], "-glamor")) {
-        fbCurrScreen->fbForceGlamor = TRUE;
+        fbCurrCard->fbForceGlamor = TRUE;
         return 1;
     }
 
     if (!strcmp(argv[i], "-noglamor")) {
-        fbCurrScreen->fbGlamorAllowed = FALSE;
+        fbCurrCard->fbGlamorAllowed = FALSE;
         return 1;
     }
 
     if (!strcmp(argv[i], "-glvendor")) {
         if (i + 1 < argc) {
-            fbCurrScreen->fbdev_glvnd_provider = strdup(argv[i + 1]);
+            fbCurrCard->fbdev_glvnd_provider = strdup(argv[i + 1]);
             return 2;
         }
         UseMsg();
@@ -167,35 +172,35 @@ ddxProcessArgument(int argc, char **argv, int i)
     if (!strcmp(argv[i], "-dri")) {
         if (i + 1 < argc) {
             if (argv[i + 1][0] == '-' || !strcmp(argv[i + 1], "auto")) {
-                fbCurrScreen->fbdev_auto_dri3 = TRUE;
+                fbCurrCard->fbdev_auto_dri3 = TRUE;
             } else {
-                fbCurrScreen->fbdev_dri_path = strdup(argv[i + 1]);
+                fbCurrCard->fbdev_dri_path = strdup(argv[i + 1]);
             }
             return 2;
         } else {
-            fbCurrScreen->fbdev_auto_dri3 = TRUE;
+            fbCurrCard->fbdev_auto_dri3 = TRUE;
             return 1;
         }
     }
 
     if (!strcmp(argv[i], "-drm-master")) {
-        fbCurrScreen->fbdev_drm_master = TRUE;
+        fbCurrCard->fbdev_drm_master = TRUE;
         return 1;
     }
 
     if (!strcmp(argv[i], "-force-gl")) {
-        fbCurrScreen->es_allowed = FALSE;
+        fbCurrCard->es_allowed = FALSE;
         return 1;
     }
 
     if (!strcmp(argv[i], "-force-es")) {
-        fbCurrScreen->force_es = TRUE;
+        fbCurrCard->force_es = TRUE;
         return 1;
     }
 
 #ifdef XV
     if (!strcmp(argv[i], "-noxv")) {
-        fbCurrScreen->fbXVAllowed = FALSE;
+        fbCurrCard->fbXVAllowed = FALSE;
         return 1;
     }
 #endif

--- a/hw/kdrive/fbdev/fbinit.c
+++ b/hw/kdrive/fbdev/fbinit.c
@@ -29,13 +29,24 @@
 #include <string.h>
 
 static FbCardConf *fbCurrCard = NULL;
+static FbScreenConf *fbCurrScreen = NULL;
 
 void
 InitCard(char *name)
 {
     fbCurrCard = XNFalloc(sizeof(*fbCurrCard));
     *fbCurrCard = (FbCardConf) {
-                                    .fbdevDevicePath = NULL,
+                                .fbdevDevicePath = NULL,
+                               };
+
+    KdCardInfoAdd(&fbdevFuncs, fbCurrCard);
+}
+
+KdScreenInfo*
+NewScreen(KdCardInfo * ci)
+{
+    fbCurrScreen = XNFalloc(sizeof(*fbCurrScreen));
+    *fbCurrScreen = (FbScreenConf) {
                                     .fbDisableShadow = FALSE,
 #ifdef GLAMOR
                                     .fbdev_glvnd_provider = NULL,
@@ -55,7 +66,8 @@ InitCard(char *name)
 #endif
                                    };
 
-    KdCardInfoAdd(&fbdevFuncs, fbCurrCard);
+
+    return KdScreenInfoAdd(ci, fbCurrScreen);
 }
 
 #if INPUTTHREAD
@@ -126,7 +138,7 @@ ddxProcessArgument(int argc, char **argv, int i)
 
         /* This is what KdInitOutput would have done */
         KdCardInfo *card = KdCardInfoLast();
-        KdScreenInfo *screen = KdScreenInfoAdd(card);
+        KdScreenInfo *screen = NewScreen(card);
         KdParseScreen(screen, NULL);
     } else if (!strcmp(argv[i], "-card")) {
         InitCard(NULL);
@@ -145,24 +157,24 @@ ddxProcessArgument(int argc, char **argv, int i)
     }
 
     if (!strcmp(argv[i], "-noshadow")) {
-        fbCurrCard->fbDisableShadow = TRUE;
+        fbCurrScreen->fbDisableShadow = TRUE;
         return 1;
     }
 
 #ifdef GLAMOR
     if (!strcmp(argv[i], "-glamor")) {
-        fbCurrCard->fbForceGlamor = TRUE;
+        fbCurrScreen->fbForceGlamor = TRUE;
         return 1;
     }
 
     if (!strcmp(argv[i], "-noglamor")) {
-        fbCurrCard->fbGlamorAllowed = FALSE;
+        fbCurrScreen->fbGlamorAllowed = FALSE;
         return 1;
     }
 
     if (!strcmp(argv[i], "-glvendor")) {
         if (i + 1 < argc) {
-            fbCurrCard->fbdev_glvnd_provider = strdup(argv[i + 1]);
+            fbCurrScreen->fbdev_glvnd_provider = strdup(argv[i + 1]);
             return 2;
         }
         UseMsg();
@@ -172,35 +184,35 @@ ddxProcessArgument(int argc, char **argv, int i)
     if (!strcmp(argv[i], "-dri")) {
         if (i + 1 < argc) {
             if (argv[i + 1][0] == '-' || !strcmp(argv[i + 1], "auto")) {
-                fbCurrCard->fbdev_auto_dri3 = TRUE;
+                fbCurrScreen->fbdev_auto_dri3 = TRUE;
             } else {
-                fbCurrCard->fbdev_dri_path = strdup(argv[i + 1]);
+                fbCurrScreen->fbdev_dri_path = strdup(argv[i + 1]);
             }
             return 2;
         } else {
-            fbCurrCard->fbdev_auto_dri3 = TRUE;
+            fbCurrScreen->fbdev_auto_dri3 = TRUE;
             return 1;
         }
     }
 
     if (!strcmp(argv[i], "-drm-master")) {
-        fbCurrCard->fbdev_drm_master = TRUE;
+        fbCurrScreen->fbdev_drm_master = TRUE;
         return 1;
     }
 
     if (!strcmp(argv[i], "-force-gl")) {
-        fbCurrCard->es_allowed = FALSE;
+        fbCurrScreen->es_allowed = FALSE;
         return 1;
     }
 
     if (!strcmp(argv[i], "-force-es")) {
-        fbCurrCard->force_es = TRUE;
+        fbCurrScreen->force_es = TRUE;
         return 1;
     }
 
 #ifdef XV
     if (!strcmp(argv[i], "-noxv")) {
-        fbCurrCard->fbXVAllowed = FALSE;
+        fbCurrScreen->fbXVAllowed = FALSE;
         return 1;
     }
 #endif

--- a/hw/kdrive/fbdev/fbinit.c
+++ b/hw/kdrive/fbdev/fbinit.c
@@ -28,10 +28,34 @@
 
 #include <string.h>
 
+static FbScreenConf *fbCurrScreen = NULL;
+
 void
 InitCard(char *name)
 {
-    KdCardInfoAdd(&fbdevFuncs, 0);
+    fbCurrScreen = XNFalloc(sizeof(*fbCurrScreen));
+    *fbCurrScreen = (FbScreenConf) {
+                                    .fbdevDevicePath = NULL,
+                                    .fbDisableShadow = FALSE,
+#ifdef GLAMOR
+                                    .fbdev_glvnd_provider = NULL,
+
+                                    .fbdev_dri_path = NULL,
+                                    .fbdev_auto_dri3 = FALSE,
+                                    .fbdev_drm_master = FALSE,
+
+                                    .es_allowed = TRUE,
+                                    .force_es = FALSE,
+
+                                    .fbGlamorAllowed = TRUE,
+                                    .fbForceGlamor = FALSE,
+#ifdef XV
+                                    .fbXVAllowed = TRUE,
+#endif
+#endif
+                                   };
+
+    KdCardInfoAdd(&fbdevFuncs, fbCurrScreen);
 }
 
 #if INPUTTHREAD
@@ -94,9 +118,21 @@ ddxUseMsg(void)
 int
 ddxProcessArgument(int argc, char **argv, int i)
 {
+    if (!fbCurrScreen || !strcmp(argv[i], "-screen")) {
+        /* Put each screen on a separate card */
+        int implicit_first_screen = !fbCurrScreen;
+        InitCard(NULL);
+        if (implicit_first_screen) {
+            /* This is what KdInitOutput would have done */
+            KdCardInfo *card = KdCardInfoLast();
+            KdScreenInfo *screen = KdScreenInfoAdd(card);
+            KdParseScreen(screen, NULL);
+        }
+    }
+
     if (!strcmp(argv[i], "-fb")) {
         if (i + 1 < argc) {
-            fbdevDevicePath = argv[i + 1];
+            fbCurrScreen->fbdevDevicePath = argv[i + 1];
             return 2;
         }
         UseMsg();
@@ -104,24 +140,24 @@ ddxProcessArgument(int argc, char **argv, int i)
     }
 
     if (!strcmp(argv[i], "-noshadow")) {
-        fbDisableShadow = TRUE;
+        fbCurrScreen->fbDisableShadow = TRUE;
         return 1;
     }
 
 #ifdef GLAMOR
     if (!strcmp(argv[i], "-glamor")) {
-        fbForceGlamor = TRUE;
+        fbCurrScreen->fbForceGlamor = TRUE;
         return 1;
     }
 
     if (!strcmp(argv[i], "-noglamor")) {
-        fbGlamorAllowed = FALSE;
+        fbCurrScreen->fbGlamorAllowed = FALSE;
         return 1;
     }
 
     if (!strcmp(argv[i], "-glvendor")) {
         if (i + 1 < argc) {
-            fbdev_glvnd_provider = strdup(argv[i + 1]);
+            fbCurrScreen->fbdev_glvnd_provider = strdup(argv[i + 1]);
             return 2;
         }
         UseMsg();
@@ -131,35 +167,35 @@ ddxProcessArgument(int argc, char **argv, int i)
     if (!strcmp(argv[i], "-dri")) {
         if (i + 1 < argc) {
             if (argv[i + 1][0] == '-' || !strcmp(argv[i + 1], "auto")) {
-                fbdev_auto_dri3 = TRUE;
+                fbCurrScreen->fbdev_auto_dri3 = TRUE;
             } else {
-                fbdev_dri_path = strdup(argv[i + 1]);
+                fbCurrScreen->fbdev_dri_path = strdup(argv[i + 1]);
             }
             return 2;
         } else {
-            fbdev_auto_dri3 = TRUE;
+            fbCurrScreen->fbdev_auto_dri3 = TRUE;
             return 1;
         }
     }
 
     if (!strcmp(argv[i], "-drm-master")) {
-        fbdev_drm_master = TRUE;
+        fbCurrScreen->fbdev_drm_master = TRUE;
         return 1;
     }
 
     if (!strcmp(argv[i], "-force-gl")) {
-        es_allowed = FALSE;
+        fbCurrScreen->es_allowed = FALSE;
         return 1;
     }
 
     if (!strcmp(argv[i], "-force-es")) {
-        force_es = TRUE;
+        fbCurrScreen->force_es = TRUE;
         return 1;
     }
 
 #ifdef XV
     if (!strcmp(argv[i], "-noxv")) {
-        fbXVAllowed = FALSE;
+        fbCurrScreen->fbXVAllowed = FALSE;
         return 1;
     }
 #endif

--- a/hw/kdrive/linux/linux.c
+++ b/hw/kdrive/linux/linux.c
@@ -195,7 +195,7 @@ LinuxApmNotify(int fd, int mask, void *blockData)
         LinuxApmRunning = TRUE;
     }
     else if (!running && LinuxApmRunning) {
-        KdSuspend();
+        KdSuspend(FALSE);
         LinuxApmRunning = FALSE;
         ioctl(fd, cmd, 0);
     }

--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -485,7 +485,7 @@ KdProcessArgument(int argc, char **argv, int i)
                 card = KdCardInfoLast();
             }
             if (card) {
-                screen = KdScreenInfoAdd(card);
+                screen = NewScreen(card);
                 KdParseScreen(screen, argv[i + 1]);
             }
             else
@@ -1106,7 +1106,7 @@ KdInitOutput(int argc, char **argv)
         InitCard(0);
         if (!(card = KdCardInfoLast()))
             FatalError("No matching cards found!\n");
-        screen = KdScreenInfoAdd(card);
+        screen = NewScreen(card);
         KdParseScreen(screen, 0);
     }
     /*

--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -150,7 +150,7 @@ KdDoSwitchCmd(const char *reason)
     }
 }
 
-void KdSuspend(void)
+void KdSuspend(int ddxAbort)
 {
     KdCardInfo *card;
     KdScreenInfo *screen;
@@ -163,14 +163,16 @@ void KdSuspend(void)
             if (card->driver && card->cfuncs->restore)
                 (*card->cfuncs->restore) (card);
         }
-        KdDisableInput();
+        if (!ddxAbort) {
+            KdDisableInput();
+        }
         KdDoSwitchCmd("suspend");
     }
 }
 
-void KdDisableScreens(void)
+void KdDisableScreens(int ddxAbort)
 {
-    KdSuspend();
+    KdSuspend(ddxAbort);
     if (kdEnabled && (kdOsFuncs->Disable))
         kdOsFuncs->Disable();
     kdEnabled = FALSE;
@@ -236,7 +238,7 @@ void
 KdProcessSwitch(void)
 {
     if (kdEnabled)
-        KdDisableScreens();
+        KdDisableScreens(FALSE);
     else
         KdEnableScreens();
 }
@@ -244,7 +246,7 @@ KdProcessSwitch(void)
 static void
 AbortDDX(enum ExitCode error)
 {
-    KdDisableScreens();
+    KdDisableScreens(TRUE);
     if (kdOsFuncs) {
         if (kdEnabled && kdOsFuncs->Disable)
             (*kdOsFuncs->Disable) ();

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -380,14 +380,14 @@ void KdSetColormap(ScreenPtr pScreen);
 /* kdrive.c */
 extern miPointerScreenFuncRec kdPointerScreenFuncs;
 
-void KdSuspend(void);
+void KdSuspend(int ddxAbort);
 
 void KdInitScreen(KdScreenInfo * screen, int argc, char **argv);
 
 void
  KdDisableScreen(ScreenPtr pScreen);
 
-void KdDisableScreens(void);
+void KdDisableScreens(int ddxAbort);
 
 Bool
  KdEnableScreen(ScreenPtr pScreen);

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -91,6 +91,7 @@ typedef struct _KdScreenInfo {
     KdCardInfo *card;
     ScreenPtr pScreen;
     void *driver;
+    void *closure;
     Rotation randr;             /* rotation and reflection */
     int x;
     int y;
@@ -459,7 +460,7 @@ KdCardInfo *KdCardInfoLast(void);
 void
  KdCardInfoDispose(KdCardInfo * ci);
 
-KdScreenInfo *KdScreenInfoAdd(KdCardInfo * ci);
+KdScreenInfo *KdScreenInfoAdd(KdCardInfo * ci, void* closure);
 
 void
  KdScreenInfoDispose(KdScreenInfo * si);
@@ -567,6 +568,9 @@ void
 /* function prototypes to be implemented by the drivers */
 void
  InitCard(char *name);
+
+KdScreenInfo*
+ NewScreen(KdCardInfo * ci);
 
 Bool KdCloseScreen(ScreenPtr pScreen);
 

--- a/hw/kdrive/src/kinfo.c
+++ b/hw/kdrive/src/kinfo.c
@@ -68,7 +68,7 @@ KdCardInfoDispose(KdCardInfo * ci)
 }
 
 KdScreenInfo *
-KdScreenInfoAdd(KdCardInfo * ci)
+KdScreenInfoAdd(KdCardInfo * ci, void* closure)
 {
     KdScreenInfo *si, **prev;
     int n;
@@ -78,6 +78,7 @@ KdScreenInfoAdd(KdCardInfo * ci)
         return 0;
     for (prev = &ci->screenList, n = 0; *prev; prev = &(*prev)->next, n++);
     *prev = si;
+    si->closure = closure;
     si->next = 0;
     si->card = ci;
     si->mynum = n;


### PR DESCRIPTION
We were storing all the per-screen state in global variables, meaning that all screens had the same values for all these globals.

This made multi-screen support almost useless.

With this, usable multi-screen support is available in Xfbdev.