### PR TITLE
(master) present: actually return the created notifies

### DIFF
--- a/present/present_notify.c
+++ b/present/present_notify.c
@@ -101,6 +101,8 @@ present_create_notifies(ClientPtr client, int num_notifies, xPresentNotify *x_no
 
         added++;
     }
+
+    *p_notifies = notifies;
     return Success;
 
 bail:


### PR DESCRIPTION
present_create_notifies() creates an array of notifies but never returns
them to the caller, despite them being passed individually to
present_add_window_notify(). The caller proceeds with a NULL notifies
array, eventually causing an OOB in present_vblank_notify() when
vblank->notifies is NULL.

Reported-by: Feng Ning, Innora Pte. Ltd.
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2204>
