### PR TITLE
(master) mi: parentheses around macro argument symbols

### DIFF
--- a/mi/miarc.c
+++ b/mi/miarc.c
@@ -66,7 +66,7 @@ SOFTWARE.
 #define EPSILON	0.000001
 #define ISEQUAL(a,b) (fabs((a) - (b)) <= EPSILON)
 #define UNEQUAL(a,b) (fabs((a) - (b)) > EPSILON)
-#define PTISEQUAL(a,b) (ISEQUAL(a.x,b.x) && ISEQUAL(a.y,b.y))
+#define PTISEQUAL(a,b) (ISEQUAL((a).x,(b).x) && ISEQUAL((a).y,(b).y))
 #define SQSECANT 108.856472512142   /* 1/sin^2(11/2) - for 11o miter cutoff */
 
 /* Point with sub-pixel positioning. */
@@ -131,7 +131,7 @@ struct line {
     int valid;
 };
 
-#define intersectLine(y,line) (line.m * (y) + line.b)
+#define intersectLine(y,line) ((line).m * (y) + (line).b)
 
 /*
  * these are all y value bounds
@@ -1540,8 +1540,8 @@ miRoundCap(DrawablePtr pDraw,
 #define M_PI_2	1.57079632679489661923
 #endif
 
-#define Dsin(d)	((d) == 0.0 ? 0.0 : ((d) == 90.0 ? 1.0 : sin(d*M_PI/180.0)))
-#define Dcos(d)	((d) == 0.0 ? 1.0 : ((d) == 90.0 ? 0.0 : cos(d*M_PI/180.0)))
+#define Dsin(d)	((d) == 0.0 ? 0.0 : ((d) == 90.0 ? 1.0 : sin((d)*M_PI/180.0)))
+#define Dcos(d)	((d) == 0.0 ? 1.0 : ((d) == 90.0 ? 0.0 : cos((d)*M_PI/180.0)))
 #define mod(a,b)	((a) >= 0 ? (a) % (b) : (b) - (-(a)) % (b))
 
 static double
@@ -3114,7 +3114,7 @@ fillSpans(DrawablePtr pDrawable, GCPtr pGC)
 
 #define findSpan(y) ((finalMiny <= (y) && (y) <= finalMaxy) ? \
 			  &finalSpans[(y) - finalMiny] : \
-			  realFindSpan (y))
+			  realFindSpan ((y)))
 
 static struct finalSpan **
 realFindSpan(int y)

--- a/mi/micmap.c
+++ b/mi/micmap.c
@@ -289,16 +289,16 @@ miCreateDefColormap(ScreenPtr pScreen)
  * driver
  */
 
-#define _RZ(d) ((d + 2) / 3)
+#define _RZ(d) (((d) + 2) / 3)
 #define _RS(d) 0
