### PR TITLE
(master) dix: parentheses around macro argument symbols

### DIFF
--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -186,12 +186,12 @@ static void FindColorInRootCmap(ColormapPtr /* pmap */ ,
                                 ColorCompareProcPtr     /* comp */
     );
 
-#define NUMRED(vis) ((vis->redMask >> vis->offsetRed) + 1)
-#define NUMGREEN(vis) ((vis->greenMask >> vis->offsetGreen) + 1)
-#define NUMBLUE(vis) ((vis->blueMask >> vis->offsetBlue) + 1)
+#define NUMRED(vis) (((vis)->redMask >> (vis)->offsetRed) + 1)
+#define NUMGREEN(vis) (((vis)->greenMask >> (vis)->offsetGreen) + 1)
+#define NUMBLUE(vis) (((vis)->blueMask >> (vis)->offsetBlue) + 1)
 #define ALPHAMASK(vis)	((vis)->nplanes < 32 ? 0 : \
 			 (CARD32) ~((vis)->redMask|(vis)->greenMask|(vis)->blueMask))
-#define RGBMASK(vis) (vis->redMask | vis->greenMask | vis->blueMask | ALPHAMASK(vis))
+#define RGBMASK(vis) ((vis)->redMask | (vis)->greenMask | (vis)->blueMask | ALPHAMASK((vis)))
 
 /* GetNextBitsOrBreak(bits, mask, base)  --
  * (Suggestion: First read the macro, then read this explanation.
@@ -1213,8 +1213,8 @@ typedef struct _bignum {
 #define BigNumGreater(x,y) (((x)->upper > (y)->upper) ||\
 			    ((x)->upper == (y)->upper && (x)->lower > (y)->lower))
 
-#define UnsignedToBigNum(u,r)	(((r)->upper = UPPERPART(u)), \
-				 ((r)->lower = LOWERPART(u)))
+#define UnsignedToBigNum(u,r)	(((r)->upper = UPPERPART((u))), \
+				 ((r)->lower = LOWERPART((u))))
 
 #define MaxBigNum(r)		(((r)->upper = BIGNUMUPPER-1), \
 				 ((r)->lower = BIGNUMLOWER-1))

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -150,10 +150,10 @@ Equipment Corporation.
 #define mskcnt ((MAXCLIENTS + 31) / 32)
 #define BITMASK(i) (1U << ((i) & 31))
 #define MASKIDX(i) ((i) >> 5)
-#define MASKWORD(buf, i) buf[MASKIDX(i)]
-#define BITSET(buf, i) MASKWORD(buf, i) |= BITMASK(i)
-#define BITCLEAR(buf, i) MASKWORD(buf, i) &= ~BITMASK(i)
-#define GETBIT(buf, i) (MASKWORD(buf, i) & BITMASK(i))
+#define MASKWORD(buf, i) (buf)[MASKIDX((i))]
+#define BITSET(buf, i) MASKWORD((buf), (i)) |= BITMASK((i))
+#define BITCLEAR(buf, i) MASKWORD((buf), (i)) &= ~BITMASK((i))
+#define GETBIT(buf, i) (MASKWORD((buf), (i)) & BITMASK((i)))
 
 xConnSetupPrefix connSetupPrefix;
 
@@ -191,7 +191,7 @@ volatile char dispatchException = 0;
 volatile char isItTimeToYield;
 
 #define SAME_SCREENS(a, b) (\
-    (a.pScreen == b.pScreen))
+    ((a).pScreen == (b).pScreen))
 
 ClientPtr
 GetCurrentClient(void)

--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -109,16 +109,16 @@ void DeleteWindowFromAnySaveSet(WindowPtr pWin);
 
 #define VALIDATE_DRAWABLE_AND_GC(drawID, pDraw, mode)                   \
     do {                                                                \
-        int tmprc = dixLookupDrawable(&(pDraw), drawID, client, M_ANY, mode); \
+        int tmprc = dixLookupDrawable(&(pDraw), (drawID), client, M_ANY, (mode)); \
         if (tmprc != Success)                                           \
             return tmprc;                                               \
         tmprc = dixLookupGC(&(pGC), stuff->gc, client, DixUseAccess);   \
         if (tmprc != Success)                                           \
             return tmprc;                                               \
-        if ((pGC->depth != pDraw->depth) || (pGC->pScreen != pDraw->pScreen)) \
+        if ((pGC->depth != (pDraw)->depth) || (pGC->pScreen != (pDraw)->pScreen)) \
             return BadMatch;                                            \
-        if (pGC->serialNumber != pDraw->serialNumber)                   \
-            ValidateGC(pDraw, pGC);                                     \
+        if (pGC->serialNumber != (pDraw)->serialNumber)                   \
+            ValidateGC((pDraw), pGC);                                     \
     } while (0)
 
 int dixLookupGC(GCPtr *result,
@@ -801,6 +801,6 @@ static inline void SwapLongs(CARD32 *list, unsigned long count) {
 }
 
 #define SwapRestL(stuff) \
-    SwapLongs((CARD32 *)(stuff + 1), (client->req_len - (sizeof(*stuff) >> 2)))
+    SwapLongs((CARD32 *)((stuff) + 1), (client->req_len - (sizeof(*(stuff)) >> 2)))
 
 #endif /* _XSERVER_DIX_PRIV_H */

