### PR TITLE
kdrive: Port `KdKeyCodeToKeySym` to xkb and update man pages accordingly

### DIFF
--- a/hw/kdrive/Xkdrive.man
+++ b/hw/kdrive/Xkdrive.man
@@ -16,7 +16,7 @@ servers; for information on a specific X server, please refer to the
 relevant manual page.
 .SH OPTIONS
 In addition to the standard options accepted by all X servers (see
-.BR Xserver (1)),
+.BR Xserver (@miscmansuffix@),
 all the
 .B Xkdrive
 servers accept the following options:
@@ -44,13 +44,35 @@ enable emulation of a middle mouse button by chording.
 .TP 8
 .B -3button
 disable emulation of a middle mouse button by chording.
+.SH KEYBOARD
+The
+.B Xkdrive
+servers are normally configured to recognize various special combinations
+of key presses that instruct the server to perform some action, rather
+than just sending the key press event to a client application.
+These actions depend on the XKB keymap loaded by a particular keyboard device
+and may or may not be available on a given configuration.
+.PP
+The following key special combinations are recognized by the
+.B Xkdrive
+servers.
+.TP 8
+.B Ctrl+Alt+Backspace
+.TP 8
+.B Ctrl+Alt+Delete
+.TP 8
+.B Ctrl+Alt+KeyPadDelete
+Immediately kills the server -- no questions asked. It can be disabled by
+adding the
+.B -nozap
+command-line argument.
 .SH SEE ALSO
 .BR X (@miscmansuffix@),
-.BR Xserver (1),
-.BR xdm (1),
-.BR xinit (1),
-.BR Xvesa (1),
-.BR Xfbdev (1).
+.BR Xserver (@miscmansuffix@),
+.BR xdm (@miscmansuffix@),
+.BR xinit (@miscmansuffix@),
+.BR Xvesa (@miscmansuffix@),
+.BR Xfbdev (@miscmansuffix@).
 .SH AUTHORS
 The Xkdrive common core was written by Keith Packard,
 and is based on the Sample Implementation of X.

--- a/hw/kdrive/ephyr/man/Xephyr.man
+++ b/hw/kdrive/ephyr/man/Xephyr.man
@@ -98,6 +98,10 @@ at the end is interpreted as the ascii character '+')
 .I a
 key is pressed)
 .RE
+.SH KEYBOARD
+.B Xephyr
+supports the common special key combinations of the Xkdrive family of servers.  Please
+see Xkdrive(@miscmansuffix@).
 .SH "SIGNALS"
 Send a SIGUSR1 to the server (e.g. pkill \-USR1 Xephyr) to
 toggle the debugging mode.

--- a/hw/kdrive/fbdev/Xfbdev.man
+++ b/hw/kdrive/fbdev/Xfbdev.man
@@ -16,7 +16,7 @@ provided by the Linux framebuffer device.
 .SH OPTIONS
 .B Xfbdev
 accepts the common options of the Xkdrive family of servers.  Please
-see Xkdrive(1).
+see Xkdrive(@miscmansuffix@).
 
 .B Xfbdev
 also accepts the following additional options:
@@ -69,23 +69,11 @@ tells the X server to only use embedded GLES contexts.
 disables X-Video support.
 
 .SH KEYBOARD
-The
 .B Xfbdev
-server is normally configured to recognize various special combinations
-of key presses that instruct the server to perform some action, rather
-than just sending the key press event to a client application.
-Currently, these are implemented using hard-coded ps2 keyboard scancodes,
-and should work regardless of the loaded XKB keymap.
-.PP
-The following key special combinations are recognized by the
+supports the common special key combinations of the Xkdrive family of servers.  Please
+see Xkdrive(@miscmansuffix@).
 .B Xfbdev
-server.
-.TP 8
-.B Ctrl+Alt+Backspace
-Immediately kills the server -- no questions asked. It can be disabled by
-adding the
-.B -nozap
-command-line argument
+also accepts the following additional special key combinations:
 .TP 8
 .B Ctrl+Alt+F1...F12
 For systems with virtual terminal support, these keystroke
@@ -93,7 +81,7 @@ combinations are used to switch to virtual terminals 1 through 12,
 respectively.
 
 .SH SEE ALSO