-#define _RM(d) ((1U << _RZ(d)) - 1)
-#define _GZ(d) ((d - _RZ(d) + 1) / 2)
-#define _GS(d) _RZ(d)
-#define _GM(d) (((1U << _GZ(d)) - 1) << _GS(d))
-#define _BZ(d) (d - _RZ(d) - _GZ(d))
-#define _BS(d) (_RZ(d) + _GZ(d))
-#define _BM(d) (((1U << _BZ(d)) - 1) << _BS(d))
-#define _CE(d) (1U << _RZ(d))
+#define _RM(d) ((1U << _RZ((d))) - 1)
+#define _GZ(d) (((d) - _RZ((d)) + 1) / 2)
+#define _GS(d) _RZ((d))
+#define _GM(d) (((1U << _GZ((d))) - 1) << _GS((d)))
+#define _BZ(d) ((d) - _RZ((d)) - _GZ((d)))
+#define _BS(d) (_RZ((d)) + _GZ((d)))
+#define _BM(d) (((1U << _BZ((d))) - 1) << _BS((d)))
+#define _CE(d) (1U << _RZ((d)))
 
 typedef struct _miVisuals {
     struct _miVisuals *next;

--- a/mi/midispcur.c
+++ b/mi/midispcur.c
@@ -72,9 +72,9 @@ typedef struct {
 } miDCBufferRec, *miDCBufferPtr;
 
 #define miGetDCDevice(dev, screen) \
- ((DevHasCursor(dev)) ? \
-  (miDCBufferPtr)dixLookupScreenPrivate(&dev->devPrivates, miDCDeviceKey, screen) : \
-  (miDCBufferPtr)dixLookupScreenPrivate(&GetMaster(dev, MASTER_POINTER)->devPrivates, miDCDeviceKey, screen))
+ ((DevHasCursor((dev))) ? \
+  (miDCBufferPtr)dixLookupScreenPrivate(&(dev)->devPrivates, miDCDeviceKey, (screen)) : \
+  (miDCBufferPtr)dixLookupScreenPrivate(&GetMaster((dev), MASTER_POINTER)->devPrivates, miDCDeviceKey, (screen)))
 
 /*
  * The core pointer buffer will point to the index of the virtual pointer
@@ -151,7 +151,7 @@ bool miDCRealizeCursor(ScreenPtr pScreen, CursorPtr pCursor)
     return TRUE;
 }
 
-#define EnsurePicture(picture,draw,win) (picture || miDCMakePicture(&picture,draw,win))
+#define EnsurePicture(picture,draw,win) ((picture) || miDCMakePicture(&(picture),(draw),(win)))
 
 static PicturePtr
 miDCMakePicture(PicturePtr * ppPicture, DrawablePtr pDraw, WindowPtr pWin)

--- a/mi/mieq.c
+++ b/mi/mieq.c
@@ -71,8 +71,8 @@ in this Software without prior written authorization from The Open Group.
 #define QUEUE_DROP_BACKTRACE_FREQUENCY     100
 #define QUEUE_DROP_BACKTRACE_MAX            10
 
-#define EnqueueScreen(dev) dev->spriteInfo->sprite->pEnqueueScreen
-#define DequeueScreen(dev) dev->spriteInfo->sprite->pDequeueScreen
+#define EnqueueScreen(dev) (dev)->spriteInfo->sprite->pEnqueueScreen
+#define DequeueScreen(dev) (dev)->spriteInfo->sprite->pDequeueScreen
 
 typedef struct _Event {
     InternalEvent *events;

--- a/mi/mifillarc.c
+++ b/mi/mifillarc.c
@@ -45,8 +45,8 @@ Author:  Bob Scheifler, MIT X Consortium
 #define M_PI	3.14159265358979323846
 #endif
 
-#define Dsin(d)	sin((double)d*(M_PI/11520.0))
-#define Dcos(d)	cos((double)d*(M_PI/11520.0))
+#define Dsin(d)	sin((double)(d)*(M_PI/11520.0))
+#define Dcos(d)	cos((double)(d)*(M_PI/11520.0))
 
 static void
 miFillArcSetup(xArc * arc, miFillArcRec * info)
@@ -524,16 +524,16 @@ miFillEllipseD(DrawablePtr pDraw, GCPtr pGC, xArc * arc, DDXPointPtr points, int
 }
 
 #define ADDSPAN(l,r) \
-    if (r >= l) \
+    if ((r) >= (l)) \
     { \
-	pts->x = l; \
+	pts->x = (l); \
 	pts->y = ya; \
 	pts++; \
-	*wids++ = r - l + 1; \
+	*wids++ = (r) - (l) + 1; \
     }
 
 #define ADDSLICESPANS(flip) \
-    if (!flip) \
+    if (!(flip)) \
     { \
 	ADDSPAN(xl, xr); \
     } \

--- a/mi/mifillarc.h
+++ b/mi/mifillarc.h
@@ -56,7 +56,7 @@ typedef struct _miFillArcD {
 			   (((arc)->width <= 800) && ((arc)->height <= 800)))
 
 #define MIFILLARCSETUP() \
-    x = 0; \
+    (x) = 0; \
     y = info.y; \
     e = info.e; \
     xk = info.xk; \
@@ -78,14 +78,14 @@ typedef struct _miFillArcD {
     } \
     y--; \
     yk -= ym; \
-    slw = (x << 1) + dx; \
-    if ((e == xk) && (slw > 1)) \
-	slw--
+    (slw) = (x << 1) + dx; \
+    if ((e == xk) && ((slw) > 1)) \
+	(slw)--
 
-#define MIFILLCIRCSTEP(slw) MIFILLARCSTEP(slw)
-#define MIFILLELLSTEP(slw) MIFILLARCSTEP(slw)
+#define MIFILLCIRCSTEP(slw) MIFILLARCSTEP((slw))
+#define MIFILLELLSTEP(slw) MIFILLARCSTEP((slw))
 
-#define miFillArcLower(slw) (((y + dy) != 0) && ((slw > 1) || (e != xk)))
+#define miFillArcLower(slw) (((y + dy) != 0) && (((slw) > 1) || (e != xk)))
 
 typedef struct _miSliceEdge {
     int x;
@@ -105,59 +105,59 @@ typedef struct _miArcSlice {
 } miArcSliceRec;
 
 #define MIARCSLICESTEP(edge) \
-    edge.x -= edge.stepx; \
-    edge.e -= edge.dx; \
-    if (edge.e <= 0) \
+    (edge).x -= (edge).stepx; \
+    (edge).e -= (edge).dx; \
+    if ((edge).e <= 0) \
     { \
-	edge.x -= edge.deltax; \
-	edge.e += edge.dy; \
+	(edge).x -= (edge).deltax; \
+	(edge).e += (edge).dy; \
     }
 
 #define miFillSliceUpper(slice) \
-		((y >= slice.min_top_y) && (y <= slice.max_top_y))
+		((y >= (slice).min_top_y) && (y <= (slice).max_top_y))
 
 #define miFillSliceLower(slice) \
-		((y >= slice.min_bot_y) && (y <= slice.max_bot_y))
+		((y >= (slice).min_bot_y) && (y <= (slice).max_bot_y))
 
 #define MIARCSLICEUPPER(xl,xr,slice,slw) \
-    xl = xorg - x; \
-    xr = xl + slw - 1; \
-    if (slice.edge1_top && (slice.edge1.x < xr)) \
-	xr = slice.edge1.x; \
-    if (slice.edge2_top && (slice.edge2.x > xl)) \
-	xl = slice.edge2.x;
+    (xl) = xorg - x; \
+    (xr) = (xl) + (slw) - 1; \
+    if ((slice).edge1_top && ((slice).edge1.x < (xr))) \
+	(xr) = (slice).edge1.x; \
+    if ((slice).edge2_top && ((slice).edge2.x > (xl))) \
+	(xl) = (slice).edge2.x;
 
 #define MIARCSLICELOWER(xl,xr,slice,slw) \
-    xl = xorg - x; \
-    xr = xl + slw - 1; \
-    if (!slice.edge1_top && (slice.edge1.x > xl)) \
-	xl = slice.edge1.x; \
-    if (!slice.edge2_top && (slice.edge2.x < xr)) \
-	xr = slice.edge2.x;
+    (xl) = xorg - x; \
+    (xr) = (xl) + (slw) - 1; \
+    if (!(slice).edge1_top && ((slice).edge1.x > (xl))) \
+	(xl) = (slice).edge1.x; \
+    if (!(slice).edge2_top && ((slice).edge2.x < (xr))) \
+	(xr) = (slice).edge2.x;
 
 #define MIWIDEARCSETUP(x,y,dy,slw,e,xk,xm,yk,ym) \
-    x = 0; \
-    y = slw >> 1; \
-    yk = y << 3; \
-    xm = 8; \
-    ym = 8; \
-    if (dy) \
+    (x) = 0; \
+    (y) = (slw) >> 1; \
+    (yk) = (y) << 3; \
+    (xm) = 8; \
+    (ym) = 8; \
+    if ((dy)) \
     { \
-	xk = 0; \
-	if (slw & 1) \
-	    e = -1; \
+	(xk) = 0; \
+	if ((slw) & 1) \
+	    (e) = -1; \
 	else \
-	    e = -(y << 2) - 2; \
+	    (e) = -((y) << 2) - 2; \
     } \
     else \
     { \
-	y++; \
-	yk += 4; \
-	xk = -4; \
-	if (slw & 1) \
-	    e = -(y << 2) - 3; \
+	(y)++; \
+	(yk) += 4; \
+	(xk) = -4; \
+	if ((slw) & 1) \
+	    (e) = -((y) << 2) - 3; \
 	else \
-	    e = - (y << 3); \
+	    (e) = -((y) << 3); \
     }
 
 #define MIFILLINARCSTEP(slw) \
@@ -170,11 +170,11 @@ typedef struct _miArcSlice {
     } \
     iny--; \
     inyk -= inym; \
-    slw = (inx << 1) + dx; \
-    if ((ine == inxk) && (slw > 1)) \
-	slw--
+    (slw) = (inx << 1) + dx; \
+    if ((ine == inxk) && ((slw) > 1)) \
+	(slw)--
 
 #define miFillInArcLower(slw) (((iny + dy) != 0) && \
-			       ((slw > 1) || (ine != inxk)))
+			       (((slw) > 1) || (ine != inxk)))
 
 #endif                          /* __MIFILLARC_H__ */

--- a/mi/mipointer.c
+++ b/mi/mipointer.c
@@ -87,14 +87,14 @@ DevPrivateKeyRec miPointerScreenKeyRec;
 
 #define GetScreenPrivate(s) ((miPointerScreenPtr) \
     dixLookupPrivate(&(s)->devPrivates, miPointerScreenKey))
