### PR TITLE
(release/25.0) os/log: handle NULL string argument in vpnprintf

### DIFF
--- a/os/log.c
+++ b/os/log.c
@@ -392,7 +392,7 @@ vpnprintf(char *string, int size_in, const char *f, va_list args)
     int f_idx = 0;
     int s_idx = 0;
     int f_len = strlen_sigsafe(f);
-    char *string_arg;
+    const char *string_arg;
     char number[21];
     int p_len;
     int i;
@@ -456,11 +456,11 @@ vpnprintf(char *string, int size_in, const char *f, va_list args)
         switch (f[f_idx]) {
         case 's':
             string_arg = va_arg(args, char*);
+            if (!string_arg)
+                string_arg = "(null)";
 
-            if (string_arg) {
-                for (i = 0; string_arg[i] != 0 && s_idx < size - 1 && s_idx < precision; i++)
-                    string[s_idx++] = string_arg[i];
-            }
+            for (i = 0; string_arg[i] != 0 && s_idx < size - 1 && s_idx < precision; i++)
+                string[s_idx++] = string_arg[i];
             break;
 
         case 'u':


### PR DESCRIPTION
backport of #2883

Since this function is called from signal handlers (e.g. OsSigHandler
processing SIGSEGV/SIGBUS), a NULL %s argument triggers a recursive fault.

Assisted-by: Claude:claude-claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2200>

----------------------------------------------------------------------------

Modified to fit Xlibre changes.
See: https://github.com/X11Libre/xserver/pull/2794

Signed-off-by: stefan11111 <stefan11111github@gmail.com>