--- a/dix/dixstruct_priv.h
+++ b/dix/dixstruct_priv.h
@@ -83,7 +83,7 @@ static inline Bool any_output_pending(void) {
 void SmartScheduleInit(void);
 
 /* This prototype is used pervasively in Xext, dix */
-#define DISPATCH_PROC(func) int func(ClientPtr /* client */)
+#define DISPATCH_PROC(func) int (func)(ClientPtr /* client */)
 
 /* proc vectors */
 

--- a/dix/events.c
+++ b/dix/events.c
@@ -279,7 +279,7 @@ static struct DeviceEventTime {
 /**
  * The root window the given device is currently on.
  */
-#define RootWindow(sprite) sprite->spriteTrace[0]
+#define RootWindow(sprite) (sprite)->spriteTrace[0]
 
 static xEvent *swapEvent = NULL;
 static int swapEventLen = 0;

--- a/dix/gc.c
+++ b/dix/gc.c
@@ -113,11 +113,11 @@ ValidateGC(DrawablePtr pDraw, GCPtr pGC)
  */
 
 #define NEXTVAL(_type, _var) { \
-	_var = (_type)(pUnion->val); pUnion++; \
+	(_var) = (_type)(pUnion->val); pUnion++; \
     }
 
 #define NEXT_PTR(_type, _var) { \
-    _var = (_type)pUnion->ptr; pUnion++; }
+    (_var) = (_type)pUnion->ptr; pUnion++; }
 
 int
 ChangeGC(ClientPtr client, GCPtr pGC, BITS32 mask, ChangeGCValPtr pUnion)

--- a/dix/grabs.c
+++ b/dix/grabs.c
@@ -74,10 +74,10 @@ SOFTWARE.
 
 #define BITMASK(i) (((Mask)1) << ((i) & 31))
 #define MASKIDX(i) ((i) >> 5)
-#define MASKWORD(buf, i) buf[MASKIDX(i)]
-#define BITSET(buf, i) MASKWORD(buf, i) |= BITMASK(i)
-#define BITCLEAR(buf, i) MASKWORD(buf, i) &= ~BITMASK(i)
-#define GETBIT(buf, i) (MASKWORD(buf, i) & BITMASK(i))
+#define MASKWORD(buf, i) (buf)[MASKIDX((i))]
+#define BITSET(buf, i) MASKWORD((buf), (i)) |= BITMASK((i))
+#define BITCLEAR(buf, i) MASKWORD((buf), (i)) &= ~BITMASK((i))
+#define GETBIT(buf, i) (MASKWORD((buf), (i)) & BITMASK((i)))
 
 void
 PrintDeviceGrabInfo(DeviceIntPtr dev)
@@ -581,7 +581,7 @@ DeletePassiveGrabFromList(GrabPtr pMinuendGrab)
     unsigned int any_key;
 
 #define UPDATE(mask,exact) \
-	if (!(details[nups] = DeleteDetailFromMask(mask, exact))) \
+	if (!(details[nups] = DeleteDetailFromMask((mask), (exact)))) \
 	  ok = FALSE; \
 	else \
 	  updates[nups++] = &(mask)

--- a/dix/region.c
+++ b/dix/region.c
@@ -97,7 +97,7 @@ Equipment Corporation.
 #define assert(expr)
 #endif
 
