### PR TITLE
glamor/glamor_egl: Export pixmaps directly from GL textures

### DIFF
--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -389,6 +389,56 @@ glamor_egl_image_from_dma_bufs(ScreenPtr screen,
                              img_attrs);
 }
 
+#ifdef GLAMOR_HAS_EXPORT_DMABUF_MESA
+static EGLImageKHR
+glamor_egl_image_from_pixmap(PixmapPtr pixmap)
+{
+    struct glamor_pixmap_private *pixmap_priv =
+        glamor_get_pixmap_private(pixmap);
+    ScreenPtr screen = pixmap->drawable.pScreen;
+    struct glamor_screen_private *glamor_priv =
+        glamor_get_screen_private(screen);
+    glamor_egl_priv_t *glamor_egl =
+        glamor_egl_get_screen_private(screen);
+
+    if (!glamor_pixmap_ensure_fbo(pixmap, 0)) {
+        return EGL_NO_IMAGE_KHR;
+    }
+
+    GLuint texture = pixmap_priv->fbo->tex;
+
+    glamor_make_current(glamor_priv);
+
+    return eglCreateImageKHR(glamor_egl->display,
+                             glamor_egl->context,
+                             EGL_GL_TEXTURE_2D,
+                             (EGLClientBuffer)(uintptr_t)texture,
+                             NULL);
+}
+
+static Bool
+glamor_egl_make_pixmap_exportable2(PixmapPtr pixmap, Bool used_modifiers)
+{
+    struct glamor_pixmap_private *pixmap_priv =
+        glamor_get_pixmap_private(pixmap);
+
+    if (pixmap_priv->image != EGL_NO_IMAGE_KHR) {
+        return TRUE;
+    }
+
+    EGLImageKHR image = glamor_egl_image_from_pixmap(pixmap);
+
+    if (image == EGL_NO_IMAGE_KHR) {
+        glamor_set_pixmap_type(pixmap, GLAMOR_DRM_ONLY);
+        return FALSE;
+    }
+
+    glamor_set_pixmap_type(pixmap, GLAMOR_TEXTURE_DRM);
+    glamor_egl_set_pixmap_image(pixmap, image, used_modifiers);
+    return TRUE;
+}
+#endif
+
 #ifdef GLAMOR_HAS_GBM
 static EGLImageKHR
 glamor_egl_image_from_gbm_bo(ScreenPtr screen, struct gbm_bo *bo)
@@ -780,10 +830,26 @@ glamor_gbm_bo_from_pixmap(ScreenPtr screen, PixmapPtr pixmap)
 #endif
 }
 
