### PR TITLE
xquartz: fix remaining non-portable code

### DIFF
--- a/hw/xquartz/NSUserDefaults+XQuartzDefaults.m
+++ b/hw/xquartz/NSUserDefaults+XQuartzDefaults.m
@@ -50,9 +50,8 @@ globalDefaultsOnce(void *arg)
     NSString * const defaultsDomain = @".GlobalPreferences";
     *defaults = [[[NSUserDefaults alloc] initWithSuiteName:defaultsDomain] retain];
 
-    NSDictionary<NSString *, id> * const defaultDefaultsDict = @{
-        @"AppleSpacesSwitchOnActivate" : @(YES),
-    };
+    NSMutableDictionary *defaultDefaultsDict = [[NSMutableDictionary alloc] init];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:YES] forKey:@"AppleSpacesSwitchOnActivate"];
 
     [*defaults registerDefaults:defaultDefaultsDict];
 }
@@ -64,9 +63,8 @@ dockDefaultsOnce(void *arg)
     NSString * const defaultsDomain = @"com.apple.dock";
     *defaults = [[[NSUserDefaults alloc] initWithSuiteName:defaultsDomain] retain];
 
-    NSDictionary<NSString *, id> * const defaultDefaultsDict = @{
-        @"workspaces" : @(NO),
-    };
+    NSMutableDictionary *defaultDefaultsDict = [[NSMutableDictionary alloc] init];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:NO] forKey:@"workspaces"];
 
     [*defaults registerDefaults:defaultDefaultsDict];
 }
@@ -75,11 +73,11 @@ static void
 xquartzDefaultsOnce(void *arg)
 {
     NSUserDefaults **defaults = (NSUserDefaults **)arg;
-    NSString *const defaultsDomain = @(BUNDLE_ID_PREFIX ".X11");
-    NSString *const defaultDefaultsDomain = NSBundle.mainBundle.bundleIdentifier;
+    NSString *const defaultsDomain = [NSString stringWithFormat:@"%s.X11", BUNDLE_ID_PREFIX];
+    NSString *const defaultDefaultsDomain = [[NSBundle mainBundle] bundleIdentifier];
 
     if ([defaultsDomain isEqualToString:defaultDefaultsDomain]) {
-        *defaults = [NSUserDefaults.standardUserDefaults retain];
+        *defaults = [[NSUserDefaults standardUserDefaults] retain];
     } else {
         *defaults = [[[NSUserDefaults alloc] initWithSuiteName:defaultsDomain] retain];
     }
@@ -92,43 +90,41 @@ xquartzDefaultsOnce(void *arg)
         defaultWindowItemModifiers = defaultWindowItemModifiersLocalized;
     }
 
-    NSDictionary<NSString *, id> * const defaultDefaultsDict = @{
-        XQuartzPrefKeyFakeButtons : @(NO),
-        /* XQuartzPrefKeyFakeButton2 nil default */
-        /* XQuartzPrefKeyFakeButton3 nil default */
-        XQuartzPrefKeyKeyEquivs : @(YES),
-        XQuartzPrefKeyFullscreenHotkeys : @(NO),
-        XQuartzPrefKeyFullscreenMenu : @(NO),
-        XQuartzPrefKeySyncKeymap : @(NO),
-        XQuartzPrefKeyDepth : @(-1),
-        XQuartzPrefKeyNoAuth : @(NO),
-        XQuartzPrefKeyNoTCP : @(NO),
-        XQuartzPrefKeyDoneXinitCheck : @(NO),
-        XQuartzPrefKeyNoQuitAlert : @(NO),
-        XQuartzPrefKeyNoRANDRAlert : @(NO),
-        XQuartzPrefKeyOptionSendsAlt : @(NO),
-        /* XQuartzPrefKeyAppKitModifiers nil default */
-        XQuartzPrefKeyWindowItemModifiers : defaultWindowItemModifiers,
-        XQuartzPrefKeyRootless : @(YES),
-        XQuartzPrefKeyRENDERExtension : @(YES),
-        XQuartzPrefKeyTESTExtension : @(NO),
-        XQuartzPrefKeyLoginShell : @"/bin/sh",
-        XQuartzPrefKeyClickThrough : @(NO),
-        XQuartzPrefKeyFocusFollowsMouse : @(NO),
-        XQuartzPrefKeyFocusOnNewWindow : @(YES),
-
-        XQuartzPrefKeyScrollInDeviceDirection : @(NO),
-        XQuartzPrefKeySyncPasteboard : @(YES),
-        XQuartzPrefKeySyncPasteboardToClipboard : @(YES),
-        XQuartzPrefKeySyncPasteboardToPrimary : @(YES),
-        XQuartzPrefKeySyncClipboardToPasteBoard : @(YES),
-        XQuartzPrefKeySyncPrimaryOnSelect : @(NO),
-    };
+    NSMutableDictionary *defaultDefaultsDict = [[NSMutableDictionary alloc] init];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:NO]   forKey:XQuartzPrefKeyFakeButtons];
+    // XQuartzPrefKeyFakeButton2 and 3 left as nil (no setObject)
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:YES]  forKey:XQuartzPrefKeyKeyEquivs];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:NO]   forKey:XQuartzPrefKeyFullscreenHotkeys];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:NO]   forKey:XQuartzPrefKeyFullscreenMenu];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:NO]   forKey:XQuartzPrefKeySyncKeymap];
+    [defaultDefaultsDict setObject:[NSNumber numberWithInt:-1]    forKey:XQuartzPrefKeyDepth];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:NO]   forKey:XQuartzPrefKeyNoAuth];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:NO]   forKey:XQuartzPrefKeyNoTCP];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:NO]   forKey:XQuartzPrefKeyDoneXinitCheck];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:NO]   forKey:XQuartzPrefKeyNoQuitAlert];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:NO]   forKey:XQuartzPrefKeyNoRANDRAlert];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:NO]   forKey:XQuartzPrefKeyOptionSendsAlt];
+    // XQuartzPrefKeyAppKitModifiers is nil
+    [defaultDefaultsDict setObject:defaultWindowItemModifiers     forKey:XQuartzPrefKeyWindowItemModifiers];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:YES]  forKey:XQuartzPrefKeyRootless];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:YES]  forKey:XQuartzPrefKeyRENDERExtension];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:NO]   forKey:XQuartzPrefKeyTESTExtension];
+    [defaultDefaultsDict setObject:@"/bin/sh"                     forKey:XQuartzPrefKeyLoginShell];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:NO]   forKey:XQuartzPrefKeyClickThrough];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:NO]   forKey:XQuartzPrefKeyFocusFollowsMouse];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:YES]  forKey:XQuartzPrefKeyFocusOnNewWindow];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:NO]   forKey:XQuartzPrefKeyScrollInDeviceDirection];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:YES]  forKey:XQuartzPrefKeySyncPasteboard];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:YES]  forKey:XQuartzPrefKeySyncPasteboardToClipboard];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:YES]  forKey:XQuartzPrefKeySyncPasteboardToPrimary];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:YES]  forKey:XQuartzPrefKeySyncClipboardToPasteBoard];
+    [defaultDefaultsDict setObject:[NSNumber numberWithBool:NO]   forKey:XQuartzPrefKeySyncPrimaryOnSelect];
 
     [*defaults registerDefaults:defaultDefaultsDict];
+    [defaultDefaultsDict release];
 
-    NSString * const systemDefaultsPlistPath = [@(XQUARTZ_DATA_DIR) stringByAppendingPathComponent:@"defaults.plist"];
-    NSDictionary<NSString *, id> * const systemDefaultsDict = [NSDictionary dictionaryWithContentsOfFile:systemDefaultsPlistPath];
+    NSString * const systemDefaultsPlistPath = [[NSString stringWithUTF8String:XQUARTZ_DATA_DIR] stringByAppendingPathComponent:@"defaults.plist"];
+    NSDictionary * const systemDefaultsDict = [NSDictionary dictionaryWithContentsOfFile:systemDefaultsPlistPath];
     [*defaults registerDefaults:systemDefaultsDict];
 }
 

--- a/hw/xquartz/NSUserDefaults+XQuartzDefaults.m
+++ b/hw/xquartz/NSUserDefaults+XQuartzDefaults.m
@@ -6,8 +6,14 @@
 //  Copyright (c) 2021 Apple Inc. All rights reserved.
 //
 