-#define SetupScreen(s)	miPointerScreenPtr  pScreenPriv = GetScreenPrivate(s)
+#define SetupScreen(s)	miPointerScreenPtr  pScreenPriv = GetScreenPrivate((s))
 
 DevPrivateKeyRec miPointerPrivKeyRec;
 
 #define MIPOINTER(dev) \
-    (InputDevIsFloating(dev) ? \
+    (InputDevIsFloating((dev)) ? \
         (miPointerPtr)dixLookupPrivate(&(dev)->devPrivates, miPointerPrivKey): \
-        (miPointerPtr)dixLookupPrivate(&(GetMaster(dev, MASTER_POINTER))->devPrivates, miPointerPrivKey))
+        (miPointerPtr)dixLookupPrivate(&(GetMaster((dev), MASTER_POINTER))->devPrivates, miPointerPrivKey))
 
 static Bool miPointerRealizeCursor(DeviceIntPtr pDev, ScreenPtr pScreen,
                                    CursorPtr pCursor);

--- a/mi/mipoly.h
+++ b/mi/mipoly.h
@@ -140,17 +140,17 @@ typedef struct _ScanLineListBlock {
  *     can reorder the Winding Active Edge Table.
  */
 #define EVALUATEEDGEWINDING(pAET, pPrevAET, y, fixWAET) { \
-   if (pAET->ymax == y) {          /* leaving this edge */ \
-      pPrevAET->next = pAET->next; \
-      pAET = pPrevAET->next; \
-      fixWAET = 1; \
-      if (pAET) \
-         pAET->back = pPrevAET; \
+   if ((pAET)->ymax == (y)) {          /* leaving this edge */ \
+      (pPrevAET)->next = (pAET)->next; \
+      (pAET) = (pPrevAET)->next; \
+      (fixWAET) = 1; \
+      if ((pAET)) \
+         (pAET)->back = (pPrevAET); \
    } \
    else { \
-      BRESINCRPGONSTRUCT(pAET->bres); \
-      pPrevAET = pAET; \
-      pAET = pAET->next; \
+      BRESINCRPGONSTRUCT((pAET)->bres); \
+      (pPrevAET) = (pAET); \
+      (pAET) = (pAET)->next; \
    } \
 }
 
@@ -162,16 +162,16 @@ typedef struct _ScanLineListBlock {
  *     The even-odd rule is in effect.
  */
 #define EVALUATEEDGEEVENODD(pAET, pPrevAET, y) { \
-   if (pAET->ymax == y) {          /* leaving this edge */ \
-      pPrevAET->next = pAET->next; \
-      pAET = pPrevAET->next; \
-      if (pAET) \
-         pAET->back = pPrevAET; \
+   if ((pAET)->ymax == (y)) {          /* leaving this edge */ \
+      (pPrevAET)->next = (pAET)->next; \
+      (pAET) = (pPrevAET)->next; \
+      if ((pAET)) \
+         (pAET)->back = (pPrevAET); \
    } \
    else { \
-      BRESINCRPGONSTRUCT(pAET->bres); \
-      pPrevAET = pAET; \
-      pAET = pAET->next; \
+      BRESINCRPGONSTRUCT((pAET)->bres); \
+      (pPrevAET) = (pAET); \
+      (pAET) = (pAET)->next; \
    } \
 }
 

--- a/mi/mipolyrect.c
+++ b/mi/mipolyrect.c
@@ -60,20 +60,20 @@ miPolyRectangle(DrawablePtr pDraw, GCPtr pGC, int nrects, xRectangle *pRects)
     xPoint rect[5];
     int bound_tmp;
 
-#define MINBOUND(dst,eqn)	bound_tmp = eqn; \
+#define MINBOUND(dst,eqn)	bound_tmp = (eqn); \
 				if (bound_tmp < -32768) \
 				    bound_tmp = -32768; \
-				dst = bound_tmp;
+				(dst) = bound_tmp;
 
-#define MAXBOUND(dst,eqn)	bound_tmp = eqn; \
+#define MAXBOUND(dst,eqn)	bound_tmp = (eqn); \
 				if (bound_tmp > 32767) \
 				    bound_tmp = 32767; \
-				dst = bound_tmp;
+				(dst) = bound_tmp;
 
-#define MAXUBOUND(dst,eqn)	bound_tmp = eqn; \
+#define MAXUBOUND(dst,eqn)	bound_tmp = (eqn); \
 				if (bound_tmp > 65535) \
 				    bound_tmp = 65535; \
-				dst = bound_tmp;
+				(dst) = bound_tmp;
 
     if (pGC->lineStyle == LineSolid && pGC->joinStyle == JoinMiter &&
         pGC->lineWidth != 0) {

--- a/mi/mipushpxl.c
+++ b/mi/mipushpxl.c
@@ -57,10 +57,10 @@ SOFTWARE.
 
 /* These were stolen from mfb.  They don't really belong here. */
 #define LONG2CHARSSAMEORDER(x) ((MiBits)(x))
-#define LONG2CHARSDIFFORDER( x ) ( ( ( ( x ) & (MiBits)0x000000FF ) << 0x18 ) \
-                        | ( ( ( x ) & (MiBits)0x0000FF00 ) << 0x08 ) \
-                        | ( ( ( x ) & (MiBits)0x00FF0000 ) >> 0x08 ) \
-                        | ( ( ( x ) & (MiBits)0xFF000000 ) >> 0x18 ) )
+#define LONG2CHARSDIFFORDER( x ) ( ( ( ( (x) ) & (MiBits)0x000000FF ) << 0x18 ) \
+                        | ( ( ( (x) ) & (MiBits)0x0000FF00 ) << 0x08 ) \
+                        | ( ( ( (x) ) & (MiBits)0x00FF0000 ) >> 0x08 ) \
+                        | ( ( ( (x) ) & (MiBits)0xFF000000 ) >> 0x18 ) )
 
 #define PGSZB	4
 #define PPW	(PGSZB<<3)      /* assuming 8 bits per byte */

--- a/mi/miscanfill.h
+++ b/mi/miscanfill.h
@@ -74,42 +74,42 @@ from The Open Group.
      *  and assumed not to be processed.  Otherwise, do this stuff. \
      */ \
     if ((dy) != 0) { \
-        xStart = (x1); \
-        dx = (x2) - xStart; \
+        (xStart) = (x1); \
+        dx = (x2) - (xStart); \
         if (dx < 0) { \
-            m = dx / (dy); \
-            m1 = m - 1; \
-            incr1 = -2 * dx + 2 * (dy) * m1; \
-            incr2 = -2 * dx + 2 * (dy) * m; \
-            d = 2 * m * (dy) - 2 * dx - 2 * (dy); \
+            (m) = dx / (dy); \
+            (m1) = (m) - 1; \
+            (incr1) = -2 * dx + 2 * (dy) * (m1); \
+            (incr2) = -2 * dx + 2 * (dy) * (m); \
+            (d) = 2 * (m) * (dy) - 2 * dx - 2 * (dy); \
         } else { \
-            m = dx / (dy); \
-            m1 = m + 1; \
-            incr1 = 2 * dx - 2 * (dy) * m1; \
-            incr2 = 2 * dx - 2 * (dy) * m; \
-            d = -2 * m * (dy) + 2 * dx; \
+            (m) = dx / (dy); \
+            (m1) = (m) + 1; \
+            (incr1) = 2 * dx - 2 * (dy) * (m1); \
+            (incr2) = 2 * dx - 2 * (dy) * (m); \
+            (d) = -2 * (m) * (dy) + 2 * dx; \
         } \
     } \
 }
 
 #define BRESINCRPGON(d, minval, m, m1, incr1, incr2) { \
