### PR TITLE
(master) xwin: catch potential realloc() failure winInitializeScreens()

### DIFF
--- a/hw/xwin/winprocarg.c
+++ b/hw/xwin/winprocarg.c
@@ -177,8 +177,15 @@ winInitializeScreens(int maxscreens)
 
     if (maxscreens > g_iNumScreens) {
         /* Reallocate the memory for DDX-specific screen info */
-        g_ScreenInfo =
+        winScreenInfo *newScreenInfo =
             realloc(g_ScreenInfo, maxscreens * sizeof(winScreenInfo));
+
+        if (!newScreenInfo) {
+            FatalError("winInitializeScreens: realloc(%p, %d) failed\n",
+                   (void *)g_ScreenInfo, maxscreens * (int)sizeof(winScreenInfo));
+            return;
+        }
+        g_ScreenInfo = newScreenInfo;
 
         /* Set default values for any new screens */
         for (i = g_iNumScreens; i < maxscreens; i++)


### PR DESCRIPTION
In the unlikely case that realloc() fails on screen init, it's better
to have a decdent error message instead of just segfault.
(at that point we don't have any serious way for recovery anyways)

X-Co-Slopped-By: BigPickle
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
