### PR TITLE
osdep: fix possible file descriptor leaks in arc4random_buf()

### DIFF
--- a/os/osdep.h
+++ b/os/osdep.h
@@ -75,6 +75,7 @@ SOFTWARE.
 
 #include "dix.h"
 #include "ospoll.h"
+#include <errno.h>
 
 extern struct ospoll    *server_poll;
 
@@ -88,7 +89,16 @@ extern Bool NewOutputPending;
 static inline void arc4random_buf(void *buf, size_t nbytes)
 {
     int fd = open("/dev/urandom", O_RDONLY);
-    read(fd, buf, nbytes);
+    if (fd < 0) {
+        perror("open /dev/urandom");
+        abort();
+    }
+    ssize_t r = read(fd, buf, nbytes);
+    if (r < 0 || (size_t)r != nbytes) {
+        perror("read /dev/urandom");
+        close(fd);
+        abort();
+    }
     close(fd);
 }
 #endif /* HAVE_ARC4RANDOM_BUF */


### PR DESCRIPTION
Even on a full-fledged Linux system, /dev/urandom may not be available inside isolated environments

- Chroot environments: If the administrator has created a chroot prison for security (for example, for a web server or FTP) and forgot to copy the device there using the mknod command or mount /dev

- Containers (Docker, LXC) with strict security profiles: If the container is started with custom, maximally stripped-down AppArmor/Seccomp rules or without mounting the base directory /dev, the process inside the container will not see this file

- FreeBSD Jails / Solaris Zones: Similar to chroot, if the zone or jail configuration rules explicitly do not allow mounting the device file system (devfs)