### PR TITLE
(master) .github: ubuntu: don't install wayland libs

### DIFF
--- a/.github/scripts/ubuntu/fetch-pkg.sh
+++ b/.github/scripts/ubuntu/fetch-pkg.sh
@@ -40,7 +40,6 @@ apt-get install -d -y \
 	libglx-mesa0 \
 	libinput10 \
 	libinput-dev \
-	libnvidia-egl-wayland-dev \
 	libpciaccess-dev \
 	libpixman-1-dev \
 	libspice-protocol-dev \

--- a/.github/scripts/ubuntu/install-pkg.sh
+++ b/.github/scripts/ubuntu/install-pkg.sh
@@ -36,7 +36,6 @@ apt-get install -y \
 	libglx-mesa0 \
 	libinput10 \
 	libinput-dev \
-	libnvidia-egl-wayland-dev \
 	libpciaccess-dev \
 	libpixman-1-dev \
 	libspice-protocol-dev \


### PR DESCRIPTION
Xwayland is long gone, so no need for those anymore.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