-X(@miscmansuffix@), Xserver(1), Xkdrive(1), xdm(1), xinit(1).
+X(@miscmansuffix@), Xserver(@miscmansuffix@), Xkdrive(@miscmansuffix@), xdm(@miscmansuffix@), xinit(@miscmansuffix@).
 .SH AUTHORS
 The
 .B Xfbdev

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -272,9 +272,6 @@ struct _KdKeyboardInfo {
     int minScanCode;
     int maxScanCode;
 
-    /* Not set by the input driver */
-    int last_scan_code;
-
     int leds;
     int bellPitch;
     int bellDuration;

--- a/hw/kdrive/src/kinput.c
+++ b/hw/kdrive/src/kinput.c
@@ -220,29 +220,24 @@ KdDisableInput(void)
     KdPointerInfo *pi;
     int found = 0, i = 0;
 
+    /**
+     * When we're doing something that causes a vt switch,
+     * if that action is a key press, the X server doesn't see
+     * the key release event.
+     *
+     * For example, if we start an X server from a terminal
+     * running inside another X server, the "host" server
+     * sees the "enter" key press, but not the key release.
+     *
+     * KdReleaseAllKeys does input_{lock,unlock} by itself.
+     */
+    KdReleaseAllKeys();
+
+    /* TODO: Do the same for any pressed mouse buttons */
+
     input_lock();
 
     for (ki = kdKeyboards; ki; ki = ki->next) {
-        if (ki->last_scan_code != -1) {
-            /**
-             * When we're doing something that causes a vt switch,
-             * if that action is a key press, the X server doesn't see
-             * the key release event.
-             *
-             * For example, if we start an X server from a terminal
-             * running inside another X server, the "host" server
-             * sees the "enter" key press, but not the key release.
-             *
-             * With this, we forge the key release event that the
-             * X server doesn't see, so that it doesn't misinterpret
-             * the missing key release as a long key press.
-             *
-             * Doesn't really matter what the value of the
-             * third argument is, as long as it is non-zero.
-             * This is what the linux keyboard driver sends.
-             */
-            KdEnqueueKeyboardEvent(ki, ki->last_scan_code, 0x80);
-        }
         if (ki->driver && ki->driver->Disable)
             (*ki->driver->Disable) (ki);
     }
@@ -1864,23 +1859,22 @@ KdReceiveTimeout(KdPointerInfo * pi)
 void
 KdReleaseAllKeys(void)
 {
-#if 0
-    int key;
-    KdKeyboardInfo *ki;
-
     input_lock();
 
-    for (ki = kdKeyboards; ki; ki = ki->next) {
-        for (key = ki->keySyms.minKeyCode; key < ki->keySyms.maxKeyCode; key++) {
+    for (KdKeyboardInfo *ki = kdKeyboards; ki; ki = ki->next) {
+        if (!ki->dixdev || !ki->dixdev->key) {
+            continue;
+        }
+
+        for (int key = ki->dixdev->key->xkbInfo->desc->min_key_code;
+             key <= ki->dixdev->key->xkbInfo->desc->max_key_code; key++) {
             if (key_is_down(ki->dixdev, key, KEY_POSTED | KEY_PROCESSED)) {
-                KdHandleKeyboardEvent(ki, KeyRelease, key);
-                QueueGetKeyboardEvents(ki->dixdev, KeyRelease, key, NULL);
+                QueueKeyboardEvents(ki->dixdev, KeyRelease, key);
             }
         }
     }
 
     input_unlock();
-#endif
 }
 
 static void
@@ -1960,9 +1954,10 @@ KdCheckSpecialKeys(KdKeyboardInfo *ki, int type, unsigned char key_code)
          * Set the dispatch exception flag so the server will terminate the
          * next time through the dispatch loop.
          */
-        if (kdAllowZap)
+        if (kdAllowZap) {
             dispatchException |= DE_TERMINATE;
-        break;
+            return TRUE;
+        }
     }
 
     return FALSE;
@@ -1984,66 +1979,11 @@ KdEnqueueKeyboardEvent(KdKeyboardInfo * ki,
         /*
          * Set up this event -- the type may be modified below
          */
-        if (is_up) {
-            type = KeyRelease;
-            ki->last_scan_code = -1;
-        } else {
-            type = KeyPress;
-            ki->last_scan_code = scan_code;
-        }
+        type = is_up ? KeyRelease : KeyPress;
 
-        /**
-         * Right now, the only special keys we have
-         * either terminate the server or switch vt.
-         *
-         * We don't really cares what happens if we terminate,
-         * but we do care if we switch vt.
-         *
-         * If we switch vt, the input driver sees the key press
-         * event, but it does't see the key release event.
-         * As such, when we switch back to the original vt,
-         * the server thinks we are still pressing the F* key.
-         *
-         * To mitigate this, we can do one of two things:
-         *
-         * Forge the key release event that the server
-         * doesn't see, and 2 key release events for
-         * the crtl key and the alt key and enqueue them.
-         *
-         * Not enqueue the key press event at all,
-         * and only forge 2 key release events,
-         * one for the crtl key, another for the alt key.
-         *
-         * Below, the latter option is implemented.
-         */
-
-        /* Scancodes are taken from https://aeb.win.tue.nl/linux/kbd/scancodes-1.html */
-
-        #define KEY_CTRL 0x1D
-        #define KEY_ALT 0x38
-
-#if 0 /* First option */
-        Bool ret = KdCheckSpecialKeys(ki, type, key_code);
-        QueueKeyboardEvents(ki->dixdev, type, key_code);
-        if (ret) {
-            unsigned char ctrl_key_code = KEY_CTRL + KD_MIN_KEYCODE - ki->minScanCode;
-            unsigned char alt_key_code = KEY_ALT + KD_MIN_KEYCODE - ki->minScanCode;
-            QueueKeyboardEvents(ki->dixdev, KeyRelease, key_code);
-            QueueKeyboardEvents(ki->dixdev, KeyRelease, ctrl_key_code);
-            QueueKeyboardEvents(ki->dixdev, KeyRelease, alt_key_code);
-            ki->last_scan_code = -1; /* No need to fix this scancode up again */
-        }
-#else /* Second option */
         if (!KdCheckSpecialKeys(ki, type, key_code)) {
             QueueKeyboardEvents(ki->dixdev, type, key_code);
-        } else {
-            unsigned char ctrl_key_code = KEY_CTRL + KD_MIN_KEYCODE - ki->minScanCode;
-            unsigned char alt_key_code = KEY_ALT + KD_MIN_KEYCODE - ki->minScanCode;
-            QueueKeyboardEvents(ki->dixdev, KeyRelease, ctrl_key_code);
-            QueueKeyboardEvents(ki->dixdev, KeyRelease, alt_key_code);
-            ki->last_scan_code = -1; /* No need to fix this scancode up again */
         }
-#endif
     }
     else {
         ErrorF("driver %s wanted to post scancode %d outside of [%d, %d]!\n",

--- a/hw/kdrive/src/kinput.c
+++ b/hw/kdrive/src/kinput.c
@@ -1904,78 +1904,13 @@ KdCheckLock(void)
 }
 
 static KeySym
-KdKeyCodeToKeySym(KdKeyboardInfo *ki, int type, unsigned char key_code)
+KdKeyCodeToKeySym(KdKeyboardInfo *ki, unsigned char key_code)
 {
-    unsigned char scan_code = key_code - KD_MIN_KEYCODE + ki->minScanCode;
-    (void)type;
+    KeySym* syms = XkbKeySymsPtr(ki->dixdev->key->xkbInfo->desc, key_code);
+    int num_syms = XkbKeyNumSyms(ki->dixdev->key->xkbInfo->desc, key_code);
 
-    /**
-     * XXX This looks really sketchy XXX
-     * Surely there is a way to query this from xkb?
-     * This doesn't work:
-     * return kbd->key->xkbInfo->desc->map->modmap[key_code];
-     *
-     * Scancodes are taken from https://aeb.win.tue.nl/linux/kbd/scancodes-1.html
-     * These scancodes can be also found at https://wiki.osdev.org/PS/2_Keyboard
-     *
-     * Only a few keys we are interested in are listed here.
-     * If we ever need more keys, we can add them later.
-     */
-
-#define KEY_BACKSPACE 0x0E
-#define KEY_F1 0x3B
-#define KEY_F2 0x3C
-#define KEY_F3 0x3D
-#define KEY_F4 0x3E
-#define KEY_F5 0x3F
-#define KEY_F6 0x40
-#define KEY_F7 0x41
-#define KEY_F8 0x42
-#define KEY_F9 0x43
-#define KEY_F10 0x44
-#define KEY_F11 0x57
-#define KEY_F12 0x58
-
-/**
- * The driver doesn't differentiate between E0 53 and 53,
- * so both are treated as the delete key being pressed
- */
-#define KEY_DEL 0x53
-
-    switch(scan_code) {
-        case KEY_BACKSPACE:
-            return XK_BackSpace;
-        case KEY_F1:
-            return XK_F1;
-        case KEY_F2:
-            return XK_F2;
-        case KEY_F3:
-            return XK_F3;
-        case KEY_F4:
-            return XK_F4;
-        case KEY_F5:
-            return XK_F5;
-        case KEY_F6:
-            return XK_F6;
-        case KEY_F7:
-            return XK_F7;
-        case KEY_F8:
-            return XK_F8;
-        case KEY_F9:
-            return XK_F9;
-        case KEY_F10:
-            return XK_F10;
-        case KEY_F11:
-            return XK_F11;
-        case KEY_F12:
-            return XK_F12;
-#if 0 /* Doesn't work from my testing */
-        case KEY_DEL:
-            return XK_Delete;
-#endif
-    }
-
-    return XK_VoidSymbol;
+    /* XXX Should we loop through the symbols? XXX */
+    return num_syms >= 1 ? syms[0] : NoSymbol;
 }
 
 /**
@@ -2003,10 +1938,7 @@ KdCheckSpecialKeys(KdKeyboardInfo *ki, int type, unsigned char key_code)
         return FALSE;
     }
 
-    sym = KdKeyCodeToKeySym(ki, type, key_code);
-    if (sym == XK_VoidSymbol) {
-        return FALSE;
-    }
+    sym = KdKeyCodeToKeySym(ki, key_code);
 
     /*
      * Let OS function see keysym first


### PR DESCRIPTION
Now special key combinations work in all kdrive X servers, and the special key combinations are documented in the various man pages.