### PR TITLE
(master) composite: parentheses around macro argument symbols

### DIFF
--- a/Xext/composite/compext.c
+++ b/Xext/composite/compext.c
@@ -132,10 +132,10 @@ ProcCompositeQueryVersion(ClientPtr client)
 #define VERIFY_WINDOW(pWindow, wid, client, mode)                       \
     do {                                                                \
         int err;                                                        \
-        err = dixLookupResourceByType((void **) &pWindow, wid,          \
-                                      X11_RESTYPE_WINDOW, client, mode);\
+        err = dixLookupResourceByType((void **) &(pWindow), (wid),      \
+                                      X11_RESTYPE_WINDOW, (client), (mode));\
         if (err != Success) {                                           \
-            client->errorValue = wid;                                   \
+            (client)->errorValue = (wid);                               \
             return err;                                                 \
         }                                                               \
     } while (0)


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
