### PR TITLE
(release/25.0) xkb: preserve buffer on realloc failure

### DIFF
--- a/xkb/maprules.c
+++ b/xkb/maprules.c
@@ -480,15 +480,19 @@ CheckLine(InputLine * line,
 static char *
 _Concat(char *str1, const char *str2)
 {
-    int len;
+    size_t len;
+    char *tmp;
 
     if ((!str1) || (!str2))
         return str1;
+
     len = strlen(str1) + strlen(str2) + 1;
-    str1 = realloc(str1, len * sizeof(char));
-    if (str1)
-        strcat(str1, str2);
-    return str1;
+    tmp = realloc(str1, len);
+    if (!tmp)
+        return str1;
+
+    strcat(tmp, str2);
+    return tmp;
 }
 
 static void


### PR DESCRIPTION
_Concat() stored the realloc() result directly in its input pointer, so
an allocation failure could drop the only reference to the original
buffer when callers assigned the return value back to their destination
pointer.

Keep the old pointer until realloc() succeeds, avoiding the leak
reported by static analysis.

Found by Linux Verification Center (linuxtesting.org) with SVACE.

Signed-off-by: Mikhail Dmitrichenko <m.dmitrichenko222@gmail.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2221>
