### PR TITLE
(master) glx: parentheses around macro argument symbols

### DIFF
--- a/Xext/glx/extension_string.c
+++ b/Xext/glx/extension_string.c
@@ -39,15 +39,15 @@
 #include "extension_string.h"
 #include "opaque.h"
 
-#define SET_BIT(m,b)    (m[ (b) / 8 ] |=  (1U << ((b) % 8)))
-#define CLR_BIT(m,b)    (m[ (b) / 8 ] &= ~(1U << ((b) % 8)))
-#define IS_SET(m,b)    ((m[ (b) / 8 ] &   (1U << ((b) % 8))) != 0)
+#define SET_BIT(m,b)    ((m)[ (b) / 8 ] |=  (1U << ((b) % 8)))
+#define CLR_BIT(m,b)    ((m)[ (b) / 8 ] &= ~(1U << ((b) % 8)))
+#define IS_SET(m,b)    (((m)[ (b) / 8 ] &   (1U << ((b) % 8))) != 0)
 #define CONCAT(a,b) a ## b
 #define GLX(n) "GLX_" # n, 4 + sizeof( # n ) - 1, CONCAT(n,_bit)
-#define VER(a,b)  a, b
+#define VER(a,b)  (a), (b)
 #define Y  1
 #define N  0
-#define EXT_ENABLED(bit,supported) (IS_SET(supported, bit))
+#define EXT_ENABLED(bit,supported) (IS_SET((supported), (bit)))
 
 struct extension_info {
     const char *const name;

--- a/Xext/glx/glx_dri/glxdricommon.c
+++ b/Xext/glx/glx_dri/glxdricommon.c
@@ -44,7 +44,7 @@
 #include <os.h>
 
 #define __ATTRIB(attrib, field) \
-    { attrib, offsetof(__GLXconfig, field) }
+    { (attrib), offsetof(__GLXconfig, field) }
 
 static const struct {
     unsigned int attrib, offset;

--- a/Xext/glx/glxcmds.c
+++ b/Xext/glx/glxcmds.c
@@ -1022,7 +1022,7 @@ DoGetFBConfigs(__GLXclientState * cl, unsigned screen)
         p = 0;
 
 #define WRITE_PAIR(tag,value) \
-    do { buf[p++] = tag ; buf[p++] = value ; } while( 0 )
+    do { buf[p++] = (tag) ; buf[p++] = (value) ; } while( 0 )
 
         WRITE_PAIR(GLX_VISUAL_ID, modes->visualID);
         WRITE_PAIR(GLX_FBCONFIG_ID, modes->fbconfigID);

--- a/Xext/glx/indirect_table.h
+++ b/Xext/glx/indirect_table.h
@@ -92,7 +92,7 @@ struct __glXDispatchInfo {
 /**
  * Declare the index \c x as a leaf index.
  */
-#define LEAF(x)            -x
+#define LEAF(x)            -(x)
 
 /**
  * Determine if an index is a leaf index.

--- a/Xext/glx/rensize.c
+++ b/Xext/glx/rensize.c
@@ -38,8 +38,8 @@
 #include "indirect_reqsize.h"
 
 #define SWAPL(a) \
-  (((a & 0xff000000U)>>24) | ((a & 0xff0000U)>>8) | \
-   ((a & 0xff00U)<<8) | ((a & 0xffU)<<24))
+  ((((a) & 0xff000000U)>>24) | (((a) & 0xff0000U)>>8) | \
+   (((a) & 0xff00U)<<8) | (((a) & 0xffU)<<24))
 
 int
 __glXMap1dReqSize(const GLbyte * pc, Bool swap, int reqlen)

--- a/Xext/glx/unpack.h
+++ b/Xext/glx/unpack.h
@@ -38,21 +38,21 @@
 /*
 ** Fetch the context-id out of a SingleReq request pointed to by pc.
 */
-#define __GLX_GET_SINGLE_CONTEXT_TAG(pc) (((xGLXSingleReq*)pc)->contextTag)
-#define __GLX_GET_VENDPRIV_CONTEXT_TAG(pc) (((xGLXVendorPrivateReq*)pc)->contextTag)
+#define __GLX_GET_SINGLE_CONTEXT_TAG(pc) (((xGLXSingleReq*)(pc))->contextTag)
+#define __GLX_GET_VENDPRIV_CONTEXT_TAG(pc) (((xGLXVendorPrivateReq*)(pc))->contextTag)
 
 /*
 ** Fetch a double from potentially unaligned memory.
 */
 #ifdef __GLX_ALIGN64
-#define __GLX_MEM_COPY(dst,src,n)	memmove(dst,src,n)
-#define __GLX_GET_DOUBLE(dst,src)	__GLX_MEM_COPY(&dst,src,8)
+#define __GLX_MEM_COPY(dst,src,n)	memmove((dst),(src),(n))
+#define __GLX_GET_DOUBLE(dst,src)	__GLX_MEM_COPY(&(dst),(src),8)
 #else
 #define __GLX_GET_DOUBLE(dst,src)	(dst) = *((GLdouble*)(src))
 #endif
 
 #define __GLX_BEGIN_REPLY(size) \
-	reply.length = __GLX_PAD(size) >> 2;	\
+	reply.length = __GLX_PAD((size)) >> 2;	\
 	reply.type = X_Reply; 			\
 	reply.sequenceNumber = client->sequence;
 
@@ -74,7 +74,7 @@
 ** pointer.
 */
 #define __GLX_GET_ANSWER_BUFFER(res,cl,size,align)			 \
-    if (size < 0) return BadLength;                                      \
+    if ((size) < 0) return BadLength;                                    \
     else if ((size) > sizeof(answerBuffer)) {				 \
 	int bump;							 \
 	if ((cl)->returnBufSize < (size)+(align)) {			 \
@@ -85,11 +85,11 @@
 	    }								 \
 	    (cl)->returnBufSize = (size)+(align);			 \
 	}								 \
-	res = (char*)cl->returnBuf;					 \
+	(res) = (char*)(cl)->returnBuf;					 \
 	bump = (long)(res) % (align);					 \
-	if (bump) res += (align) - (bump);				 \
+	if (bump) (res) += (align) - (bump);				 \
     } else {								 \
-	res = (char *)answerBuffer;					 \
+	(res) = (char *)answerBuffer;					 \
     }
 
 #define __GLX_SEND_BYTE_ARRAY(len) \
@@ -107,10 +107,10 @@
 #define __GLX_SEND_DOUBLE_ARRAY(len) \
 	WriteToClient(client, (len)*__GLX_SIZE_FLOAT64, answer)
 
-#define __GLX_SEND_VOID_ARRAY(len)  __GLX_SEND_BYTE_ARRAY(len)
-#define __GLX_SEND_UBYTE_ARRAY(len)  __GLX_SEND_BYTE_ARRAY(len)
-#define __GLX_SEND_USHORT_ARRAY(len) __GLX_SEND_SHORT_ARRAY(len)
-#define __GLX_SEND_UINT_ARRAY(len)  __GLX_SEND_INT_ARRAY(len)
+#define __GLX_SEND_VOID_ARRAY(len)  __GLX_SEND_BYTE_ARRAY((len))
+#define __GLX_SEND_UBYTE_ARRAY(len)  __GLX_SEND_BYTE_ARRAY((len))
+#define __GLX_SEND_USHORT_ARRAY(len) __GLX_SEND_SHORT_ARRAY((len))
+#define __GLX_SEND_UINT_ARRAY(len)  __GLX_SEND_INT_ARRAY((len))
 
 /*
 ** PERFORMANCE NOTE:


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
