### PR TITLE
(master) fb: parentheses around macro argument symbols

### DIFF
--- a/fb/fb_priv.h
+++ b/fb/fb_priv.h
@@ -16,7 +16,7 @@
 extern _X_EXPORT DevPrivateKey
 fbGetGCPrivateKey(GCPtr pGC);
 
-#define fbGetGCPrivate(pGC) ((FbGCPrivPtr)dixLookupPrivate(&(pGC)->devPrivates, fbGetGCPrivateKey(pGC)))
+#define fbGetGCPrivate(pGC) ((FbGCPrivPtr)dixLookupPrivate(&(pGC)->devPrivates, fbGetGCPrivateKey((pGC))))
 
 #define fbGetScreenPixmap(s)    ((PixmapPtr) (s)->devPrivate)
 

--- a/fb/fbbits.h
+++ b/fb/fbbits.h
@@ -29,18 +29,18 @@
 #define isClipped(c,ul,lr)  (((c) | ((c) - (ul)) | ((lr) - (c))) & 0x80008000)
 
 #define __FbMaskBits(x,w,l,n,r) { \
-    n = (w); \
-    r = FbRightMask((x)+n); \
-    l = FbLeftMask(x); \
-    if (l) { \
-        n -= FB_UNIT - ((x) & FB_MASK); \
-        if (n < 0) { \
-            n = 0; \
-            l &= r; \
-            r = 0; \
+    (n) = (w); \
+    (r) = FbRightMask((x)+(n)); \
+    (l) = FbLeftMask((x)); \
+    if ((l)) { \
+        (n) -= FB_UNIT - ((x) & FB_MASK); \
+        if ((n) < 0) { \
+            (n) = 0; \
+            (l) &= (r); \
+            (r) = 0; \
         } \
     } \
-    n >>= FB_SHIFT; \
+    (n) >>= FB_SHIFT; \
 }
 
 /* Macros for dealing with dashing */
@@ -77,25 +77,25 @@
     (dashlen) = *++__dash;                                  \
 }
 
-#define FbDashNextOdd(dashlen)  FbDashNext(dashlen)
+#define FbDashNextOdd(dashlen)  FbDashNext((dashlen))
 
 #define FbDashStep(dashlen,even) {                          \
     if (!--(dashlen)) {                                     \
-        FbDashNext(dashlen);                                \
+        FbDashNext((dashlen));                              \
         (even) = 1-(even);                                  \
     }                                                       \
 }
 
 #ifdef BITSSTORE
-#define STORE(b,x)  BITSSTORE(b,x)
+#define STORE(b,x)  BITSSTORE((b),(x))
 #else
 #define STORE(b,x)  WRITE((b), (x))
 #endif
 
 #ifdef BITSRROP
-#define RROP(b,a,x)	BITSRROP(b,a,x)
+#define RROP(b,a,x)	BITSRROP((b),(a),(x))
 #else
-#define RROP(b,a,x)	WRITE((b), FbDoRRop (READ(b), (a), (x)))
+#define RROP(b,a,x)	WRITE((b), FbDoRRop (READ((b)), (a), (x)))
 #endif
 
 #ifdef BITSUNIT
