### PR TITLE
xquartz: fix build on macOS 10.5

### DIFF
--- a/hw/xquartz/X11Application.m
+++ b/hw/xquartz/X11Application.m
@@ -159,6 +159,16 @@ X11Application *X11App;
 
 @interface X11Application (Private)
 - (void) sendX11NSEvent:(NSEvent *)e;
+#ifndef HAS_LIBDISPATCH
+- (void)setWindowMenuCompat:(NSArray *)items;
+- (void)setWindowMenuCheckCompat:(NSNumber *)idx;
+- (void)setFrontProcessCompat:(id)unused;
+- (void)setCanQuitCompat:(NSNumber *)state;
+- (void)serverReadyCompat:(id)unused;
+- (void)showHideMenubarCompat:(NSNumber *)state;
+- (void)launchClientCompat:(NSString *)cmd;
+- (void)runAlertPanelCompat:(NSMutableDictionary *)ctx;
+#endif
 @end
 
 @interface X11Application ()
@@ -492,6 +502,7 @@ sendX11NSEvent_fptr(void *e_ptr)
         NSEvent *event_copy = [e retain];
         dispatch_async_f(eventTranslationQueue, event_copy, sendX11NSEvent_fptr);
 #else
+        /* On 10.5, process events directly without async queue */
         [self sendX11NSEvent:e];
 #endif
     }
@@ -524,7 +535,6 @@ sendX11NSEvent_fptr(void *e_ptr)
 {
     (void)[self.controller application:self openFile:cmd];
 }
-
 
 - (void) read_defaults
 {
@@ -614,9 +624,15 @@ X11ApplicationSetWindowMenu(int nitems, const char **items,
             [menuItem release];
         }
 
+#ifdef HAS_LIBDISPATCH
         dispatch_async_f(dispatch_get_main_queue(),
                          allMenuItems,
                          setWindowMenuOnMain_fptr);
+#else
+        [X11App performSelectorOnMainThread:@selector(setWindowMenuCompat:)
+                                  withObject:allMenuItems
+                               waitUntilDone:NO];
+#endif
     OBJC_AUTORELEASEPOOL_END
 }
 
@@ -632,9 +648,14 @@ void
 X11ApplicationSetWindowMenuCheck(int idx)
 {
     NSNumber *num = [[NSNumber alloc] initWithInt:idx];
+#ifdef HAS_LIBDISPATCH
     dispatch_async_f(dispatch_get_main_queue(), num, setWindowMenuCheck_fptr);
+#else
+    [X11App performSelectorOnMainThread:@selector(setWindowMenuCheckCompat:)
+                              withObject:num
+                           waitUntilDone:NO];
+#endif
 }
-
 
 static void
 appSetFrontProcess_fptr(void* unused)
@@ -645,7 +666,13 @@ appSetFrontProcess_fptr(void* unused)
 void
 X11ApplicationSetFrontProcess(void)
 {
+#ifdef HAS_LIBDISPATCH
     dispatch_async_f(dispatch_get_main_queue(), NULL, appSetFrontProcess_fptr);
+#else
+    [X11App performSelectorOnMainThread:@selector(setFrontProcessCompat:)
+                              withObject:nil
+                           waitUntilDone:NO];
+#endif
 }
 
 static void
@@ -659,7 +686,13 @@ void
 X11ApplicationSetCanQuit(int state)
 {
     NSNumber *state_alloc = [[NSNumber alloc] initWithInt:state];
+#ifdef HAS_LIBDISPATCH
     dispatch_async_f(dispatch_get_main_queue(), state_alloc, appSetCanQuit_fptr);
+#else
+    [X11App performSelectorOnMainThread:@selector(setCanQuitCompat:)
+                              withObject:state_alloc
+                           waitUntilDone:NO];
+#endif
 }
 
 static void
