### PR TITLE
(release/25.1) Xext/xres: fix client PID value swap in ConstructClientIdValue

### DIFF
--- a/Xext/xres.c
+++ b/Xext/xres.c
@@ -432,6 +432,7 @@ ConstructClientIdValue(ClientPtr sendClient, ClientPtr client, CARD32 mask,
             }
 
             CARD32 *value = (void*) ((char*) ptr + sizeof(reply));
+            *value = pid;
 
             reply.spec.mask = X_XResLocalClientPIDMask;
             reply.length = 4;
@@ -442,7 +443,6 @@ ConstructClientIdValue(ClientPtr sendClient, ClientPtr client, CARD32 mask,
                 swapl (value);
             }
             memcpy(ptr, &reply, sizeof(reply));
-            *value = pid;
 
             ctx->resultBytes += sizeof(reply) + sizeof(CARD32);
             ++ctx->numIds;


### PR DESCRIPTION
value points to the location of the client PID, assign it first before
we swap it. For consistency move the memcpy up too so the copy commands
are all in the same location.

Assisted-by: Claude:claude-claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2200>
