### PR TITLE
meson: Add -Dgbm build option

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -13,6 +13,55 @@ on:
     pull_request:
 
 jobs:
+    xserver-build-ubuntu-no-gbm:
+        env:
+            MESON_ARGS: -Dprefix=/usr -Dxephyr=true -Dwerror=true -Dxcsecurity=true -Dgbm=false -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=true -Dtest_xephyr_gles=false
+            LIBGL_ALWAYS_SOFTWARE: 1
+            GALLIUM_DRIVER: llvmpipe
+            PIGLIT_PLATFORM: x11_egl
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out repository code
+              uses: actions/checkout@v4
+
+            - name: prepare build environment
+              run: |
+                MACHINE=`gcc -dumpmachine`
+                echo "MACHINE=$MACHINE" >> "$GITHUB_ENV"
+                echo "PKG_CONFIG_PATH=$X11_PREFIX/share/pkgconfig:$X11_PREFIX/lib/$MACHINE/pkgconfig:$X11_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
+                sudo chown root /bin/tar && sudo chmod u+s /bin/tar
+
+            - name: apt cache
+              uses: actions/cache@v4
+              with:
+                path: /var/cache/apt
+                key: apt-cache-${{ hashFiles('.github/scripts/ubuntu/install-pkg.sh') }}
+                restore-keys: apt-cache-
+
+            - name: pkg install
+              run:  sudo .github/scripts/ubuntu/install-pkg.sh
+
+            - name: X11 prereq cache
+              uses: actions/cache@v4
+              with:
+                path: |
+                    ${{ env.X11_PREFIX }}
+                    ${{ env.X11_BUILD_DIR }}/xts
+                    ${{ env.X11_BUILD_DIR }}/piglit
+                key: ${{ runner.name }}-x11-deps-${{ hashFiles('.github/scripts/ubuntu/install-prereq.sh') }}
+                restore-keys: ${{ runner.name }}-x11-deps-
+
+            - name: build and test
+              run:  .github/scripts/ubuntu/run-xserver-build-and-test.sh
+
+            - name: archive build logs
+              uses: actions/upload-artifact@v4
+              with:
+                  name: build-logs
+                  path: |
+                      __BUILD/meson-logs/*
+                      __BUILD/test/piglit-results/*
+
     xserver-build-ubuntu:
         env:
             MESON_ARGS: -Dprefix=/usr -Dxephyr=true -Dwerror=true -Dxcsecurity=true -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=true -Dtest_xephyr_gles=false

--- a/hw/xfree86/meson.build
+++ b/hw/xfree86/meson.build
@@ -117,7 +117,7 @@ xserver_exec = executable(
 subdir('dixmods')
 subdir('exa')
 subdir('fbdevhw')
-if build_glamor and gbm_dep.found()
+if build_glamor and build_gbm
     subdir('glamor_egl')
 endif
 if int10 != 'false'

--- a/include/meson.build
+++ b/include/meson.build
@@ -107,17 +107,17 @@ conf_data.set('GLAMOR_HAS_EXPORT_DMABUF_MESA',
               epoxy_dep.found() and cc.has_header_symbol('epoxy/egl.h','eglExportDMABUFImageQueryMESA', dependencies: epoxy_dep ) ? '1' : false)
 conf_data.set('GLXEXT', build_glx ? '1' : false)
 conf_data.set('GLAMOR', build_glamor ? '1' : false)
-conf_data.set('GLAMOR_HAS_GBM', gbm_dep.found() ? '1' : false)
+conf_data.set('GLAMOR_HAS_GBM', build_gbm ? '1' : false)
 conf_data.set('GBM_BO_WITH_MODIFIERS',
-              build_glamor and gbm_dep.found() and gbm_dep.version().version_compare('>= 17.1') ? '1' : false)
+              build_glamor and build_gbm and gbm_dep.version().version_compare('>= 17.1') ? '1' : false)
 conf_data.set('GBM_BO_FD_FOR_PLANE',
-              build_glamor and gbm_dep.found() and gbm_dep.version().version_compare('>= 21.1') ? '1' : false)
+              build_glamor and build_gbm and gbm_dep.version().version_compare('>= 21.1') ? '1' : false)
 conf_data.set('GBM_BO_WITH_MODIFIERS2',
-              build_glamor and gbm_dep.found() and gbm_dep.version().version_compare('>= 21.3') ? '1' : false)
+              build_glamor and build_gbm and gbm_dep.version().version_compare('>= 21.3') ? '1' : false)
 conf_data.set('GBM_HAVE_BO_USE_LINEAR',
-              build_glamor and gbm_dep.found() and cc.has_header_symbol('gbm.h', 'GBM_BO_USE_LINEAR', dependencies : gbm_dep )  ? '1' : false)
+              build_glamor and build_gbm and cc.has_header_symbol('gbm.h', 'GBM_BO_USE_LINEAR', dependencies : gbm_dep )  ? '1' : false)
 conf_data.set('GBM_HAVE_BO_USE_FRONT_RENDERING',
-              build_glamor and gbm_dep.found() and cc.has_header_symbol('gbm.h','GBM_BO_USE_FRONT_RENDERING', dependencies: gbm_dep ) ? '1' : false)
+              build_glamor and build_gbm and cc.has_header_symbol('gbm.h','GBM_BO_USE_FRONT_RENDERING', dependencies: gbm_dep ) ? '1' : false)
 
 conf_data.set_quoted('SERVER_MISC_CONFIG_PATH', serverconfigdir)
 conf_data.set_quoted('PROJECTROOT', get_option('prefix'))

--- a/meson.build
+++ b/meson.build
@@ -388,6 +388,22 @@ if build_glamor
     epoxy_dep = dependency('epoxy', required: false)
 endif
 
+gbm_option = get_option('gbm')
+if gbm_option == 'auto'
+    build_gbm = gbm_dep.found()
+else
+    build_gbm = (gbm_option == 'true')
+endif
+
+if build_gbm and not gbm_dep.found()
+    error('libgbm support requested, but libgbm is not available')
+endif
+
+# Don't even link to libgbm
+if not build_gbm
+    gbm_dep = dependency('', required: false)
+endif
+
 # Lots of sha1 options, because Linux is about choice :)
 
 # The idea behind the ordering here is that we should first prefer system
@@ -548,7 +564,7 @@ if not libdrm_dep.found() and libdrm_required
     error('DRI requested, but LIBDRM not found')
 endif
 
-build_modesetting = libdrm_dep.found() and dri2proto_dep.found() and gbm_dep.found()
+build_modesetting = libdrm_dep.found() and dri2proto_dep.found() and build_gbm
 
 build_vgahw = false
 if get_option('vgahw') == 'auto'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -35,6 +35,9 @@ option('fontrootdir', type: 'string',
 option('serverconfigdir', type: 'string',
         description: 'Miscellaneous server configuration files path. Default: $libdir/xorg')
 
+option('gbm', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
+       description: 'Enable libgbm support (default yes if available)')
+
 option('glx_dri', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
         description: 'Build the dri-based glx backends. Default: true')
 


### PR DESCRIPTION
Allow libgbm to be explicitly enabled/disabled.
Useful for testing (and maybe packaging).

Added a job for building the X server with `-Dgbm=false`.
I'm not too familiar with CI, If anyone knows how to just build the X server without gbm, but not run any test, please post a patch.