### PR TITLE
xfree86/parser: Fix warning around `strchr`

### DIFF
--- a/hw/xfree86/parser/patterns.c
+++ b/hw/xfree86/parser/patterns.c
@@ -93,7 +93,7 @@ xf86createMatchGroup(const char *arg, xf86MatchMode pref_mode,
         pattern->mode = MATCH_REGEX;
         str ++;
         if (*str) {
-            char *last;
+            const char *last;
             last = strchr(str+1, *str);
             if (last)
                 n = last-str-1;


### PR DESCRIPTION
This warning happens because I built the X server with gcc 16 (a C23-capable compiler)

../xlibre-server-9999/hw/xfree86/parser/patterns.c: In function 'xf86createMatchGroup': ../xlibre-server-9999/hw/xfree86/parser/patterns.c:97:18: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
   97 |             last = strchr(str+1, *str);
      |                  ^
cc1: all warnings being treated as errors