### PR TITLE
glamor/glamor_egl: Import pixmaps directly from dma bufs

### DIFF
--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -63,6 +63,10 @@
 #include "glamor_glx_provider.h"
 #include "dri3.h"
 
+#ifndef GBM_MAX_PLANES
+#define GBM_MAX_PLANES 4
+#endif
+
 /**
  * EGLDeviceEXT's are internally stored as a globals.
  * As such, when multiple screens query the same device,
@@ -206,7 +210,6 @@ glamor_get_flink_name(int fd, int handle, int *name)
 }
 #endif
 
-#ifdef GLAMOR_HAS_GBM
 static Bool
 glamor_create_texture_from_image(ScreenPtr screen,
                                  EGLImageKHR image, GLuint * texture)
@@ -226,7 +229,6 @@ glamor_create_texture_from_image(ScreenPtr screen,
 
     return TRUE;
 }
-#endif
 
 struct gbm_device *
 glamor_egl_get_gbm_device(ScreenPtr screen)
@@ -238,7 +240,6 @@ glamor_egl_get_gbm_device(ScreenPtr screen)
 #endif
 }
 
-#ifdef GLAMOR_HAS_GBM
 static void
 glamor_egl_set_pixmap_image(PixmapPtr pixmap, EGLImageKHR image,
                             Bool used_modifiers)
@@ -259,7 +260,6 @@ glamor_egl_set_pixmap_image(PixmapPtr pixmap, EGLImageKHR image,
     pixmap_priv->image = image;
     pixmap_priv->used_modifiers = used_modifiers;
 }
-#endif
 
 Bool
 glamor_egl_create_textured_pixmap(PixmapPtr pixmap, int handle, int stride)
@@ -299,25 +299,18 @@ glamor_egl_create_textured_pixmap(PixmapPtr pixmap, int handle, int stride)
 #endif
 }
 
-Bool
-glamor_egl_create_textured_pixmap_from_gbm_bo(PixmapPtr pixmap,
-                                              struct gbm_bo *bo,
-                                              Bool used_modifiers)
+static EGLImageKHR
+glamor_egl_image_from_dma_bufs(ScreenPtr screen,
+                               uint32_t num_fds, const int *fds,
+                               int width, int height,
+                               const int *strides, const int *offsets,
+                               uint32_t format, uint64_t modifier)
 {
-#ifdef GLAMOR_HAS_GBM
-    ScreenPtr screen = pixmap->drawable.pScreen;
     struct glamor_screen_private *glamor_priv =
         glamor_get_screen_private(screen);
-    glamor_egl_priv_t *glamor_egl;
-    EGLImageKHR image = EGL_NO_IMAGE_KHR;
-    GLuint texture;
-    Bool ret = FALSE;
+    glamor_egl_priv_t *glamor_egl =
+        glamor_egl = glamor_egl_get_screen_private(screen);
 
-    glamor_egl = glamor_egl_get_screen_private(screen);
-#ifdef GBM_BO_FD_FOR_PLANE
-    uint64_t modifier = gbm_bo_get_modifier(bo);
-    const int num_planes = gbm_bo_get_plane_count(bo);
-    int fds[GBM_MAX_PLANES];
     int plane;
     int attr_num = 0;
     EGLint img_attrs[64] = {0};
@@ -360,76 +353,187 @@ glamor_egl_create_textured_pixmap_from_gbm_bo(PixmapPtr pixmap,
         },
     };
 
-    for (plane = 0; plane < num_planes; plane++) fds[plane] = -1;
-#endif
-
     glamor_make_current(glamor_priv);
 
+#define ADD_ATTR(attrs, num, attr)                                      \
+    do {                                                            \
+        assert(((num) + 1) < (sizeof(attrs) / sizeof((attrs)[0]))); \
+        (attrs)[(num)++] = (attr);                                  \
+    } while (0)
+    ADD_ATTR(img_attrs, attr_num, EGL_WIDTH);
+    ADD_ATTR(img_attrs, attr_num, width);
+    ADD_ATTR(img_attrs, attr_num, EGL_HEIGHT);
+    ADD_ATTR(img_attrs, attr_num, height);
+    ADD_ATTR(img_attrs, attr_num, EGL_LINUX_DRM_FOURCC_EXT);
+    ADD_ATTR(img_attrs, attr_num, format);
+
+    for (plane = 0; plane < num_fds; plane++) {
+        ADD_ATTR(img_attrs, attr_num, planeAttrs[plane][PLANE_FD]);
+        ADD_ATTR(img_attrs, attr_num, fds[plane]);
+        ADD_ATTR(img_attrs, attr_num, planeAttrs[plane][PLANE_OFFSET]);
+        ADD_ATTR(img_attrs, attr_num, offsets[plane]);
+        ADD_ATTR(img_attrs, attr_num, planeAttrs[plane][PLANE_PITCH]);
+        ADD_ATTR(img_attrs, attr_num, strides[plane]);
+        ADD_ATTR(img_attrs, attr_num, planeAttrs[plane][PLANE_MODIFIER_LO]);
+        ADD_ATTR(img_attrs, attr_num, (uint32_t)(modifier & 0xFFFFFFFFULL));
+        ADD_ATTR(img_attrs, attr_num, planeAttrs[plane][PLANE_MODIFIER_HI]);
+        ADD_ATTR(img_attrs, attr_num, (uint32_t)(modifier >> 32ULL));
+    }
+    ADD_ATTR(img_attrs, attr_num, EGL_NONE);
+#undef ADD_ATTR
+
+    return eglCreateImageKHR(glamor_egl->display,
+                             EGL_NO_CONTEXT,
+                             EGL_LINUX_DMA_BUF_EXT,
+                             NULL,
+                             img_attrs);
+}
+
+#ifdef GLAMOR_HAS_GBM
+static EGLImageKHR
+glamor_egl_image_from_gbm_bo(ScreenPtr screen, struct gbm_bo *bo)
+{
+    glamor_egl_priv_t *glamor_egl =
+        glamor_egl = glamor_egl_get_screen_private(screen);
+
+    Bool tried_fast_import = FALSE;
+
     if (glamor_egl->fast_gbm_import) {
+        EGLImageKHR image;
         image = eglCreateImageKHR(glamor_egl->display,
                                   EGL_NO_CONTEXT,
                                   EGL_NATIVE_PIXMAP_KHR, bo, NULL);
-    }
-#ifdef GBM_BO_FD_FOR_PLANE
-    if (image == EGL_NO_IMAGE_KHR &&
-        glamor_egl->dmabuf_capable) {
-#define ADD_ATTR(attrs, num, attr)                                      \
-        do {                                                            \
-            assert(((num) + 1) < (sizeof(attrs) / sizeof((attrs)[0]))); \
-            (attrs)[(num)++] = (attr);                                  \
-        } while (0)
-        ADD_ATTR(img_attrs, attr_num, EGL_WIDTH);
-        ADD_ATTR(img_attrs, attr_num, gbm_bo_get_width(bo));
-        ADD_ATTR(img_attrs, attr_num, EGL_HEIGHT);
-        ADD_ATTR(img_attrs, attr_num, gbm_bo_get_height(bo));
-        ADD_ATTR(img_attrs, attr_num, EGL_LINUX_DRM_FOURCC_EXT);
-        ADD_ATTR(img_attrs, attr_num, gbm_bo_get_format(bo));
-
-        for (plane = 0; plane < num_planes; plane++) {
-            fds[plane] = gbm_bo_get_fd_for_plane(bo, plane);
-            ADD_ATTR(img_attrs, attr_num, planeAttrs[plane][PLANE_FD]);
-            ADD_ATTR(img_attrs, attr_num, fds[plane]);
-            ADD_ATTR(img_attrs, attr_num, planeAttrs[plane][PLANE_OFFSET]);
-            ADD_ATTR(img_attrs, attr_num, gbm_bo_get_offset(bo, plane));
-            ADD_ATTR(img_attrs, attr_num, planeAttrs[plane][PLANE_PITCH]);
-            ADD_ATTR(img_attrs, attr_num, gbm_bo_get_stride_for_plane(bo, plane));
-            ADD_ATTR(img_attrs, attr_num, planeAttrs[plane][PLANE_MODIFIER_LO]);
-            ADD_ATTR(img_attrs, attr_num, (uint32_t)(modifier & 0xFFFFFFFFULL));
-            ADD_ATTR(img_attrs, attr_num, planeAttrs[plane][PLANE_MODIFIER_HI]);
-            ADD_ATTR(img_attrs, attr_num, (uint32_t)(modifier >> 32ULL));
-        }
-        ADD_ATTR(img_attrs, attr_num, EGL_NONE);
-#undef ADD_ATTR
-
-        image = eglCreateImageKHR(glamor_egl->display,
-                                  EGL_NO_CONTEXT,
-                                  EGL_LINUX_DMA_BUF_EXT,
-                                  NULL,
-                                  img_attrs);
-
         if (image != EGL_NO_IMAGE_KHR) {
-            glamor_egl->fast_gbm_import = FALSE;
+            return image;
         }
+        tried_fast_import = TRUE;
+    }
 
-        for (plane = 0; plane < num_planes; plane++) {
+    if (glamor_egl->dmabuf_capable) {
+        EGLImageKHR image;
+        uint64_t modifier = gbm_bo_get_modifier(bo);
+        uint32_t num_planes = gbm_bo_get_plane_count(bo);
+        uint32_t format = gbm_bo_get_format(bo);
+        int fds[GBM_MAX_PLANES];
+        int strides[GBM_MAX_PLANES];
+        int offsets[GBM_MAX_PLANES];
+
+        uint32_t width = gbm_bo_get_width(bo);
+        uint32_t height = gbm_bo_get_height(bo);
+
+#ifdef GBM_BO_FD_FOR_PLANE
+        if (num_planes > GBM_MAX_PLANES) {
+            goto fallback;
+        }
+        for (int plane = 0; plane < num_planes; plane++) {
+            fds[plane] = gbm_bo_get_fd_for_plane(bo, plane);
+            offsets[plane] = gbm_bo_get_offset(bo, plane);
+            strides[plane] = gbm_bo_get_stride_for_plane(bo, plane);
+        }
+#else
+#ifdef GBM_BO_FD
+        num_planes = 1;
+        fds[0] = gbm_bo_get_fd(bo);
+        offsets[0] = 0;
+        strides[0] = gbm_bo_get_stride(bo);
+#else
+        goto fallback;
+#endif
+#endif
+
+        /* -Werror=maybe-uninitialized */
+        memset(fds + num_planes, -1, (GBM_MAX_PLANES - num_planes) * sizeof(*fds));
+        memset(offsets + num_planes, 0, (GBM_MAX_PLANES - num_planes) * sizeof(*offsets));
+        memset(strides + num_planes, 0, (GBM_MAX_PLANES - num_planes) * sizeof(*strides));
+
+        image = glamor_egl_image_from_dma_bufs(screen,
+                                               num_planes, fds,
+                                               width, height,
+                                               strides, offsets,
+                                               format, modifier);
+
+        for (int plane = 0; plane < num_planes; plane++) {
             close(fds[plane]);
             fds[plane] = -1;
         }
