### PR TITLE
Adds #mesondefine for conf variable added in a86be24e.

### DIFF
--- a/hw/xfree86/xlibre-server.h.meson.in
+++ b/hw/xfree86/xlibre-server.h.meson.in
@@ -178,6 +178,9 @@
 /* Use libpciaccess */
 #mesondefine XSERVER_LIBPCIACCESS
 
+/* Have the pci_device_is_boot_display function */
+#mesondefine HAVE_PCI_DEVICE_IS_BOOT_DISPLAY
+
 /* X Access Control Extension */
 #mesondefine XACE
 


### PR DESCRIPTION
This configuration variable was getting defined in `include/meson.build` but it didn't have a #mesondefine "anchor" in
`hw/xfree86/xlibre-server.h.meson.in`, so it did not end up in the configuration headers, and lead to broken builds (due to a double define of `pci_device_is_boot_display`) with libpciaccess version 19.

Added the appropriate #mesondefine line to fix it.

Fixes #2892 (My previous explanation of this bug was entirely incorrect on that thread so I deleted it).