### PR TITLE
(master) randr: parentheses around macro argument symbols

### DIFF
--- a/Xext/randr/randr.c
+++ b/Xext/randr/randr.c
@@ -47,12 +47,12 @@ Bool noRRExtension = FALSE;
 static int RRNScreens;
 
 #define wrap(priv,real,mem,func) {\
-    priv->mem = real->mem; \
-    real->mem = func; \
+    (priv)->mem = (real)->mem; \
+    (real)->mem = (func); \
 }
 
 #define unwrap(priv,real,mem) {\
-    real->mem = priv->mem; \
+    (real)->mem = (priv)->mem; \
 }
 
 int RREventBase;

--- a/Xext/randr/randrstr_priv.h
+++ b/Xext/randr/randrstr_priv.h
@@ -46,56 +46,56 @@ extern RESTYPE RRLeaseType;     /* X resource type: Randr LEASE */
 
 #define VERIFY_RR_OUTPUT(id, ptr, a)\
     {\
-	int rc = dixLookupResourceByType((void **)&(ptr), id,\
-	                                 RROutputType, client, a);\
+	int rc = dixLookupResourceByType((void **)&(ptr), (id),\
+	                                 RROutputType, client, (a));\
 	if (rc != Success) {\
-	    client->errorValue = id;\
+	    client->errorValue = (id);\
 	    return rc;\
 	}\
     }
 
 #define VERIFY_RR_CRTC(id, ptr, a)\
     {\
-	int rc = dixLookupResourceByType((void **)&(ptr), id,\
-	                                 RRCrtcType, client, a);\
+	int rc = dixLookupResourceByType((void **)&(ptr), (id),\
+	                                 RRCrtcType, client, (a));\
 	if (rc != Success) {\
-	    client->errorValue = id;\
+	    client->errorValue = (id);\
 	    return rc;\
 	}\
     }
 
 #define VERIFY_RR_MODE(id, ptr, a)\
     {\
-	int rc = dixLookupResourceByType((void **)&(ptr), id,\
-	                                 RRModeType, client, a);\
+	int rc = dixLookupResourceByType((void **)&(ptr), (id),\
+	                                 RRModeType, client, (a));\
 	if (rc != Success) {\
-	    client->errorValue = id;\
+	    client->errorValue = (id);\
 	    return rc;\
 	}\
     }
 
 #define VERIFY_RR_PROVIDER(id, ptr, a)\
     {\
-        int rc = dixLookupResourceByType((void **)&(ptr), id,\
-                                         RRProviderType, client, a);\
+        int rc = dixLookupResourceByType((void **)&(ptr), (id),\
+                                         RRProviderType, client, (a));\
         if (rc != Success) {\
-            client->errorValue = id;\
+            client->errorValue = (id);\
             return rc;\
         }\
     }
 
 #define VERIFY_RR_LEASE(id, ptr, a)\
     {\
-        int rc = dixLookupResourceByType((void **)&(ptr), id,\
-                                         RRLeaseType, client, a);\
+        int rc = dixLookupResourceByType((void **)&(ptr), (id),\
+                                         RRLeaseType, client, (a));\
         if (rc != Success) {\
-            client->errorValue = id;\
+            client->errorValue = (id);\
             return rc;\
         }\
     }
 
 #define GetRRClient(pClient)    ((RRClientPtr)dixLookupPrivate(&(pClient)->devPrivates, RRClientPrivateKey))
-#define rrClientPriv(pClient)	RRClientPtr pRRClient = GetRRClient(pClient)
+#define rrClientPriv(pClient)	RRClientPtr pRRClient = GetRRClient((pClient))
 
 void RRConstrainCursorHarder(DeviceIntPtr, ScreenPtr, int, int *, int *);
 

--- a/Xext/randr/rrscreen.c
+++ b/Xext/randr/rrscreen.c
@@ -297,9 +297,9 @@ ProcRRSetScreenSize(ClientPtr client)
 
 
 #define update_totals(gpuscreen, pScrPriv) do {       \
-    total_crtcs += pScrPriv->numCrtcs;                \
-    total_outputs += pScrPriv->numOutputs;            \
-    modes = RRModesForScreen(gpuscreen, &num_modes);  \
+    total_crtcs += (pScrPriv)->numCrtcs;                \
+    total_outputs += (pScrPriv)->numOutputs;            \
+    modes = RRModesForScreen((gpuscreen), &num_modes);  \
     if (!modes)                                       \
         return BadAlloc;                              \
     for (j = 0; j < num_modes; j++)                   \
@@ -326,26 +326,26 @@ static inline void swap_modeinfos(xRRModeInfo *modeinfos, int i)
 }
 
 #define update_arrays(gpuscreen, pScrPriv, primary_crtc, has_primary) do {            \
-    for (j = 0; j < pScrPriv->numCrtcs; j++) {             \
-        if (has_primary && \
-            primary_crtc == pScrPriv->crtcs[j]) { \
-            has_primary = 0;   \
+    for (j = 0; j < (pScrPriv)->numCrtcs; j++) {             \
+        if ((has_primary) && \
+            (primary_crtc) == (pScrPriv)->crtcs[j]) { \
+            (has_primary) = 0;   \
             continue; \
         }\
-        crtcs[crtc_count] = pScrPriv->crtcs[j]->id;        \
+        crtcs[crtc_count] = (pScrPriv)->crtcs[j]->id;        \
         if (client->swapped)                               \
             swapl(&crtcs[crtc_count]);                     \
         crtc_count++;                                      \
     }                                                      \
-    for (j = 0; j < pScrPriv->numOutputs; j++) {           \
-        outputs[output_count] = pScrPriv->outputs[j]->id;  \
+    for (j = 0; j < (pScrPriv)->numOutputs; j++) {           \
+        outputs[output_count] = (pScrPriv)->outputs[j]->id;  \
         if (client->swapped)                               \
             swapl(&outputs[output_count]);                 \
         output_count++;                                    \
     }                                                      \
     {                                                      \
         RRModePtr mode;                                    \
-        modes = RRModesForScreen(gpuscreen, &num_modes);   \
+        modes = RRModesForScreen((gpuscreen), &num_modes);   \
         for (j = 0; j < num_modes; j++) {                  \
             mode = modes[j];                               \
             modeinfos[mode_count] = mode->mode;            \

--- a/Xext/randr/rrtransform.c
+++ b/Xext/randr/rrtransform.c
@@ -106,7 +106,7 @@ RRTransformCopy(RRTransformPtr dst, RRTransformPtr src)
     return TRUE;
 }
 
-#define F(x)	IntToxFixed(x)
+#define F(x)	IntToxFixed((x))
 
 static void
 RRTransformRescale(struct pixman_f_transform *f_transform, double limit)


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
