### PR TITLE
(release/25.1) os/auth: prefer getrandom() over arc4random_buf() and /dev/urandom

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -137,6 +137,7 @@ conf_data.set('HAVE_SYS_UTSNAME_H', cc.has_header('sys/utsname.h') ? '1' : false
 conf_data.set('HAVE_SYS_SYSMACROS_H', cc.has_header('sys/sysmacros.h') ? '1' : false)
 
 conf_data.set('HAVE_ARC4RANDOM_BUF', cc.has_function('arc4random_buf', dependencies: libbsd_dep) ? '1' : false)
+conf_data.set('HAVE_GETRANDOM', cc.has_function('getrandom', prefix: '#include <sys/random.h>') ? '1' : false)
 conf_data.set('HAVE_BACKTRACE', cc.has_function('backtrace') ? '1' : false)
 conf_data.set('HAVE_CBRT', cc.has_function('cbrt') ? '1' : false)
 conf_data.set('HAVE_EPOLL_CREATE1', cc.has_function('epoll_create1',dependencies:epoll_dep, prefix:'#include<sys/epoll.h>') ? '1' : false)

--- a/os/auth.c
+++ b/os/auth.c
@@ -45,6 +45,9 @@ from The Open Group.
 #include    <X11/Xw32defs.h>
 #endif
 #include   <stdlib.h>       /* for arc4random_buf() */
+#ifdef HAVE_GETRANDOM
+#include   <sys/random.h>   /* for getrandom() */
+#endif
 
 #include "os/auth.h"
 

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -88,12 +88,25 @@ extern Bool NewOutputPending;
 #ifndef HAVE_ARC4RANDOM_BUF
 static inline void arc4random_buf(void *buf, size_t nbytes)
 {
+    ssize_t ret;
+    int pos = 0;
+#ifdef HAVE_GETRANDOM
+    while (pos < len) {
+        ret = getrandom(buf + pos, len - pos, 0);
+        if (ret <= 0) {
+            if (ret < 0 && errno == EINTR)
+                continue;
+            FatalError("Cannot read random data via getrandom(): %s\n",
+                       strerror(errno));
+        }
+        pos += ret;
+    }
+#else
     int fd = open("/dev/urandom", O_RDONLY);
     if (fd < 0)
         FatalError("Cannot open /dev/urandom for random data generation\n");
-    int pos = 0;
     while (pos < nbytes) {
-        int ret = read(fd, (unsigned char*)buf + pos, nbytes - pos);
+        ret = read(fd, (unsigned char*)buf + pos, nbytes - pos);
         if (ret <= 0) {
             if (ret < 0 && errno == EINTR)
                 continue;
@@ -103,6 +116,7 @@ static inline void arc4random_buf(void *buf, size_t nbytes)
         pos += ret;
     }
     close(fd);
+#endif
 }
 #endif /* HAVE_ARC4RANDOM_BUF */
 


### PR DESCRIPTION
backport from Xorg

Use getrandom() as the preferred source of random data when available,
getrandom() works in chroots and containers without the random device
node.

Note this is a build-time preference, not a runtime preference.

Assisted-by: Claude:claude-claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2200>
