### PR TITLE
(release/25.0) os: check ospoll allocation failures

### DIFF
--- a/os/ospoll.c
+++ b/os/ospoll.c
@@ -208,6 +208,8 @@ ospoll_create(void)
 {
 #if POLLSET
     struct ospoll *ospoll = calloc(1, sizeof (struct ospoll));
+    if (!ospoll)
+        return NULL;
 
     ospoll->ps = pollset_create(-1);
     if (ospoll->ps < 0) {
@@ -218,6 +220,8 @@ ospoll_create(void)
 #endif
 #if PORT
     struct ospoll *ospoll = calloc(1, sizeof (struct ospoll));
+    if (!ospoll)
+        return NULL;
 
     ospoll->epoll_fd = port_create();
     if (ospoll->epoll_fd < 0) {


### PR DESCRIPTION
ospoll_create() initializes backend-specific state immediately after
allocating the ospoll structure. Check the allocation result for each
backend before dereferencing it and return NULL on failure.

Signed-off-by: Mikhail Dmitrichenko <m.dmitrichenko222@gmail.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2217>
