### PR TITLE
(release/25.0) config: Fix build with udev disabled

### DIFF
--- a/config/config-backends.h
+++ b/config/config-backends.h
@@ -39,13 +39,16 @@ BOOL device_is_duplicate(const char *config_info);
 int config_udev_pre_init(void);
 int config_udev_init(void);
 void config_udev_fini(void);
-void config_udev_odev_probe(config_odev_probe_proc_ptr probe_callback);
 #elif defined(CONFIG_HAL)
 int config_hal_init(void);
 void config_hal_fini(void);
 #elif defined(CONFIG_WSCONS)
 int config_wscons_init(void);
 void config_wscons_fini(void);
+#endif
+
+#ifdef CONFIG_UDEV_KMS
+void config_udev_odev_probe(config_odev_probe_proc_ptr probe_callback);
 #endif
 
 #endif /* XSERVER_CONFIG_BACKENDS_H */


### PR DESCRIPTION
Commit b5b52979 has split the options "udev" and "udev_kms" for systems
without systemd.

Yet, when building with "-Dudev=false", "udev_kms" still defaults to
true.

That breaks the build because "config_udev_odev_probe()" is not defined:

| config/config.c: In function ‘config_odev_probe’:
| config/config.c:77:5: error: implicit declaration of function
|                       ‘config_udev_odev_probe’; did you mean
|                       ‘config_odev_probe’?
|                       [-Wimplicit-function-declaration]
|   77 |     config_udev_odev_probe(probe_callback);
|      |     ^~~~~~~~~~~~~~~~~~~~~~
|      |     config_odev_probe
| config/config.c:77:5: warning: nested extern declaration of
|                       ‘config_udev_odev_probe’ [-Wnested-externs]

Yet, the code of the function "config_udev_odev_probe()" in config/udev.c
is within a "#ifdef udev_kms" conditional, so it is built.

The problem is that the function definition is within an "#ifdef udev"
in the "config_backends.h" header.

So, even though the actual code is compiled, the compiler will fail to
find the function definition, hence the "implicit declaration" error.

To avoid the issue, move the function definition within a separate
"udev_kms" conditional in the "config-backends.h" header file.

Closes: https://gitlab.freedesktop.org/xorg/xserver/-/work_items/1890
Fixes: b5b52979 ("meson: split udev from udev_kms which requires systemd")
Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2203>
