### PR TITLE
(release/25.1) Xi/exevents: fix off-by-one in UpdateDeviceState valuator bounds check

### DIFF
--- a/Xi/exevents.c
+++ b/Xi/exevents.c
@@ -910,7 +910,7 @@ UpdateDeviceState(DeviceIntPtr device, DeviceEvent *event)
                        "Ignoring event.\n", device->name);
                 return DONT_PROCESS;
             }
-            else if (v->numAxes < i) {
+            else if (v->numAxes <= i) {
                 ErrorF("[Xi] Too many valuators reported for device '%s'. "
                        "Ignoring event.\n", device->name);
                 return DONT_PROCESS;


### PR DESCRIPTION
There is no OOB write, the loop a few lines below has the correct
i < numAxes check. But this does set last_valuator to an invalid
value which may have flow-on effects elsewhere later.

Assisted-by: Claude:claude-claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2200>