+
+        if (image != EGL_NO_IMAGE_KHR) {
+            glamor_egl->fast_gbm_import = FALSE;
+            return image;
+        }
     }
+
+#if defined(GBM_BO_FD_FOR_PLANE) || !defined(GBM_BO_FD) /* -Werror=unused-label */
+fallback:
 #endif
+    if (tried_fast_import) {
+        return EGL_NO_IMAGE_KHR;
+    }
+
+    return eglCreateImageKHR(glamor_egl->display,
+                             EGL_NO_CONTEXT,
+                             EGL_NATIVE_PIXMAP_KHR, bo, NULL);
+}
+#endif
+
+static Bool
+glamor_egl_create_textured_pixmap_from_egl_image(PixmapPtr pixmap,
+                                                 EGLImageKHR image,
+                                                 Bool used_modifiers)
+{
+    ScreenPtr screen = pixmap->drawable.pScreen;
+    GLuint texture;
 
     if (image == EGL_NO_IMAGE_KHR) {
         glamor_set_pixmap_type(pixmap, GLAMOR_DRM_ONLY);
-        goto done;
+        return FALSE;
     }
+
     glamor_create_texture_from_image(screen, image, &texture);
     glamor_set_pixmap_type(pixmap, GLAMOR_TEXTURE_DRM);
     glamor_set_pixmap_texture(pixmap, texture);
     glamor_egl_set_pixmap_image(pixmap, image, used_modifiers);
-    ret = TRUE;
+    return TRUE;
+}
 