-    if (m1 > 0) { \
-        if (d > 0) { \
-            minval += m1; \
-            d += incr1; \
+    if ((m1) > 0) { \
+        if ((d) > 0) { \
+            (minval) += (m1); \
+            (d) += (incr1); \
         } \
         else { \
-            minval += m; \
-            d += incr2; \
+            (minval) += (m); \
+            (d) += (incr2); \
         } \
     } else {\
-        if (d >= 0) { \
-            minval += m1; \
-            d += incr1; \
+        if ((d) >= 0) { \
+            (minval) += (m1); \
+            (d) += (incr1); \
         } \
         else { \
-            minval += m; \
-            d += incr2; \
+            (minval) += (m); \
+            (d) += (incr2); \
         } \
     } \
 }
@@ -129,10 +129,10 @@ typedef struct {
 } BRESINFO;
 
 #define BRESINITPGONSTRUCT(dmaj, min1, min2, bres) \
-	BRESINITPGON(dmaj, min1, min2, bres.minor, bres.d, \
-                     bres.m, bres.m1, bres.incr1, bres.incr2)
+	BRESINITPGON((dmaj), (min1), (min2), (bres).minor, (bres).d, \
+                     (bres).m, (bres).m1, (bres).incr1, (bres).incr2)
 
 #define BRESINCRPGONSTRUCT(bres) \
-        BRESINCRPGON(bres.d, bres.minor, bres.m, bres.m1, bres.incr1, bres.incr2)
+        BRESINCRPGON((bres).d, (bres).minor, (bres).m, (bres).m1, (bres).incr1, (bres).incr2)
 
 #endif

--- a/mi/misprite.c
+++ b/mi/misprite.c
@@ -122,8 +122,8 @@ typedef struct {
 
 #define LINE_SORT(x1,y1,x2,y2) \
 { int _t; \
-  if (x1 > x2) { _t = x1; x1 = x2; x2 = _t; } \
-  if (y1 > y2) { _t = y1; y1 = y2; y2 = _t; } }
+  if ((x1) > (x2)) { _t = (x1); (x1) = (x2); (x2) = _t; } \
+  if ((y1) > (y2)) { _t = (y1); (y1) = (y2); (y2) = _t; } }
 
 #define LINE_OVERLAP(pCbox,x1,y1,x2,y2,lw2) \
     BOX_OVERLAP((pCbox), (x1)-(lw2), (y1)-(lw2), (x2)+(lw2), (y2)+(lw2))
@@ -515,8 +515,8 @@ miSpriteStoreColors(ColormapPtr pMap, int ndef, xColorItem * pdef)
 #define MaskMatch(a,b,mask) (((a) & (pVisual->mask)) == ((b) & (pVisual->mask)))
 
 #define UpdateDAC(dev, plane,dac,mask) {\
-    if (MaskMatch (dev->colors[plane].pixel,pdef[i].pixel,mask)) {\
-	dev->colors[plane].dac = pdef[i].dac; \
+    if (MaskMatch ((dev)->colors[(plane)].pixel,pdef[i].pixel,mask)) {\
+	(dev)->colors[(plane)].dac = pdef[i].dac; \
 	updated = 1; \
     } \
 }

--- a/mi/mivaltree.c
+++ b/mi/mivaltree.c
@@ -168,7 +168,7 @@ miShapedWindowIn(RegionPtr universe, RegionPtr bounding,
 #define TreatAsTransparent(w)	((w)->redirectDraw == RedirectDrawManual)
 
 #define HasParentRelativeBorder(w) (!(w)->borderIsPixel && \
-				    HasBorder(w) && \
+				    HasBorder((w)) && \
 				    (w)->backgroundState == ParentRelative)
 
 /*

--- a/mi/miwideline.c
+++ b/mi/miwideline.c
@@ -87,7 +87,7 @@ typedef struct {
 
 /* Rops which must use span groups */
 #define miSpansCarefulRop(rop)	(((rop) & 0xc) == 0x8 || ((rop) & 0x3) == 0x2)
-#define miSpansEasyRop(rop)	(!miSpansCarefulRop(rop))
+#define miSpansEasyRop(rop)	(!miSpansCarefulRop((rop)))
 
 /*
 
@@ -108,8 +108,8 @@ miInitSpanGroup(SpanGroup * spanGroup)
     spanGroup->ymax = MINSHORT;
 }                               /* InitSpanGroup */
 
-#define YMIN(spans) (spans->points[0].y)
-#define YMAX(spans)  (spans->points[spans->count-1].y)
+#define YMIN(spans) ((spans)->points[0].y)
+#define YMAX(spans)  ((spans)->points[(spans)->count-1].y)
 
 static void
 miSubtractSpans(SpanGroup * spanGroup, Spans * sub)
@@ -271,8 +271,8 @@ QuickSortSpansX(xPoint points[], int widths[], int numSpans)
     xPoint		tpt;				    \
     int    		tw;				    \
 							    \
-    tpt = points[a]; points[a] = points[b]; points[b] = tpt;    \
-    tw = widths[a]; widths[a] = widths[b]; widths[b] = tw;  \
+    tpt = points[(a)]; points[(a)] = points[(b)]; points[(b)] = tpt;    \
+    tw = widths[(a)]; widths[(a)] = widths[(b)]; widths[(b)] = tw;  \
 }
 
     do {
@@ -828,7 +828,7 @@ miPolyBuildEdge(double x0, double y0, double k, /* x0 * dy - y0 * dx */
     return y + yi;
 }
 
-#define StepAround(v, incr, max) (((v) + (incr) < 0) ? (max - 1) : ((v) + (incr) == max) ? 0 : ((v) + (incr)))
+#define StepAround(v, incr, max) (((v) + (incr) < 0) ? ((max) - 1) : ((v) + (incr) == (max)) ? 0 : ((v) + (incr)))
 
 static int
 miPolyBuildPoly(PolyVertexPtr vertices,
@@ -1155,25 +1155,25 @@ miLineArcI(DrawablePtr pDraw,
 }
 
 #define CLIPSTEPEDGE(edgey,edge,edgeleft) \
-    if (ybase == edgey) \
+    if (ybase == (edgey)) \
     { \
-	if (edgeleft) \
+	if ((edgeleft)) \
 	{ \
-	    if (edge->x > xcl) \
-		xcl = edge->x; \
+	    if ((edge)->x > xcl) \
+		xcl = (edge)->x; \
 	} \
 	else \
 	{ \
-	    if (edge->x < xcr) \
-		xcr = edge->x; \
+	    if ((edge)->x < xcr) \
+		xcr = (edge)->x; \
 	} \
-	edgey++; \
-	edge->x += edge->stepx; \
-	edge->e += edge->dx; \
-	if (edge->e > 0) \
+	(edgey)++; \
+	(edge)->x += (edge)->stepx; \
+	(edge)->e += (edge)->dx; \
+	if ((edge)->e > 0) \
 	{ \
-	    edge->x += edge->signdx; \
-	    edge->e -= edge->dy; \
+	    (edge)->x += (edge)->signdx; \
+	    (edge)->e -= (edge)->dy; \
 	} \
     }
 

--- a/mi/miwideline.h
+++ b/mi/miwideline.h
@@ -78,20 +78,20 @@ typedef struct _LineFace {
  */
 
 #define MILINESETPIXEL(pDrawable, pGC, pixel, oldPixel) { \
-    oldPixel = pGC->fgPixel; \
-    if (pixel != oldPixel) { \
+    (oldPixel) = (pGC)->fgPixel; \
+    if ((pixel) != (oldPixel)) { \
 	ChangeGCVal gcval; \
-	gcval.val = pixel; \
-	ChangeGC (NULL, pGC, GCForeground, &gcval); \
-	ValidateGC (pDrawable, pGC); \
+	gcval.val = (pixel); \
+	ChangeGC (NULL, (pGC), GCForeground, &gcval); \
+	ValidateGC ((pDrawable), (pGC)); \
     } \
 }
 #define MILINERESETPIXEL(pDrawable, pGC, pixel, oldPixel) { \
-    if (pixel != oldPixel) { \
+    if ((pixel) != (oldPixel)) { \
 	ChangeGCVal gcval; \
-	gcval.val = oldPixel; \
-	ChangeGC (NULL, pGC, GCForeground, &gcval); \
-	ValidateGC (pDrawable, pGC); \
+	gcval.val = (oldPixel); \
+	ChangeGC (NULL, (pGC), GCForeground, &gcval); \
+	ValidateGC ((pDrawable), (pGC)); \
     } \
 }
 

--- a/mi/mizerarc.c
+++ b/mi/mizerarc.c
@@ -57,11 +57,11 @@ Author:  Bob Scheifler, MIT X Consortium
 
 #define Dsin(d)	((d) == 0 ? 0.0 : ((d) == QUADRANT ? 1.0 : \
 		 ((d) == HALFCIRCLE ? 0.0 : \
-		 ((d) == QUADRANT3 ? -1.0 : sin((double)d*(M_PI/11520.0))))))
+		 ((d) == QUADRANT3 ? -1.0 : sin((double)(d)*(M_PI/11520.0))))))
 
 #define Dcos(d)	((d) == 0 ? 1.0 : ((d) == QUADRANT ? 0.0 : \
 		 ((d) == HALFCIRCLE ? -1.0 : \
-		 ((d) == QUADRANT3 ? 0.0 : cos((double)d*(M_PI/11520.0))))))
+		 ((d) == QUADRANT3 ? 0.0 : cos((double)(d)*(M_PI/11520.0))))))
 
 #define EPSILON45 64
 