-#define good(reg) assert(RegionIsValid(reg))
+#define good(reg) assert(RegionIsValid((reg)))
 
 /*
  * The functions in this file implement the Region abstraction used extensively
@@ -155,10 +155,10 @@ Equipment Corporation.
 
 /* true iff (x,y) is in Box */
 #define INBOX(r,x,y) \
-      ( ((r)->x2 >  x) && \
-        ((r)->x1 <= x) && \
-        ((r)->y2 >  y) && \
-        ((r)->y1 <= y) )
+      ( ((r)->x2 >  (x)) && \
+        ((r)->x1 <= (x)) && \
+        ((r)->y2 >  (y)) && \
+        ((r)->y1 <= (y)) )
 
 /* true iff Box r1 contains Box r2 */
 #define SUBSUMES(r1,r2) \
@@ -179,38 +179,38 @@ static inline void xfreeData(RegionPtr reg) {
 
 #define RECTALLOC_BAIL(pReg,n,bail) \
 if (!(pReg)->data || (((pReg)->data->numRects + (n)) > (pReg)->data->size)) \
-    if (!RegionRectAlloc(pReg, n)) { goto bail; }
+    if (!RegionRectAlloc((pReg), (n))) { goto bail; }
 
 #define RECTALLOC(pReg,n) \
 if (!(pReg)->data || (((pReg)->data->numRects + (n)) > (pReg)->data->size)) \
-    if (!RegionRectAlloc(pReg, n)) { return FALSE; }
+    if (!RegionRectAlloc((pReg), (n))) { return FALSE; }
 
 #define ADDRECT(pNextRect,nx1,ny1,nx2,ny2)	\
 {						\
-    pNextRect->x1 = nx1;			\
-    pNextRect->y1 = ny1;			\
-    pNextRect->x2 = nx2;			\
-    pNextRect->y2 = ny2;			\
-    pNextRect++;				\
+    (pNextRect)->x1 = (nx1);			\
+    (pNextRect)->y1 = (ny1);			\
+    (pNextRect)->x2 = (nx2);			\
+    (pNextRect)->y2 = (ny2);			\
+    (pNextRect)++;				\
 }
 
 #define NEWRECT(pReg,pNextRect,nx1,ny1,nx2,ny2)			\
 {									\
     if (!(pReg)->data || ((pReg)->data->numRects == (pReg)->data->size))\
     {									\
-	if (!RegionRectAlloc(pReg, 1))					\
+	if (!RegionRectAlloc((pReg), 1))					\
 	    return FALSE;						\
-	pNextRect = RegionTop(pReg);					\
+	(pNextRect) = RegionTop((pReg));					\
     }									\
-    ADDRECT(pNextRect,nx1,ny1,nx2,ny2);					\
-    pReg->data->numRects++;						\
-    assert(pReg->data->numRects<=pReg->data->size);			\
+    ADDRECT((pNextRect),(nx1),(ny1),(nx2),(ny2));					\
+    (pReg)->data->numRects++;						\
+    assert((pReg)->data->numRects<=(pReg)->data->size);			\
 }
 
 #define DOWNSIZE(reg,numRects)						 \
 if (((numRects) < ((reg)->data->size >> 1)) && ((reg)->data->size > 50)) \
 {									 \
-    size_t NewSize = RegionSizeof(numRects);				 \
+    size_t NewSize = RegionSizeof((numRects));				 \
     RegDataPtr NewData =						 \
         (NewSize > 0) ? realloc((reg)->data, NewSize) : NULL ;		 \
     if (NewData)							 \
@@ -467,10 +467,10 @@ RegionCoalesce(RegionPtr pReg,  /* Region to coalesce                */
 /* Quicky macro to avoid trivial reject procedure calls to RegionCoalesce */
 
 #define Coalesce(newReg, prevBand, curBand)				\
-    if (curBand - prevBand == newReg->data->numRects - curBand) {	\
-	prevBand = RegionCoalesce(newReg, prevBand, curBand);		\
+    if ((curBand) - (prevBand) == (newReg)->data->numRects - (curBand)) { \
+	(prevBand) = RegionCoalesce((newReg), (prevBand), (curBand));		\
     } else {								\
-	prevBand = curBand;						\
+	(prevBand) = (curBand);						\
     }
 
 /*-
@@ -516,21 +516,21 @@ RegionAppendNonO(RegionPtr pReg, BoxPtr r, BoxPtr rEnd, int y1, int y2)
 
 #define FindBand(r, rBandEnd, rEnd, ry1)		    \
 {							    \
-    ry1 = r->y1;					    \
-    rBandEnd = r+1;					    \
-    while ((rBandEnd != rEnd) && (rBandEnd->y1 == ry1)) {   \
-	rBandEnd++;					    \
+    (ry1) = (r)->y1;					    \
+    (rBandEnd) = (r)+1;					    \
+    while (((rBandEnd) != (rEnd)) && ((rBandEnd)->y1 == (ry1))) {   \
+	(rBandEnd)++;					    \
     }							    \
 }
 
 #define	AppendRegions(newReg, r, rEnd)					\
 {									\
     int newRects;							\
-    if ((newRects = rEnd - r)) {					\
-	RECTALLOC(newReg, newRects);					\
-	memmove((char *)RegionTop(newReg),(char *)r, 			\
+    if ((newRects = (rEnd) - (r))) {					\
+	RECTALLOC((newReg), newRects);					\
+	memmove((char *)RegionTop((newReg)),(char *)(r), 		\
               newRects * sizeof(BoxRec));				\
-	newReg->data->numRects += newRects;				\
+	(newReg)->data->numRects += newRects;				\
     }									\
 }
 
@@ -863,17 +863,17 @@ RegionSetExtents(RegionPtr pReg)
  /*ARGSUSED*/
 #define MERGERECT(r)						\
 {								\
-    if (r->x1 <= x2) {						\
+    if ((r)->x1 <= x2) {						\
 	/* Merge with current rectangle */			\
-	if (r->x1 < x2) *pOverlap = TRUE;				\
-	if (x2 < r->x2) x2 = r->x2;				\
+	if ((r)->x1 < x2) *pOverlap = TRUE;				\
+	if (x2 < (r)->x2) x2 = (r)->x2;				\
     } else {							\
 	/* Add current rectangle, start new one */		\
 	NEWRECT(pReg, pNextRect, x1, y1, x2, y2);		\
-	x1 = r->x1;						\
-	x2 = r->x2;						\
+	x1 = (r)->x1;						\
+	x2 = (r)->x2;						\
     }								\
-    r++;							\
+    (r)++;							\
 }
 /*======================================================================
  *	    Region Union
@@ -1047,9 +1047,9 @@ RegionAppend(RegionPtr dstrgn, RegionPtr rgn)
 #define ExchangeRects(a, b) \
 {			    \
     BoxRec     t;	    \
-    t = rects[a];	    \
-    rects[a] = rects[b];    \
-    rects[b] = t;	    \
+    t = rects[(a)];	    \
+    rects[(a)] = rects[(b)];    \
+    rects[(b)] = t;	    \
 }
 
 static void

--- a/dix/request_priv.h
+++ b/dix/request_priv.h
@@ -89,7 +89,7 @@ static inline int __write_reply_hdr_simple(
  * return             X11 result code
  */
 #define X_SEND_REPLY_WITH_RPCBUF(client, hdrstruct, rpcbuf) \
-    __write_reply_hdr_and_rpcbuf(client, &(hdrstruct), sizeof(hdrstruct), &(rpcbuf));
+    __write_reply_hdr_and_rpcbuf((client), &(hdrstruct), sizeof(hdrstruct), &(rpcbuf));
 
 /*
  * send reply with header struct (not pointer!) without any payload
@@ -99,7 +99,7 @@ static inline int __write_reply_hdr_simple(
  * @return            X11 result code (=Success)
  */
 #define X_SEND_REPLY_SIMPLE(client, hdrstruct) \
-    __write_reply_hdr_simple(client, &(hdrstruct), sizeof(hdrstruct));
+    __write_reply_hdr_simple((client), &(hdrstruct), sizeof(hdrstruct));
 
 /*
  * macros for request handlers
@@ -147,15 +147,15 @@ static inline int __write_reply_hdr_simple(
 
 /* swap CARD16 rest of request (after the struct) - check fixed count */
 #define X_REQUEST_REST_COUNT_CARD16(count) \
-    REQUEST_FIXED_SIZE(*stuff, count * sizeof(CARD16)); \
+    REQUEST_FIXED_SIZE(*stuff, (count) * sizeof(CARD16)); \
     CARD16 *request_rest = (CARD16 *) (&stuff[1]); \
-    do { if (client->swapped) SwapShorts((signed short*)request_rest, count); } while (0)
+    do { if (client->swapped) SwapShorts((signed short*)request_rest, (count)); } while (0)
 
 /* swap CARD32 rest of request (after the struct) - check fixed count */
 #define X_REQUEST_REST_COUNT_CARD32(count) \
-    REQUEST_FIXED_SIZE(*stuff, count * sizeof(CARD32)); \
+    REQUEST_FIXED_SIZE(*stuff, (count) * sizeof(CARD32)); \
     CARD32 *request_rest = (CARD32 *) (&stuff[1]); \
-    do { if (client->swapped) SwapLongs(request_rest, count); } while (0) \
+    do { if (client->swapped) SwapLongs(request_rest, (count)); } while (0) \
 
 /*
  * macros for request handlers

--- a/dix/resource.c
+++ b/dix/resource.c
@@ -148,7 +148,7 @@ Equipment Corporation.
 
 #ifdef XSERVER_DTRACE
 
-#define TypeNameString(t) LookupResourceName(t)
+#define TypeNameString(t) LookupResourceName((t))
 #endif
 
 static void RebuildTable(int    /*client */

--- a/dix/screen_hooks.c
+++ b/dix/screen_hooks.c
@@ -17,12 +17,12 @@
 #define DECLARE_HOOK_PROC(NAME, FIELD, TYPE) \
     void dixScreenHook##NAME(ScreenPtr pScreen, TYPE func) \
     { \
-        AddCallback(&pScreen->FIELD, (CallbackProcPtr)func, pScreen); \
+        AddCallback(&pScreen->FIELD, (CallbackProcPtr)(func), pScreen); \
     } \
     \
     void dixScreenUnhook##NAME(ScreenPtr pScreen, TYPE func) \
     { \
-        DeleteCallback(&pScreen->FIELD, (CallbackProcPtr)func, pScreen); \
+        DeleteCallback(&pScreen->FIELD, (CallbackProcPtr)(func), pScreen); \
     }
 
 DECLARE_HOOK_PROC(WindowDestroy, hookWindowDestroy, XorgScreenWindowDestroyProcPtr)

--- a/dix/swaprep.h
+++ b/dix/swaprep.h
@@ -47,7 +47,7 @@ extern void WriteSConnSetupPrefix(ClientPtr /* pClient */ ,
                                   xConnSetupPrefix * /* pcsp */ );
 
 #undef SWAPREP_PROC
-#define SWAPREP_PROC(func) extern void func(xEvent * /* from */, xEvent * /* to */)
+#define SWAPREP_PROC(func) extern void (func)(xEvent * /* from */, xEvent * /* to */)
 
 SWAPREP_PROC(SCirculateEvent);
 SWAPREP_PROC(SClientMessageEvent);

--- a/dix/window.c
+++ b/dix/window.c
@@ -179,15 +179,15 @@ static Bool TileScreenSaver(ScreenPtr pScreen, int kind);
 	( ((b1)->y1 >= (b2)->y2)) ) )
 
 #define RedirectSend(pWin) \
-    ((pWin->eventMask|wOtherEventMasks(pWin)) & SubstructureRedirectMask)
+    (((pWin)->eventMask|wOtherEventMasks((pWin))) & SubstructureRedirectMask)
 
 #define SubSend(pWin) \
-    ((pWin->eventMask|wOtherEventMasks(pWin)) & SubstructureNotifyMask)
+    (((pWin)->eventMask|wOtherEventMasks((pWin))) & SubstructureNotifyMask)
 
 #define StrSend(pWin) \
-    ((pWin->eventMask|wOtherEventMasks(pWin)) & StructureNotifyMask)
+    (((pWin)->eventMask|wOtherEventMasks((pWin))) & StructureNotifyMask)
 
-#define SubStrSend(pWin,pParent) (StrSend(pWin) || SubSend(pParent))
+#define SubStrSend(pWin,pParent) (StrSend((pWin)) || SubSend((pParent)))
 
 static const char *overlay_win_name = "<composite overlay>";
 
@@ -1876,22 +1876,22 @@ ResizeChildrenWinSize(WindowPtr pWin, int dx, int dy, int dw, int dh)
 }
 
 #define GET_INT16(m, f) \
-	if (m & mask) \
+	if ((m) & mask) \
 	  { \
-	     f = (INT16) *pVlist;\
+	     (f) = (INT16) *pVlist;\
 	    pVlist++; \
 	 }
 #define GET_CARD16(m, f) \
-	if (m & mask) \
+	if ((m) & mask) \
 	 { \
-	    f = (CARD16) *pVlist;\
+	    (f) = (CARD16) *pVlist;\
 	    pVlist++;\
 	 }
 
 #define GET_CARD8(m, f) \
-	if (m & mask) \
+	if ((m) & mask) \
 	 { \
-	    f = (CARD8) *pVlist;\
+	    (f) = (CARD8) *pVlist;\
 	    pVlist++;\
 	 }
 

--- a/dix/window_priv.h
+++ b/dix/window_priv.h
@@ -13,31 +13,31 @@
 
 #define wTrackParent(w,field)   ((w)->optional ? \
                                     (w)->optional->field \
-                                 : FindWindowWithOptional(w)->optional->field)
+                                 : FindWindowWithOptional((w))->optional->field)
 #define wUseDefault(w,field,def)        ((w)->optional ? \
                                     (w)->optional->field \
