### PR TITLE
(master) xfixes: parentheses around macro argument symbols

### DIFF
--- a/Xext/xfixes/cursor.c
+++ b/Xext/xfixes/cursor.c
@@ -72,10 +72,10 @@ static void deleteCursorHideCountsForScreen(ScreenPtr pScreen);
 #define VERIFY_CURSOR(pCursor, cursor, client, access)			\
     do {								\
 	int err;							\
-	err = dixLookupResourceByType((void **) &pCursor, cursor,	\
-				      X11_RESTYPE_CURSOR, client, access);	\
+	err = dixLookupResourceByType((void **) &(pCursor), (cursor),	\
+				      X11_RESTYPE_CURSOR, (client), (access));	\
 	if (err != Success) {						\
-	    client->errorValue = cursor;				\
+	    (client)->errorValue = (cursor);				\
 	    return err;							\
 	}								\
     } while (0)
@@ -116,7 +116,7 @@ typedef struct _CursorHideCountRec {
  * Wrap DisplayCursor to catch cursor change events
  */
 
-#define Wrap(as,s,elt,func)	(((as)->elt = (s)->elt), (s)->elt = func)
+#define Wrap(as,s,elt,func)	(((as)->elt = (s)->elt), (s)->elt = (func))
 #define Unwrap(as,s,elt,backup)	(((backup) = (s)->elt), (s)->elt = (as)->elt)
 
 /* The cursor doesn't show up until the first XDefineCursor() */

--- a/Xext/xfixes/xfixes.h
+++ b/Xext/xfixes/xfixes.h
@@ -31,17 +31,17 @@ extern int XFixesErrorBase;
 #define VERIFY_REGION(pRegion, rid, client, mode)			\
     do {								\
 	int err;							\
-	err = dixLookupResourceByType((void **) &pRegion, rid,	\
-				      RegionResType, client, mode);	\
+	err = dixLookupResourceByType((void **) &(pRegion), (rid),	\
+				      RegionResType, (client), (mode));	\
 	if (err != Success) {						\
-	    client->errorValue = rid;					\
+	    (client)->errorValue = (rid);				\
 	    return err;							\
 	}								\
     } while (0)
 
 #define VERIFY_REGION_OR_NONE(pRegion, rid, client, mode) { \
-    pRegion = 0; \
-    if (rid) VERIFY_REGION(pRegion, rid, client, mode); \
+    (pRegion) = 0; \
+    if ((rid)) VERIFY_REGION((pRegion), (rid), (client), (mode)); \
 }
 
 extern RegionPtr


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
