### PR TITLE
(master) .github: drivers: use hash of prereq script instead of commit SHA for cache key

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -76,8 +76,8 @@ jobs:
                     ${{ env.X11_PREFIX }}
                     ${{ env.X11_BUILD_DIR }}/xts
                     ${{ env.X11_BUILD_DIR }}/piglit
-                key:          drivers-deps-${{ github.sha }}
-                restore-keys: drivers-deps-${{ github.sha }}
+                key:          drivers-deps-${{ hashFiles('.github/scripts/ubuntu/install-prereq-drivers.sh') }}
+                restore-keys: drivers-deps-${{ hashFiles('.github/scripts/ubuntu/install-prereq-drivers.sh') }}
 
             - name: generic prereq and xserver
               run:  .github/scripts/ubuntu/install-prereq-drivers.sh
@@ -161,7 +161,7 @@ jobs:
                     ${{ env.X11_PREFIX }}
                     ${{ env.X11_BUILD_DIR }}/xts
                     ${{ env.X11_BUILD_DIR }}/piglit
-                key:          drivers-deps-${{ github.sha }}
+                key:          drivers-deps-${{ hashFiles('.github/scripts/ubuntu/install-prereq-drivers.sh') }}
                 fail-on-cache-miss: true
 
             - name: compile driver ${{ matrix.driver }}


### PR DESCRIPTION
We're currently using the commit SHA in the cache key for the prebuilt dependencies.
This leads to cache inflation (each commit getting different cache), thus premature
cache eviction, which on high loads causes build breaks.

What we actually want is invalidating the cache only when the dependencies really
have changed - thus use the hash of .github/scripts/ubuntu/install-prereq-drivers.sh

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
