### PR TITLE
(release/25.0) dix/colormap: fix out-of-bounds read in FindColorInRootCmap

### DIFF
--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -1296,7 +1296,7 @@ FindColorInRootCmap(ColormapPtr pmap, EntryPtr pentFirst, int size,
 
     if ((pixel = *pPixel) >= size)
         pixel = 0;
-    for (pent = pentFirst + pixel, count = size; --count >= 0; pent++, pixel++) {
+    for (pent = pentFirst + pixel, count = size; --count >= 0;) {
         if (pent->refcnt > 0 && (*comp) (pent, prgb)) {
             switch (channel) {
             case REDMAP:
@@ -1313,6 +1313,13 @@ FindColorInRootCmap(ColormapPtr pmap, EntryPtr pentFirst, int size,
             }
             *pPixel = pixel;
         }
+        pixel++;
+        if (pixel >= size) {
+            pent = pentFirst;
+            pixel = 0;
+        }
+        else
+            pent++;
     }
 }
 


### PR DESCRIPTION
The for loop here always iterates size times but the client controls the
starting offset. When the starting pixel is non-zero (e.g., pixel=10 in
a size=256 colormap), the loop reads from pentFirst[10] through
pentFirst[265], reading 10 entries past the end of the array.

Fix this by wrapping around once we reach size, same as FindColor()
already does.

Assisted-by: Claude:claude-claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2215>
