### PR TITLE
(master) present: parentheses around macro argument symbols

### DIFF
--- a/Xext/dri3/dri3_priv.h
+++ b/Xext/dri3/dri3_priv.h
@@ -55,12 +55,12 @@ typedef struct dri3_screen_priv {
 } dri3_screen_priv_rec, *dri3_screen_priv_ptr;
 
 #define wrap(priv,real,mem,func) {\
-    priv->mem = real->mem; \
-    real->mem = func; \
+    (priv)->mem = (real)->mem; \
+    (real)->mem = (func); \
 }
 
 #define unwrap(priv,real,mem) {\
-    real->mem = priv->mem; \
+    (real)->mem = (priv)->mem; \
 }
 
 #define VERIFY_DRI3_SYNCOBJ(id, ptr, a)\

--- a/Xext/present/present_priv.h
+++ b/Xext/present/present_priv.h
@@ -41,7 +41,7 @@
 #include "dri3.h"
 
 #if 0
-#define DebugPresent(x) ErrorF x
+#define DebugPresent(x) ErrorF (x)
 #else
 #define DebugPresent(x)
 #endif
@@ -204,12 +204,12 @@ struct present_screen_priv {
 };
 
 #define wrap(priv,real,mem,func) {\
-    priv->mem = real->mem; \
-    real->mem = func; \
+    (priv)->mem = (real)->mem; \
+    (real)->mem = (func); \
 }
 
 #define unwrap(priv,real,mem) {\
-    real->mem = priv->mem; \
+    (real)->mem = (priv)->mem; \
 }
 
 static inline present_screen_priv_ptr

--- a/Xext/present/present_request.c
+++ b/Xext/present/present_request.c
@@ -64,7 +64,7 @@ proc_present_query_version(ClientPtr client)
         if ((fence_id) == None)                                         \
             (fence_ptr) = NULL;                                         \
         else {                                                          \
-            int __rc__ = SyncVerifyFence(&fence_ptr, fence_id, client, access); \
+            int __rc__ = SyncVerifyFence(&(fence_ptr), (fence_id), (client), (access)); \
             if (__rc__ != Success)                                      \
                 return __rc__;                                          \
         }                                                               \
@@ -74,7 +74,7 @@ proc_present_query_version(ClientPtr client)
         if ((crtc_id) == None)                                          \
             (crtc_ptr) = NULL;                                          \
         else {                                                          \
-            VERIFY_RR_CRTC(crtc_id, crtc_ptr, access);                  \
+            VERIFY_RR_CRTC((crtc_id), (crtc_ptr), (access));            \
         }                                                               \
     } while (0)
 


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