-int
-glamor_egl_fds_from_pixmap(ScreenPtr screen, PixmapPtr pixmap, int *fds,
-                           uint32_t *strides, uint32_t *offsets,
-                           uint64_t *modifier)
+/* Used for untextured pixmaps */
+/**
+ * XXX Do we even need this? XXX
+ *
+ * During normal operation, all pixmaps created by glamor
+ * are textured. Unless we've run out of video memory,
+ * the only unxtured pixmaps we can have are the root
+ * pixmaps for each screen.
+ * (The root pixmaps can be textured, but they don't have to be)
+ *
+ * I don't see how an X client could request us to export
+ * the root pixmap through DRI3. If this ever gets called,
+ * it really feels like a bug to me.
+ *
+ * Same for the gbm fallback single-fd export.
+ */
+static int
+glamor_egl_fds_from_pixmap_slow(ScreenPtr screen, PixmapPtr pixmap, int *fds,
+                                uint32_t *strides, uint32_t *offsets,
+                                uint64_t *modifier)
 {
 #if defined(GLAMOR_HAS_GBM) && defined (WITH_LIBDRM)
     struct gbm_bo *bo;
@@ -808,6 +874,7 @@ glamor_egl_fds_from_pixmap(ScreenPtr screen, PixmapPtr pixmap, int *fds,
 #ifdef GBM_BO_FD_FOR_PLANE
         fds[i] = gbm_bo_get_fd_for_plane(bo, i);
 #else
+#ifdef GBM_BO_FD
         union gbm_bo_handle plane_handle = gbm_bo_get_handle_for_plane(bo, i);
 
         if (i == 0)
@@ -821,6 +888,7 @@ glamor_egl_fds_from_pixmap(ScreenPtr screen, PixmapPtr pixmap, int *fds,
 	if (first_handle == plane_handle.s32)
             fds[i] = gbm_bo_get_fd(bo);
         else
+#endif
             fds[i] = -1;
 #endif
         if (fds[i] == -1) {
@@ -834,7 +902,11 @@ glamor_egl_fds_from_pixmap(ScreenPtr screen, PixmapPtr pixmap, int *fds,
     *modifier = gbm_bo_get_modifier(bo);
 #else
     num_fds = 1;
+#ifdef GBM_BO_FD
     fds[0] = gbm_bo_get_fd(bo);
+#else
+    fds[0] = -1;
+#endif
     if (fds[0] == -1)
         return 0;
     strides[0] = gbm_bo_get_stride(bo);
@@ -849,11 +921,73 @@ glamor_egl_fds_from_pixmap(ScreenPtr screen, PixmapPtr pixmap, int *fds,
 #endif
 }
 
-int
-glamor_egl_fd_from_pixmap(ScreenPtr screen, PixmapPtr pixmap,
-                          CARD16 *stride, CARD32 *size)
+/* for textured pixmaps */
+static int
+glamor_egl_fds_from_pixmap_fast(ScreenPtr screen, PixmapPtr pixmap, int *fds,
+                                uint32_t *strides, uint32_t *offsets,
+                                uint64_t *modifier)
 {
-#ifdef GLAMOR_HAS_GBM
+#ifdef GLAMOR_HAS_EXPORT_DMABUF_MESA
+    glamor_egl_priv_t *glamor_egl =
+        glamor_egl_get_screen_private(screen);
+    struct glamor_pixmap_private *pixmap_priv =
+        glamor_get_pixmap_private(pixmap);
+
+    if (!glamor_egl_make_pixmap_exportable2(pixmap, TRUE)) {
+        return 0;
+    }
+
+    int num_planes = 0;
+    EGLuint64KHR modifiers[GBM_MAX_PLANES] = {0};
+    if (!eglExportDMABUFImageQueryMESA(glamor_egl->display, pixmap_priv->image, NULL, &num_planes, modifiers)) {
+        return 0;
+    }
+
+    /* typedef int32_t EGLint; */
+    if (!eglExportDMABUFImageMESA(glamor_egl->display, pixmap_priv->image,
+                                  fds,
+                                  (EGLint*)strides,
+                                  (EGLint*)offsets)) {
+        return 0;
+    }
+
+    *modifier = modifiers[0];
+
+    pixmap_priv->used_modifiers = (*modifier != DRM_FORMAT_MOD_INVALID);
+
+    return num_planes;
+#else
+    return 0;
+#endif
+}
+
+int
+glamor_egl_fds_from_pixmap(ScreenPtr screen, PixmapPtr pixmap, int *fds,
+                           uint32_t *strides, uint32_t *offsets,
+                           uint64_t *modifier)
+{
+    static int warned = FALSE;
+    int ret = glamor_egl_fds_from_pixmap_fast(screen, pixmap, fds,
+                                              strides, offsets, modifier);
+    if (ret) {
+        return ret;
+    }
+
+    ret = glamor_egl_fds_from_pixmap_slow(screen, pixmap, fds,
+                                          strides, offsets, modifier);
+
+    if (!warned && ret) {
+        LogMessage(X_WARNING, "glamor(%d): glamor_egl_fds_from_pixmap_fast failed\n", screen->myNum);
+        warned = TRUE;
+    }
+    return ret;
+}
+
+static int
+glamor_egl_fd_from_pixmap_slow(ScreenPtr screen, PixmapPtr pixmap,
+                               CARD16 *stride, CARD32 *size)
+{
+#ifdef GBM_BO_FD
     struct gbm_bo *bo;
     int fd;
 
@@ -873,6 +1007,50 @@ glamor_egl_fd_from_pixmap(ScreenPtr screen, PixmapPtr pixmap,
 #else
     return -1;
 #endif
+}
+
+static int
+glamor_egl_fd_from_pixmap_fast(ScreenPtr screen, PixmapPtr pixmap,
+                               CARD16 *stride, CARD32 *size)
+{
+    uint32_t strides[GBM_MAX_PLANES] = {0};
+    uint32_t offsets[GBM_MAX_PLANES] = {0};
+    int fds[GBM_MAX_PLANES] = {-1, -1, -1, -1};
+    uint64_t modifier = 0;
+
+    int ret = glamor_egl_fds_from_pixmap_fast(screen, pixmap, fds,
+                                              strides, offsets, &modifier);
+
+    if (ret == 1) {
+        *stride = strides[0];
+        *size = *stride * pixmap->drawable.height;
+        return fds[0];
+    }
+
+    for (int i = 0; i < ret; i++) {
+        close(fds[i]);
+    }
+    return -1;
+}
+
+int
+glamor_egl_fd_from_pixmap(ScreenPtr screen, PixmapPtr pixmap,
+                          CARD16 *stride, CARD32 *size)
+{
+    static int warned = FALSE;
+    int fd = glamor_egl_fd_from_pixmap_fast(screen, pixmap, stride, size);
+    if (fd >= 0) {
+        return fd;
+    }
+
+    fd = glamor_egl_fd_from_pixmap_slow(screen, pixmap, stride, size);
+
+    if (!warned && (fd >= 0)) {
+        LogMessage(X_WARNING, "glamor(%d): glamor_egl_fd_from_pixmap_fast failed\n", screen->myNum);
+        warned = TRUE;
+    }
+
+    return fd;
 }
 
 int
@@ -1360,7 +1538,7 @@ glamor_dri3_open_client(ClientPtr client,
     return Success;
 }
 
-static const dri3_screen_info_rec glamor_dri3_info = {
+static dri3_screen_info_rec glamor_dri3_info = {
     .version = 2,
     .open_client = glamor_dri3_open_client,
     .pixmap_from_fds = glamor_pixmap_from_fds,
@@ -2181,6 +2359,13 @@ glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
 	}
 
     GLAMOR_CHECK_EGL_EXTENSION(KHR_surfaceless_context);
+
+    if (!epoxy_has_egl_extension(glamor_egl->display, "EGL_MESA_image_dma_buf_export")) {
+        LogMessage(X_WARNING, "glamor: Egl extension EGL_MESA_image_dma_buf_export not available\n");
+        LogMessage(X_WARNING, "glamor: DRI3 dmabuf export will be slower\n");
+        glamor_dri3_info.fd_from_pixmap = glamor_egl_fd_from_pixmap_slow;
+        glamor_dri3_info.fds_from_pixmap = glamor_egl_fds_from_pixmap_slow;
+    }
 
     if (!glamor_egl_conf->force_es) {
         if(!glamor_egl_try_big_gl_api(glamor_egl))


### PR DESCRIPTION
With this change, we create EGLImages directly from the GL texture of the pixmap to be exported, and set the pixmap's image to the newly created EGLImage.

Before this, we were creating a gbm bo with the same dimensions as the pixmap. We were then creating a new pixmap with the dimensions of the old pixmap. We were then exporting the gbm bo as dmabufs, and importing the dmabufs into an EGLImage. We were then creating a GL texture from this EGLImage, and we were setting the newly created pixmap's texture and EGLImage to the newly created ones.

Then we were swapping the texture and image of the newly created pixmap into the old pixmap, and destroying the newly created pixmap.

DRI3 pixmap exports are a pretty rare operation.
Most of the time, we do pixmap imports.

As such, here is some code for testing this change. I cannot attest to the quality of the test code, as I have copied the code from somewhere else and did not write it myself:
```
// compile with:
// gcc dri3_export_demo.c -o dri3_export_demo \
//     -lxcb -lxcb-dri3 -lxcb-present -lxcb-xfixes

int main() {
    xcb_connection_t *conn = xcb_connect(NULL, NULL);
    if (xcb_connection_has_error(conn)) {
        fprintf(stderr, "Failed to connect to X\n");
        return 1;
    }

    const xcb_setup_t *setup = xcb_get_setup(conn);
    xcb_screen_iterator_t iter = xcb_setup_roots_iterator(setup);
    xcb_screen_t *screen = iter.data;

    // Create a pixmap
    xcb_pixmap_t pixmap = xcb_generate_id(conn);
    uint16_t width = 256, height = 256;

    xcb_create_pixmap(conn,
                      screen->root_depth,
                      pixmap,
                      screen->root,
                      width,
                      height);

    xcb_flush(conn);

    printf("Created pixmap %u\n", pixmap);
    xcb_generic_error_t *error = NULL;

    // --- Single FD export (fd_from_pixmap) ---
    xcb_dri3_buffer_from_pixmap_cookie_t cookie1 =
        xcb_dri3_buffer_from_pixmap(conn, pixmap);

    //xcb_generic_error_t *error = NULL;
    xcb_dri3_buffer_from_pixmap_reply_t *reply1 =
        xcb_dri3_buffer_from_pixmap_reply(conn, cookie1, &error);

    if (!reply1 || error) {
        fprintf(stderr, "buffer_from_pixmap failed\n");
        free(error);
    } else {
        int fd = xcb_dri3_buffer_from_pixmap_reply_fds(conn, reply1)[0];

        printf("fd_from_pixmap:\n");
        printf("  fd = %d\n", fd);
        printf("  size = %u\n", reply1->size);
        printf("  stride = %u\n", reply1->stride);
        printf("  depth = %u\n", reply1->depth);
        printf("  bpp = %u\n", reply1->bpp);

        close(fd);
        free(reply1);
    }

    // --- Multi-FD export (fds_from_pixmap) ---
    xcb_dri3_buffers_from_pixmap_cookie_t cookie2 =
        xcb_dri3_buffers_from_pixmap(conn, pixmap);

    xcb_dri3_buffers_from_pixmap_reply_t *reply2 =
        xcb_dri3_buffers_from_pixmap_reply(conn, cookie2, &error);

    if (!reply2 || error) {
        fprintf(stderr, "buffers_from_pixmap failed\n");
        free(error);
    } else {
        int nfd = 4;//xcb_dri3_buffers_from_pixmap_reply_fds_length(conn, reply2);
        int *fds = xcb_dri3_buffers_from_pixmap_reply_fds(conn, reply2);

        printf("fds_from_pixmap:\n");
        printf("  num_fds = %d\n", nfd);
        printf("  width = %u height = %u\n", reply2->width, reply2->height);

        for (int i = 0; i < nfd; i++) {
            printf("  fd[%d] = %d\n", i, fds[i]);
            close(fds[i]);
        }

        free(reply2);
    }

    xcb_free_pixmap(conn, pixmap);
    xcb_disconnect(conn);

    return 0;
}
```

See: https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2057#note_3442757