### PR TITLE
(release/25.1) glx: fix duplicate tagInfo->vendor = NULL assignment

### DIFF
--- a/glx/vndservermapping.c
+++ b/glx/vndservermapping.c
@@ -159,7 +159,7 @@ GlxContextTagInfo *GlxLookupContextTag(ClientPtr client, GLXContextTag tag)
 void GlxFreeContextTag(GlxContextTagInfo *tagInfo)
 {
     if (tagInfo != NULL) {
-        tagInfo->vendor = NULL;
+        tagInfo->client = NULL;
         tagInfo->vendor = NULL;
         tagInfo->data = NULL;
         tagInfo->context = None;


### PR DESCRIPTION
Assisted-by: Claude:claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2226>
