### PR TITLE
(release/25.0) xkb: Fix out-of-bounds array access in xkmread.c ReadXkmGeometry

### DIFF
--- a/xkb/xkmread.c
+++ b/xkb/xkmread.c
@@ -1133,9 +1133,11 @@ ReadXkmGeometry(FILE * file, XkbDescPtr xkb)
                         shape->bounds.y2 = ptWire.y;
                 }
             }
-            if (shapeWire.primary_ndx != XkbNoShape)
+            if (shapeWire.primary_ndx != XkbNoShape &&
+                shapeWire.primary_ndx < shapeWire.num_outlines)
                 shape->primary = &shape->outlines[shapeWire.primary_ndx];
-            if (shapeWire.approx_ndx != XkbNoShape)
+            if (shapeWire.approx_ndx != XkbNoShape &&
+                shapeWire.approx_ndx < shapeWire.num_outlines)
                 shape->approx = &shape->outlines[shapeWire.approx_ndx];
         }
     }


### PR DESCRIPTION
The primary_ndx and approx_ndx fields from the XKM shape wire
description are used as indices into the shape->outlines[] array without
bounds checking against num_outlines.

Exploiting this (if it can be exploited) requires a malicious xkbcomp -
the path of which is built-in at compile time. There are lower-hanging
targets than trying to exploit through an XKM file.

Assisted-by: Claude:claude-claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2207>
