### PR TITLE
(master) .github: ubuntu: use apt-cache also for *BSD builds

### DIFF
--- a/.github/actions/ubuntu-pkg-cache/action.yml
+++ b/.github/actions/ubuntu-pkg-cache/action.yml
@@ -1,0 +1,14 @@
+name: deploy ubuntu package cache
+runs:
+    using: "composite"
+    steps:
+        - name: root suid tar for apt caching
+          run:  sudo chmod u+s /bin/tar
+          shell: bash
+
+        - name: apt cache pull
+          uses: actions/cache/restore@v5
+          with:
+            fail-on-cache-miss: true
+            path: /var/cache/apt
+            key:  ${{ runner.os }}-apt-cache-v4

--- a/.github/scripts/ubuntu/fetch-pkg.sh
+++ b/.github/scripts/ubuntu/fetch-pkg.sh
@@ -96,7 +96,11 @@ apt-get install -d -y \
 	python3-mako \
 	libxcvt-dev \
 	git \
-	sudo
-
-# only pull them into apt cache -- for mingw32 build
-apt-get install -d -y mingw-w64-tools gcc-mingw-w64 gcc-mingw-w64-i686 libz-mingw-w64-dev
+	sudo \
+	mingw-w64-tools \
+	gcc-mingw-w64 \
+	gcc-mingw-w64-i686 \
+	libz-mingw-w64-dev \
+	qemu-utils \
+	qemu-system-x86 \
+	ovmf

--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -314,11 +314,13 @@ jobs:
 
     xserver-build-freebsd:
         runs-on: ubuntu-latest
+        needs: ubuntu-fetch-pkg
         env:
             MYTOKEN : ${{ secrets.MYTOKEN }}
             MESON_ARGS: -Dprefix=/usr -Dxephyr=true -Dwerror=true -Dxcsecurity=true -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=false
         steps:
             - uses: actions/checkout@v6
+            - uses: ./.github/actions/ubuntu-pkg-cache
             - name: run in freebsd VM
               id: xserver-build
               uses: vmactions/freebsd-vm@v1
@@ -330,10 +332,12 @@ jobs:
 
     xserver-build-dragonflybsd:
         runs-on: ubuntu-latest
+        needs: ubuntu-fetch-pkg
         env:
             MESON_ARGS: -Dwerror=true -Dxephyr=true -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=false
         steps:
             - uses: actions/checkout@v6
+            - uses: ./.github/actions/ubuntu-pkg-cache
             - name: run in DragonFlyBSD VM
               id: xserver-build
               uses: vmactions/dragonflybsd-vm@v1.1.4
@@ -345,10 +349,12 @@ jobs:
 
     xserver-build-netbsd:
         runs-on: ubuntu-latest
+        needs: ubuntu-fetch-pkg
         env:
             MESON_ARGS: -Dwerror=true -Dxephyr=true -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=false
         steps:
             - uses: actions/checkout@v6
+            - uses: ./.github/actions/ubuntu-pkg-cache
             - uses: vmactions/netbsd-vm@v1.2.3
               id: vm
               with:


### PR DESCRIPTION
also cache qemu et al.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
