### PR TITLE
(master) os/access: fix off-by-one in hostname character validation range

### DIFF
--- a/os/access.c
+++ b/os/access.c
@@ -1872,7 +1872,7 @@ siHostnameCheckAddr(const char *valueString, int length, void *typePriv)
                     dotAllowed = FALSE;
                 }
             }
-            else if (((c >= 0x30) && (c <= 0x3A)) /* 0-9 */ ||
+            else if (((c >= 0x30) && (c <= 0x39)) /* 0-9 */ ||
                      ((c >= 0x61) && (c <= 0x7A)) /* a-z */ ||
                      ((c >= 0x41) && (c <= 0x5A)) /* A-Z */ ) {
                 dotAllowed = TRUE;


### PR DESCRIPTION
In siHostnameCheckAddr(), the digit validation range was 0x30-0x3A, but
0x3A is the colon character (':'). The ASCII range for digits 0-9 is
0x30-0x39.

Colons in hostnames violate RFC 2396 section 3.2.2 and we're not parsing
the host:port notation here.

Assisted-by: Claude:claude-claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2200>
