### PR TITLE
kdrive/fbdev: Add multi-screen support

### DIFF
--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -63,6 +63,75 @@
 #include "glamor_glx_provider.h"
 #include "dri3.h"
 
+/**
+ * EGLDeviceEXT's are internally stored as a globals.
+ * As such, when multiple screens query the same device,
+ * they end up with the same exact pointer value for the device.
+ *
+ * Then, per the spec, eglGetPlatformDisplayEXT returns the
+ * same EGLDisplay handle.
+ *
+ * This is a problem, because on teardown, each screen
+ * destroys it's EGLDevice, and since it can be shared by
+ * multiple screens, we risk destroying the display from under it.
+ *
+ * See: https://github.com/X11Libre/xserver/pull/2721
+ */
+
+typedef struct _freeDisplayList{
+    EGLDisplay dpy;
+    struct _freeDisplayList *next;
+} FreeDisplayList;
+
+static FreeDisplayList *freeDisplayList = NULL;
+
+static void
+glamor_egl_add_display_to_list(EGLDisplay dpy)
+{
+    if (dpy == EGL_NO_DISPLAY) {
+        return;
+    }
+
+    FreeDisplayList **ptr = &freeDisplayList;
+    while (*ptr) {
+        ptr = &(*ptr)->next;
+    }
+
+    *ptr = XNFalloc(sizeof(**ptr));
+    (*ptr)->dpy = dpy;
+    (*ptr)->next = NULL;
+}
+
+static void
+glamor_egl_destroy_display(EGLDisplay dpy)
+{
+    int num_found = 0;
+
+    if (dpy == EGL_NO_DISPLAY) {
+        return;
+    }
+
+    FreeDisplayList **ptr = &freeDisplayList;
+    while (*ptr) {
+        if ((*ptr)->dpy == dpy) {
+            num_found++;
+            if (num_found == 1) {
+                /* We found it once, remove it from the list */
+                *ptr = (*ptr)->next;
+                continue;
+            } else {
+                /* We found it more than once, stop searching */
+                break;
+            }
+        }
+        ptr = &(*ptr)->next;
+    }
+
+    if (num_found == 1) {
+        eglTerminate(dpy);
+    }
+}
+
 static DevPrivateKeyRec glamor_egl_screen_private_key;
 
 static inline Bool
@@ -1567,7 +1636,7 @@ glamor_egl_pre_close_screen_cleanup(glamor_egl_priv_t *glamor_egl)
          * (on hot unplug another GPU may still be using glamor)
          */
         lastGLContext = NULL;
-        eglTerminate(glamor_egl->display);
+        glamor_egl_destroy_display(glamor_egl->display);
         glamor_egl->display = EGL_NO_DISPLAY;
     }
 
@@ -1801,6 +1870,7 @@ glamor_egl_init_display(glamor_egl_priv_t *glamor_egl, int *dri_fd)
      */
 #define GLAMOR_EGL_TRY_PLATFORM(platform, native, platform_fallback) \
     glamor_egl->display = glamor_egl_get_display2(platform, native, platform_fallback); \