- done:
-    return ret;
+#ifdef WITH_LIBDRM
+/**
+ * XXX We only need libdrm for fourcc's here XXX
+ *
+ * Perhaps we should have some compatibility defines somewhere?
+ */
+static Bool
+glamor_egl_create_textured_pixmap_from_dma_bufs(PixmapPtr pixmap,
+                                                uint32_t num_fds, const int *fds,
+                                                int width, int height,
+                                                const int *strides, const int *offsets,
+                                                uint32_t format, uint64_t modifier)
+{
+    ScreenPtr screen = pixmap->drawable.pScreen;
+    Bool used_modifiers = modifier != DRM_FORMAT_MOD_INVALID;
+
+    EGLImageKHR image = glamor_egl_image_from_dma_bufs(screen,
+                                                       num_fds, fds,
+                                                       width, height,
+                                                       strides, offsets,
+                                                       format, modifier);
+
+    return glamor_egl_create_textured_pixmap_from_egl_image(pixmap, image,
+                                                            used_modifiers);
+}
+#endif
+
+Bool
+glamor_egl_create_textured_pixmap_from_gbm_bo(PixmapPtr pixmap,
+                                              struct gbm_bo *bo,
+                                              Bool used_modifiers)
+{
+#ifdef GLAMOR_HAS_GBM
+    ScreenPtr screen = pixmap->drawable.pScreen;
+    EGLImageKHR image = glamor_egl_image_from_gbm_bo(screen, bo);
+
+    return glamor_egl_create_textured_pixmap_from_egl_image(pixmap, image,
+                                                            used_modifiers);
 #else
     return FALSE;
 #endif
@@ -624,10 +728,6 @@ glamor_gbm_bo_from_pixmap_internal(ScreenPtr screen, PixmapPtr pixmap)
         return ret;
     }
 
