### PR TITLE
hw: xquartz: Replace `xorg-server` version string with XLibre Xserver

### DIFF
--- a/hw/xquartz/X11Application.m
+++ b/hw/xquartz/X11Application.m
@@ -204,7 +204,7 @@ QuartzModeBundleInit(void);
     [dict setObject:[NSString stringWithFormat:@"XQuartz %@", tem]
              forKey:@"ApplicationVersion"];
 
-    [dict setObject:[NSString stringWithFormat:@"xorg-server %s",
+    [dict setObject:[NSString stringWithFormat:@"XLibre Xserver %s",
                      XSERVER_VERSION]
      forKey:@"Version"];
 


### PR DESCRIPTION
XLibre maintains the Xquartz DDX separately from the Xorg development repository. Users should know which Xserver they are using when they are shown the "About" window.