-#import "NSUserDefaults+XQuartzDefaults.h"
-#import <dispatch/dispatch.h>
+#include "NSUserDefaults+XQuartzDefaults.h"
+#include "osxcompat.h"
+
+#ifdef HAS_LIBDISPATCH
+#include <dispatch/dispatch.h>
+#else
+#include <pthread.h>
+#endif
 
 NSString * const XQuartzPrefKeyAppsMenu = @"apps_menu";
 NSString * const XQuartzPrefKeyFakeButtons = @"enable_fake_buttons";
@@ -128,32 +134,50 @@ xquartzDefaultsOnce(void *arg)
     [*defaults registerDefaults:systemDefaultsDict];
 }
 
+#ifdef HAS_LIBDISPATCH
+    typedef dispatch_once_t compat_once_t;
+    #define COMPAT_ONCE_INIT 0
+    #define compat_once_f dispatch_once_f
+#else
+    typedef pthread_once_t compat_once_t;
+    #define COMPAT_ONCE_INIT PTHREAD_ONCE_INIT
+    static inline void compat_once_f(compat_once_t *once, void *context, void (*func)(void *)) {
+        // pthread_once only takes a void(*)(void), so wrap context in a static
+        static void *compat_context;
+        static void (*compat_func)(void *);
+        compat_context = context;
+        compat_func = func;
+        void wrapper(void) { compat_func(compat_context); }
+        pthread_once(once, wrapper);
+    }
+#endif
+
 @implementation NSUserDefaults (XQuartzDefaults)
 
 + (NSUserDefaults *)globalDefaults
 {
-    static dispatch_once_t once;
+    static compat_once_t once = COMPAT_ONCE_INIT;
     static NSUserDefaults *defaults;
 
-    dispatch_once_f(&once, &defaults, globalDefaultsOnce);
+    compat_once_f(&once, &defaults, globalDefaultsOnce);
     return defaults;
 }
 
 + (NSUserDefaults *)dockDefaults
 {
-    static dispatch_once_t once;
+    static compat_once_t once = COMPAT_ONCE_INIT;
     static NSUserDefaults *defaults;
 
-    dispatch_once_f(&once, &defaults, dockDefaultsOnce);
+    compat_once_f(&once, &defaults, dockDefaultsOnce);
     return defaults;
 }
 
 + (NSUserDefaults *)xquartzDefaults
 {
-    static dispatch_once_t once;
+    static compat_once_t once = COMPAT_ONCE_INIT;
     static NSUserDefaults *defaults;
 
-    dispatch_once_f(&once, &defaults, xquartzDefaultsOnce);
+    compat_once_f(&once, &defaults, xquartzDefaultsOnce);
     return defaults;
 }
 

--- a/hw/xquartz/X11Application.h
+++ b/hw/xquartz/X11Application.h
@@ -35,12 +35,15 @@
 
 #if __OBJC__
 
-#import "X11Controller.h"
+#include "X11Controller.h"
 
-@interface X11Application : NSApplication
+@interface X11Application : NSApplication {
+    X11Controller *_controller;
+    OSX_BOOL _x_active;
+}
 
 @property (nonatomic, readwrite, strong) X11Controller *controller;
-@property (nonatomic, readonly, assign) OSX_BOOL x_active;
+@property (nonatomic, readwrite, assign) OSX_BOOL x_active;
 
 @end
 

--- a/hw/xquartz/X11Application.m
+++ b/hw/xquartz/X11Application.m
@@ -61,9 +61,14 @@ xpbproxy_run(void);
 #define XSERVER_VERSION "?"
 #endif
 
+#ifdef HAS_LIBDISPATCH
 #include <dispatch/dispatch.h>
 
 static dispatch_queue_t eventTranslationQueue;
+#else
+// aquaMenuBarHeight is just a proxy for initialization
+#define eventTranslationQueue aquaMenuBarHeight
+#endif
 
 #ifndef __has_feature
 #define __has_feature(x) 0
@@ -483,8 +488,12 @@ sendX11NSEvent_fptr(void *e_ptr)
     }
 
     if (for_x) {
+#ifdef HAS_LIBDISPATCH
         NSEvent *event_copy = [e retain];
         dispatch_async_f(eventTranslationQueue, event_copy, sendX11NSEvent_fptr);
+#else
+        [self sendX11NSEvent:e];
+#endif
     }
 }
 
@@ -842,13 +851,20 @@ X11ApplicationMain(int argc, char **argv, char **envp)
 
         /* Calculate the height of the menubar so we can avoid it. */
         aquaMenuBarHeight = [[NSApp mainMenu] menuBarHeight];
+#if ! __LP64__
+        if (!aquaMenuBarHeight) {
+            aquaMenuBarHeight = [NSMenuView menuBarHeight];
+        }
+#endif
         if (!aquaMenuBarHeight) {
             NSScreen* primaryScreen = [[NSScreen screens] objectAtIndex:0];
             aquaMenuBarHeight = NSHeight(primaryScreen.frame) - NSMaxY(primaryScreen.visibleFrame);
         }
 
+#ifdef HAS_LIBDISPATCH
         eventTranslationQueue = dispatch_queue_create(BUNDLE_ID_PREFIX ".X11.NSEventsToX11EventsQueue", NULL);
         assert(eventTranslationQueue != NULL);
+#endif
 
         /* Set the key layout seed before we start the server */
         last_key_layout = TISCopyCurrentKeyboardLayoutInputSource();

--- a/hw/xquartz/X11Application.m
+++ b/hw/xquartz/X11Application.m
@@ -44,6 +44,7 @@
 #include <X11/extensions/applewmconst.h>
 #include "micmap.h"
 #include "exglobals.h"
+#include "osxcompat.h"
 
 #include <mach/mach.h>
 #include <unistd.h>
@@ -156,10 +157,12 @@ X11Application *X11App;
 @end
 
 @interface X11Application ()
-@property (nonatomic, readwrite, assign) OSX_BOOL x_active;
 @end
 
 @implementation X11Application
+
+@synthesize controller = _controller;
+@synthesize x_active = _x_active;
 
 typedef struct message_struct message;
 struct message_struct {
@@ -439,9 +442,9 @@ sendX11NSEvent_fptr(void *e_ptr)
                 [self set_front_process:nil];
 
                 /* Get the Spaces preference for SwitchOnActivate */
-                BOOL const workspaces = [NSUserDefaults.dockDefaults boolForKey:@"workspaces"];
+                BOOL const workspaces = [[NSUserDefaults dockDefaults] boolForKey:@"workspaces"];
                 if (workspaces) {
-                    order_all_windows = [NSUserDefaults.globalDefaults boolForKey:@"AppleSpacesSwitchOnActivate"];
+                    order_all_windows = [[NSUserDefaults globalDefaults] boolForKey:@"AppleSpacesSwitchOnActivate"];
                 }
 
                 /* TODO: In the workspaces && !AppleSpacesSwitchOnActivate case, the windows are ordered
@@ -581,15 +584,15 @@ void
 X11ApplicationSetWindowMenu(int nitems, const char **items,
                             const char *shortcuts)
 {
-    @autoreleasepool {
-        NSMutableArray<NSArray<NSString *> *> *allMenuItems =
+    OBJC_AUTORELEASEPOOL_BEGIN
+        NSMutableArray *allMenuItems =
             [[NSMutableArray alloc] init];
 
         for (int i = 0; i < nitems; i++) {
-            NSMutableArray<NSString *> *menuItem =
+            NSMutableArray *menuItem =
                 [[NSMutableArray alloc] init];
 
-            [menuItem addObject:@(items[i])];
+            [menuItem addObject:[NSString stringWithUTF8String:items[i]]];
 
             if (shortcuts[i] == 0) {
                 [menuItem addObject:@""];
@@ -605,7 +608,7 @@ X11ApplicationSetWindowMenu(int nitems, const char **items,
         dispatch_async_f(dispatch_get_main_queue(),
                          allMenuItems,
                          setWindowMenuOnMain_fptr);
-    }
+    OBJC_AUTORELEASEPOOL_END
 }
 
 static void
@@ -686,12 +689,11 @@ appLaunchClient_fptr(void *string_ptr)
 void
 X11ApplicationLaunchClient(const char *cmd)
 {
-    @autoreleasepool {
+    OBJC_AUTORELEASEPOOL_BEGIN
         NSString *string_alloc = [[NSString alloc] initWithUTF8String:cmd];
         dispatch_async_f(dispatch_get_main_queue(), string_alloc, appLaunchClient_fptr);
-    }
+    OBJC_AUTORELEASEPOOL_END
 }
-
 
 
 /* helper function for X11ApplicationCanEnterRandR(),
@@ -822,12 +824,12 @@ X11ApplicationMain(int argc, char **argv, char **envp)
     while (access("/tmp/x11-block", F_OK) == 0) sleep(1);
 #endif
 
-    @autoreleasepool {
+    OBJC_AUTORELEASEPOOL_BEGIN
         X11App = (X11Application *)[X11Application sharedApplication];
         [X11App read_defaults];
 
         [NSBundle loadNibNamed:@"main" owner:NSApp];
-        [NSNotificationCenter.defaultCenter addObserver:NSApp
+        [[NSNotificationCenter defaultCenter] addObserver:NSApp
                                                selector:@selector (became_key:)
                                                    name:NSWindowDidBecomeKeyNotification
                                                  object:nil];
@@ -839,9 +841,9 @@ X11ApplicationMain(int argc, char **argv, char **envp)
         QuartzModeBundleInit();
 
         /* Calculate the height of the menubar so we can avoid it. */
-        aquaMenuBarHeight = NSApp.mainMenu.menuBarHeight;
+        aquaMenuBarHeight = [[NSApp mainMenu] menuBarHeight];
         if (!aquaMenuBarHeight) {
-            NSScreen* primaryScreen = NSScreen.screens[0];
+            NSScreen* primaryScreen = [[NSScreen screens] objectAtIndex:0];
             aquaMenuBarHeight = NSHeight(primaryScreen.frame) - NSMaxY(primaryScreen.visibleFrame);
         }
 
@@ -874,7 +876,7 @@ X11ApplicationMain(int argc, char **argv, char **envp)
         [[SUUpdater sharedUpdater] resetUpdateCycle];
         //    [[SUUpdater sharedUpdater] checkForUpdates:X11App];
 #endif
-    }
+    OBJC_AUTORELEASEPOOL_END
 
     [NSApp run];
     /* not reached */

