### PR TITLE
(release/25.1) hw/xwin: Allow DefWindowProc to SetFocus() as needed after WM_ACTIVE

### DIFF
--- a/hw/xwin/winmultiwindowwndproc.c
+++ b/hw/xwin/winmultiwindowwndproc.c
@@ -911,11 +911,8 @@ winTopLevelWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
         /* Pass the message to the root window */
         SendMessage(hwndScreen, message, wParam, lParam);
 
-        /* Prevent the mouse wheel from stalling when another window is minimized */
-        if (HIWORD(wParam) == 0 && LOWORD(wParam) == WA_ACTIVE &&
-            (HWND) lParam != NULL && (HWND) lParam != GetParent(hwnd))
-            SetFocus(hwnd);
-        return 0;
+        /* Allow DefWindowProc to SetFocus() as needed */
+        break;
 
     case WM_ACTIVATEAPP:
         /*


### PR DESCRIPTION
backport from Xorg

Don't indicate we've processed WM_ACTIVATE, so DefWindowProc can do
not-clearly specified default things with the focus.

Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/736>
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
