### PR TITLE
(master) Xi: parentheses around macro argument symbols

### DIFF
--- a/Xext/xinput/extinit.c
+++ b/Xext/xinput/extinit.c
@@ -1061,7 +1061,7 @@ MakeDeviceTypeAtoms(void)
  *
  *	Swap any events defined in this extension.
  */
-#define DO_SWAP(func,type) func ((type *)from, (type *)to)
+#define DO_SWAP(func,type) (func) ((type *)from, (type *)to)
 
 static void _X_COLD
 SEventIDispatch(xEvent *from, xEvent *to)

--- a/Xext/xinput/opendev.c
+++ b/Xext/xinput/opendev.c
@@ -76,8 +76,8 @@ extern CARD8 event_base[];
  */
 
 #define WRITE_ICI(cls) do { \
-        x_rpcbuf_write_CARD8(&rpcbuf, cls); \
-        x_rpcbuf_write_CARD8(&rpcbuf, event_base[cls]); \
+        x_rpcbuf_write_CARD8(&rpcbuf, (cls)); \
+        x_rpcbuf_write_CARD8(&rpcbuf, event_base[(cls)]); \
         num_classes++; \
     } while (0)
 

--- a/Xext/xinput/xibarriers.c
+++ b/Xext/xinput/xibarriers.c
@@ -101,8 +101,8 @@ typedef struct _BarrierScreen {
 } BarrierScreenRec, *BarrierScreenPtr;
 
 #define GetBarrierScreen(s) ((BarrierScreenPtr)dixLookupPrivate(&(s)->devPrivates, BarrierScreenPrivateKey))
-#define GetBarrierScreenIfSet(s) GetBarrierScreen(s)
-#define SetBarrierScreen(s,p) dixSetPrivate(&(s)->devPrivates, BarrierScreenPrivateKey, p)
+#define GetBarrierScreenIfSet(s) GetBarrierScreen((s))
+#define SetBarrierScreen(s,p) dixSetPrivate(&(s)->devPrivates, BarrierScreenPrivateKey, (p))
 
 static struct PointerBarrierDevice *AllocBarrierDevice(void)
 {
@@ -209,7 +209,7 @@ inside_segment(int v, int v1, int v2)
         return v >= v1 && v <= v2;
 }
 
-#define T(v, a, b) (((float)v) - (a)) / ((b) - (a))
+#define T(v, a, b) (((float)(v)) - (a)) / ((b) - (a))
 #define F(t, a, b) ((t) * ((a) - (b)) + (a))
 
 /**


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
