### PR TITLE
(master) render: fix memory leaks on XaceHook failure in resource creation

### DIFF
--- a/render/render.c
+++ b/render/render.c
@@ -740,8 +740,10 @@ ProcRenderCreateGlyphSet(ClientPtr client)
     /* security creation/labeling check */
     rc = XaceHookResourceAccess(client, stuff->gsid, GlyphSetType,
                   glyphSet, X11_RESTYPE_NONE, NULL, DixCreateAccess);
-    if (rc != Success)
+    if (rc != Success) {
+        FreeGlyphSet(glyphSet, (XID) 0);
         return rc;
+    }
     if (!AddResource(stuff->gsid, GlyphSetType, (void *) glyphSet))
         return BadAlloc;
     return Success;
@@ -1703,8 +1705,10 @@ SingleRenderCreateSolidFill(ClientPtr client, xRenderCreateSolidFillReq *stuff)
     /* security creation/labeling check */
     error = XaceHookResourceAccess(client, stuff->pid, PictureType,
                      pPicture, X11_RESTYPE_NONE, NULL, DixCreateAccess);
-    if (error != Success)
+    if (error != Success) {
+        FreePicture(pPicture, (XID) 0);
         return error;
+    }
     if (!AddResource(stuff->pid, PictureType, (void *) pPicture))
         return BadAlloc;
     return Success;
@@ -1738,8 +1742,10 @@ SingleRenderCreateLinearGradient(ClientPtr client, xRenderCreateLinearGradientRe
     /* security creation/labeling check */
     error = XaceHookResourceAccess(client, stuff->pid, PictureType,
                      pPicture, X11_RESTYPE_NONE, NULL, DixCreateAccess);
-    if (error != Success)
+    if (error != Success) {
+        FreePicture(pPicture, (XID) 0);
         return error;
+    }
     if (!AddResource(stuff->pid, PictureType, (void *) pPicture))
         return BadAlloc;
     return Success;
@@ -1775,8 +1781,10 @@ SingleRenderCreateRadialGradient(ClientPtr client,
     /* security creation/labeling check */
     error = XaceHookResourceAccess(client, stuff->pid, PictureType,
                      pPicture, X11_RESTYPE_NONE, NULL, DixCreateAccess);
-    if (error != Success)
+    if (error != Success) {
+        FreePicture(pPicture, (XID) 0);
         return error;
+    }
     if (!AddResource(stuff->pid, PictureType, (void *) pPicture))
         return BadAlloc;
     return Success;
@@ -1811,8 +1819,10 @@ SingleRenderCreateConicalGradient(ClientPtr client,
     /* security creation/labeling check */
     error = XaceHookResourceAccess(client, stuff->pid, PictureType,
                      pPicture, X11_RESTYPE_NONE, NULL, DixCreateAccess);
-    if (error != Success)
+    if (error != Success) {
+        FreePicture(pPicture, (XID) 0);
         return error;
+    }
     if (!AddResource(stuff->pid, PictureType, (void *) pPicture))
         return BadAlloc;
     return Success;


### PR DESCRIPTION
Same pattern for all hunks here: if Xace fails, free the
allocated data.

Assisted-by: Claude:claude-claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2205>
