### PR TITLE
kdrive: Move special key logic to the os driver

### DIFF
--- a/hw/kdrive/fbdev/Xfbdev.man
+++ b/hw/kdrive/fbdev/Xfbdev.man
@@ -82,6 +82,10 @@ The following key special combinations are recognized by the
 server.
 .TP 8
 .B Ctrl+Alt+Backspace
+.TP 8
+.B Ctrl+Alt+Delete
+.TP 8
+.B Ctrl+Alt+KeyPadDelete
 Immediately kills the server -- no questions asked. It can be disabled by
 adding the
 .B -nozap

--- a/hw/kdrive/linux/linux.c
+++ b/hw/kdrive/linux/linux.c
@@ -30,6 +30,7 @@
 #include <X11/keysym.h>
 #include <linux/apm_bios.h>
 
+#include "dix/dix_priv.h" /* for dispatchException */
 #include "os/osdep.h"
 #include "os/ddx_priv.h"
 
@@ -248,19 +249,93 @@ LinuxEnable(void)
 }
 
 static Bool
-LinuxSpecialKey(KeySym sym)
+LinuxSwitchToVT(int con)
 {
     struct vt_stat vts;
-    int con;
 
-    if (XK_F1 <= sym && sym <= XK_F12) {
-        con = sym - XK_F1 + 1;
-        memset(&vts, '\0', sizeof(vts));    /* valgrind */
-        ioctl(LinuxConsoleFd, VT_GETSTATE, &vts);
-        if (con != vts.v_active && (vts.v_state & (1 << con))) {
-            ioctl(LinuxConsoleFd, VT_ACTIVATE, con);
-            return TRUE;
-        }
+    memset(&vts, '\0', sizeof(vts));    /* valgrind */
+    ioctl(LinuxConsoleFd, VT_GETSTATE, &vts);
+
+    /* Only switch to active vt's */
+    if (con != vts.v_active && (vts.v_state & (1 << con))) {
+        ioctl(LinuxConsoleFd, VT_ACTIVATE, con);
+        return TRUE;
+    }
+    return FALSE;
+}
+
+static Bool
+LinuxSpecialKey(KdKeyboardInfo *ki, unsigned char scan_code)
+{
+    const char* driver_name = ki->driver->name;
+
+    /**
+     * Scancodes are taken from https://aeb.win.tue.nl/linux/kbd/scancodes-1.html
+     * These scancodes can be also found at https://wiki.osdev.org/PS/2_Keyboard
+     *
+     * Only a few keys we are interested in are listed here.
+     * If we ever need more keys, we can add them later.
+     */
+
+#define KEY_BACKSPACE 0x0E
+#define KEY_F1 0x3B
+#define KEY_F2 0x3C
+#define KEY_F3 0x3D
+#define KEY_F4 0x3E
+#define KEY_F5 0x3F
+#define KEY_F6 0x40
+#define KEY_F7 0x41
+#define KEY_F8 0x42
+#define KEY_F9 0x43
+#define KEY_F10 0x44
+
+#define KEY_KP_DEL 0x53
+
+#define KEY_F11 0x57
+#define KEY_F12 0x58
+
+/* This one is taken from the linux keyboard driver */
+#define KEY_DEL 0x63
+
+    switch(scan_code) {
+        case KEY_F1:
+            return LinuxSwitchToVT(1);
+        case KEY_F2:
+            return LinuxSwitchToVT(2);
+        case KEY_F3:
+            return LinuxSwitchToVT(3);
+        case KEY_F4:
+            return LinuxSwitchToVT(4);
+        case KEY_F5:
+            return LinuxSwitchToVT(5);
+        case KEY_F6:
+            return LinuxSwitchToVT(6);
+        case KEY_F7:
+            return LinuxSwitchToVT(7);
+        case KEY_F8:
+            return LinuxSwitchToVT(8);
+        case KEY_F9:
+            return LinuxSwitchToVT(9);
+        case KEY_F10:
+            return LinuxSwitchToVT(10);
+        case KEY_F11:
+            return LinuxSwitchToVT(11);
+        case KEY_F12:
+            return LinuxSwitchToVT(12);
+        case KEY_DEL:
+            if (!driver_name || strcmp(driver_name, "keyboard")) {
+                /* Only fallthrough for the non-evdev keyboard driver */
+                return FALSE;
+            }
+        case KEY_BACKSPACE:
+        case KEY_KP_DEL:
+            /*
+             * Set the dispatch exception flag so the server will terminate the
+             * next time through the dispatch loop.
+             */
+            if (kdAllowZap) {
+                dispatchException |= DE_TERMINATE;
+            }
     }
     return FALSE;
 }

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -296,7 +296,7 @@ typedef struct _KdOsFuncs {
     int (*Init) (void);           /* only called when the X server is started */
     void (*Enable) (void);        /* called when screen is enabled */
     void (*Disable) (void);       /* called when screen is disabled */
-    Bool (*SpecialKey) (KeySym);
+    Bool (*SpecialKey) (KdKeyboardInfo *, unsigned char);
     void (*Fini) (void);
     void (*pollEvents) (void);    /* called when driver shall poll for new events */
     void (*Bell) (int, int, int); /* if not NULL called instead of the keyboard driver's function */

--- a/hw/kdrive/src/kinput.c
+++ b/hw/kdrive/src/kinput.c
@@ -1903,81 +1903,6 @@ KdCheckLock(void)
     }
 }
 