@@ -357,12 +357,12 @@ miZeroArcSetup(xArc * arc, miZeroArcRec * info, Bool ok360)
 
 #define Pixelate(xval,yval) \
     { \
-	pts->x = xval; \
-	pts->y = yval; \
+	pts->x = (xval); \
+	pts->y = (yval); \
 	pts++; \
     }
 
-#define DoPix(idx,xval,yval) if (mask & (1 << idx)) Pixelate(xval, yval);
+#define DoPix(idx,xval,yval) if (mask & (1 << (idx))) Pixelate((xval), (yval));
 
 static DDXPointPtr
 miZeroArcPts(xArc * arc, DDXPointPtr pts)
@@ -454,11 +454,11 @@ miZeroArcPts(xArc * arc, DDXPointPtr pts)
 
 #undef DoPix
 #define DoPix(idx,xval,yval) \
-    if (mask & (1 << idx)) \
+    if (mask & (1 << (idx))) \
     { \
-	arcPts[idx]->x = xval; \
-	arcPts[idx]->y = yval; \
-	arcPts[idx]++; \
+	arcPts[(idx)]->x = (xval); \
+	arcPts[(idx)]->y = (yval); \
+	arcPts[(idx)]++; \
     }
 
 static void

--- a/mi/mizerclip.c
+++ b/mi/mizerclip.c
@@ -397,11 +397,11 @@ the numerator is therefore (2^32 - 1), which does not overflow an unsigned
 #define EQN8B	(T_2NDX | T_ADDDY | T_BIASSUBONE | T_DIV2DY)
 
 #define SWAPINT(i, j) \
