### PR TITLE
(master) .github: ubuntu: move apt install & caching into separate action

### DIFF
--- a/.github/actions/ubuntu-install-pkg/action.yml
+++ b/.github/actions/ubuntu-install-pkg/action.yml
@@ -1,0 +1,25 @@
+name: ubuntu package install
+description: install required packages and cache apt downloads
+runs:
+    using: "composite"
+    steps:
+        - name: root suid tar for apt caching
+          run:  sudo chmod u+s /bin/tar
+          shell: bash
+
+        - name: apt cache pull
+          uses: actions/cache/restore@v5
+          with:
+            path: /var/cache/apt
+            key:          xserver-apt-cache-${{ hashFiles('.github/scripts/ubuntu/install-pkg.sh') }}-v2
+            restore-keys: xserver-apt-cache-
+
+        - name: pkg install
+          run:  sudo .github/scripts/ubuntu/install-pkg.sh
+          shell: bash
+
+        - name: apt cache push
+          uses: actions/cache/save@v5
+          with:
+            path: /var/cache/apt
+            key:          xserver-apt-cache-${{ hashFiles('.github/scripts/ubuntu/install-pkg.sh') }}-v2-${{ github.run_id }}

--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -24,30 +24,13 @@ jobs:
             - name: Check out repository code
               uses: actions/checkout@v6
 
+            - uses: ./.github/actions/ubuntu-install-pkg
+
             - name: prepare build environment
               run: |
                 MACHINE=`gcc -dumpmachine`
                 echo "MACHINE=$MACHINE" >> "$GITHUB_ENV"
                 echo "PKG_CONFIG_PATH=$X11_PREFIX/share/pkgconfig:$X11_PREFIX/lib/$MACHINE/pkgconfig:$X11_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
-
-            - name: root suid tar for apt caching
-              run:  sudo chmod u+s /bin/tar
-
-            - name: apt cache pull
-              uses: actions/cache/restore@v5
-              with:
-                path: /var/cache/apt
-                key:          xserver-apt-cache-${{ hashFiles('.github/scripts/ubuntu/install-pkg.sh') }}-v2
-                restore-keys: xserver-apt-cache-
-
-            - name: pkg install
-              run:  sudo .github/scripts/ubuntu/install-pkg.sh
-
-            - name: apt cache push
-              uses: actions/cache/save@v5
-              with:
-                path: /var/cache/apt
-                key:          xserver-apt-cache-${{ hashFiles('.github/scripts/ubuntu/install-pkg.sh') }}-v2-${{ github.run_id }}
 
             - name: X11 prereq cache
               uses: actions/cache@v4


### PR DESCRIPTION
subsequent commits will reuse this action in other places, too.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
