### PR TITLE
(master) cursor: fix AllocARGBCursor leak/double-free for psrcbits/pmaskbits/argb

### DIFF
--- a/dix/cursor.c
+++ b/dix/cursor.c
@@ -226,7 +226,9 @@ RealizeCursorAllScreens(CursorPtr pCurs)
 
 /**
  * does nothing about the resource table, just creates the data structure.
- * does not copy the src and mask bits
+ *
+ * Takes ownership of \p psrcbits, \p pmaskbits, and \p argb -- all three
+ * are freed on error, the caller must not free them after calling this.
  *
  *  \param psrcbits  server-defined padding
  *  \param pmaskbits server-defined padding
@@ -242,8 +244,12 @@ AllocARGBCursor(unsigned char *psrcbits, unsigned char *pmaskbits,
     *ppCurs = NULL;
 
     CursorPtr pCurs = (CursorPtr) calloc(CURSOR_REC_SIZE + CURSOR_BITS_SIZE, 1);
-    if (!pCurs)
+    if (!pCurs) {
+        free(psrcbits);
+        free(pmaskbits);
+        free(argb);
         return BadAlloc;
+    }
 
     CursorBitsPtr bits = (CursorBitsPtr) ((char *) pCurs + CURSOR_REC_SIZE);
     dixInitPrivates(pCurs, pCurs + 1, PRIVATE_CURSOR);

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -3182,17 +3182,11 @@ ProcCreateCursor(ClientPtr client)
                          &pCursor, client, stuff->cid);
 
     if (rc != Success)
-        goto bail;
-    if (!AddResource(stuff->cid, X11_RESTYPE_CURSOR, (void *) pCursor)) {
-        rc = BadAlloc;
-        goto bail;
-    }
+        return rc;
+    if (!AddResource(stuff->cid, X11_RESTYPE_CURSOR, (void *) pCursor))
+        return BadAlloc;
 
     return Success;
- bail:
-    free(srcbits);
-    free(mskbits);
-    return rc;
 }
 
 int

--- a/dix/window.c
+++ b/dix/window.c
@@ -3241,10 +3241,6 @@ TileScreenSaver(ScreenPtr pScreen, int kind)
             else
                 cursor = 0;
         }
-        else {
-            free(srcbits);
-            free(mskbits);
-        }
     }
 
     pWin = pScreen->screensaver.pWindow =

--- a/render/render.c
+++ b/render/render.c
@@ -1474,17 +1474,11 @@ ProcRenderCreateCursor(ClientPtr client)
                          GetColor(twocolor[1], 0),
                          &pCursor, client, stuff->cid);
     if (rc != Success)
-        goto bail;
-    if (!AddResource(stuff->cid, X11_RESTYPE_CURSOR, (void *) pCursor)) {
-        rc = BadAlloc;
-        goto bail;
-    }
+        return rc;
+    if (!AddResource(stuff->cid, X11_RESTYPE_CURSOR, (void *) pCursor))
+        return BadAlloc;
 
     return Success;
- bail:
-    free(srcbits);
-    free(mskbits);
-    return rc;
 }
 
 static int


### PR DESCRIPTION
AllocARGBCursor took ownership of the psrcbits/pmaskbits/argb arguments.
But if the initial calloc failed none of them were freed, without the
caller knowing about it. Depending on the code path, those arguments
would thus either leak or be double-freed.

Fix it by always freeing those on error and updating the callers
accordingly.

Assisted-by: Claude:claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2214>