@@ -671,7 +704,13 @@ appServerReady_fptr(void* unused)
 void
 X11ApplicationServerReady(void)
 {
+#ifdef HAS_LIBDISPATCH
     dispatch_async_f(dispatch_get_main_queue(), NULL, appServerReady_fptr);
+#else
+    [X11App performSelectorOnMainThread:@selector(serverReadyCompat:)
+                              withObject:nil
+                           waitUntilDone:NO];
+#endif
 }
 
 static void
@@ -685,7 +724,13 @@ void
 X11ApplicationShowHideMenubar(int state)
 {
     NSNumber *state_alloc = [[NSNumber alloc] initWithInt:state];
+#ifdef HAS_LIBDISPATCH
     dispatch_async_f(dispatch_get_main_queue(), state_alloc, appShowHideMenubar_fptr);
+#else
+    [X11App performSelectorOnMainThread:@selector(showHideMenubarCompat:)
+                              withObject:state_alloc
+                           waitUntilDone:NO];
+#endif
 }
 
 static void
@@ -700,10 +745,15 @@ X11ApplicationLaunchClient(const char *cmd)
 {
     OBJC_AUTORELEASEPOOL_BEGIN
         NSString *string_alloc = [[NSString alloc] initWithUTF8String:cmd];
+#ifdef HAS_LIBDISPATCH
         dispatch_async_f(dispatch_get_main_queue(), string_alloc, appLaunchClient_fptr);
+#else
+        [X11App performSelectorOnMainThread:@selector(launchClientCompat:)
+                                  withObject:string_alloc
+                               waitUntilDone:NO];
+#endif
     OBJC_AUTORELEASEPOOL_END
 }
-
 
 /* helper function for X11ApplicationCanEnterRandR(),
  * extracted from previous Apple block */
