### PR TITLE
(release/25.1) xkb: Add bounds check for action data in CheckKeyActions()

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -1873,6 +1873,11 @@ CheckKeyActions(ClientPtr client,
     if (req->nKeyActs % 4)
         wire += 4 - (req->nKeyActs % 4);
     *wireRtrn = (CARD8 *) (((XkbAnyAction *) wire) + nActs);
+    if (nActs > 0 &&
+        !_XkbCheckRequestBounds(client, req, wire, *wireRtrn)) {
+        *nActsRtrn = _XkbErrCode2(0x25, nActs);
+        return 0;
+    }
     *nActsRtrn = nActs;
     return 1;
 }


### PR DESCRIPTION
CheckKeyActions() validates the per-key action count bytes individually
but does not verify that the computed total action data region falls
within the request buffer before advancing the wire pointer past it.

After the loop, the function calculates the final wire position as
wire + nActs * sizeof(XkbAnyAction), where nActs is the sum of per-key
action counts read from the request. The upstream length validation in
_XkbSetMapCheckLength() uses req->totalActs from the request header,
not the computed nActs. If a crafted request provides a totalActs value
that passes the length check but per-key action counts that sum to a
different nActs, the wire pointer could advance past the actual request
buffer.

The subsequent SetKeyActions() function uses memcpy to read from this
potentially out-of-bounds region, which could leak heap data or cause
a crash.

Assisted-by: Claude:claude-claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2208>
