### PR TITLE
Kdrive xvideo cleanups

### DIFF
--- a/hw/kdrive/fbdev/fbdev.c
+++ b/hw/kdrive/fbdev/fbdev.c
@@ -30,6 +30,10 @@
 
 #include "fbdev.h"
 
+#ifdef XV
+#include "kxv.h"
+#endif
+
 static Bool
 fbdevInitialize(KdCardInfo * card, FbdevPriv * priv)
 {
@@ -801,6 +805,10 @@ fbdevEnable(ScreenPtr pScreen)
 
         fbdevUpdateFbColormap(priv, 0, i);
     }
+
+#ifdef XV
+    KdXVEnable (pScreen);
+#endif
     return TRUE;
 }
 
@@ -831,6 +839,9 @@ fbdevDPMS(ScreenPtr pScreen, int mode)
 void
 fbdevDisable(ScreenPtr pScreen)
 {
+#ifdef XV
+    KdXVDisable (pScreen);
+#endif
 }
 
 void

--- a/hw/kdrive/src/kxv.c
+++ b/hw/kdrive/src/kxv.c
@@ -89,7 +89,7 @@ static void KdXVWindowDestroy(CallbackListPtr *pcbl, ScreenPtr pScreen, WindowPt
 
 static void KdXVWindowExposures(WindowPtr pWin, RegionPtr r1);
 static void KdXVClipNotify(WindowPtr pWin, int dx, int dy);
-static Bool KdXVCloseScreen(ScreenPtr);
+static void KdXVCloseScreen(CallbackListPtr *pcbl, ScreenPtr pScreen, void *unused);
 
 /* misc */
 static Bool KdXVInitAdaptors(ScreenPtr, KdVideoAdaptorPtr, int);
@@ -147,8 +147,8 @@ KdXVScreenInit(ScreenPtr pScreen, KdVideoAdaptorPtr adaptors, int num)
 
     pScreen->WindowExposures = KdXVWindowExposures;
     pScreen->ClipNotify = KdXVClipNotify;
-    /* it will call KdCloseScreen() as it's the last act */
-    pScreen->CloseScreen = KdXVCloseScreen;
+
+    dixScreenHookClose(pScreen, KdXVCloseScreen);
 
     if (!KdXVInitAdaptors(pScreen, adaptors, num))
         return FALSE;
@@ -976,8 +976,8 @@ KdXVClipNotify(WindowPtr pWin, int dx, int dy)
 
 /**** Required XvScreenRec fields ****/
 
-static Bool
-KdXVCloseScreen(ScreenPtr pScreen)
+static void
+KdXVCloseScreen(CallbackListPtr *pcbl, ScreenPtr pScreen, void *unused)
 {
     XvScreenPtr pxvs = GET_XV_SCREEN(pScreen);
     KdXVScreenPtr ScreenPriv = GET_KDXV_SCREEN(pScreen);
@@ -985,7 +985,9 @@ KdXVCloseScreen(ScreenPtr pScreen)
     int c;
 
     if (!ScreenPriv)
-        return TRUE;
+        return;
+
+    KdXVGeneration = 0;
 
     pScreen->WindowExposures = ScreenPriv->WindowExposures;
     pScreen->ClipNotify = ScreenPriv->ClipNotify;
@@ -997,7 +999,7 @@ KdXVCloseScreen(ScreenPtr pScreen)
     free(pxvs->pAdaptors);
     free(ScreenPriv);
 
-    return KdCloseScreen(pScreen);
+    dixScreenUnhookClose(pScreen, KdXVCloseScreen);
 }
 
 /**** XvAdaptorRec fields ****/

--- a/hw/kdrive/src/kxv.c
+++ b/hw/kdrive/src/kxv.c
@@ -99,6 +99,7 @@ static DevPrivateKeyRec KdXVWindowKeyRec;
 #define KdXVWindowKey (&KdXVWindowKeyRec)
 static DevPrivateKey KdXvScreenKey;
 static DevPrivateKeyRec KdXVScreenPrivateKey;
+static unsigned long KdXVGeneration = 0;
 static unsigned long PortResource = 0;
 
 #define GET_XV_SCREEN(pScreen) ((XvScreenPtr) \
@@ -151,6 +152,8 @@ KdXVScreenInit(ScreenPtr pScreen, KdVideoAdaptorPtr adaptors, int num)
 
     if (!KdXVInitAdaptors(pScreen, adaptors, num))
         return FALSE;
+
+    KdXVGeneration = serverGeneration;
 
     return TRUE;
 }
