### PR TITLE
(master) .github: xserver-ubuntu: make apt-cache actually work

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -30,15 +30,24 @@ jobs:
                 echo "MACHINE=$MACHINE" >> "$GITHUB_ENV"
                 echo "PKG_CONFIG_PATH=$X11_PREFIX/share/pkgconfig:$X11_PREFIX/lib/$MACHINE/pkgconfig:$X11_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
 
-            - name: apt cache
-              uses: actions/cache@v4
+            - name: root suid tar for apt caching
+              run:  sudo chmod u+s /bin/tar
+
+            - name: apt cache pull
+              uses: actions/cache/restore@v5
               with:
                 path: /var/cache/apt
-                key: apt-cache-${{ hashFiles('.github/scripts/ubuntu/install-pkg.sh') }}
-                restore-keys: apt-cache-
+                key:          xserver-apt-cache-${{ hashFiles('.github/scripts/ubuntu/install-pkg.sh') }}-v2
+                restore-keys: xserver-apt-cache-
 
             - name: pkg install
               run:  sudo .github/scripts/ubuntu/install-pkg.sh
+
+            - name: apt cache push
+              uses: actions/cache/save@v5
+              with:
+                path: /var/cache/apt
+                key:          xserver-apt-cache-${{ hashFiles('.github/scripts/ubuntu/install-pkg.sh') }}-v2-${{ github.run_id }}
 
             - name: X11 prereq cache
               uses: actions/cache@v4


### PR DESCRIPTION
Using separate restore and save steps in order to save the cache as soon
as possible, instead of relying on the post-action working properly.

For accessing the apt cache files, we need to chmod +S /bin/tar, because
it needs to run as root, and cache action doesn't have an sudo option.

Note: we need to store the cache with some unique ID (and restore from
common prefix), otherwise getting with Github's cache API - it seems to
lock the cache key as soon as it's retrieved once.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
