### PR TITLE
(master) .github: drop chmod on /bin/tar

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -29,7 +29,6 @@ jobs:
                 MACHINE=`gcc -dumpmachine`
                 echo "MACHINE=$MACHINE" >> "$GITHUB_ENV"
                 echo "PKG_CONFIG_PATH=$X11_PREFIX/share/pkgconfig:$X11_PREFIX/lib/$MACHINE/pkgconfig:$X11_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
-                sudo chown root /bin/tar && sudo chmod u+s /bin/tar
 
             - name: apt cache
               uses: actions/cache@v4
@@ -75,7 +74,6 @@ jobs:
                 MACHINE=`gcc -dumpmachine`
                 echo "MACHINE=$MACHINE" >> "$GITHUB_ENV"
                 echo "PKG_CONFIG_PATH=$X11_PREFIX/share/pkgconfig:$X11_PREFIX/lib/$MACHINE/pkgconfig:$X11_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
-                sudo chown root /bin/tar && sudo chmod u+s /bin/tar
 
             - name: apt cache
               uses: actions/cache@v4
@@ -116,7 +114,6 @@ jobs:
                 MACHINE=`gcc -dumpmachine`
                 echo "MACHINE=$MACHINE" >> "$GITHUB_ENV"
                 echo "PKG_CONFIG_PATH=$X11_PREFIX/share/pkgconfig:$X11_PREFIX/lib/$MACHINE/pkgconfig:$X11_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
-                sudo chown root /bin/tar && sudo chmod u+s /bin/tar
 
             - name: apt cache
               uses: actions/cache@v4


### PR DESCRIPTION
This was a workaround for buggy older Ubuntu CI images that's not
needed anymore.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
