### PR TITLE
(master) .github: ubuntu: fix apt cache

### DIFF
--- a/.github/actions/ubuntu-fetch-pkg/action.yml
+++ b/.github/actions/ubuntu-fetch-pkg/action.yml
@@ -1,0 +1,15 @@
+name: ubuntu fetch packages
+runs:
+    using: "composite"
+    steps:
+        - run:  sudo chmod u+s /bin/tar
+          shell: bash
+
+        - uses: actions/cache@v5
+          id:   apt-cache-restore
+          with:
+            path: /var/cache/apt
+            key:  ${{ runner.os }}-apt-cache-v3
+
+        - run:  sudo .github/scripts/ubuntu/fetch-pkg.sh
+          shell: bash

--- a/.github/actions/ubuntu-install-pkg/action.yml
+++ b/.github/actions/ubuntu-install-pkg/action.yml
@@ -10,16 +10,10 @@ runs:
         - name: apt cache pull
           uses: actions/cache/restore@v5
           with:
+            fail-on-cache-miss: true
             path: /var/cache/apt
-            key:          xserver-apt-cache-${{ hashFiles('.github/scripts/ubuntu/install-pkg.sh') }}-v2
-            restore-keys: xserver-apt-cache-
+            key:  ${{ runner.os }}-apt-cache-v3
 
         - name: pkg install
           run:  sudo .github/scripts/ubuntu/install-pkg.sh
           shell: bash
-
-        - name: apt cache push
-          uses: actions/cache/save@v5
-          with:
-            path: /var/cache/apt
-            key:          xserver-apt-cache-${{ hashFiles('.github/scripts/ubuntu/install-pkg.sh') }}-v2-${{ github.run_id }}

--- a/.github/scripts/ubuntu/fetch-pkg.sh
+++ b/.github/scripts/ubuntu/fetch-pkg.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# NOTE: don't forget to update both fetch-pkg and install-pkg and change cache name
+
 set -e
 
 # Packages which are needed by this script, but not for the xserver build
@@ -13,7 +15,9 @@ EPHEMERAL="
 	xvfb
 "
 
-apt-get install -y \
+apt-get update
+
+apt-get install -d -y \
 	$EPHEMERAL \
 	autoconf \
 	automake \
@@ -94,3 +98,6 @@ apt-get install -y \
 	libxcvt-dev \
 	git \
 	sudo
+
+# only pull them into apt cache -- for mingw32 build
+apt-get install -d -y mingw-w64-tools gcc-mingw-w64 gcc-mingw-w64-i686 libz-mingw-w64-dev

--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -13,6 +13,12 @@ on:
     pull_request:
 
 jobs:
+    ubuntu-fetch-pkg:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: ./.github/actions/ubuntu-fetch-pkg
+
     xserver-build-ubuntu-no-gbm:
         env:
             MESON_ARGS: -Dprefix=/usr -Dxephyr=true -Dwerror=true -Dxcsecurity=true -Dgbm=false -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=true -Dtest_xephyr_gles=false
@@ -20,9 +26,12 @@ jobs:
             GALLIUM_DRIVER: llvmpipe
             PIGLIT_PLATFORM: x11_egl
         runs-on: ubuntu-latest
+        needs: ubuntu-fetch-pkg
         steps:
             - name: Check out repository code
               uses: actions/checkout@v4
+
+            - uses: ./.github/actions/ubuntu-install-pkg
 
             - name: prepare build environment
               run: |
@@ -30,16 +39,6 @@ jobs:
                 echo "MACHINE=$MACHINE" >> "$GITHUB_ENV"
                 echo "PKG_CONFIG_PATH=$X11_PREFIX/share/pkgconfig:$X11_PREFIX/lib/$MACHINE/pkgconfig:$X11_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH" >> "$GITHUB_ENV"
                 sudo chown root /bin/tar && sudo chmod u+s /bin/tar
-
-            - name: apt cache
-              uses: actions/cache@v4
-              with:
-                path: /var/cache/apt
-                key: apt-cache-${{ hashFiles('.github/scripts/ubuntu/install-pkg.sh') }}
-                restore-keys: apt-cache-
-
-            - name: pkg install
-              run:  sudo .github/scripts/ubuntu/install-pkg.sh
 
             - name: X11 prereq cache
               uses: actions/cache@v4
@@ -69,6 +68,7 @@ jobs:
             GALLIUM_DRIVER: llvmpipe
             PIGLIT_PLATFORM: x11_egl
         runs-on: ubuntu-latest
+        needs: ubuntu-fetch-pkg
         steps:
             - name: Check out repository code
               uses: actions/checkout@v6
@@ -106,6 +106,7 @@ jobs:
         env:
             MESON_ARGS: -Dprefix=/home/runner/x11 -Dxorg-sdk=true -Dxorg=false -Dxephyr=false -Dwerror=false -Dxcsecurity=false -Dxorg=true -Dxvfb=false -Dxnest=false -Dxfbdev=false
         runs-on: ubuntu-latest
+        needs: ubuntu-fetch-pkg
         steps:
             - name: Check out repository code
               uses: actions/checkout@v6
@@ -133,6 +134,7 @@ jobs:
 
     drivers-build-ubuntu:
         needs:
+            - ubuntu-fetch-pkg
             - drivers-prepare-ubuntu
         runs-on: ubuntu-latest
         strategy:
@@ -220,6 +222,7 @@ jobs:
         runs-on: ubuntu-latest
         env:
             MESON_ARGS: -Dprefix=/home/runner/x11 --cross-file=.github/scripts/mingw32/cross-i686-w64-mingw32.txt -Dwerror=true -Dglx=false -Dlisten_tcp=true -Dxvmc=true -Dxv=true -Dxvfb=true -Dxnest=true -Dxephyr=true -Dxfbdev=false
+        needs: ubuntu-fetch-pkg
         steps:
             - name: Check out repository code
               uses: actions/checkout@v6


### PR DESCRIPTION
The previous approach flooded the repository with new caches,
thus leading to unnecessary eviction of other caches. Previously
had splitted restore and save, but that required using separate
keys, and github doesn't report partial cache hits (prefix-only),
thus no chance of skipping unnecessary cache saves.

Instead now moving out populating the cache into a separate job,
which is run before all those who need the cache. This also allows
us skipping `apt-get update` in the individual jobs, thus saving
a bit more time.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
