### PR TITLE
(master) record: parentheses around macro argument symbols

### DIFF
--- a/record/record.c
+++ b/record/record.c
@@ -134,8 +134,8 @@ static int numEnabledRCAPs;
  *  returns an error.
  */
 #define VERIFY_CONTEXT(_pContext, _contextid, _client) { \
-    int rc = dixLookupResourceByType((void **)&(_pContext), _contextid, \
-                                     RTContext, _client, DixUseAccess); \
+    int rc = dixLookupResourceByType((void **)&(_pContext), (_contextid), \
+                                     RTContext, (_client), DixUseAccess); \
     if (rc != Success) \
 	return rc; \
 }
@@ -1513,7 +1513,7 @@ RecordConvertRangesToIntervals(SetInfoPtr psi,
 }                               /* end RecordConvertRangesToIntervals */
 
 #define offset_of(_structure, _field) \
-    ((char *)(& (_structure . _field)) - (char *)(&_structure))
+    ((char *)(&(_structure._field)) - (char *)(&(_structure)))
 
 /* RecordRegisterClients
  *

--- a/record/set.c
+++ b/record/set.c
@@ -58,7 +58,7 @@ from The Open Group.
  * should be a valid assumption on all supported architectures.
  */
 #if defined(__STDC__) && (__STDC_VERSION__ - 0 >= 201112L)
-#define MinSetAlignment(type) max(_Alignof(type), _Alignof(unsigned long))
+#define MinSetAlignment(type) max(_Alignof((type)), _Alignof(unsigned long))
 #else
 #define MinSetAlignment(type) max(sizeof(void*), sizeof(unsigned long))
 #endif

--- a/record/set.h
+++ b/record/set.h
@@ -102,23 +102,23 @@ int RecordSetMemoryRequirements(RecordSetInterval * /*pIntervals */ ,
     );
 
 #define RecordDestroySet(_pSet) \
-	/* void */ (*_pSet->ops->DestroySet)(/* RecordSetPtr */ _pSet)
+	/* void */ (*(_pSet)->ops->DestroySet)(/* RecordSetPtr */ (_pSet))
 /*
     RecordDestroySet frees all resources used by _pSet.  _pSet should not be
     used after it is destroyed.
 */
 
 #define RecordIsMemberOfSet(_pSet, _m) \
-  /* unsigned long */ (*_pSet->ops->IsMemberOfSet)(/* RecordSetPtr */ _pSet, \
-						   /* int */ _m)
+  /* unsigned long */ (*(_pSet)->ops->IsMemberOfSet)(/* RecordSetPtr */ (_pSet), \
+						   /* int */ (_m))
 /*
     RecordIsMemberOfSet returns a non-zero value if _m is a member of
     _pSet, else it returns zero.
 */
 
 #define RecordIterateSet(_pSet, _pIter, _interval) \
- /* RecordSetIteratePtr */ (*_pSet->ops->IterateSet)(/* RecordSetPtr */ _pSet,\
-	/* RecordSetIteratePtr */ _pIter, /* RecordSetInterval */ _interval)
+ /* RecordSetIteratePtr */ (*(_pSet)->ops->IterateSet)(/* RecordSetPtr */ (_pSet),\
+	/* RecordSetIteratePtr */ (_pIter), /* RecordSetInterval */ (_interval))
 /*
     RecordIterateSet returns successive intervals of members of _pSet.  If
     _pIter is NULL, the first interval of set members is copied into _interval.


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
