### PR TITLE
(master) render: parentheses around macro argument symbols

### DIFF
--- a/Xext/render/animcur.c
+++ b/Xext/render/animcur.c
@@ -82,7 +82,7 @@ static DevPrivateKeyRec AnimCurScreenPrivateKeyRec;
 #define GetAnimCur(c)	    ((AnimCurPtr) ((((char *)(c) + CURSOR_REC_SIZE))))
 #define GetAnimCurScreen(s) ((AnimCurScreenPtr)dixLookupPrivate(&(s)->devPrivates, &AnimCurScreenPrivateKeyRec))
 
-#define Wrap(as,s,elt,func) (((as)->elt = (s)->elt), (s)->elt = func)
+#define Wrap(as,s,elt,func) (((as)->elt = (s)->elt), (s)->elt = (func))
 #define Unwrap(as,s,elt)    ((s)->elt = (as)->elt)
 
 static void AnimCurScreenClose(CallbackListPtr *pcbl, ScreenPtr pScreen, void *unused)

--- a/Xext/render/glyph.c
+++ b/Xext/render/glyph.c
@@ -539,7 +539,7 @@ GlyphExtents(int nlist, GlyphListPtr list, GlyphPtr * glyphs, BoxPtr extents)
     }
 }
 
-#define NeedsComponent(f) (PIXMAN_FORMAT_A(f) != 0 && PIXMAN_FORMAT_RGB(f) != 0)
+#define NeedsComponent(f) (PIXMAN_FORMAT_A((f)) != 0 && PIXMAN_FORMAT_RGB((f)) != 0)
 
 void
 CompositeGlyphs(CARD8 op,

--- a/Xext/render/glyphstr_priv.h
+++ b/Xext/render/glyphstr_priv.h
@@ -44,10 +44,10 @@ typedef struct {
 } GlyphSetRec, *GlyphSetPtr;
 
 #define GlyphSetGetPrivate(pGlyphSet,k) \
-    dixLookupPrivate(&(pGlyphSet)->devPrivates, k)
+    dixLookupPrivate(&(pGlyphSet)->devPrivates, (k))
 
 #define GlyphSetSetPrivate(pGlyphSet,k,ptr) \
-    dixSetPrivate(&(pGlyphSet)->devPrivates, k, ptr)
+    dixSetPrivate(&(pGlyphSet)->devPrivates, (k), (ptr))
 
 void GlyphUninit(ScreenPtr pScreen);
 GlyphPtr FindGlyphByHash(unsigned char sha1[20], int format);

--- a/Xext/render/picturestr_priv.h
+++ b/Xext/render/picturestr_priv.h
@@ -19,17 +19,17 @@ extern RESTYPE PictFormatType;
 extern RESTYPE GlyphSetType;
 
 #define VERIFY_PICTURE(pPicture, pid, client, mode) {\
-    int tmprc = dixLookupResourceByType((void *)&(pPicture), pid,\
-	                                PictureType, client, mode);\
+    int tmprc = dixLookupResourceByType((void *)&(pPicture), (pid),\
+                                        PictureType, (client), (mode));\
     if (tmprc != Success)\
 	return tmprc;\
 }
 
 #define VERIFY_ALPHA(pPicture, pid, client, mode) {\
-    if (pid == None) \
-	pPicture = 0; \
+    if ((pid) == None) \
+	(pPicture) = 0; \
     else { \
-	VERIFY_PICTURE(pPicture, pid, client, mode); \
+	VERIFY_PICTURE((pPicture), (pid), (client), (mode)); \
     } \
 } \
 

--- a/Xext/render/render.c
+++ b/Xext/render/render.c
@@ -784,7 +784,7 @@ typedef struct _GlyphNew {
     unsigned char sha1[20];
 } GlyphNewRec, *GlyphNewPtr;
 
-#define NeedsComponent(f) (PIXMAN_FORMAT_A(f) != 0 && PIXMAN_FORMAT_RGB(f) != 0)
+#define NeedsComponent(f) (PIXMAN_FORMAT_A((f)) != 0 && PIXMAN_FORMAT_RGB((f)) != 0)
 
 static int
 ProcRenderAddGlyphs(ClientPtr client)
@@ -1427,7 +1427,7 @@ ProcRenderCreateCursor(ClientPtr client)
     }
 
 #define GetByte(p,s)	(((p) >> (s)) & 0xff)
-#define GetColor(p,s)	(GetByte(p,s) | (GetByte(p,s) << 8))
+#define GetColor(p,s)	(GetByte((p),(s)) | (GetByte((p),(s)) << 8))
 
     cm.width = width;
     cm.height = height;
@@ -1857,17 +1857,17 @@ swapStops(void *stuff, int num)
 
 #ifdef XINERAMA
 #define VERIFY_XIN_PICTURE(pPicture, pid, client, mode) {\
-    int rc = dixLookupResourceByType((void **)&(pPicture), pid,\
-                                     XRT_PICTURE, client, mode);\
+    int rc = dixLookupResourceByType((void **)&(pPicture), (pid),\
+                                     XRT_PICTURE, (client), (mode));\
     if (rc != Success)\
 	return rc;\
 }
 
 #define VERIFY_XIN_ALPHA(pPicture, pid, client, mode) {\
-    if (pid == None) \
-	pPicture = 0; \
+    if ((pid) == None) \
+	(pPicture) = 0; \
     else { \
-	VERIFY_XIN_PICTURE(pPicture, pid, client, mode); \
+	VERIFY_XIN_PICTURE((pPicture), (pid), (client), (mode)); \
     } \
 } \
 


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
