### PR TITLE
(release/25.1) os: osdep.h: fix FTBS on musl

### DIFF
--- a/os/osdep.h
+++ b/os/osdep.h
@@ -50,6 +50,7 @@ SOFTWARE.
 
 #include <X11/Xdefs.h>
 
+#include <errno.h>
 #include <limits.h>
 #include <signal.h>
 #include <stddef.h>


### PR DESCRIPTION
https://github.com/X11Libre/xserver/issues/2890

musl doesn't indirectly include errno.h as much as other libc's do.
In general it's a good idea to always explicitly include what's needed,
instead of relying on indirect includes.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
