### PR TITLE
(release/25.0) dix: increase XLFDMAXFONTNAMELEN to match libXfont2's MAXFONTNAMELEN

### DIFF
--- a/dix/closestr.h
+++ b/dix/closestr.h
@@ -57,7 +57,12 @@ typedef struct _OFclosure {
 
 /* ListFontsWithInfo */
 
-#define XLFDMAXFONTNAMELEN	256
+/* libXfont2 allows font names/aliases up to MAXFONTNAMELEN (1024) bytes in
+ * fonts.alias files.  The server's pattern buffers must be large enough to
+ * hold resolved alias targets returned by the font library.
+ * ZDI-CAN-30136
+ */
+#define XLFDMAXFONTNAMELEN	1024
 typedef struct _LFWIstate {
     char pattern[XLFDMAXFONTNAMELEN];
     int patlen;

--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -674,6 +674,10 @@ doListFontsAndAliases(ClientPtr client, LFclosurePtr c)
                  * is BadFontName, indicating the alias resolution
                  * is complete.
                  */
+                if (resolvedlen > XLFDMAXFONTNAMELEN) {
+                    err = BadFontName;
+                    goto ContBadFontName;
+                }
                 memcpy(tmp_pattern, resolved, resolvedlen);
                 if (c->haveSaved) {
                     char *tmpname;
@@ -941,6 +945,10 @@ doListFontsWithInfo(ClientPtr client, LFWIclosurePtr c)
                 if (c->savedName)
                     memcpy(c->savedName, name, namelen + 1);
                 aliascount = 20;
+            }
+            if (namelen > XLFDMAXFONTNAMELEN) {
+                err = BadFontName;
+                goto ContBadFontName;
             }
             memmove(c->current.pattern, name, namelen);
             c->current.patlen = namelen;


### PR DESCRIPTION
XLFDMAXFONTNAMELEN was 256 bytes, but libXfont2 defines MAXFONTNAMELEN
as 1024 and allows font names and alias targets up to that length in
fonts.alias files.

doListFontsAndAliases copies the resolved alias target into a
stack-allocated tmp_pattern[XLFDMAXFONTNAMELEN] and then into
c->current.pattern[XLFDMAXFONTNAMELEN] (defined in LFWIstateRec).
doListFontsWithInfo has the same pattern, copying the resolved name into
c->current.pattern[]. With the old 256-byte limit, a fonts.alias entry
with a target name between 257 and 1023 bytes would overflow both
buffers.

An attacker can exploit this by:
  1. Creating a font directory with a fonts.alias containing an alias
     whose target name exceeds 256 bytes
  2. Using SetFontPath to add the malicious directory
  3. Calling ListFonts with the alias name to trigger alias resolution
  4. The oversized resolved name overflows the 256-byte stack buffer

Increase XLFDMAXFONTNAMELEN from 256 to 1024 to match libXfont2's
MAXFONTNAMELEN, ensuring the server can handle any name the font library
produces.

This vulnerability was discovered by:
Anonymous working with TrendAI Zero Day Initiative

ZDI-CAN-30136

Assisted-by: Claude:claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2228>