-{  int _t = i;  i = j;  j = _t; }
+{  int _t = (i);  (i) = (j);  (j) = _t; }
 
 #define SWAPINT_PAIR(x1, y1, x2, y2)\
-{   int t = x1;  x1 = x2;  x2 = t;\
-        t = y1;  y1 = y2;  y2 = t;\
+{   int t = (x1);  (x1) = (x2);  (x2) = t;\
+        t = (y1);  (y1) = (y2);  (y2) = t;\
 }
 
 #define IsXMajorOctant(_octant)         (!((_octant) & YMAJOR))

--- a/mi/mizerline.c
+++ b/mi/mizerline.c
@@ -76,10 +76,10 @@ SOFTWARE.
 
 #define MI_OUTPUT_POINT(xx, yy)\
 {\
-    if ( !new_span && yy == current_y)\
+    if ( !new_span && (yy) == current_y)\
     {\
-        if (xx < spans->x)\
-	    spans->x = xx;\
+        if ((xx) < spans->x)\
+	    spans->x = (xx);\
 	++*widths;\
     }\
     else\
@@ -87,10 +87,10 @@ SOFTWARE.
         ++Nspans;\
 	++spans;\
 	++widths;\
-	spans->x = xx;\
-	spans->y = yy;\
+	spans->x = (xx);\
+	spans->y = (yy);\
 	*widths = 1;\
-	current_y = yy;\
+	current_y = (yy);\
         new_span = FALSE;\
     }\
 }


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
