### PR TITLE
CVE Jun 2026 - xkb: reject key types with num_levels exceeding XkbMaxShiftLevel

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -1632,7 +1632,7 @@ CheckKeyTypes(ClientPtr client,
         }
         n = i + req->firstType;
         width = wire->numLevels;
-        if (width < 1) {
+        if (width < 1 || width > XkbMaxShiftLevel) {
             *nMapsRtrn = _XkbErrCode3(0x04, n, width);
             return 0;
         }


### PR DESCRIPTION
Fix from https://gitlab.freedesktop.org/xorg/xserver/-/commit/543e108516428fc8c3bea91d6563ad266f9a801e
No modification required.