--- a/hw/xquartz/X11Controller.h
+++ b/hw/xquartz/X11Controller.h
@@ -42,6 +42,10 @@
 #undef BOOL
 #endif
 
+#ifndef strong
+#define strong retain
+#endif
+
 @interface X11Controller : NSObject <NSTableViewDataSource>
 @property (nonatomic, readwrite, strong) IBOutlet NSPanel *prefs_panel;
 

--- a/hw/xquartz/X11Controller.h
+++ b/hw/xquartz/X11Controller.h
@@ -46,7 +46,50 @@
 #define strong retain
 #endif
 
-@interface X11Controller : NSObject <NSTableViewDataSource>
+@interface X11Controller : NSObject {
+    NSArray *_apps;
+    NSMutableArray *_table_apps;
+    NSInteger _windows_menu_nitems;
+    int _checked_window_item;
+    x_list *_pending_apps;
+    OSX_BOOL _finished_launching;
+#ifdef XQUARTZ_SPARKLE
+    NSMenuItem *_check_for_updates_item;
+#endif
+
+    NSPanel *_prefs_panel;
+    NSButton *_fake_buttons;
+    NSButton *_enable_fullscreen;
+    NSButton *_enable_fullscreen_menu;
+    NSTextField *_enable_fullscreen_menu_text;
+    NSButton *_enable_keyequivs;
+    NSButton *_sync_keymap;
+    NSButton *_option_sends_alt;
+    NSButton *_scroll_in_device_direction;
+    NSButton *_click_through;
+    NSButton *_focus_follows_mouse;
+    NSButton *_focus_on_new_window;
+    NSButton *_enable_auth;
+    NSButton *_enable_tcp;
+    NSButton *_sync_pasteboard;
+    NSButton *_sync_pasteboard_to_clipboard;
+    NSButton *_sync_pasteboard_to_primary;
+    NSButton *_sync_clipboard_to_pasteboard;
+    NSButton *_sync_primary_immediately;
+    NSTextField *_sync_text1;
+    NSTextField *_sync_text2;
+    NSPopUpButton *_depth;
+    NSMenuItem *_x11_about_item;
+    NSMenuItem *_dock_window_separator;
+    NSMenuItem *_apps_separator;
+    NSMenuItem *_toggle_fullscreen_item;
+    NSMenuItem *_copy_menu_item;
+    NSMenu *_dock_apps_menu;
+    NSTableView *_apps_table;
+    NSMenu *_dock_menu;
+    OSX_BOOL _can_quit;
+}
+
 @property (nonatomic, readwrite, strong) IBOutlet NSPanel *prefs_panel;
 
 @property (nonatomic, readwrite, strong) IBOutlet NSButton *fake_buttons;

--- a/hw/xquartz/X11Controller.m
+++ b/hw/xquartz/X11Controller.m
@@ -59,19 +59,60 @@ extern aslclient aslc;
 extern char *bundle_id_prefix;
 
 @interface X11Controller ()
-#ifdef XQUARTZ_SPARKLE
-@property (nonatomic, readwrite, strong) NSMenuItem *check_for_updates_item; // Programmatically enabled
-#endif
 
-@property (nonatomic, readwrite, strong) NSArray <NSArray <NSString *> *> *apps;
-@property (nonatomic, readwrite, strong) NSMutableArray <NSMutableArray <NSString *> *> *table_apps;
+@property (nonatomic, readwrite, strong) NSArray *apps;
+@property (nonatomic, readwrite, strong) NSMutableArray *table_apps;
 @property (nonatomic, readwrite, assign) NSInteger windows_menu_nitems;
 @property (nonatomic, readwrite, assign) int checked_window_item;
 @property (nonatomic, readwrite, assign) x_list *pending_apps;
 @property (nonatomic, readwrite, assign) OSX_BOOL finished_launching;
+#ifdef XQUARTZ_SPARKLE
+@property (nonatomic, readwrite, strong) NSMenuItem *check_for_updates_item; // Programmatically enabled
+#endif
 @end
 
 @implementation X11Controller
