### PR TITLE
(master) xwin/glx: prevent sprintf overflow in glxWinErrorMessage

### DIFF
--- a/hw/xwin/glx/indirect.c
+++ b/hw/xwin/glx/indirect.c
@@ -180,7 +180,8 @@ glxWinErrorMessage(void)
         (errorbuffer[strlen(errorbuffer) - 1] == '\r'))
         errorbuffer[strlen(errorbuffer) - 1] = 0;
 
-    sprintf(errorbuffer + strlen(errorbuffer), " (%08x)", last_error);
+    size_t len = strlen(errorbuffer);
+    snprintf(errorbuffer + len, sizeof(errorbuffer) - len, " (%08x)", last_error);
 
     return errorbuffer;
 }


### PR DESCRIPTION
Replace unbounded sprintf() with snprintf() bounded by remaining
space in errorbuffer[1024] to prevent overflow when FormatMessage
nearly fills the buffer.

Signed-off-by: OpenCode <opencode@opencode.ai>
