### PR TITLE
(release/25.0) Xext/xres: fix client PID value swap in ConstructClientIdValue

### DIFF
--- a/Xext/xres.c
+++ b/Xext/xres.c
@@ -475,6 +475,7 @@ ConstructClientIdValue(ClientPtr sendClient, ClientPtr client, CARD32 mask,
             }
 
             value = (void*) ((char*) ptr + sizeof(rep));
+            *value = pid;
 
             rep.spec.mask = X_XResLocalClientPIDMask;
             rep.length = 4;
@@ -484,8 +485,8 @@ ConstructClientIdValue(ClientPtr sendClient, ClientPtr client, CARD32 mask,
                 swapl (&rep.length);
                 swapl (value);
             }
+
             memcpy(ptr, &rep, sizeof(rep));
-            *value = pid;
 
             ctx->resultBytes += sizeof(rep) + sizeof(CARD32);
             ++ctx->numIds;


### PR DESCRIPTION
value points to the location of the client PID, assign it first before
we swap it. For consistency move the memcpy up too so the copy commands
are all in the same location.

Assisted-by: Claude:claude-claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2200>
