### PR TITLE
(master) randr/rrsdispatch: reject invalid format in SProcRRChangeProviderProperty

### DIFF
--- a/randr/rrproviderproperty.c
+++ b/randr/rrproviderproperty.c
@@ -446,6 +446,9 @@ ProcRRChangeProviderProperty(ClientPtr client)
             case 32:
                 SwapRestL(stuff);
                 break;
+            default:
+                client->errorValue = stuff->format;
+                return BadValue;
         }
     }
 


### PR DESCRIPTION
No real effect here since we check stuff->format early in
ProcRRChangeProviderProperty anyway. But this just makes it a bit more
obvious (and more consistent with other functions).

Assisted-by: Claude:claude-claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2200>