-static KeySym
-KdKeyCodeToKeySym(KdKeyboardInfo *ki, int type, unsigned char key_code)
-{
-    unsigned char scan_code = key_code - KD_MIN_KEYCODE + ki->minScanCode;
-    (void)type;
-
-    /**
-     * XXX This looks really sketchy XXX
-     * Surely there is a way to query this from xkb?
-     * This doesn't work:
-     * return kbd->key->xkbInfo->desc->map->modmap[key_code];
-     *
-     * Scancodes are taken from https://aeb.win.tue.nl/linux/kbd/scancodes-1.html
-     * These scancodes can be also found at https://wiki.osdev.org/PS/2_Keyboard
-     *
-     * Only a few keys we are interested in are listed here.
-     * If we ever need more keys, we can add them later.
-     */
-
-#define KEY_BACKSPACE 0x0E
-#define KEY_F1 0x3B
-#define KEY_F2 0x3C
-#define KEY_F3 0x3D
-#define KEY_F4 0x3E
-#define KEY_F5 0x3F
-#define KEY_F6 0x40
-#define KEY_F7 0x41
-#define KEY_F8 0x42
-#define KEY_F9 0x43
-#define KEY_F10 0x44
-#define KEY_F11 0x57
-#define KEY_F12 0x58
-
-/**
- * The driver doesn't differentiate between E0 53 and 53,
- * so both are treated as the delete key being pressed
- */
-#define KEY_DEL 0x53
-
-    switch(scan_code) {
-        case KEY_BACKSPACE:
-            return XK_BackSpace;
-        case KEY_F1:
-            return XK_F1;
-        case KEY_F2:
-            return XK_F2;
-        case KEY_F3:
-            return XK_F3;
-        case KEY_F4:
-            return XK_F4;
-        case KEY_F5:
-            return XK_F5;
-        case KEY_F6:
-            return XK_F6;
-        case KEY_F7:
-            return XK_F7;
-        case KEY_F8:
-            return XK_F8;
-        case KEY_F9:
-            return XK_F9;
-        case KEY_F10:
-            return XK_F10;
-        case KEY_F11:
-            return XK_F11;
-        case KEY_F12:
-            return XK_F12;
-#if 0 /* Doesn't work from my testing */
-        case KEY_DEL:
-            return XK_Delete;
-#endif
-    }
-
-    return XK_VoidSymbol;
-}
-
 /**
  * Returns FALSE if we should treat this like a regular keyboard event
  * Returns TRUE if we should fixup the event
@@ -1985,7 +1910,7 @@ KdKeyCodeToKeySym(KdKeyboardInfo *ki, int type, unsigned char key_code)
 static Bool
 KdCheckSpecialKeys(KdKeyboardInfo *ki, int type, unsigned char key_code)
 {
-    KeySym sym;
+    unsigned char scan_code = key_code - KD_MIN_KEYCODE + ki->minScanCode;
 
     /*
      * Ignore key releases
@@ -2003,35 +1928,13 @@ KdCheckSpecialKeys(KdKeyboardInfo *ki, int type, unsigned char key_code)
         return FALSE;
     }
 
-    sym = KdKeyCodeToKeySym(ki, type, key_code);
-    if (sym == XK_VoidSymbol) {
-        return FALSE;
-    }
-
     /*
-     * Let OS function see keysym first
+     * Let OS function see scancode
      */
 
     if (kdOsFuncs->SpecialKey)
-        if ((*kdOsFuncs->SpecialKey) (sym))
+        if ((*kdOsFuncs->SpecialKey) (ki, scan_code))
             return TRUE;
-
-    /*
-     * Now check for backspace or delete; these signal the
-     * X server to terminate
-     */
-    switch (sym) {
-    case XK_BackSpace:
-    case XK_Delete:
-    case XK_KP_Delete:
-        /*
-         * Set the dispatch exception flag so the server will terminate the
-         * next time through the dispatch loop.
-         */
-        if (kdAllowZap)
-            dispatchException |= DE_TERMINATE;
-        break;
-    }
 
     return FALSE;
 }


### PR DESCRIPTION
It makes sense for all this to be moved to the os driver, since the scancodes depend on the keyboard drivers.

This allows us to have a cleaner `KdCheckSpecialKeys` and not involve X11 KeySyms at all.

Saner implementation of https://github.com/X11Libre/xserver/pull/2817 , and this actually allows proper separation between linux,ephyr,<whatever> special keys, if we eventually add special key support to Xephyr or something else.