### PR TITLE
(release/25.0) Xi/xichangehierarchy: reject zero-length hierarchy change entries

### DIFF
--- a/Xi/xichangehierarchy.c
+++ b/Xi/xichangehierarchy.c
@@ -456,8 +456,10 @@ ProcXIChangeHierarchy(ClientPtr client)
         SWAPIF(swaps(&any->type));
         SWAPIF(swaps(&any->length));
 
-        if (len < ((size_t)any->length << 2))
-            return BadLength;
+        if (any->length == 0 || len < ((size_t)any->length << 2)) {
+            rc = BadLength;
+            goto unwind;
+        }
 
 #define CHANGE_SIZE_MATCH(type) \
     do { \


### PR DESCRIPTION
No need to spin for a zero-length change. The loop is already bounded to
255 iterations so this just keeps the room slightly cooler.

This is a slight behavior change in that subsequent hierarchy changes
will no longer be accepted (but already-applied changes remain).  But a
client sending zero length hierarchy changes is buggy anyway, so meh.

Assisted-by: Claude:claude-claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2200>