+    glamor_egl_add_display_to_list(glamor_egl->display); \
     if (glamor_egl->display == EGL_NO_DISPLAY) { \
         LogMessage(X_ERROR, "glamor: eglGetDisplay(" #platform ", " #native ") failed\n"); \
     } else { \
@@ -1816,7 +1886,7 @@ glamor_egl_init_display(glamor_egl_priv_t *glamor_egl, int *dri_fd)
             return TRUE; \
         } \
         LogMessage(X_ERROR, "glamor: eglInitialize() failed on " #platform "\n"); \
-        eglTerminate(glamor_egl->display); \
+        glamor_egl_destroy_display(glamor_egl->display); \
         glamor_egl->display = EGL_NO_DISPLAY; \
     }
 

--- a/hw/kdrive/fbdev/fb_glamor.c
+++ b/hw/kdrive/fbdev/fb_glamor.c
@@ -24,70 +24,60 @@
 
 #include <errno.h>
 
-char *fbdev_glvnd_provider = NULL;
-char *fbdev_dri_path = NULL;
-
-bool fbdev_auto_dri3 = FALSE;
-bool fbdev_drm_master = FALSE;
-bool es_allowed = TRUE;
-bool force_es = FALSE;
-bool fbGlamorAllowed = TRUE;
-bool fbForceGlamor = FALSE;
-bool fbXVAllowed = TRUE;
-
 Bool
 fbdevInitAccel(ScreenPtr pScreen)
 {
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     FbdevScrPriv *scrpriv = screen->driver;
+    FbScreenConf *config = screen->card->closure;
 
-    if (fbdev_dri_path) {
-        scrpriv->dri_fd = open(fbdev_dri_path, O_RDWR);
+    if (config->fbdev_dri_path) {
+        scrpriv->dri_fd = open(config->fbdev_dri_path, O_RDWR);
         if (scrpriv->dri_fd >= 0) {
 #ifdef WITH_LIBDRM
-            if (fbdev_drm_master) {
+            if (config->fbdev_drm_master) {
                 drmSetMaster(scrpriv->dri_fd);
             } else {
                 drmDropMaster(scrpriv->dri_fd);
             }
 #endif
         } else {
-            LogMessage(X_WARNING, "Could not open %s: %s\n", fbdev_dri_path, strerror(errno));
+            LogMessage(X_WARNING, "Could not open %s: %s\n", config->fbdev_dri_path, strerror(errno));
         }
     } else {
         scrpriv->dri_fd = -1;
     }
 
     if (scrpriv->dri_fd >= 0) {
-        fbdev_auto_dri3 = FALSE;
+        config->fbdev_auto_dri3 = FALSE;
     }
 
     glamor_egl_conf_t glamor_egl_conf = {
                                          .screen = pScreen,
-                                         .glvnd_vendor = fbdev_glvnd_provider,
+                                         .glvnd_vendor = config->fbdev_glvnd_provider,
                                          .fd = scrpriv->dri_fd,
-                                         .auto_dri = fbdev_auto_dri3,
+                                         .auto_dri = config->fbdev_auto_dri3,
                                          .llvmpipe_allowed = TRUE,
                                          .force_glamor = TRUE,
-                                         .es_disallowed = !es_allowed,
-                                         .force_es = force_es,
+                                         .es_disallowed = !config->es_allowed,
+                                         .force_es = config->force_es,
                                         };
 
     if (!glamor_egl_init_internal(&glamor_egl_conf, NULL)) {
         return FALSE;
     }
 
-    if (fbdev_auto_dri3) {
+    if (config->fbdev_auto_dri3) {
         scrpriv->dri_fd = glamor_egl_get_fd(pScreen);
     }
 
     const char *renderer = (const char*)glGetString(GL_RENDERER);
 
     int flags = GLAMOR_USE_EGL_SCREEN;
-    if (!fbGlamorAllowed) {
+    if (!config->fbGlamorAllowed) {
         flags |= GLAMOR_NO_RENDER_ACCEL;
-    } else if (!fbForceGlamor){
+    } else if (!config->fbForceGlamor){
         if (!renderer ||
             strstr(renderer, "softpipe") ||
             strstr(renderer, "llvmpipe")) {
@@ -106,7 +96,7 @@ fbdevInitAccel(ScreenPtr pScreen)
 
 #ifdef XV
     /* X-Video needs glamor render accel */
-    if (fbXVAllowed && !(flags & GLAMOR_NO_RENDER_ACCEL)) {
+    if (config->fbXVAllowed && !(flags & GLAMOR_NO_RENDER_ACCEL)) {
         kd_glamor_xv_init(pScreen);
     }
 #endif
@@ -121,8 +111,9 @@ fbdevEnableAccel(ScreenPtr pScreen)
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     FbdevScrPriv *scrpriv = screen->driver;
+    FbScreenConf *config = screen->card->closure;
 
-    if (fbdev_drm_master && scrpriv->dri_fd >= 0) {
+    if (config->fbdev_drm_master && scrpriv->dri_fd >= 0) {
         drmSetMaster(scrpriv->dri_fd);
     }
 #endif
@@ -135,8 +126,9 @@ fbdevDisableAccel(ScreenPtr pScreen)
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     FbdevScrPriv *scrpriv = screen->driver;
+    FbScreenConf *config = screen->card->closure;
 
-    if (fbdev_drm_master && scrpriv->dri_fd >= 0) {
+    if (config->fbdev_drm_master && scrpriv->dri_fd >= 0) {
         drmDropMaster(scrpriv->dri_fd);
     }
 #endif

--- a/hw/kdrive/fbdev/fbdev.c
+++ b/hw/kdrive/fbdev/fbdev.c
@@ -30,19 +30,17 @@
 
 #include "fbdev.h"
 
-const char *fbdevDevicePath = NULL;
-Bool fbDisableShadow = FALSE;
-
 static Bool
 fbdevInitialize(KdCardInfo * card, FbdevPriv * priv)
 {
     unsigned long off;
+    FbScreenConf *config = card->closure;
 
-    if (fbdevDevicePath) {
-        priv->fd = open(fbdevDevicePath, O_RDWR);
+    if (config->fbdevDevicePath) {
+        priv->fd = open(config->fbdevDevicePath, O_RDWR);
         if (priv->fd < 0) {
             ErrorF("Error opening framebuffer %s: %s\n",
-                   fbdevDevicePath, strerror(errno));
+                   config->fbdevDevicePath, strerror(errno));
             return FALSE;
         }
     } else {
@@ -366,8 +364,9 @@ fbdevMapFramebuffer(KdScreenInfo * screen)
     FbdevScrPriv *scrpriv = screen->driver;
     KdPointerMatrix m;
     FbdevPriv *priv = screen->card->driver;
+    FbScreenConf *config = screen->card->closure;
 
-    if (!fbDisableShadow) {
+    if (!config->fbDisableShadow) {
         scrpriv->shadow = TRUE;
     } else if (scrpriv->randr != RR_Rotate_0 ||
         priv->fix.type != FB_TYPE_PACKED_PIXELS) {
@@ -852,6 +851,10 @@ fbdevCardFini(KdCardInfo * card)
     munmap(priv->fb_base, priv->fix.smem_len);
     close(priv->fd);
     free(priv);
+    card->driver = NULL;
+
+    free(card->closure);
+    card->closure = NULL;
 }
 
 /*

--- a/hw/kdrive/fbdev/fbdev.h
+++ b/hw/kdrive/fbdev/fbdev.h
@@ -52,23 +52,29 @@ typedef struct _fbdevScrPriv {
 #endif
 } FbdevScrPriv;
 
-extern KdCardFuncs fbdevFuncs;
-extern const char *fbdevDevicePath;
-extern Bool fbDisableShadow;
+typedef struct _fbScreenConf {
+const char *fbdevDevicePath;
+Bool fbDisableShadow;
 
 #ifdef GLAMOR
-extern char *fbdev_glvnd_provider;
-extern char *fbdev_dri_path;
-extern bool fbdev_auto_dri3;
-extern bool fbdev_drm_master;
-extern bool es_allowed;
-extern bool force_es;
-extern bool fbGlamorAllowed;
-extern bool fbForceGlamor;
+char *fbdev_glvnd_provider;
+
+char *fbdev_dri_path;
+bool fbdev_auto_dri3;
+bool fbdev_drm_master;
+
+bool es_allowed;
+bool force_es;
+
+bool fbGlamorAllowed;
+bool fbForceGlamor;
 #ifdef XV
-extern bool fbXVAllowed;
+bool fbXVAllowed;
 #endif
 #endif
+} FbScreenConf;
+
+extern KdCardFuncs fbdevFuncs;
 
 Bool fbdevCardInit(KdCardInfo * card);
 

--- a/hw/kdrive/fbdev/fbinit.c
+++ b/hw/kdrive/fbdev/fbinit.c
@@ -28,10 +28,34 @@
 
 #include <string.h>
 
+static FbScreenConf *fbCurrScreen = NULL;
+
 void
 InitCard(char *name)
 {
-    KdCardInfoAdd(&fbdevFuncs, 0);
+    fbCurrScreen = XNFalloc(sizeof(*fbCurrScreen));
+    *fbCurrScreen = (FbScreenConf) {
+                                    .fbdevDevicePath = NULL,
+                                    .fbDisableShadow = FALSE,
+#ifdef GLAMOR
+                                    .fbdev_glvnd_provider = NULL,
+
+                                    .fbdev_dri_path = NULL,
+                                    .fbdev_auto_dri3 = FALSE,
+                                    .fbdev_drm_master = FALSE,
+
+                                    .es_allowed = TRUE,
+                                    .force_es = FALSE,
+
+                                    .fbGlamorAllowed = TRUE,
+                                    .fbForceGlamor = FALSE,
+#ifdef XV
+                                    .fbXVAllowed = TRUE,
+#endif
+#endif
+                                   };
+
+    KdCardInfoAdd(&fbdevFuncs, fbCurrScreen);
 }
 
 #if INPUTTHREAD
@@ -94,9 +118,21 @@ ddxUseMsg(void)
 int
 ddxProcessArgument(int argc, char **argv, int i)
 {
+    if (!fbCurrScreen || !strcmp(argv[i], "-screen")) {
+        /* Put each screen on a separate card */
+        int implicit_first_screen = !fbCurrScreen;
+        InitCard(NULL);
+        if (implicit_first_screen) {
+            /* This is what KdInitOutput would have done */
+            KdCardInfo *card = KdCardInfoLast();
+            KdScreenInfo *screen = KdScreenInfoAdd(card);
+            KdParseScreen(screen, NULL);
+        }
+    }
+
     if (!strcmp(argv[i], "-fb")) {
         if (i + 1 < argc) {
-            fbdevDevicePath = argv[i + 1];
+            fbCurrScreen->fbdevDevicePath = argv[i + 1];
             return 2;
         }
         UseMsg();
@@ -104,24 +140,24 @@ ddxProcessArgument(int argc, char **argv, int i)
     }
 
     if (!strcmp(argv[i], "-noshadow")) {
-        fbDisableShadow = TRUE;
+        fbCurrScreen->fbDisableShadow = TRUE;
         return 1;
     }
 
 #ifdef GLAMOR
     if (!strcmp(argv[i], "-glamor")) {
-        fbForceGlamor = TRUE;
+        fbCurrScreen->fbForceGlamor = TRUE;
         return 1;
     }
 
     if (!strcmp(argv[i], "-noglamor")) {
-        fbGlamorAllowed = FALSE;
+        fbCurrScreen->fbGlamorAllowed = FALSE;
         return 1;
     }
 
     if (!strcmp(argv[i], "-glvendor")) {
         if (i + 1 < argc) {
-            fbdev_glvnd_provider = strdup(argv[i + 1]);
+            fbCurrScreen->fbdev_glvnd_provider = strdup(argv[i + 1]);
             return 2;
         }
         UseMsg();
@@ -131,35 +167,35 @@ ddxProcessArgument(int argc, char **argv, int i)
     if (!strcmp(argv[i], "-dri")) {
         if (i + 1 < argc) {
             if (argv[i + 1][0] == '-' || !strcmp(argv[i + 1], "auto")) {
-                fbdev_auto_dri3 = TRUE;
+                fbCurrScreen->fbdev_auto_dri3 = TRUE;
             } else {
-                fbdev_dri_path = strdup(argv[i + 1]);
+                fbCurrScreen->fbdev_dri_path = strdup(argv[i + 1]);
             }
             return 2;
         } else {
-            fbdev_auto_dri3 = TRUE;
+            fbCurrScreen->fbdev_auto_dri3 = TRUE;
             return 1;
         }
     }
 
     if (!strcmp(argv[i], "-drm-master")) {
-        fbdev_drm_master = TRUE;
+        fbCurrScreen->fbdev_drm_master = TRUE;
         return 1;
     }
 
     if (!strcmp(argv[i], "-force-gl")) {
-        es_allowed = FALSE;
+        fbCurrScreen->es_allowed = FALSE;
         return 1;
     }
 
     if (!strcmp(argv[i], "-force-es")) {
-        force_es = TRUE;
+        fbCurrScreen->force_es = TRUE;
         return 1;
     }
 
 #ifdef XV
     if (!strcmp(argv[i], "-noxv")) {
-        fbXVAllowed = FALSE;
+        fbCurrScreen->fbXVAllowed = FALSE;
         return 1;
     }
 #endif

--- a/hw/kdrive/linux/linux.c
+++ b/hw/kdrive/linux/linux.c
@@ -195,7 +195,7 @@ LinuxApmNotify(int fd, int mask, void *blockData)
         LinuxApmRunning = TRUE;
     }
     else if (!running && LinuxApmRunning) {
-        KdSuspend();
+        KdSuspend(FALSE);
         LinuxApmRunning = FALSE;
         ioctl(fd, cmd, 0);
     }

--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -476,22 +476,19 @@ KdProcessArgument(int argc, char **argv, int i)
     KdScreenInfo *screen;
 
     if (!strcmp(argv[i], "-screen")) {
-        if ((i + 1) < argc) {
+        char *screen_arg = ((i + 1) < argc && argv[i + 1][0] != '-') ? argv[i + 1] : NULL;
+        card = KdCardInfoLast();
+        if (!card) {
+            InitCard(0);
             card = KdCardInfoLast();
-            if (!card) {
-                InitCard(0);
-                card = KdCardInfoLast();
-            }
-            if (card) {
-                screen = KdScreenInfoAdd(card);
-                KdParseScreen(screen, argv[i + 1]);
-            }
-            else
-                ErrorF("No matching card found!\n");
         }
-        else
-            UseMsg();
-        return 2;
+        if (card) {
+            screen = KdScreenInfoAdd(card);
+            KdParseScreen(screen, screen_arg);
+        } else {
+            ErrorF("No matching card found!\n");
+        }
+        return screen_arg ? 2 : 1;
     }
     if (!strcmp(argv[i], "-zaphod")) {
         kdDisableZaphod = TRUE;

--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -150,7 +150,7 @@ KdDoSwitchCmd(const char *reason)
     }
 }
 
-void KdSuspend(void)
+void KdSuspend(int ddxAbort)
 {
     KdCardInfo *card;
     KdScreenInfo *screen;
@@ -163,14 +163,16 @@ void KdSuspend(void)
             if (card->driver && card->cfuncs->restore)
                 (*card->cfuncs->restore) (card);
         }
-        KdDisableInput();
+        if (!ddxAbort) {
+            KdDisableInput();
+        }
         KdDoSwitchCmd("suspend");
     }
 }
 
-void KdDisableScreens(void)
+void KdDisableScreens(int ddxAbort)
 {
-    KdSuspend();
+    KdSuspend(ddxAbort);
     if (kdEnabled && (kdOsFuncs->Disable))
         kdOsFuncs->Disable();
     kdEnabled = FALSE;
@@ -236,7 +238,7 @@ void
 KdProcessSwitch(void)
 {
     if (kdEnabled)
-        KdDisableScreens();
+        KdDisableScreens(FALSE);
     else
         KdEnableScreens();
 }
@@ -244,7 +246,7 @@ KdProcessSwitch(void)
 static void
 AbortDDX(enum ExitCode error)
 {
-    KdDisableScreens();
+    KdDisableScreens(TRUE);
     if (kdOsFuncs) {
         if (kdEnabled && kdOsFuncs->Disable)
             (*kdOsFuncs->Disable) ();

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -380,14 +380,14 @@ void KdSetColormap(ScreenPtr pScreen);
 /* kdrive.c */
 extern miPointerScreenFuncRec kdPointerScreenFuncs;
 
-void KdSuspend(void);
+void KdSuspend(int ddxAbort);
 
 void KdInitScreen(KdScreenInfo * screen, int argc, char **argv);
 
 void
  KdDisableScreen(ScreenPtr pScreen);
 
-void KdDisableScreens(void);
+void KdDisableScreens(int ddxAbort);
 
 Bool
  KdEnableScreen(ScreenPtr pScreen);


### PR DESCRIPTION
We were storing all the per-screen state in global variables, meaning that all screens had the same values for all these globals.

This made multi-screen support almost useless.

With this, usable multi-screen support is available in Xfbdev.