### PR TITLE
(master) .github: ubuntu-drivers: install Xserver to X11_PREFIX

### DIFF
--- a/.github/scripts/ubuntu/install-prereq-drivers.sh
+++ b/.github/scripts/ubuntu/install-prereq-drivers.sh
@@ -19,3 +19,6 @@ echo "export PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> .meson_environment
 sudo meson install --no-rebuild -C "$MESON_BUILDDIR"
 sudo mkdir -p /usr/local/lib/$MACHINE/xorg/modules # /home/runner/x11/lib/xorg/modules
 sudo chown -R runner /usr/local/lib/$MACHINE/xorg/modules # /home/runner/x11/lib/xorg/modules
+
+# copy over xserver SDK autoconf .m4 file so drivers can find it
+cp $X11_PREFIX/share/aclocal/xorg-server.m4 /usr/share/aclocal

--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -63,7 +63,7 @@ jobs:
 
     drivers-build-ubuntu:
         env:
-            MESON_ARGS: -Dprefix=/usr -Dxorg-sdk=true -Dxorg=false -Dxephyr=false -Dwerror=false -Dxcsecurity=false -Dxorg=true -Dxvfb=false -Dxnest=false -Dxfbdev=false
+            MESON_ARGS: -Dprefix=/home/runner/x11 -Dxorg-sdk=true -Dxorg=false -Dxephyr=false -Dwerror=false -Dxcsecurity=false -Dxorg=true -Dxvfb=false -Dxnest=false -Dxfbdev=false
         runs-on: ubuntu-latest
         steps:
             - name: Check out repository code


### PR DESCRIPTION
Install our own xserver build into X11_PREFIX (/home/runner/x11) instead of /usr.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
