### PR TITLE
CVEs June 2026 - xkb: reject key types with num_levels exceeding XkbMaxShiftLevel

### DIFF
--- a/xkb/xkb.c
+++ b/xkb/xkb.c
@@ -1632,7 +1632,7 @@ CheckKeyTypes(ClientPtr client,
         }
         n = i + req->firstType;
         width = wire->numLevels;
-        if (width < 1) {
+        if (width < 1 || width > XkbMaxShiftLevel) {
             *nMapsRtrn = _XkbErrCode3(0x04, n, width);
             return 0;
         }


### PR DESCRIPTION
From:
https://gitlab.freedesktop.org/xorg/xserver/-/commit/543e108516428fc8c3bea91d6563ad266f9a801e

Applies without modifications.

Part of: https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2228

Original commit message:

> CheckKeyTypes validates incoming key type definitions from XkbSetMap
> requests but does not enforce an upper bound on numLevels. A client can set
> numLevels up to 255 on a non-canonical key type, which is stored in the
> server's type table.
> 
> When ChangeKeyboardMapping later triggers XkbUpdateKeyTypesFromCore, the
> function XkbKeyTypesForCoreSymbols computes groupsWidth from num_levels and
> uses the XKB_OFFSET(g, l) = (g * groupsWidth) + l macro to index into
> tsyms[], a stack-allocated buffer of XkbMaxSymsPerKey (252) entries. With
> num_levels=255, groupsWidth=255, and indices reach up to 3*255+254 = 1019,
> overflowing the 252-element stack buffer by 767 KeySym-sized entries.
> 
> Fix by rejecting numLevels values greater than XkbMaxShiftLevel (63) in
> CheckKeyTypes, alongside the existing lower-bound check for numLevels < 1.