### PR TITLE
(master) xf86: drop no longer needed entries from default driver list for Intel

### DIFF
--- a/hw/xfree86/common/xf86pciBus.c
+++ b/hw/xfree86/common/xf86pciBus.c
@@ -1115,45 +1115,6 @@ xf86VideoPtrToDriverList(struct pci_device *dev, XF86MatchedDrivers *md)
 			driverList[0] = "psb";
 			driverList[1] = "psb_drv";
 			break;
-		/* GMA600/Oaktrail */
-		case 0x4100:
-		case 0x4101:
-		case 0x4102:
-		case 0x4103:
-		case 0x4104:
-		case 0x4105:
-		case 0x4106:
-		case 0x4107:
-		/* Atom E620/Oaktrail */
-		case 0x4108:
-		/* Medfield */
-		case 0x0130:
-		case 0x0131:
-		case 0x0132:
-		case 0x0133:
-		case 0x0134:
-		case 0x0135:
-		case 0x0136:
-		case 0x0137:
-		/* GMA 3600/CDV */
-		case 0x0be0:
-		case 0x0be1:
-		case 0x0be2:
-		case 0x0be3:
-		case 0x0be4:
-		case 0x0be5:
-		case 0x0be6:
-		case 0x0be7:
-		case 0x0be8:
-		case 0x0be9:
-		case 0x0bea:
-		case 0x0beb:
-		case 0x0bec:
-		case 0x0bed:
-		case 0x0bee:
-		case 0x0bef:
-			/* Use fbdev/vesa driver on Oaktrail, Medfield, CDV */
-			break;
 		/* Default to intel only on pre-gen3 chips */
 		case 0x7121:
 		case 0x7123:


### PR DESCRIPTION
backport from Xorg

Now that the Intel driver is no longer the default case, we don't
need to maintain a long list of entries to override the default.

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2168>