-                                 : def)
+                                 : (def))
 
-#define wVisual(w)              wTrackParent(w, visual)
-#define wCursor(w)              ((w)->cursorIsNone ? None : wTrackParent(w, cursor))
-#define wColormap(w)            ((w)->drawable.class == InputOnly ? None : wTrackParent(w, colormap))
-#define wDontPropagateMask(w)   wUseDefault(w, dontPropagateMask, DontPropagateMasks[(w)->dontPropagate])
-#define wOtherEventMasks(w)     wUseDefault(w, otherEventMasks, 0)
-#define wOtherClients(w)        wUseDefault(w, otherClients, NULL)
-#define wOtherInputMasks(w)     wUseDefault(w, inputMasks, NULL)
-#define wPassiveGrabs(w)        wUseDefault(w, passiveGrabs, NULL)
-#define wBackingBitPlanes(w)    wUseDefault(w, backingBitPlanes, ~0L)
-#define wBackingPixel(w)        wUseDefault(w, backingPixel, 0)
-#define wBoundingShape(w)       wUseDefault(w, boundingShape, NULL)
-#define wClipShape(w)           wUseDefault(w, clipShape, NULL)
-#define wInputShape(w)          wUseDefault(w, inputShape, NULL)
+#define wVisual(w)              wTrackParent((w), visual)
+#define wCursor(w)              ((w)->cursorIsNone ? None : wTrackParent((w), cursor))
+#define wColormap(w)            ((w)->drawable.class == InputOnly ? None : wTrackParent((w), colormap))
+#define wDontPropagateMask(w)   wUseDefault((w), dontPropagateMask, DontPropagateMasks[(w)->dontPropagate])
+#define wOtherEventMasks(w)     wUseDefault((w), otherEventMasks, 0)
+#define wOtherClients(w)        wUseDefault((w), otherClients, NULL)
+#define wOtherInputMasks(w)     wUseDefault((w), inputMasks, NULL)
+#define wPassiveGrabs(w)        wUseDefault((w), passiveGrabs, NULL)
+#define wBackingBitPlanes(w)    wUseDefault((w), backingBitPlanes, ~0L)
+#define wBackingPixel(w)        wUseDefault((w), backingPixel, 0)
+#define wBoundingShape(w)       wUseDefault((w), boundingShape, NULL)
+#define wClipShape(w)           wUseDefault((w), clipShape, NULL)
+#define wInputShape(w)          wUseDefault((w), inputShape, NULL)
 
 #define SameBackground(as, a, bs, b)				\
     ((as) == (bs) && ((as) == None ||				\
                       (as) == ParentRelative ||			\
-                      SamePixUnion(a,b,as == BackgroundPixel)))
+                      SamePixUnion((a),(b),(as) == BackgroundPixel)))
 
-#define SameBorder(as, a, bs, b) EqualPixUnion(as, a, bs, b)
+#define SameBorder(as, a, bs, b) EqualPixUnion((as), (a), (bs), (b))
 
 /*
  * @brief create a window


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
