### PR TITLE
(release/25.0) glamor: fix an error path cleanup

### DIFF
--- a/glamor/glamor_font.c
+++ b/glamor/glamor_font.c
@@ -159,10 +159,13 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
     glTexImage2D(GL_TEXTURE_2D, 0, GL_R8UI, overall_width, overall_height,
                  0, GL_RED_INTEGER, GL_UNSIGNED_BYTE, bits);
     glamor_priv->suppress_gl_out_of_memory_logging = false;
-    if (glGetError() == GL_OUT_OF_MEMORY)
-        return NULL;
-
     free(bits);
+
+    if (glGetError() == GL_OUT_OF_MEMORY) {
+        glDeleteTextures(1, &glamor_font->texture_id);
+        glamor_font->texture_id = 0;
+        return NULL;
+    }
 
     glamor_font->realized = TRUE;
 


### PR DESCRIPTION
The GL_OUT_OF_MEMORY error path returns NULL without freeing the
allocated `bits` buffer or deleting the GL texture.

Assisted-by: Claude:claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2233>
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