@@ -334,8 +334,8 @@ DOTS(FbBits * dst,
 
 #ifdef ARC
 
-#define ARCCOPY(d)  STORE(d,xorBits)
-#define ARCRROP(d)  RROP(d,andBits,xorBits)
+#define ARCCOPY(d)  STORE((d),xorBits)
+#define ARCRROP(d)  RROP((d),andBits,xorBits)
 
 void
 ARC(FbBits * dst,
@@ -530,18 +530,18 @@ ARC(FbBits * dst,
 #define WRITE_ADDR4(n)	    ((n))
 #endif
 
-#define WRITE1(d,n,fg)	    WRITE(d + WRITE_ADDR1(n), (BITS) (fg))
+#define WRITE1(d,n,fg)	    WRITE((d) + WRITE_ADDR1((n)), (BITS) (fg))
 
 #ifdef BITS2
-#define WRITE2(d,n,fg)	    WRITE((BITS2 *) &((d)[WRITE_ADDR2(n)]), (BITS2) (fg))
+#define WRITE2(d,n,fg)	    WRITE((BITS2 *) &((d)[WRITE_ADDR2((n))]), (BITS2) (fg))
 #else
-#define WRITE2(d,n,fg)	    (WRITE1(d,n,fg), WRITE1(d,(n)+1,fg))
+#define WRITE2(d,n,fg)	    (WRITE1((d),(n),(fg)), WRITE1((d),(n)+1,(fg)))
 #endif
 
 #ifdef BITS4
-#define WRITE4(d,n,fg)	    WRITE((BITS4 *) &((d)[WRITE_ADDR4(n)]), (BITS4) (fg))
+#define WRITE4(d,n,fg)	    WRITE((BITS4 *) &((d)[WRITE_ADDR4((n))]), (BITS4) (fg))
 #else
-#define WRITE4(d,n,fg)	    (WRITE2(d,n,fg), WRITE2(d,(n)+2,fg))
+#define WRITE4(d,n,fg)	    (WRITE2((d),(n),(fg)), WRITE2((d),(n)+2,(fg)))
 #endif
 
 void

--- a/fb/fbblt.c
+++ b/fb/fbblt.c
@@ -30,7 +30,7 @@
 #define MEMCPY_WRAPPED(dst, src, size) do {                       \
     size_t _i;                                                    \
     CARD8 *_dst = (CARD8*)(dst), *_src = (CARD8*)(src);           \
-    for(_i = 0; _i < size; _i++) {                                \
+    for(_i = 0; _i < (size); _i++) {                              \
         WRITE(_dst +_i, READ(_src + _i));                         \
     }                                                             \
 } while(0)
@@ -38,7 +38,7 @@
 #define MEMSET_WRAPPED(dst, val, size) do {                       \
     size_t _i;                                                    \
     CARD8 *_dst = (CARD8*)(dst);                                  \
-    for(_i = 0; _i < size; _i++) {                                \
+    for(_i = 0; _i < (size); _i++) {                              \
         WRITE(_dst +_i, (val));                                   \
     }                                                             \
 } while(0)
@@ -53,13 +53,13 @@
 #define FbStipStrideToBitsStride(s) (((s) >> (FB_SHIFT - FB_STIP_SHIFT)))
 
 #define InitializeShifts(sx,dx,ls,rs) { \
-    if (sx != dx) { \
-	if (sx > dx) { \
-	    ls = sx - dx; \
-	    rs = FB_UNIT - ls; \
+    if ((sx) != (dx)) { \
+	if ((sx) > (dx)) { \
+	    (ls) = (sx) - (dx); \
+	    (rs) = FB_UNIT - (ls); \
 	} else { \
-	    rs = dx - sx; \
-	    ls = FB_UNIT - rs; \
+	    (rs) = (dx) - (sx); \
+	    (ls) = FB_UNIT - (rs); \
 	} \
     } \
 }

--- a/fb/fbbltone.c
+++ b/fb/fbbltone.c
@@ -34,30 +34,30 @@
 
 #define Mask(x,w)	BitsMask((x)*(w),(w))
 
-#define SelMask(b,n,w)	((((b) >> n) & 1) * Mask(n,w))
+#define SelMask(b,n,w)	((((b) >> (n)) & 1) * Mask((n),(w)))
 
 #define C1(b,w) \
-    (SelMask(b,0,w))
+    (SelMask((b),0,(w)))
 
 #define C2(b,w) \
-    (SelMask(b,0,w) | \
-     SelMask(b,1,w))
+    (SelMask((b),0,(w)) | \
+     SelMask((b),1,(w)))
 
 #define C4(b,w) \
-    (SelMask(b,0,w) | \
-     SelMask(b,1,w) | \
-     SelMask(b,2,w) | \
-     SelMask(b,3,w))
+    (SelMask((b),0,(w)) | \
+     SelMask((b),1,(w)) | \
+     SelMask((b),2,(w)) | \
+     SelMask((b),3,(w)))
 
 #define C8(b,w) \
-    (SelMask(b,0,w) | \
-     SelMask(b,1,w) | \
-     SelMask(b,2,w) | \
-     SelMask(b,3,w) | \
-     SelMask(b,4,w) | \
-     SelMask(b,5,w) | \
-     SelMask(b,6,w) | \
-     SelMask(b,7,w))
+    (SelMask((b),0,(w)) | \
+     SelMask((b),1,(w)) | \
+     SelMask((b),2,(w)) | \
+     SelMask((b),3,(w)) | \
+     SelMask((b),4,(w)) | \
+     SelMask((b),5,(w)) | \
+     SelMask((b),6,(w)) | \
+     SelMask((b),7,(w)))
 
 static const FbBits fbStipple8Bits[256] = {
     C8(0, 4), C8(1, 4), C8(2, 4), C8(3, 4), C8(4, 4), C8(5, 4),

--- a/fb/fbpixmap.c
+++ b/fb/fbpixmap.c
@@ -91,27 +91,27 @@ fbDestroyPixmap(PixmapPtr pPixmap)
 #define ADDRECT(reg,r,fr,rx1,ry1,rx2,ry2)			\
 if (((rx1) < (rx2)) && ((ry1) < (ry2)) &&			\
     (!((reg)->data->numRects &&					\
-       ((r-1)->y1 == (ry1)) &&					\
-       ((r-1)->y2 == (ry2)) &&					\
-       ((r-1)->x1 <= (rx1)) &&					\
-       ((r-1)->x2 >= (rx2)))))					\
+       (((r)-1)->y1 == (ry1)) &&				\
+       (((r)-1)->y2 == (ry2)) &&				\
+       (((r)-1)->x1 <= (rx1)) &&				\
+       (((r)-1)->x2 >= (rx2)))))				\
 {								\
     if ((reg)->data->numRects == (reg)->data->size)		\
     {								\
-	RegionRectAlloc(reg, 1);					\
-	fr = RegionBoxptr(reg);				\
-	r = fr + (reg)->data->numRects;				\
+	RegionRectAlloc((reg), 1);				\
+	(fr) = RegionBoxptr((reg));				\
+	(r) = (fr) + (reg)->data->numRects;			\
     }								\
-    r->x1 = (rx1);						\
-    r->y1 = (ry1);						\
-    r->x2 = (rx2);						\
-    r->y2 = (ry2);						\
+    (r)->x1 = (rx1);						\
+    (r)->y1 = (ry1);						\
+    (r)->x2 = (rx2);						\
+    (r)->y2 = (ry2);						\
     (reg)->data->numRects++;					\
-    if(r->x1 < (reg)->extents.x1)				\
-	(reg)->extents.x1 = r->x1;				\
-    if(r->x2 > (reg)->extents.x2)				\
-	(reg)->extents.x2 = r->x2;				\
-    r++;							\
+    if((r)->x1 < (reg)->extents.x1)				\
+	(reg)->extents.x1 = (r)->x1;				\
+    if((r)->x2 > (reg)->extents.x2)				\
+	(reg)->extents.x2 = (r)->x2;				\
+    (r)++;							\
 }
 
 /* Convert bitmap clip mask into clipping region.

--- a/fb/fbseg.c
+++ b/fb/fbseg.c
@@ -29,9 +29,9 @@
 
 #include "miline.h"
 
-#define fbBresShiftMask(mask,dir,bpp) ((bpp == FB_STIP_UNIT) ? 0 : \
-					((dir < 0) ? FbStipLeft(mask,bpp) : \
-					 FbStipRight(mask,bpp)))
+#define fbBresShiftMask(mask,dir,bpp) (((bpp) == FB_STIP_UNIT) ? 0 : \
+					(((dir) < 0) ? FbStipLeft((mask),(bpp)) : \
+					 FbStipRight((mask),(bpp))))
 
 static void
 fbBresSolid(DrawablePtr pDrawable,

--- a/fb/fbsolid.c
+++ b/fb/fbsolid.c
@@ -20,7 +20,7 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-#define FbSelectPart(xor,o,t)    xor
+#define FbSelectPart(xor,o,t)    (xor)
 
 #include <dix-config.h>
 


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
