### PR TITLE
(master) .github: ubuntu: don't install libnvidia-egl-wayland-dev anymore

### DIFF
--- a/.github/actions/ubuntu-fetch-pkg/action.yml
+++ b/.github/actions/ubuntu-fetch-pkg/action.yml
@@ -9,7 +9,7 @@ runs:
           id:   apt-cache-restore
           with:
             path: /var/cache/apt
-            key:  ${{ runner.os }}-apt-cache-v3
+            key:  ${{ runner.os }}-apt-cache-v4
 
         - run:  sudo .github/scripts/ubuntu/fetch-pkg.sh
           shell: bash

--- a/.github/actions/ubuntu-install-pkg/action.yml
+++ b/.github/actions/ubuntu-install-pkg/action.yml
@@ -12,7 +12,7 @@ runs:
           with:
             fail-on-cache-miss: true
             path: /var/cache/apt
-            key:  ${{ runner.os }}-apt-cache-v3
+            key:  ${{ runner.os }}-apt-cache-v4
 
         - name: pkg install
           run:  sudo .github/scripts/ubuntu/install-pkg.sh


### PR DESCRIPTION
This package isn't needed anymore, since xwayland removal.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