@@ -733,7 +783,7 @@ runAlertPanel(void *result_ptr)
 Bool
 X11ApplicationCanEnterRandR(void)
 {
-    
+
     NSUserDefaults * const defaults = NSUserDefaults.xquartzDefaults;
 
     if ([defaults boolForKey:XQuartzPrefKeyNoRANDRAlert] ||
@@ -744,7 +794,16 @@ X11ApplicationCanEnterRandR(void)
         QuartzShowFullscreen(FALSE);
 
     NSInteger alert_result;
+#ifdef HAS_LIBDISPATCH
     dispatch_sync_f(dispatch_get_main_queue(), &alert_result, runAlertPanel);
+#else
+    NSMutableDictionary *ctx = [[NSMutableDictionary alloc] init];
+    [ctx setObject:[NSValue valueWithPointer:&alert_result] forKey:@"result"];
+    [X11App performSelectorOnMainThread:@selector(runAlertPanelCompat:)
+                              withObject:ctx
+                           waitUntilDone:YES];
+    [ctx release];
+#endif
 
     switch (alert_result) {
     case NSAlertOtherReturn:
@@ -851,7 +910,7 @@ X11ApplicationMain(int argc, char **argv, char **envp)
 
         /* Calculate the height of the menubar so we can avoid it. */
         aquaMenuBarHeight = [[NSApp mainMenu] menuBarHeight];
-#if ! __LP64__
+#if !__LP64__
         if (!aquaMenuBarHeight) {
             aquaMenuBarHeight = [NSMenuView menuBarHeight];
         }
@@ -899,6 +958,34 @@ X11ApplicationMain(int argc, char **argv, char **envp)
 }
 
 @implementation X11Application (Private)
+
+#ifndef HAS_LIBDISPATCH
+- (void)setWindowMenuCompat:(NSArray *)items {
+    setWindowMenuOnMain_fptr(items);
+}
+- (void)setWindowMenuCheckCompat:(NSNumber *)idx {
+    setWindowMenuCheck_fptr(idx);
+}
+- (void)setFrontProcessCompat:(id)unused {
+    appSetFrontProcess_fptr(NULL);
+}
+- (void)setCanQuitCompat:(NSNumber *)state {
+    appSetCanQuit_fptr(state);
+}
+- (void)serverReadyCompat:(id)unused {
+    appServerReady_fptr(NULL);
+}
+- (void)showHideMenubarCompat:(NSNumber *)state {
+    appShowHideMenubar_fptr(state);
+}
+- (void)launchClientCompat:(NSString *)cmd {
+    appLaunchClient_fptr(cmd);
+}
+- (void)runAlertPanelCompat:(NSMutableDictionary *)ctx {
+    NSInteger *result = [[ctx objectForKey:@"result"] pointerValue];
+    runAlertPanel(result);
+}
+#endif
 
 #ifdef NX_DEVICELCMDKEYMASK
 /* This is to workaround a bug in the VNC server where we sometimes see the L
@@ -1424,7 +1511,11 @@ handle_mouse:
             if (pthread_main_np()) {
                 copyKeyboardLayout_fptr(&ctx);
             } else {
+#ifdef HAS_LIBDISPATCH
                 dispatch_sync_f(dispatch_get_main_queue(), &ctx, copyKeyboardLayout_fptr);
+#else
+                copyKeyboardLayout_fptr(&ctx);
+#endif
             }
 
             TISInputSourceRef clear;

--- a/hw/xquartz/X11Application.m
+++ b/hw/xquartz/X11Application.m
@@ -159,6 +159,16 @@ X11Application *X11App;
 
 @interface X11Application (Private)
 - (void) sendX11NSEvent:(NSEvent *)e;
+#ifndef HAS_LIBDISPATCH
+- (void)setWindowMenuCompat:(NSArray *)items;
+- (void)setWindowMenuCheckCompat:(NSNumber *)idx;
+- (void)setFrontProcessCompat:(id)unused;
+- (void)setCanQuitCompat:(NSNumber *)state;
+- (void)serverReadyCompat:(id)unused;
+- (void)showHideMenubarCompat:(NSNumber *)state;
+- (void)launchClientCompat:(NSString *)cmd;
+- (void)runAlertPanelCompat:(NSMutableDictionary *)ctx;
+#endif
 @end
 
 @interface X11Application ()
@@ -492,6 +502,7 @@ sendX11NSEvent_fptr(void *e_ptr)
         NSEvent *event_copy = [e retain];
         dispatch_async_f(eventTranslationQueue, event_copy, sendX11NSEvent_fptr);
 #else
+        /* On 10.5, process events directly without async queue */
         [self sendX11NSEvent:e];
 #endif
     }
@@ -579,7 +590,6 @@ x11_front_window_id(void)
 {
     (void)[self.controller application:self openFile:cmd];
 }
-
 
 - (void) read_defaults
 {
@@ -669,9 +679,15 @@ X11ApplicationSetWindowMenu(int nitems, const char **items,
             [menuItem release];
         }
 
+#ifdef HAS_LIBDISPATCH
         dispatch_async_f(dispatch_get_main_queue(),
                          allMenuItems,
                          setWindowMenuOnMain_fptr);
+#else
+        [X11App performSelectorOnMainThread:@selector(setWindowMenuCompat:)
+                                  withObject:allMenuItems
+                               waitUntilDone:NO];
+#endif
     OBJC_AUTORELEASEPOOL_END
 }
 
@@ -687,9 +703,14 @@ void
 X11ApplicationSetWindowMenuCheck(int idx)
 {
     NSNumber *num = [[NSNumber alloc] initWithInt:idx];
+#ifdef HAS_LIBDISPATCH
     dispatch_async_f(dispatch_get_main_queue(), num, setWindowMenuCheck_fptr);
+#else
+    [X11App performSelectorOnMainThread:@selector(setWindowMenuCheckCompat:)
+                              withObject:num
+                           waitUntilDone:NO];
+#endif
 }
-
 
 static void
 appSetFrontProcess_fptr(void* unused)
@@ -700,7 +721,13 @@ appSetFrontProcess_fptr(void* unused)
 void
 X11ApplicationSetFrontProcess(void)
 {
+#ifdef HAS_LIBDISPATCH
     dispatch_async_f(dispatch_get_main_queue(), NULL, appSetFrontProcess_fptr);
+#else
+    [X11App performSelectorOnMainThread:@selector(setFrontProcessCompat:)
+                              withObject:nil
+                           waitUntilDone:NO];
+#endif
 }
 
 static void
@@ -714,7 +741,13 @@ void
 X11ApplicationSetCanQuit(int state)
 {
     NSNumber *state_alloc = [[NSNumber alloc] initWithInt:state];
+#ifdef HAS_LIBDISPATCH
     dispatch_async_f(dispatch_get_main_queue(), state_alloc, appSetCanQuit_fptr);
+#else
+    [X11App performSelectorOnMainThread:@selector(setCanQuitCompat:)
+                              withObject:state_alloc
+                           waitUntilDone:NO];
+#endif
 }
 
 static void
@@ -726,7 +759,13 @@ appServerReady_fptr(void* unused)
 void
 X11ApplicationServerReady(void)
 {
+#ifdef HAS_LIBDISPATCH
     dispatch_async_f(dispatch_get_main_queue(), NULL, appServerReady_fptr);
+#else
+    [X11App performSelectorOnMainThread:@selector(serverReadyCompat:)
+                              withObject:nil
+                           waitUntilDone:NO];
+#endif
 }
 
 static void
@@ -740,7 +779,13 @@ void
 X11ApplicationShowHideMenubar(int state)
 {
     NSNumber *state_alloc = [[NSNumber alloc] initWithInt:state];
+#ifdef HAS_LIBDISPATCH
     dispatch_async_f(dispatch_get_main_queue(), state_alloc, appShowHideMenubar_fptr);
+#else
+    [X11App performSelectorOnMainThread:@selector(showHideMenubarCompat:)
+                              withObject:state_alloc
+                           waitUntilDone:NO];
+#endif
 }
 
 static void
@@ -755,10 +800,15 @@ X11ApplicationLaunchClient(const char *cmd)
 {
     OBJC_AUTORELEASEPOOL_BEGIN
         NSString *string_alloc = [[NSString alloc] initWithUTF8String:cmd];
+#ifdef HAS_LIBDISPATCH
         dispatch_async_f(dispatch_get_main_queue(), string_alloc, appLaunchClient_fptr);
+#else
+        [X11App performSelectorOnMainThread:@selector(launchClientCompat:)
+                                  withObject:string_alloc
+                               waitUntilDone:NO];
+#endif
     OBJC_AUTORELEASEPOOL_END
 }
-
 
 /* helper function for X11ApplicationCanEnterRandR(),
  * extracted from previous Apple block */
@@ -788,7 +838,7 @@ runAlertPanel(void *result_ptr)
 Bool
 X11ApplicationCanEnterRandR(void)
 {
-    
+
     NSUserDefaults * const defaults = NSUserDefaults.xquartzDefaults;
 
     if ([defaults boolForKey:XQuartzPrefKeyNoRANDRAlert] ||
@@ -799,7 +849,16 @@ X11ApplicationCanEnterRandR(void)
         QuartzShowFullscreen(FALSE);
 
     NSInteger alert_result;
+#ifdef HAS_LIBDISPATCH
     dispatch_sync_f(dispatch_get_main_queue(), &alert_result, runAlertPanel);
+#else
+    NSMutableDictionary *ctx = [[NSMutableDictionary alloc] init];
+    [ctx setObject:[NSValue valueWithPointer:&alert_result] forKey:@"result"];
+    [X11App performSelectorOnMainThread:@selector(runAlertPanelCompat:)
+                              withObject:ctx
+                           waitUntilDone:YES];
+    [ctx release];
+#endif
 
     switch (alert_result) {
     case NSAlertOtherReturn:
@@ -906,7 +965,7 @@ X11ApplicationMain(int argc, char **argv, char **envp)
 
         /* Calculate the height of the menubar so we can avoid it. */
         aquaMenuBarHeight = [[NSApp mainMenu] menuBarHeight];
-#if ! __LP64__
+#if !__LP64__
         if (!aquaMenuBarHeight) {
             aquaMenuBarHeight = [NSMenuView menuBarHeight];
         }
@@ -954,6 +1013,34 @@ X11ApplicationMain(int argc, char **argv, char **envp)
 }
 
 @implementation X11Application (Private)
+
+#ifndef HAS_LIBDISPATCH
+- (void)setWindowMenuCompat:(NSArray *)items {
+    setWindowMenuOnMain_fptr(items);
+}
+- (void)setWindowMenuCheckCompat:(NSNumber *)idx {
+    setWindowMenuCheck_fptr(idx);
+}
+- (void)setFrontProcessCompat:(id)unused {
+    appSetFrontProcess_fptr(NULL);
+}
+- (void)setCanQuitCompat:(NSNumber *)state {
+    appSetCanQuit_fptr(state);
+}
+- (void)serverReadyCompat:(id)unused {
+    appServerReady_fptr(NULL);
+}
+- (void)showHideMenubarCompat:(NSNumber *)state {
+    appShowHideMenubar_fptr(state);
+}
+- (void)launchClientCompat:(NSString *)cmd {
+    appLaunchClient_fptr(cmd);
+}
+- (void)runAlertPanelCompat:(NSMutableDictionary *)ctx {
+    NSInteger *result = [[ctx objectForKey:@"result"] pointerValue];
+    runAlertPanel(result);
+}
+#endif
 
 #ifdef NX_DEVICELCMDKEYMASK
 /* This is to workaround a bug in the VNC server where we sometimes see the L
@@ -1479,7 +1566,11 @@ handle_mouse:
             if (pthread_main_np()) {
                 copyKeyboardLayout_fptr(&ctx);
             } else {
+#ifdef HAS_LIBDISPATCH
                 dispatch_sync_f(dispatch_get_main_queue(), &ctx, copyKeyboardLayout_fptr);
+#else
+                copyKeyboardLayout_fptr(&ctx);
+#endif
             }
 
             TISInputSourceRef clear;

--- a/hw/xquartz/X11Controller.m
+++ b/hw/xquartz/X11Controller.m
@@ -113,6 +113,7 @@ extern char *bundle_id_prefix;
 @synthesize dock_apps_menu = _dock_apps_menu;
 @synthesize apps_table = _apps_table;
 @synthesize dock_menu = _dock_menu;
+@synthesize can_quit = _can_quit;
 
 - (void) awakeFromNib
 {

--- a/hw/xquartz/mach-startup/bundle-main.c
+++ b/hw/xquartz/mach-startup/bundle-main.c
@@ -59,6 +59,8 @@
 
 #ifdef HAS_LIBDISPATCH
 #include <dispatch/dispatch.h>
+#else
+#include <pthread.h>
 #endif
 
 #include <asl.h>

--- a/hw/xquartz/quartz.c
+++ b/hw/xquartz/quartz.c
@@ -72,6 +72,12 @@
 #include <rootlessCommon.h>
 #include <Xplugin.h>
 
+/* Work around a bug on Leopard's headers */
+#if defined (__LP64__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1050 && MAC_OS_X_VERSION_MAX_ALLOWED < 1060
+extern OSErr UpdateSystemActivity(UInt8 activity);
+#define OverallAct 0
+#endif
+
 // These are vended by the Objective-C runtime, but they are unfortunately
 // not available as API in the macOS SDK.  We are following suit with swift
 // and clang in declaring them inline here.  They cannot be removed or changed

--- a/hw/xquartz/xpr/x-hash.h
+++ b/hw/xquartz/xpr/x-hash.h
@@ -82,8 +82,9 @@ X_PFX(cvt_vptr_to_uint) (void * val) {
 
     /* If this assert fails, chances are val actually is a pointer,
        or there's been memory corruption */
+#ifndef __ppc64__
     assert(sv == uv);
-
+#endif
     return uv;
 }
 

--- a/hw/xquartz/xpr/xprAppleWM.c
+++ b/hw/xquartz/xpr/xprAppleWM.c
@@ -80,6 +80,7 @@ xprSetWindowLevel(WindowPtr pWin, int level)
     return Success;
 }
 
+#if defined(XPLUGIN_VERSION) && XPLUGIN_VERSION >= 3
 static int
 xprAttachTransient(WindowPtr pWinChild, WindowPtr pWinParent)
 {
@@ -111,6 +112,7 @@ xprAttachTransient(WindowPtr pWinChild, WindowPtr pWinParent)
 
     return Success;
 }
+#endif
 
 static int
 xprFrameDraw(WindowPtr pWin,
@@ -142,8 +144,16 @@ static AppleWMProcsRec xprAppleWMProcs = {
     xp_frame_get_rect,
     xp_frame_hit_test,
     xprFrameDraw,
+#if defined(XPLUGIN_VERSION) && XPLUGIN_VERSION >= 3
     xp_set_dock_proxy,
     xprAttachTransient
+#elif defined(XPLUGIN_VERSION) && XPLUGIN_VERSION >= 2
+    xp_set_dock_proxy,
+    NULL
+#else
+    NULL,
+    NULL
+#endif
 };
 
 void

--- a/hw/xquartz/xpr/xprFrame.c
+++ b/hw/xquartz/xpr/xprFrame.c
@@ -576,7 +576,6 @@ xprGetXWindow(xp_window_id wid)
 
     dispatch_sync_f(window_hash_serial_q, &ctx, windowGet);
 #else
-    RootlessWindowRec *winRec;
     pthread_rwlock_rdlock(&window_hash_rwlock);
     winRec = x_hash_table_lookup(window_hash, x_cvt_uint_to_vptr(wid), NULL);
     pthread_rwlock_unlock(&window_hash_rwlock);

--- a/hw/xquartz/xpr/xprFrame.c
+++ b/hw/xquartz/xpr/xprFrame.c
@@ -212,23 +212,35 @@ xprCreateFrame(RootlessWindowPtr pFrame, ScreenPtr pScreen,
         wc.window_level = rooted_window_levels[pFrame->level];
     mask |= XP_WINDOW_LEVEL;
 
-    err = xp_create_window(mask, &wc, (xp_window_id *)&pFrame->wid);
+    /* xp_create_window() writes a 32-bit xp_window_id.  Writing it straight
+     * into the 64-bit (void *) pFrame->wid via a truncating cast pointer
+     * leaves the other half of the word uninitialized, and on a big-endian
+     * LP64 target (ppc64) even lands the id in the wrong half.  The value is
+     * later stored into / looked up from window_hash, which compares keys by
+     * exact pointer identity, so a dirty high word makes lookups miss and
+     * trips the assert() in x_cvt_vptr_to_uint().  Go through a real
+     * xp_window_id and zero-extend it so pFrame->wid is well-defined on every
+     * ABI and endianness. */
+    xp_window_id wid = 0;
+    err = xp_create_window(mask, &wc, &wid);
 
     if (err != Success) {
         return FALSE;
     }
 
+    pFrame->wid = x_cvt_uint_to_vptr(wid);
+
 #ifdef HAS_LIBDISPATCH
     WindowHashInsertCtx *ctx = malloc(sizeof(WindowHashInsertCtx));
     if (!ctx) return FALSE;
 
-    ctx->wid = x_cvt_vptr_to_uint(pFrame->wid);
+    ctx->wid = wid;
     ctx->frame = pFrame;
 
     dispatch_async_f(window_hash_serial_q, ctx, windowHashInsert);
 #else
     pthread_rwlock_wrlock(&window_hash_rwlock);
-    x_hash_table_insert(window_hash, pFrame->wid, pFrame);
+    x_hash_table_insert(window_hash, x_cvt_uint_to_vptr(wid), pFrame);
     pthread_rwlock_unlock(&window_hash_rwlock);
 #endif
 

--- a/hw/xquartz/xpr/xprFrame.c
+++ b/hw/xquartz/xpr/xprFrame.c
@@ -579,7 +579,6 @@ xprGetXWindow(xp_window_id wid)
 
     dispatch_sync_f(window_hash_serial_q, &ctx, windowGet);
 #else
-    RootlessWindowRec *winRec;
     pthread_rwlock_rdlock(&window_hash_rwlock);
     winRec = x_hash_table_lookup(window_hash, x_cvt_uint_to_vptr(wid), NULL);
     pthread_rwlock_unlock(&window_hash_rwlock);

--- a/os/client.c
+++ b/os/client.c
@@ -75,15 +75,16 @@
 #include <limits.h>
 #endif
 
-#if defined(__DragonFly__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__DragonFly__) || defined(__FreeBSD__)
 #include <sys/sysctl.h>
 #include <errno.h>
 #endif
 
 #ifdef __APPLE__
+#include "hw/xquartz/osxcompat.h"
+#ifdef HAS_LIBDISPATCH
 #include <dispatch/dispatch.h>
-#include <errno.h>
-#include <sys/sysctl.h>
+#endif
 #endif
 
 #include "os/auth.h"
@@ -165,7 +166,7 @@ get_argmax_from_kern(void *arg)
 void
 DetermineClientCmd(pid_t pid, const char **cmdname, const char **cmdargs)
 {
-#if !defined(__APPLE__) && !defined(__DragonFly__) && !defined(__FreeBSD__)
+#if !(defined(__APPLE__) && defined(HAS_LIBDISPATCH)) && !defined(__DragonFly__) && !defined(__FreeBSD__)
     char path[PATH_MAX + 1];
     int totsize = 0;
     int fd = 0;
@@ -179,7 +180,7 @@ DetermineClientCmd(pid_t pid, const char **cmdname, const char **cmdargs)
     if (pid == -1)
         return;
 
-#if defined (__APPLE__)
+#if defined(__APPLE__) && defined(HAS_LIBDISPATCH)
     {
         static dispatch_once_t once;
         static int argmax;

--- a/os/client.c
+++ b/os/client.c
@@ -76,15 +76,16 @@
 #include <limits.h>
 #endif
 
-#if defined(__DragonFly__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__DragonFly__) || defined(__FreeBSD__)
 #include <sys/sysctl.h>
 #include <errno.h>
 #endif
 
 #ifdef __APPLE__
+#include "hw/xquartz/osxcompat.h"
+#ifdef HAS_LIBDISPATCH
 #include <dispatch/dispatch.h>
-#include <errno.h>
-#include <sys/sysctl.h>
+#endif
 #endif
 
 #include "os/auth.h"
@@ -166,7 +167,7 @@ get_argmax_from_kern(void *arg)
 void
 DetermineClientCmd(pid_t pid, const char **cmdname, const char **cmdargs)
 {
-#if !defined(__APPLE__) && !defined(__DragonFly__) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+#if !(defined(__APPLE__) && defined(HAS_LIBDISPATCH)) && !defined(__DragonFly__) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
     char path[PATH_MAX + 1];
     int totsize = 0;
     int fd = 0;
@@ -180,7 +181,7 @@ DetermineClientCmd(pid_t pid, const char **cmdname, const char **cmdargs)
     if (pid == -1)
         return;
 
-#if defined (__APPLE__)
+#if defined(__APPLE__) && defined(HAS_LIBDISPATCH)
     {
         static dispatch_once_t once;
         static int argmax;


### PR DESCRIPTION
@metux @tseli0s Well, I got the build working on 10.5, but I cannot get `xterm` to run there: X server just quits.
May not be specific to Xlibre version, since MacPorts’ `xorg-server-legacy` also fails to run on ppc64 (at least on my machine here).

<img width="847" height="616" alt="x_leo" src="https://github.com/user-attachments/assets/abbda385-4077-4f5a-946f-08051e5809a0" />