@@ -705,6 +708,27 @@ KdXVReputImage(XvPortRecPrivatePtr portPriv)
 }
 
 static int
+KdXVReputAllVideo(WindowPtr pWin, void *data)
+{
+    KdXVWindowPtr WinPriv;
+
+    if (pWin->drawable.type != DRAWABLE_WINDOW)
+        return WT_DONTWALKCHILDREN;
+
+    WinPriv = GET_KDXV_WINDOW(pWin);
+
+    while (WinPriv) {
+        if (WinPriv->PortRec->type == XvInputMask)
+            KdXVReputVideo(WinPriv->PortRec);
+        else
+            KdXVRegetVideo(WinPriv->PortRec);
+        WinPriv = WinPriv->next;
+    }
+
+    return WT_WALKCHILDREN;
+}
+
+static int
 KdXVEnlistPortInWindow(WindowPtr pWin, XvPortRecPrivatePtr portPriv)
 {
     KdXVWindowPtr winPriv, PrivRoot;
@@ -749,6 +773,61 @@ KdXVRemovePortFromWindow(WindowPtr pWin, XvPortRecPrivatePtr portPriv)
         winPriv = winPriv->next;
     }
     portPriv->pDraw = NULL;
+}
+
+static Bool
+KdXVRunning(ScreenPtr pScreen)
+{
+    return (KdXVGeneration == serverGeneration && GET_XV_SCREEN(pScreen) != 0);
+}
+
+Bool
+KdXVEnable(ScreenPtr pScreen)
+{
+    if (!KdXVRunning(pScreen))
+        return TRUE;
+
+    WalkTree(pScreen, KdXVReputAllVideo, 0);
+
+    return TRUE;
+}
+
+void
+KdXVDisable(ScreenPtr pScreen)
+{
+    XvScreenPtr pxvs;
+    XvAdaptorPtr pAdaptor;
+    XvPortPtr pPort;
+    XvPortRecPrivatePtr pPriv;
+    int i, j;
+
+    if (!KdXVRunning(pScreen))
+        return;
+
+    pxvs = GET_XV_SCREEN(pScreen);
+
+    for (i = 0; i < pxvs->nAdaptors; i++) {
+        pAdaptor = &pxvs->pAdaptors[i];
+        for (j = 0; j < pAdaptor->nPorts; j++) {
+            pPort = &pAdaptor->pPorts[j];
+            pPriv = (XvPortRecPrivatePtr) pPort->devPriv.ptr;
+            if (pPriv->isOn > XV_OFF) {
+
+                (*pPriv->AdaptorRec->StopVideo) (pPriv->screen,
+                                                 pPriv->DevPriv.ptr, TRUE);
+                pPriv->isOn = XV_OFF;
+
+                if (pPriv->pCompositeClip && pPriv->FreeCompositeClip)
+                    RegionDestroy(pPriv->pCompositeClip);
+
+                pPriv->pCompositeClip = NULL;
+
+                if (!pPriv->type && pPriv->pDraw) {     /* still */
+                    KdXVRemovePortFromWindow((WindowPtr) pPriv->pDraw, pPriv);
+                }
+            }
+        }
+    }
 }
 
 /****  ScreenRec fields ****/

--- a/hw/kdrive/src/kxv.h
+++ b/hw/kdrive/src/kxv.h
@@ -147,6 +147,10 @@ typedef struct {
 Bool
  KdXVScreenInit(ScreenPtr pScreen, KdVideoAdaptorPtr Adaptors, int num);
 
+/* Must be called from KdCardInfo functions, can be called without Xv enabled */
+Bool KdXVEnable(ScreenPtr);
+void KdXVDisable(ScreenPtr);
+
 /*** These are DDX layer privates ***/
 
 typedef struct {


### PR DESCRIPTION
`KdXVCloseScreen` was not properly hooked into the CloseScreen chain, so we were leaking some memory there.