### PR TITLE
(master) .github: ubuntu: install-pkg.sh: install extra packages

### DIFF
--- a/.github/scripts/ubuntu/install-pkg.sh
+++ b/.github/scripts/ubuntu/install-pkg.sh
@@ -93,4 +93,7 @@ apt-get install -y \
 	xutils-dev \
 	libxaw7-dev \
 	python3-mako \
-	libxcvt-dev
+	libxcvt-dev \
+	git \
+	sudo
+


### PR DESCRIPTION
Install some needed packages which are only installed on Github's
VM images, but missing in Ubuntu containers.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