+
+@synthesize apps = _apps;
+@synthesize table_apps = _table_apps;
+@synthesize windows_menu_nitems = _windows_menu_nitems;
+@synthesize checked_window_item = _checked_window_item;
+@synthesize pending_apps = _pending_apps;
+@synthesize finished_launching = _finished_launching;
+#ifdef XQUARTZ_SPARKLE
+@synthesize check_for_updates_item = _check_for_updates_item;
+#endif
+
+@synthesize prefs_panel = _prefs_panel;
+@synthesize fake_buttons = _fake_buttons;
+@synthesize enable_fullscreen = _enable_fullscreen;
+@synthesize enable_fullscreen_menu = _enable_fullscreen_menu;
+@synthesize enable_fullscreen_menu_text = _enable_fullscreen_menu_text;
+@synthesize enable_keyequivs = _enable_keyequivs;
+@synthesize sync_keymap = _sync_keymap;
+@synthesize option_sends_alt = _option_sends_alt;
+@synthesize scroll_in_device_direction = _scroll_in_device_direction;
+@synthesize click_through = _click_through;
+@synthesize focus_follows_mouse = _focus_follows_mouse;
+@synthesize focus_on_new_window = _focus_on_new_window;
+@synthesize enable_auth = _enable_auth;
+@synthesize enable_tcp = _enable_tcp;
+@synthesize sync_pasteboard = _sync_pasteboard;
+@synthesize sync_pasteboard_to_clipboard = _sync_pasteboard_to_clipboard;
+@synthesize sync_pasteboard_to_primary = _sync_pasteboard_to_primary;
+@synthesize sync_clipboard_to_pasteboard = _sync_clipboard_to_pasteboard;
+@synthesize sync_primary_immediately = _sync_primary_immediately;
+@synthesize sync_text1 = _sync_text1;
+@synthesize sync_text2 = _sync_text2;
+@synthesize depth = _depth;
+@synthesize x11_about_item = _x11_about_item;
+@synthesize dock_window_separator = _dock_window_separator;
+@synthesize apps_separator = _apps_separator;
+@synthesize toggle_fullscreen_item = _toggle_fullscreen_item;
+@synthesize copy_menu_item = _copy_menu_item;
+@synthesize dock_apps_menu = _dock_apps_menu;
+@synthesize apps_table = _apps_table;
+@synthesize dock_menu = _dock_menu;
 
 - (void) awakeFromNib
 {
@@ -88,7 +129,7 @@ extern char *bundle_id_prefix;
 
         /* convert from [TITLE1 COMMAND1 TITLE2 COMMAND2 ...]
            to [[TITLE1 COMMAND1] [TITLE2 COMMAND2] ...] format. */
-        if (count > 0 && ![appsMenu[0] isKindOfClass:NSArray.class]) {
+        if (count > 0 && ![[appsMenu objectAtIndex:0] isKindOfClass:[NSArray class]]) {
             int i;
             NSMutableArray *copy, *sub;
 
@@ -96,8 +137,8 @@ extern char *bundle_id_prefix;
 
             for (i = 0; i < count / 2; i++) {
                 sub = [[NSMutableArray alloc] initWithCapacity:3];
-                [sub addObject:appsMenu[i * 2]];
-                [sub addObject:appsMenu[i * 2 + 1]];
+                [sub addObject:[appsMenu objectAtIndex:i * 2]];
+                [sub addObject:[appsMenu objectAtIndex:i * 2 + 1]];
                 [sub addObject:@""];
                 [copy addObject:sub];
                 [sub release];
@@ -110,10 +151,10 @@ extern char *bundle_id_prefix;
         [self set_apps_menu:appsMenu];
     }
 
-    [NSNotificationCenter.defaultCenter addObserver:self
+    [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(apps_table_done:)
                                                name:NSWindowWillCloseNotification
-                                             object:self.apps_table.window];
+                                             object:[self.apps_table window]];
 }
 
 - (void) item_selected:sender
@@ -156,10 +197,10 @@ extern char *bundle_id_prefix;
     self.apps = nil;
 }
 
-- (void) prepend_apps_item:(NSArray <NSArray <NSString *> *> *)list index:(int)i menu:(NSMenu *)menu
+- (void) prepend_apps_item:(NSArray *)list index:(int)i menu:(NSMenu *)menu
 {
     NSString *title, *shortcut = @"";
-    NSArray <NSString *> *group;
+    NSArray *group;
     NSMenuItem *item;
 
     group = [list objectAtIndex:i];
@@ -183,7 +224,7 @@ extern char *bundle_id_prefix;
     [item setTag:i + 1];                  /* can't be zero, so add one */
 }
 
-- (void) install_apps_menu:(NSArray <NSArray <NSString *> *> *)list
+- (void) install_apps_menu:(NSArray *)list
 {
     NSMenu *menu;
     int i, count;
@@ -207,7 +248,7 @@ extern char *bundle_id_prefix;
     self.apps = list;
 }
 
-- (void) set_window_menu:(NSArray <NSArray <NSString *> *> *)list
+- (void) set_window_menu:(NSArray *)list
 {
     NSMenu * const menu = X11App.windowsMenu;
     NSMenu * const dock_menu = self.dock_menu;
@@ -237,9 +278,10 @@ extern char *bundle_id_prefix;
 
         for (NSInteger i = 0; i < itemsToAdd; i++) {
             NSString *name, *shortcut;
+            NSArray *row = [list objectAtIndex:i];
 
-            name = list[i][0];
-            shortcut = list[i][1];
+            name = [row objectAtIndex:0];
+            shortcut = [row objectAtIndex:1];
 
             if (windowItemModMask == 0 || windowItemModMask == -1)
                 shortcut = @"";
@@ -303,7 +345,7 @@ extern char *bundle_id_prefix;
     self.checked_window_item = n;
 }
 
-- (void) set_apps_menu:(NSArray <NSArray <NSString *> *> *)list
+- (void) set_apps_menu:(NSArray *)list
 {
     [self remove_apps_menu];
     [self install_apps_menu:list];
@@ -454,7 +496,7 @@ extern char *bundle_id_prefix;
 {
     int tag;
     NSString *item;
-    NSArray <NSArray <NSString *> *> * const apps = self.apps;
+    NSArray * const apps = self.apps;
 
     tag = [sender tag] - 1;
     if (apps == nil || tag < 0 || tag >= [apps count])
@@ -468,15 +510,15 @@ extern char *bundle_id_prefix;
 - (IBAction) apps_table_show:sender
 {
     NSArray *columns;
-    NSMutableArray <NSMutableArray <NSString *> *> * const oldapps = self.table_apps;
+    NSMutableArray * const oldapps = self.table_apps;
     NSTableView * const apps_table = self.apps_table;
 
-    NSMutableArray <NSMutableArray <NSString *> *> * const table_apps = [[NSMutableArray alloc] initWithCapacity:1];
+    NSMutableArray * const table_apps = [[NSMutableArray alloc] initWithCapacity:1];
     self.table_apps = table_apps;
 
-    NSArray <NSArray <NSString *> *> * const apps = self.apps;
+    NSArray * const apps = self.apps;
     if (apps != nil) {
-        for (NSArray <NSString *> * row in apps) {
+        for (NSArray * row in apps) {
             [table_apps addObject:row.mutableCopy];
         }
     }
@@ -498,7 +540,7 @@ extern char *bundle_id_prefix;
 
 - (IBAction) apps_table_done:sender
 {
-    NSMutableArray <NSMutableArray <NSString *> *> * const table_apps = self.table_apps;
+    NSMutableArray * const table_apps = self.table_apps;
     NSTableView * const apps_table = self.apps_table;
     [apps_table deselectAll:sender];    /* flush edits? */
 
@@ -516,7 +558,7 @@ extern char *bundle_id_prefix;
 - (IBAction) apps_table_new:sender
 {
     NSMutableArray *item;
-    NSMutableArray <NSMutableArray <NSString *> *> * const table_apps = self.table_apps;
+    NSMutableArray * const table_apps = self.table_apps;
     NSTableView * const apps_table = self.apps_table;
 
     int row = [apps_table selectedRow], i;
@@ -545,10 +587,10 @@ extern char *bundle_id_prefix;
 
 - (IBAction) apps_table_duplicate:sender
 {
-    NSMutableArray <NSMutableArray <NSString *> *> * const table_apps = self.table_apps;
+    NSMutableArray * const table_apps = self.table_apps;
     NSTableView * const apps_table = self.apps_table;
     int row = [apps_table selectedRow], i;
-    NSMutableArray <NSString *> *item;
+    NSMutableArray *item;
 
     if (row < 0) {
         [self apps_table_new:sender];
@@ -571,7 +613,7 @@ extern char *bundle_id_prefix;
 
 - (IBAction) apps_table_delete:sender
 {
-    NSMutableArray <NSMutableArray <NSString *> *> * const table_apps = self.table_apps;
+    NSMutableArray * const table_apps = self.table_apps;
     NSTableView * const apps_table = self.apps_table;
     int row = [apps_table selectedRow];
 
@@ -595,7 +637,7 @@ extern char *bundle_id_prefix;
 
 - (NSInteger) numberOfRowsInTableView:(NSTableView *)tableView
 {
-    NSMutableArray <NSMutableArray <NSString *> *> * const table_apps = self.table_apps;
+    NSMutableArray * const table_apps = self.table_apps;
     if (table_apps == nil) return 0;
 
     return [table_apps count];
@@ -604,7 +646,7 @@ extern char *bundle_id_prefix;
 - (id)             tableView:(NSTableView *)tableView
    objectValueForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row
 {
-    NSMutableArray <NSMutableArray <NSString *> *> * const table_apps = self.table_apps;
+    NSMutableArray * const table_apps = self.table_apps;
     NSArray *item;
     int col;
 
@@ -622,8 +664,8 @@ extern char *bundle_id_prefix;
 - (void) tableView:(NSTableView *)tableView setObjectValue:(id)object
     forTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row
 {
-    NSMutableArray <NSMutableArray <NSString *> *> * const table_apps = self.table_apps;
-    NSMutableArray <NSString *> *item;
+    NSMutableArray * const table_apps = self.table_apps;
+    NSMutableArray *item;
     int col;
 
     if (table_apps == nil) return;
@@ -686,7 +728,7 @@ extern char *bundle_id_prefix;
     XQuartzRootlessDefault = !self.enable_fullscreen.state;
 
     [self.enable_fullscreen_menu setEnabled:!XQuartzRootlessDefault];
-    [self.enable_fullscreen_menu_text setTextColor:XQuartzRootlessDefault ? NSColor.disabledControlTextColor : NSColor.controlTextColor];
+    [self.enable_fullscreen_menu_text setTextColor:XQuartzRootlessDefault ? [NSColor disabledControlTextColor] : [NSColor controlTextColor]];
 
     DarwinSendDDXEvent(kXquartzSetRootless, 1, XQuartzRootlessDefault);
 
@@ -748,8 +790,8 @@ extern char *bundle_id_prefix;
         [self.sync_primary_immediately setEnabled:pbproxy_active];
 
         // setEnabled doesn't do this...
-        [self.sync_text1 setTextColor:pbproxy_active ? NSColor.controlTextColor : NSColor.disabledControlTextColor];
-        [self.sync_text2 setTextColor:pbproxy_active ? NSColor.controlTextColor : NSColor.disabledControlTextColor];
+        [self.sync_text1 setTextColor:pbproxy_active ? [NSColor controlTextColor] : [NSColor disabledControlTextColor]];
+        [self.sync_text2 setTextColor:pbproxy_active ? [NSColor controlTextColor] : [NSColor disabledControlTextColor]];
     } else if (sender == self.sync_pasteboard_to_clipboard) {
         [defaults setBool:!!self.sync_pasteboard_to_clipboard.state forKey:XQuartzPrefKeySyncPasteboardToClipboard];
     } else if (sender == self.sync_pasteboard_to_primary) {
@@ -799,13 +841,13 @@ extern char *bundle_id_prefix;
     [self.sync_primary_immediately setEnabled:pbproxy_active];
 
     // setEnabled doesn't do this...
-    [self.sync_text1 setTextColor:pbproxy_active ? NSColor.controlTextColor : NSColor.disabledControlTextColor];
-    [self.sync_text2 setTextColor:pbproxy_active ? NSColor.controlTextColor : NSColor.disabledControlTextColor];
+    [self.sync_text1 setTextColor:pbproxy_active ? [NSColor controlTextColor] : [NSColor disabledControlTextColor]];
+    [self.sync_text2 setTextColor:pbproxy_active ? [NSColor controlTextColor] : [NSColor disabledControlTextColor]];
 
     [self.enable_fullscreen setIntValue:!XQuartzRootlessDefault];
     [self.enable_fullscreen_menu setIntValue:XQuartzFullscreenMenu];
     [self.enable_fullscreen_menu setEnabled:!XQuartzRootlessDefault];
-    [self.enable_fullscreen_menu_text setTextColor:XQuartzRootlessDefault ? NSColor.disabledControlTextColor : NSColor.controlTextColor];
+    [self.enable_fullscreen_menu_text setTextColor:XQuartzRootlessDefault ? [NSColor disabledControlTextColor] : [NSColor controlTextColor]];
 
     [self.prefs_panel makeKeyAndOrderFront:sender];
 }

--- a/hw/xquartz/X11Controller.m
+++ b/hw/xquartz/X11Controller.m
@@ -53,6 +53,7 @@
 #include <stdlib.h>
 
 #include "dix_priv.h"
+#include "osxcompat.h"
 
 extern aslclient aslc;
 extern char *bundle_id_prefix;
@@ -362,6 +363,7 @@ extern char *bundle_id_prefix;
         setenv("DISPLAY", buf, TRUE);
     }
 
+#ifdef HAS_ASL_LOG_DESCRIPTOR
     if (&asl_log_descriptor) {
         char *asl_sender;
         aslmsg amsg = asl_new(ASL_TYPE_MSG);
@@ -393,6 +395,7 @@ extern char *bundle_id_prefix;
 
         asl_free(amsg);
     }
+#endif
 
     /* Do the fork-twice trick to avoid having to reap zombies */
     child1 = fork();
@@ -410,12 +413,13 @@ extern char *bundle_id_prefix;
             _exit(1);
 
         case 0:                                     /* child2 */
+#ifdef HAS_ASL_LOG_DESCRIPTOR
             if (&asl_log_descriptor) {
                 /* Replace our stdout/stderr */
                 dup2(stdout_pipe[1], STDOUT_FILENO);
                 dup2(stderr_pipe[1], STDERR_FILENO);
             }
-
+#endif
             /* close all open files except for standard streams */
             max_files = sysconf(_SC_OPEN_MAX);
             for (i = 3; i < max_files; i++)
@@ -437,11 +441,13 @@ extern char *bundle_id_prefix;
         waitpid(child1, &status, 0);
     }
 
+#ifdef HAS_ASL_LOG_DESCRIPTOR
     if (&asl_log_descriptor) {
         /* Close the write ends of the pipe */
         close(stdout_pipe[1]);
         close(stderr_pipe[1]);
     }
+#endif
 }
 
 - (void) app_selected:sender

--- a/hw/xquartz/applewmExt.h
+++ b/hw/xquartz/applewmExt.h
@@ -35,6 +35,12 @@
 #include "window.h"
 #include <Xplugin.h>
 
+#if XPLUGIN_VERSION < 4
+typedef int xp_frame_attr;
+typedef int xp_frame_class;
+typedef int xp_frame_rect;
+#endif
+
 typedef int (*DisableUpdateProc)(void);
 typedef int (*EnableUpdateProc)(void);
 typedef int (*SetWindowLevelProc)(WindowPtr pWin, int level);

--- a/hw/xquartz/mach-startup/bundle-main.c
+++ b/hw/xquartz/mach-startup/bundle-main.c
@@ -44,8 +44,6 @@
 #include <stdbool.h>
 #include <signal.h>
 
-#include <dispatch/dispatch.h>
-
 #include <sys/socket.h>
 #include <sys/un.h>
 
@@ -54,8 +52,12 @@
 #include <mach/mach.h>
 #include <mach/mach_error.h>
 #include <servers/bootstrap.h>
+
 #include "mach_startup.h"
 #include "mach_startupServer.h"
+#include "osxcompat.h"
+
+#include <dispatch/dispatch.h>
 
 #include <asl.h>
 
@@ -524,8 +526,10 @@ setup_console_redirect(const char *bundle_id)
 
     asl_set_filter(aslc, ASL_FILTER_MASK_UPTO(ASL_LEVEL_WARNING));
 
+#ifdef HAS_ASL_LOG_DESCRIPTOR
     asl_log_descriptor(aslc, NULL, ASL_LEVEL_INFO, STDOUT_FILENO, ASL_LOG_DESCRIPTOR_WRITE);
     asl_log_descriptor(aslc, NULL, ASL_LEVEL_NOTICE, STDERR_FILENO, ASL_LOG_DESCRIPTOR_WRITE);
+#endif
 }
 
 static void

--- a/hw/xquartz/mach-startup/bundle-main.c
+++ b/hw/xquartz/mach-startup/bundle-main.c
@@ -57,7 +57,9 @@
 #include "mach_startupServer.h"
 #include "osxcompat.h"
 
+#ifdef HAS_LIBDISPATCH
 #include <dispatch/dispatch.h>
+#endif
 
 #include <asl.h>
 
@@ -114,6 +116,23 @@ static char *pref_app_to_run;
 static char *pref_login_shell;
 static char *pref_startx_script;
 
+#ifndef HAS_LIBDISPATCH
+/*** Pthread Magics ***/
+static pthread_t
+create_thread(void *(*func)(void *), void *arg)
+{
+    pthread_attr_t attr;
+    pthread_t tid;
+
+    pthread_attr_init(&attr);
+    pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    pthread_create(&tid, &attr, func, arg);
+    pthread_attr_destroy(&attr);
+
+    return tid;
+}
+#endif
 
 /*** Mach-O IPC Stuffs ***/
 
@@ -221,9 +240,16 @@ typedef struct {
 /* This thread accepts an incoming connection and hands off the file
  * descriptor for the new connection to accept_fd_handoff()
  */
+#ifdef HAS_LIBDISPATCH
 static void
 socket_handoff(socket_handoff_t *handoff_data)
 {
+#else
+static void *
+socket_handoff_thread(void *arg)
+{
+    socket_handoff_t *handoff_data = (socket_handoff_t *)arg;
+#endif
 
     int launchd_fd = -1;
     int connected_fd;
@@ -258,6 +284,9 @@ socket_handoff(socket_handoff_t *handoff_data)
         launchd_fd);
     DarwinListenOnOpenFD(launchd_fd);
 
+#ifndef HAS_LIBDISPATCH
+    return NULL;
+#endif
 }
 
 static int
@@ -345,9 +374,13 @@ do_request_fd_handoff_socket(mach_port_t port, string_t filename)
 
     strlcpy(filename, handoff_data->filename, STRING_T_SIZE);
 
+#ifdef HAS_LIBDISPATCH
     dispatch_async_f(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
                      handoff_data,
                      socketHandoff_fptr);
+#else
+    create_thread(socket_handoff_thread, handoff_data);
+#endif
 
 #ifdef DEBUG
     ErrorF(

--- a/hw/xquartz/mach-startup/meson.build
+++ b/hw/xquartz/mach-startup/meson.build
@@ -28,14 +28,32 @@ x11appdir = join_paths(bundle_root, 'Contents/MacOS')
 
 x11_bin_deps = [
      meson.get_compiler('c').find_library('Xplugin'),
+]
+
+# Work around meson bug:
+if cc.get_id() == 'clang'
+  x11_bin_deps += [
      dependency('Carbon', method: 'extraframework'),
      cocoa,
      dependency('CoreAudio', method: 'extraframework'),
      dependency('IOKit', method: 'extraframework')
-]
+  ]
+  binlinkargs = ['-Objc']
+else
+  binlinkargs = [
+    '-framework', 'Carbon',
+    '-framework', 'Cocoa',
+    '-framework', 'CoreAudio',
+    '-framework', 'IOKit'
+  ]
+endif
 
 if build_glx
+  if cc.get_id() == 'clang'
     x11_bin_deps += [dependency('OpenGL', method: 'extraframework')]
+  else
+    binlinkargs += ['-framework', 'OpenGL']
+  endif
 endif
 
 if build_sparkle
@@ -65,10 +83,16 @@ x11_bin = executable('X11.bin',
      dependencies: [xproto_dep, x11_dep, x11_bin_deps, mach_startup_dep],
      include_directories: [inc, '..', top_dir_inc],
      c_args: xquartz_defs,
-     link_args: ['-Objc'],
+     link_args: binlinkargs,
      install: true,
      install_dir: x11appdir,
 )
+
+if cc.get_id() == 'clang'
+     execlinkargs = ['-Objc']
+else
+     execlinkargs = []
+endif
 
 # X11 (Bundle trampoline)
 x11 = executable('X11',
@@ -76,15 +100,21 @@ x11 = executable('X11',
       'bundle_trampoline.c',
      ],
      c_args: xquartz_defs,
-     link_args: ['-Objc'],
+     link_args: execlinkargs,
      install: true,
      install_dir: x11appdir,
 )
 
 # Xquartz
-xquartz_deps = [
+if cc.get_id() == 'clang'
+  xquartz_deps = [
     dependency('CoreServices', method: 'extraframework'),
-]
+  ]
+  xquartz_linkargs = []
+else
+  xquartz_deps = []
+  xquartz_linkargs = ['-framework', 'CoreServices']
+endif
 
 xquartz = executable('Xquartz',
     [
@@ -94,6 +124,7 @@ xquartz = executable('Xquartz',
     ],
     include_directories: inc,
     c_args: xquartz_defs,
+    link_args: xquartz_linkargs,
     dependencies: [xquartz_deps, mach_startup_dep],
     install: true,
 )

--- a/hw/xquartz/meson.build
+++ b/hw/xquartz/meson.build
@@ -69,7 +69,7 @@ libxquartz_defs = [
 ]
 
 if cc.has_function('dispatch_async')
-    libxquartz_defs += '-DHAVE_LIBDISPATCH'
+    libxquartz_defs += '-DHAS_LIBDISPATCH'
 endif
 
 libXquartz = static_library('Xquartz',

--- a/hw/xquartz/osxcompat.h
+++ b/hw/xquartz/osxcompat.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008 Apple, Inc.
+ * Copyright (c) 2001-2004 Torrey T. Lyons. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE ABOVE LISTED COPYRIGHT HOLDER(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name(s) of the above copyright
+ * holders shall not be used in advertising or otherwise to promote the sale,
+ * use or other dealings in this Software without prior written authorization.
+ */
+
+#ifndef _OSXCOMPAT_H
+#define _OSXCOMPAT_H
+
+#include <AvailabilityMacros.h>
+
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+#define HAS_LIBDISPATCH
+#endif
+
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1080
+#define HAS_ASL_LOG_DESCRIPTOR
+#endif
+
+#if __OBJC__
+#ifdef __clang__
+  #define OBJC_AUTORELEASEPOOL_BEGIN @autoreleasepool {
+  #define OBJC_AUTORELEASEPOOL_END }
+  #define OBJC_AUTORELEASEPOOL_EXIT
+#else
+  #define OBJC_AUTORELEASEPOOL_BEGIN NSAutoreleasePool *_pool = [[NSAutoreleasePool alloc] init];
+  #define OBJC_AUTORELEASEPOOL_END [_pool drain];
+  #define OBJC_AUTORELEASEPOOL_EXIT [_pool drain];
+#endif
+#endif
+
+#endif /* _OSXCOMPAT_H */

--- a/hw/xquartz/pbproxy/main.m
+++ b/hw/xquartz/pbproxy/main.m
@@ -35,6 +35,8 @@
 #include <unistd.h>
 #include <X11/extensions/applewm.h>
 
+#include "osxcompat.h"
+
 Display *xpbproxy_dpy;
 int xpbproxy_apple_wm_event_base, xpbproxy_apple_wm_error_base;
 int xpbproxy_xfixes_event_base, xpbproxy_xfixes_error_base;
@@ -78,7 +80,7 @@ x_error_handler(Display *dpy, XErrorEvent *errevent)
 int
 xpbproxy_run(void)
 {
-    @autoreleasepool {
+    OBJC_AUTORELEASEPOOL_BEGIN
         size_t i;
 
         for (i = 0, xpbproxy_dpy = NULL; !xpbproxy_dpy && i < 5; i++) {
@@ -97,6 +99,7 @@ xpbproxy_run(void)
 
         if (xpbproxy_dpy == NULL) {
             ErrorF("xpbproxy: can't open default display\n");
+            OBJC_AUTORELEASEPOOL_EXIT
             return EXIT_FAILURE;
         }
 
@@ -106,6 +109,7 @@ xpbproxy_run(void)
         if (!XAppleWMQueryExtension(xpbproxy_dpy, &xpbproxy_apple_wm_event_base,
                                     &xpbproxy_apple_wm_error_base)) {
             ErrorF("xpbproxy: can't open AppleWM server extension\n");
+            OBJC_AUTORELEASEPOOL_EXIT
             return EXIT_FAILURE;
         }
 
@@ -117,9 +121,10 @@ xpbproxy_run(void)
         _selection_object = [x_selection new];
 
         if (!xpbproxy_input_register()) {
+            OBJC_AUTORELEASEPOOL_EXIT
             return EXIT_FAILURE;
         }
-    }
+    OBJC_AUTORELEASEPOOL_END
 
     CFRunLoopRun();
 

--- a/hw/xquartz/pbproxy/meson.build
+++ b/hw/xquartz/pbproxy/meson.build
@@ -20,13 +20,19 @@ libxpbproxy = static_library('xpbproxy',
     objc_args: pbproxy_defs,
 )
 
-cocoa = dependency('Cocoa', method: 'extraframework')
+if cc.get_id() == 'clang'
+  cocoa = dependency('Cocoa', method: 'extraframework')
+  xpbproxy_linkargs = []
+else
+  xpbproxy_linkargs = ['-framework Cocoa']
+endif
 
 # standalone xpbproxy
 if build_standalone_pbproxy
     executable('xpbproxy',
         'app-main.m',
         link_with: libxpbproxy,
+        link_args: xpbproxy_linkargs,
         dependencies: [cocoa, dependency('x11')],
         objc_args: pbproxy_defs,
         install: true,

--- a/hw/xquartz/pbproxy/x-input.m
+++ b/hw/xquartz/pbproxy/x-input.m
@@ -40,6 +40,8 @@
 
 #include <unistd.h>
 
+#include "osxcompat.h"
+
 static CFRunLoopSourceRef xpbproxy_dpy_source;
 
 #ifdef STANDALONE_XPBPROXY
@@ -89,7 +91,8 @@ x_event_apple_wm_notify(XAppleWMNotifyEvent *e)
 static void
 xpbproxy_process_xevents(void)
 {
-    while (XPending(xpbproxy_dpy) != 0) { @autoreleasepool {
+    while (XPending(xpbproxy_dpy) != 0) {
+        OBJC_AUTORELEASEPOOL_BEGIN
         XEvent e;
 
         XNextEvent(xpbproxy_dpy, &e);
@@ -127,7 +130,8 @@ xpbproxy_process_xevents(void)
         }
 
         XFlush(xpbproxy_dpy);
-    }}
+        OBJC_AUTORELEASEPOOL_END
+    }
 }
 
 static BOOL

--- a/hw/xquartz/quartz.c
+++ b/hw/xquartz/quartz.c
@@ -64,6 +64,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <AvailabilityMacros.h>
 #include <IOKit/pwr_mgt/IOPMLib.h>
 #include <libkern/OSAtomic.h>
 #include <signal.h>
@@ -77,8 +78,10 @@
 // in the OS without major bincompat ramifications.
 //
 // These were added in macOS 10.7.
+#if defined(__clang__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1070)
 void * _Nonnull objc_autoreleasePoolPush(void);
 void objc_autoreleasePoolPop(void * _Nonnull context);
+#endif
 
 DevPrivateKeyRec quartzScreenKeyRec;
 int aquaMenuBarHeight = 0;
@@ -160,12 +163,14 @@ QuartzSetupScreen(int index,
 static void
 QuartzBlockHandler(void *blockData, void *pTimeout)
 {
+#if defined(__clang__) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1070)
     static void *poolToken = NULL;
 
     if (poolToken) {
         objc_autoreleasePoolPop(poolToken);
     }
     poolToken = objc_autoreleasePoolPush();
+#endif
 }
 
 /*

--- a/hw/xquartz/quartzKeyboard.c
+++ b/hw/xquartz/quartzKeyboard.c
@@ -60,6 +60,7 @@
 #include "exevents.h"
 #include "X11/keysym.h"
 #include "keysym2ucs.h"
+#include "osxcompat.h"
 
 extern void
 CopyKeyClass(DeviceIntPtr device, DeviceIntPtr master);
@@ -771,11 +772,15 @@ QuartzReadSystemKeymap(darwinKeyboardInfo *info)
     KeySym *k;
 
     /* This is an ugly ant-pattern, but it is more expedient to address the problem right now. */
+#ifdef HAS_LIBDISPATCH
     if (pthread_main_np()) {
         getKeyboardData(&ctx);
     } else {
         dispatch_sync_f(dispatch_get_main_queue(), &ctx, getKeyboardData);
     }
+#else
+    getKeyboardData(&ctx);
+#endif
 
     if (ctx.chr_data == NULL) {
         ErrorF("Couldn't get uchr or kchr resource\n");

--- a/hw/xquartz/quartzRandR.c
+++ b/hw/xquartz/quartzRandR.c
@@ -63,6 +63,155 @@ static Bool ignore_next_fake_mode_update = FALSE;
 typedef int (*QuartzModeCallback)
     (ScreenPtr, QuartzModeInfoPtr, void *);
 
+/* Modern CG APIs may not work on 10.6 ppc */
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060 || defined(__ppc__)
+
+static long
+getDictLong(CFDictionaryRef dictRef, CFStringRef key)
+{
+    long value;
+
+    CFNumberRef numRef = (CFNumberRef)CFDictionaryGetValue(dictRef, key);
+    if (!numRef)
+        return 0;
+
+    if (!CFNumberGetValue(numRef, kCFNumberLongType, &value))
+        return 0;
+    return value;
+}
+
+static double
+getDictDouble(CFDictionaryRef dictRef, CFStringRef key)
+{
+    double value;
+
+    CFNumberRef numRef = (CFNumberRef)CFDictionaryGetValue(dictRef, key);
+    if (!numRef)
+        return 0.0;
+
+    if (!CFNumberGetValue(numRef, kCFNumberDoubleType, &value))
+        return 0.0;
+    return value;
+}
+
+static void
+QuartzRandRGetModeInfo(CFDictionaryRef modeRef,
+                       QuartzModeInfoPtr pMode)
+{
+    pMode->width = (size_t)getDictLong(modeRef, kCGDisplayWidth);
+    pMode->height = (size_t)getDictLong(modeRef, kCGDisplayHeight);
+    pMode->refresh =
+        (int)(getDictDouble(modeRef, kCGDisplayRefreshRate) + 0.5);
+    if (pMode->refresh == 0)
+        pMode->refresh = DEFAULT_REFRESH;
+    pMode->ref = NULL;
+    pMode->pSize = NULL;
+}
+
+static Bool
+QuartzRandRCopyCurrentModeInfo(CGDirectDisplayID screenId,
+                               QuartzModeInfoPtr pMode)
+{
+    CFDictionaryRef curModeRef = CGDisplayCurrentMode(screenId);
+    if (!curModeRef)
+        return FALSE;
+
+    QuartzRandRGetModeInfo(curModeRef, pMode);
+    pMode->ref = (void *)curModeRef;
+    CFRetain(pMode->ref);
+    return TRUE;
+}
+
+static Bool
+QuartzRandRSetCGMode(CGDirectDisplayID screenId,
+                     QuartzModeInfoPtr pMode)
+{
+    CFDictionaryRef modeRef = (CFDictionaryRef)pMode->ref;
+    return (CGDisplaySwitchToMode(screenId, modeRef) == kCGErrorSuccess);
+}
+
+static Bool
+QuartzRandREnumerateModes(ScreenPtr pScreen,
+                          QuartzModeCallback callback,
+                          void *data)
+{
+    Bool retval = FALSE;
+    QuartzScreenPtr pQuartzScreen = QUARTZ_PRIV(pScreen);
+
+    /* Just an 800x600 fallback if we have no attached heads */
+    if (pQuartzScreen->displayIDs) {
+        CFDictionaryRef curModeRef, modeRef;
+        long curBpp;
+        CFArrayRef modes;
+        QuartzModeInfo modeInfo;
+        int i;
+        CGDirectDisplayID screenId = pQuartzScreen->displayIDs[0];
+
+        curModeRef = CGDisplayCurrentMode(screenId);
+        if (!curModeRef)
+            return FALSE;
+        curBpp = getDictLong(curModeRef, kCGDisplayBitsPerPixel);
+
+        modes = CGDisplayAvailableModes(screenId);
+        if (!modes)
+            return FALSE;
+        for (i = 0; i < CFArrayGetCount(modes); i++) {
+            int cb;
+            modeRef = (CFDictionaryRef)CFArrayGetValueAtIndex(modes, i);
+
+            /* Skip modes that are not usable on the current display or have
+               a different pixel encoding than the current mode. */
+            if (((unsigned long)getDictLong(modeRef, kCGDisplayIOFlags) &
+                 kDisplayModeUsableFlags) != kDisplayModeUsableFlags)
+                continue;
+            if (getDictLong(modeRef, kCGDisplayBitsPerPixel) != curBpp)
+                continue;
+
+            QuartzRandRGetModeInfo(modeRef, &modeInfo);
+            modeInfo.ref = (void *)modeRef;
+            cb = callback(pScreen, &modeInfo, data);
+            if (cb == CALLBACK_CONTINUE)
+                retval = TRUE;
+            else if (cb == CALLBACK_SUCCESS)
+                return TRUE;
+            else if (cb == CALLBACK_ERROR)
+                return FALSE;
+        }
+    }
+
+    switch (callback(pScreen, &pQuartzScreen->rootlessMode, data)) {
+    case CALLBACK_SUCCESS:
+        return TRUE;
+
+    case CALLBACK_ERROR:
+        return FALSE;
+
+    case CALLBACK_CONTINUE:
+        retval = TRUE;
+
+    default:
+        break;
+    }
+
+    switch (callback(pScreen, &pQuartzScreen->fullscreenMode, data)) {
+    case CALLBACK_SUCCESS:
+        return TRUE;
+
+    case CALLBACK_ERROR:
+        return FALSE;
+
+    case CALLBACK_CONTINUE:
+        retval = TRUE;
+
+    default:
+        break;
+    }
+
+    return retval;
+}
+
+#else /* We have the new CG APIs */
+
 static void
 QuartzRandRGetModeInfo(CGDisplayModeRef modeRef,
                        QuartzModeInfoPtr pMode)
@@ -198,6 +347,8 @@ QuartzRandREnumerateModes(ScreenPtr pScreen,
 
     return retval;
 }
+
+#endif  /* Modern CoreGraphics APIs */
 
 static Bool
 QuartzRandRModesEqual(QuartzModeInfoPtr pMode1,

--- a/hw/xquartz/xpr/x-list.h
+++ b/hw/xquartz/xpr/x-list.h
@@ -45,7 +45,11 @@ struct x_list_struct {
 #endif
 
 #ifndef X_EXTERN
+#ifdef __private_extern__
 #define X_EXTERN __private_extern__
+#else
+#define X_EXTERN __attribute__((visibility("hidden")))
+#endif
 #endif
 
 X_EXTERN void X_PFX(list_free_1) (x_list * node);

--- a/hw/xquartz/xpr/xprEvent.c
+++ b/hw/xquartz/xpr/xprEvent.c
@@ -50,16 +50,17 @@
 #include "darwinEvents.h"
 #include "quartz.h"
 #include "quartzKeyboard.h"
-
-#include <dispatch/dispatch.h>
-
 #include "rootlessWindow.h"
 #include "xprEvent.h"
+
+#if XPLUGIN_VERSION >= 6
+#include <dispatch/dispatch.h>
 
 static void bringAllToFront(void *unused) {
   (void)unused; /* to silence the compiler warning */
   xp_window_bring_all_to_front();
 }
+#endif
 
 bool QuartzModeEventHandler(int screenNum, XQuartzEvent *e, DeviceIntPtr dev) {
   switch (e->subtype) {
@@ -75,9 +76,13 @@ bool QuartzModeEventHandler(int screenNum, XQuartzEvent *e, DeviceIntPtr dev) {
 
   case kXquartzBringAllToFront:
     DEBUG_LOG("kXquartzBringAllToFront\n");
+#if XPLUGIN_VERSION >= 6
     dispatch_async_f(
         dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), NULL,
         bringAllToFront);
+#else
+        RootlessOrderAllWindows(e->data[0]);
+#endif
 
     return TRUE;
 

--- a/hw/xquartz/xpr/xprEvent.c
+++ b/hw/xquartz/xpr/xprEvent.c
@@ -52,10 +52,13 @@
 #include "quartzKeyboard.h"
 #include "rootlessWindow.h"
 #include "xprEvent.h"
+#include "osxcompat.h"
+
+#ifdef HAS_LIBDISPATCH
+#include <dispatch/dispatch.h>
+#endif
 
 #if XPLUGIN_VERSION >= 6
-#include <dispatch/dispatch.h>
-
 static void bringAllToFront(void *unused) {
   (void)unused; /* to silence the compiler warning */
   xp_window_bring_all_to_front();
@@ -76,7 +79,7 @@ bool QuartzModeEventHandler(int screenNum, XQuartzEvent *e, DeviceIntPtr dev) {
 
   case kXquartzBringAllToFront:
     DEBUG_LOG("kXquartzBringAllToFront\n");
-#if XPLUGIN_VERSION >= 6
+#if defined(HAS_LIBDISPATCH) && (XPLUGIN_VERSION >= 6)
     dispatch_async_f(
         dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), NULL,
         bringAllToFront);

--- a/hw/xquartz/xpr/xprFrame.c
+++ b/hw/xquartz/xpr/xprFrame.c
@@ -44,8 +44,13 @@
 #include <X11/Xatom.h>
 #include "windowstr.h"
 #include "quartz.h"
+#include "osxcompat.h"
 
+#ifdef HAS_LIBDISPATCH
 #include <dispatch/dispatch.h>
+#else
+#include <pthread.h>
+#endif
 
 #define DEFINE_ATOM_HELPER(func, atom_name)                      \
     static Atom func(void) {                                       \
@@ -63,7 +68,11 @@ typedef struct _WindowHashInsertCtx {
 static x_hash_table * window_hash;
 
 /* Need to guard window_hash since xprIsX11Window can be called from any thread. */
+#ifdef HAS_LIBDISPATCH
 static dispatch_queue_t window_hash_serial_q;
+#else
+static pthread_rwlock_t window_hash_rwlock;
+#endif
 
 /* Prototypes for static functions */
 static Bool
@@ -206,6 +215,7 @@ xprCreateFrame(RootlessWindowPtr pFrame, ScreenPtr pScreen,
         return FALSE;
     }
 
+#ifdef HAS_LIBDISPATCH
     WindowHashInsertCtx *ctx = malloc(sizeof(WindowHashInsertCtx));
     if (!ctx) return FALSE;
 
@@ -213,6 +223,12 @@ xprCreateFrame(RootlessWindowPtr pFrame, ScreenPtr pScreen,
     ctx->frame = pFrame;
 
     dispatch_async_f(window_hash_serial_q, ctx, windowHashInsert);
+#else
+    pthread_rwlock_wrlock(&window_hash_rwlock);
+    x_hash_table_insert(window_hash, pFrame->wid, pFrame);
+    pthread_rwlock_unlock(&window_hash_rwlock);
+#endif
+
     xprSetNativeProperty(pFrame);
 
     return TRUE;
@@ -248,11 +264,18 @@ static void windowLookup(void *arg) {
 static void
 xprDestroyFrame(RootlessFrameID wid)
 {
+#ifdef HAS_LIBDISPATCH
     WindowHashRemoveCtx *ctx = malloc(sizeof(WindowHashRemoveCtx));
     if (!ctx) FatalError("Could not allocate memory for the hash removal context.");
 
     ctx->wid = wid;
+
     dispatch_async_f(window_hash_serial_q, ctx, windowHashRemove);
+#else
+    pthread_rwlock_wrlock(&window_hash_rwlock);
+    x_hash_table_remove(window_hash, wid);
+    pthread_rwlock_unlock(&window_hash_rwlock);
+#endif
 
     xp_error err = xp_destroy_window(x_cvt_vptr_to_uint(wid));
     if (err != Success)
@@ -324,7 +347,13 @@ xprRestackFrame(RootlessFrameID wid, RootlessFrameID nextWid)
         wc.sibling = x_cvt_vptr_to_uint(nextWid);
     }
 
+#ifdef HAS_LIBDISPATCH
     dispatch_sync_f(window_hash_serial_q, &ctx, windowLookup);
+#else
+    pthread_rwlock_rdlock(&window_hash_rwlock);
+    winRec = x_hash_table_lookup(window_hash, wid, NULL);
+    pthread_rwlock_unlock(&window_hash_rwlock);
+#endif
 
     if (winRec) {
         if (XQuartzIsRootless)
@@ -515,9 +544,13 @@ xprInit(ScreenPtr pScreen)
     rootless_CopyWindow_threshold = xp_scroll_area_threshold;
 
     assert((window_hash = x_hash_table_new(NULL, NULL, NULL, NULL)));
+#ifdef HAS_LIBDISPATCH
     assert((window_hash_serial_q =
                 dispatch_queue_create(BUNDLE_ID_PREFIX ".X11.xpr_window_hash",
                                       NULL)));
+#else
+    assert(0 == pthread_rwlock_init(&window_hash_rwlock, NULL));
+#endif
 
     return TRUE;
 }
@@ -535,12 +568,19 @@ WindowPtr
 xprGetXWindow(xp_window_id wid)
 {
     RootlessWindowRec *winRec;
+#ifdef HAS_LIBDISPATCH
     WindowGetCtx ctx = {
         .wid = x_cvt_uint_to_vptr(wid),
         .winrec = &winRec
     };
 
     dispatch_sync_f(window_hash_serial_q, &ctx, windowGet);
+#else
+    RootlessWindowRec *winRec;
+    pthread_rwlock_rdlock(&window_hash_rwlock);
+    winRec = x_hash_table_lookup(window_hash, x_cvt_uint_to_vptr(wid), NULL);
+    pthread_rwlock_unlock(&window_hash_rwlock);
+#endif
 
     return winRec != NULL ? winRec->win : NULL;
 }

--- a/hw/xquartz/xpr/xprScreen.c
+++ b/hw/xquartz/xpr/xprScreen.c
@@ -318,6 +318,11 @@ xprAddScreen(int index, ScreenPtr pScreen)
     DEBUG_LOG("index=%d depth=%d\n", index, depth);
 
     if (depth == -1) {
+/* Modern CG APIs may not work on 10.6 ppc */
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060 || defined(__ppc__)
+        depth = CGDisplaySamplesPerPixel(kCGDirectMainDisplay) *
+                CGDisplayBitsPerSample(kCGDirectMainDisplay);
+#else
         CGDisplayModeRef modeRef;
         CFStringRef encStrRef;
 
@@ -347,9 +352,12 @@ xprAddScreen(int index, ScreenPtr pScreen)
         }
 
         CFRelease(encStrRef);
+#endif
     }
 
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060 && !defined(__ppc__)
 have_depth:
+#endif
     switch (depth) {
     case 8:     // pseudo-working
         dfb->visuals = PseudoColorMask;

--- a/meson.build
+++ b/meson.build
@@ -12,9 +12,7 @@ cc = meson.get_compiler('c')
 
 add_project_arguments('-fno-strict-aliasing', language : 'c')
 add_project_arguments('-fvisibility=hidden', language : 'c')
-add_project_arguments('-Wvla', language: 'c')
 add_project_arguments('-fno-common', language: 'c')
-add_project_arguments('-Wshift-negative-value', language: 'c')
 add_project_arguments('-Wchar-subscripts', language: 'c')
 
 # workaround for mesa bug causing GLsync to be typedef'ed multiple times
@@ -67,6 +65,7 @@ if cc.get_id() == 'gcc' or cc.get_id() == 'clang'
         '-Werror=int-to-pointer-cast',
         '-Werror=pointer-to-int-cast',
         '-Woverride-init',
+        '-Wshift-negative-value',
         '-Wvla',
         '-Wincompatible-pointer-types',
     ]


### PR DESCRIPTION
This will be a follow-up to https://github.com/X11Libre/xserver/pull/1743
See also: https://github.com/X11Libre/xserver/issues/1719

Update. Tested on 10.6.8 ppc (Apple gcc-4.2 and gcc-14), 10.15.8 x86_64 (Apple clang) and 14.7.1 arm64 (Apple clang).