-#ifndef GBM_MAX_PLANES
-/* This is the actual value, and what the spec says it should be */
-#define GBM_MAX_PLANES 4
-#endif
     int fourcc = 0;
     int num_planes = 0;
     EGLuint64KHR modifiers[GBM_MAX_PLANES] = {0};
@@ -808,25 +908,25 @@ glamor_egl_fd_name_from_pixmap(ScreenPtr screen,
 #endif
 }
 
-#ifdef GLAMOR_HAS_GBM
+#ifdef WITH_LIBDRM
 static bool
-gbm_format_for_depth(CARD8 depth, uint32_t *format)
+glamor_drm_format_for_depth(CARD8 depth, uint32_t *format)
 {
     switch (depth) {
     case 15:
-        *format = GBM_FORMAT_ARGB1555;
+        *format = DRM_FORMAT_ARGB1555;
         return true;
     case 16:
-        *format = GBM_FORMAT_RGB565;
+        *format = DRM_FORMAT_RGB565;
         return true;
     case 24:
-        *format = GBM_FORMAT_XRGB8888;
+        *format = DRM_FORMAT_XRGB8888;
         return true;
     case 30:
-        *format = GBM_FORMAT_ARGB2101010;
+        *format = DRM_FORMAT_ARGB2101010;
         return true;
     case 32:
-        *format = GBM_FORMAT_ARGB8888;
+        *format = DRM_FORMAT_ARGB8888;
         return true;
     default:
         ErrorF("unexpected depth: %d\n", depth);
@@ -840,35 +940,26 @@ glamor_back_pixmap_from_fd(PixmapPtr pixmap,
                            int fd,
                            CARD16 width,
                            CARD16 height,
-                           CARD16 stride, CARD8 depth, CARD8 bpp)
+                           CARD16 _stride, CARD8 depth, CARD8 bpp)
 {
-#ifdef GLAMOR_HAS_GBM
+#ifdef WITH_LIBDRM
     ScreenPtr screen = pixmap->drawable.pScreen;
-    glamor_egl_priv_t *glamor_egl;
-    struct gbm_bo *bo;
-    struct gbm_import_fd_data import_data = { 0 };
-    Bool ret;
+    uint32_t format;
+    const int stride = _stride;
+    const int offset = 0;
 
-    glamor_egl = glamor_egl_get_screen_private(screen);
-
-    if (!gbm_format_for_depth(depth, &import_data.format) ||
-        width == 0 || height == 0)
+    if (width == 0 || height == 0 ||
+        !glamor_drm_format_for_depth(depth, &format)) {
         return FALSE;
-
-    import_data.fd = fd;
-    import_data.width = width;
-    import_data.height = height;
-    import_data.stride = stride;
-    bo = gbm_bo_import(glamor_egl->gbm, GBM_BO_IMPORT_FD, &import_data,
-                       GBM_BO_USE_RENDERING);
-    if (!bo)
-        return FALSE;
+    }
 
     screen->ModifyPixmapHeader(pixmap, width, height, 0, 0, stride, NULL);
 
-    ret = glamor_egl_create_textured_pixmap_from_gbm_bo(pixmap, bo, FALSE);
-    gbm_bo_destroy(bo);
-    return ret;
+    return glamor_egl_create_textured_pixmap_from_dma_bufs(pixmap,
+                                                           1, &fd,
+                                                           width, height,
+                                                           &stride, &offset,
+                                                           format, DRM_FORMAT_MOD_INVALID);
 #else
     return FALSE;
 #endif
@@ -878,51 +969,60 @@ PixmapPtr
 glamor_pixmap_from_fds(ScreenPtr screen,
                        CARD8 num_fds, const int *fds,
                        CARD16 width, CARD16 height,
-                       const CARD32 *strides, const CARD32 *offsets,
+                       const CARD32 *_strides, const CARD32 *_offsets,
                        CARD8 depth, CARD8 bpp,
                        uint64_t modifier)
 {
-#if defined(GLAMOR_HAS_GBM) && defined(WITH_LIBDRM)
+#ifdef WITH_LIBDRM
     PixmapPtr pixmap;
     glamor_egl_priv_t *glamor_egl;
     Bool ret = FALSE;
-    int i;
 
     glamor_egl = glamor_egl_get_screen_private(screen);
 
     pixmap = screen->CreatePixmap(screen, 0, 0, depth, 0);
 
-#ifdef GBM_BO_WITH_MODIFIERS
-    if (glamor_egl->dmabuf_capable && modifier != DRM_FORMAT_MOD_INVALID) {
-        struct gbm_import_fd_modifier_data import_data = { 0 };
-        struct gbm_bo *bo;
-
-        if (!gbm_format_for_depth(depth, &import_data.format) ||
-            width == 0 || height == 0)
+    if ((glamor_egl->dmabuf_capable && modifier != DRM_FORMAT_MOD_INVALID)) {
+        uint32_t format;
+        if (width == 0 || height == 0 ||
+            !glamor_drm_format_for_depth(depth, &format)) {
             goto error;
+        }
 
-        import_data.width = width;
-        import_data.height = height;
-        import_data.num_fds = num_fds;
-        import_data.modifier = modifier;
-        for (i = 0; i < num_fds; i++) {
-            import_data.fds[i] = fds[i];
-            import_data.strides[i] = strides[i];
-            import_data.offsets[i] = offsets[i];
+
+        int strides_mem[GBM_MAX_PLANES];
+        int offsets_mem[GBM_MAX_PLANES];
+
+        int *strides;
+        int *offsets;
+
+        /* XXX Could we do this at compile-time? XXX */
+        if (sizeof(int) == sizeof(CARD32)) {
+            strides = (int*)_strides;
+            offsets = (int*)_offsets;
+        } else {
+            strides = strides_mem;
+            offsets = offsets_mem;
+            if (num_fds > GBM_MAX_PLANES) {
+                goto error;
+            }
+            for (int i = 0; i < num_fds; i++) {
+                offsets[i] = _offsets[i];
+                strides[i] = _strides[i];
+            }
         }
-        bo = gbm_bo_import(glamor_egl->gbm, GBM_BO_IMPORT_FD_MODIFIER, &import_data,
-                           GBM_BO_USE_RENDERING);
-        if (bo) {
-            screen->ModifyPixmapHeader(pixmap, width, height, 0, 0, strides[0], NULL);
-            ret = glamor_egl_create_textured_pixmap_from_gbm_bo(pixmap, bo, TRUE);
-            gbm_bo_destroy(bo);
-        }
-    } else
-#endif
-    {
+
+        screen->ModifyPixmapHeader(pixmap, width, height, 0, 0, strides[0], NULL);
+
+        ret = glamor_egl_create_textured_pixmap_from_dma_bufs(pixmap,
+                                                              num_fds, fds,
+                                                              width, height,
+                                                              strides, offsets,
+                                                              format, modifier);
+    } else {
         if (num_fds == 1) {
             ret = glamor_back_pixmap_from_fd(pixmap, fds[0], width, height,
-                                             strides[0], depth, bpp);
+                                             _strides[0], depth, bpp);
         }
     }
 
@@ -944,7 +1044,6 @@ glamor_pixmap_from_fd(ScreenPtr screen,
                       CARD16 height,
                       CARD16 stride, CARD8 depth, CARD8 bpp)
 {
-#ifdef GLAMOR_HAS_GBM
     PixmapPtr pixmap;
     Bool ret;
 
@@ -958,9 +1057,6 @@ glamor_pixmap_from_fd(ScreenPtr screen,
         return NULL;
     }
     return pixmap;
-#else
-    return NULL;
-#endif
 }
 
 static Bool
@@ -2149,7 +2245,6 @@ glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
     glamor_egl->has_image_dma_buf_export = epoxy_has_egl_extension(glamor_egl->display, "EGL_MESA_image_dma_buf_export");
 #endif
 
-#ifdef GBM_BO_WITH_MODIFIERS
     if (epoxy_has_egl_extension(glamor_egl->display,
                                 "EGL_EXT_image_dma_buf_import") &&
         epoxy_has_egl_extension(glamor_egl->display,
@@ -2170,7 +2265,6 @@ glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
         else
             glamor_egl->dmabuf_capable = FALSE;
     }
-#endif
 
 #ifdef GLAMOR_HAS_GBM
     glamor_egl->fast_gbm_import = renderer && !strstr((const char *)renderer, "NVIDIA");

--- a/include/meson.build
+++ b/include/meson.build
@@ -110,6 +110,8 @@ conf_data.set('GLAMOR', build_glamor ? '1' : false)
 conf_data.set('GLAMOR_HAS_GBM', build_gbm ? '1' : false)
 conf_data.set('GBM_BO_WITH_MODIFIERS',
               build_glamor and build_gbm and gbm_dep.version().version_compare('>= 17.1') ? '1' : false)
+conf_data.set('GBM_BO_FD',
+              build_glamor and gbm_dep.found() and cc.has_header_symbol('gbm.h', 'gbm_bo_get_fd', dependencies : gbm_dep )  ? '1' : false)
 conf_data.set('GBM_BO_FD_FOR_PLANE',
               build_glamor and build_gbm and gbm_dep.version().version_compare('>= 21.1') ? '1' : false)
 conf_data.set('GBM_BO_WITH_MODIFIERS2',


### PR DESCRIPTION
Before this, when we wanted to import pixmaps from dma bufs, we were importing a gbm bo from dma bufs, exporting the gbm bo as dmabufs, importing an EGLImageKHR from those dmabufs, and finally creating a pixmap from the EGLImageKHR.

Now, we just import the image and create a pixmap from it.

See: https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2057#note_3442757