### PR TITLE
(master) test: pyxtest: fix meson.build

### DIFF
--- a/test/pyxtest/meson.build
+++ b/test/pyxtest/meson.build
@@ -21,10 +21,6 @@ if pytest.found()
         pyxtest_env.set('XVFB_PATH', xvfb_server.full_path())
     endif
 
-    if build_xwayland
-        pyxtest_env.set('XWAYLAND_PATH', xwayland_server.full_path())
-    endif
-
     # Tell the test suite if the server was built with AddressSanitizer
     if 'address' in get_option('b_sanitize')
         pyxtest_env.set('XSERVER_ASAN', '1')


### PR DESCRIPTION
fallout of picking from Xorg: we don't have build_xwayland anymore.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
