### PR TITLE
kdrive: Implement vt switching for vts 11 and 12

### DIFF
--- a/hw/kdrive/fbdev/Xfbdev.man
+++ b/hw/kdrive/fbdev/Xfbdev.man
@@ -66,7 +66,29 @@ tells the X server to only use embedded GLES contexts.
 disables X-Video support.
 
 .SH KEYBOARD
-To be written.
+The
+.B Xfbdev
+server is normally configured to recognize various special combinations
+of key presses that instruct the server to perform some action, rather
+than just sending the key press event to a client application.
+Currently, these are implemented using hard-coded ps2 keyboard scancodes,
+and should work regardless of the loaded XKB keymap.
+.PP
+The following key special combinations are recognized by the
+.B Xfbdev
+server.
+.TP 8
+.B Ctrl+Alt+Backspace
+Immediately kills the server -- no questions asked. It can be disabled by
+adding the
+.B -nozap
+command-line argument
+.TP 8
+.B Ctrl+Alt+F1...F12
+For systems with virtual terminal support, these keystroke
+combinations are used to switch to virtual terminals 1 through 12,
+respectively.
+
 .SH SEE ALSO
 X(@miscmansuffix@), Xserver(1), Xkdrive(1), xdm(1), xinit(1).
 .SH AUTHORS

--- a/hw/kdrive/src/kinput.c
+++ b/hw/kdrive/src/kinput.c
@@ -1916,6 +1916,7 @@ KdKeyCodeToKeySym(KdKeyboardInfo *ki, int type, unsigned char key_code)
      * return kbd->key->xkbInfo->desc->map->modmap[key_code];
      *
      * Scancodes are taken from https://aeb.win.tue.nl/linux/kbd/scancodes-1.html
+     * These scancodes can be also found at https://wiki.osdev.org/PS/2_Keyboard
      *
      * Only a few keys we are interested in are listed here.
      * If we ever need more keys, we can add them later.
@@ -1932,6 +1933,8 @@ KdKeyCodeToKeySym(KdKeyboardInfo *ki, int type, unsigned char key_code)
 #define KEY_F8 0x42
 #define KEY_F9 0x43
 #define KEY_F10 0x44
+#define KEY_F11 0x57
+#define KEY_F12 0x58
 
 /**
  * The driver doesn't differentiate between E0 53 and 53,
@@ -1962,6 +1965,10 @@ KdKeyCodeToKeySym(KdKeyboardInfo *ki, int type, unsigned char key_code)
             return XK_F9;
         case KEY_F10:
             return XK_F10;
+        case KEY_F11:
+            return XK_F11;
+        case KEY_F12:
+            return XK_F12;
 #if 0 /* Doesn't work from my testing */
         case KEY_DEL:
             return XK_Delete;


### PR DESCRIPTION
kdrive/fbdev: Write the KEYBOARD man page section
documenting special key combinations

@metux @X11Libre/dev Should this go in the Xkdrive man page instead?
The special key handling is implemented in the common kdrive code, but since Xephyr uses it's own input drivers, it doesn't support special key combinations.