### PR TITLE
(master) Xext: parentheses around macro argument symbols

### DIFF
--- a/Xext/damage/damageext.c
+++ b/Xext/damage/damageext.c
@@ -58,8 +58,8 @@ typedef struct _DamageExt {
 } DamageExtRec, *DamageExtPtr;
 
 #define VERIFY_DAMAGEEXT(pDamageExt, rid, client, mode) { \
-    int rc = dixLookupResourceByType((void **)&(pDamageExt), rid, \
-                                     DamageExtType, client, mode); \
+    int rc = dixLookupResourceByType((void **)&(pDamageExt), (rid), \
+                                     DamageExtType, (client), (mode)); \
     if (rc != Success) \
         return rc; \
 }

--- a/Xext/dpms/dpms.c
+++ b/Xext/dpms/dpms.c
@@ -496,8 +496,8 @@ DPMSExtensionInit(void)
     ExtensionEntry *extEntry;
 
 #define CONDITIONALLY_SET_DPMS_TIMEOUT(_timeout_value_)         \
-    if (_timeout_value_ == -1) { /* not yet set from config */  \
-        _timeout_value_ = ScreenSaverTime;                      \
+    if ((_timeout_value_) == -1) { /* not yet set from config */  \
+        (_timeout_value_) = ScreenSaverTime;                      \
     }
 
     CONDITIONALLY_SET_DPMS_TIMEOUT(DPMSStandbyTime)

--- a/Xext/dri2/pci_ids/pci_id_driver_map.h
+++ b/Xext/dri2/pci_ids/pci_id_driver_map.h
@@ -4,7 +4,7 @@
 #include <stddef.h>
 
 #ifndef ARRAY_SIZE
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+#define ARRAY_SIZE(a) (sizeof((a)) / sizeof((a)[0]))
 #endif
 
 static const int i915_chip_ids[] = {

--- a/Xext/dri2/pci_ids/pci_id_util.h
+++ b/Xext/dri2/pci_ids/pci_id_util.h
@@ -1,6 +1,6 @@
 #ifndef _PCI_ID_UTIL_H_
 #define _PCI_ID_UTIL_H_
 
-#define CHIPSET(chip, desc, name) chip,
+#define CHIPSET(chip, desc, name) (chip),
 
 #endif /* _PCI_ID_UTIL_H_ */

--- a/Xext/namespace/config.c
+++ b/Xext/namespace/config.c
@@ -43,9 +43,9 @@ static struct Xnamespace* select_ns(const char* name)
     return newns;
 }
 
-#define atox(c) ('0' <= c && c <= '9' ? c - '0' : \
-                 'a' <= c && c <= 'f' ? c - 'a' + 10 : \
-                 'A' <= c && c <= 'F' ? c - 'A' + 10 : -1)
+#define atox(c) ('0' <= (c) && (c) <= '9' ? (c) - '0' : \
+                 'a' <= (c) && (c) <= 'f' ? (c) - 'a' + 10 : \
+                 'A' <= (c) && (c) <= 'F' ? (c) - 'A' + 10 : -1)
 
 // warning: no error checking, no buffer clearing
 static int hex2bin(const char *in, char *out)

--- a/Xext/panoramiX/panoramiX.h
+++ b/Xext/panoramiX/panoramiX.h
@@ -80,7 +80,7 @@ typedef struct {
         for (unsigned walkScreenIdx = 0; walkScreenIdx < PanoramiXNumScreens; walkScreenIdx++) { \
             ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx]; \
             (void)walkScreen; \
-            (__LAMBDA__); \
+            __LAMBDA__; \
         } \
     } while (0);
 
@@ -95,7 +95,7 @@ typedef struct {
         for (unsigned walkScreenIdx = 1; walkScreenIdx < PanoramiXNumScreens; walkScreenIdx++) { \
             ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx]; \
             (void)walkScreen; \
-            (__LAMBDA__); \
+            __LAMBDA__; \
         } \
     } while (0);
 
@@ -110,7 +110,7 @@ typedef struct {
             unsigned walkScreenIdx = __walkidx - 1; \
             ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx]; \
             (void)walkScreen; \
-            (__LAMBDA__); \
+            __LAMBDA__; \
         } \
     } while (0);
 

--- a/Xext/panoramiX/panoramiX.h
+++ b/Xext/panoramiX/panoramiX.h
@@ -80,7 +80,7 @@ typedef struct {
         for (unsigned walkScreenIdx = 0; walkScreenIdx < PanoramiXNumScreens; walkScreenIdx++) { \
             ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx]; \
             (void)walkScreen; \
-            __LAMBDA__; \
+            (__LAMBDA__); \
         } \
     } while (0);
 
@@ -95,7 +95,7 @@ typedef struct {
         for (unsigned walkScreenIdx = 1; walkScreenIdx < PanoramiXNumScreens; walkScreenIdx++) { \
             ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx]; \
             (void)walkScreen; \
-            __LAMBDA__; \
+            (__LAMBDA__); \
         } \
     } while (0);
 
@@ -110,13 +110,13 @@ typedef struct {
             unsigned walkScreenIdx = __walkidx - 1; \
             ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx]; \
             (void)walkScreen; \
-            __LAMBDA__; \
+            (__LAMBDA__); \
         } \
     } while (0);
 
-#define FOR_NSCREENS_FORWARD(j) for(j = 0; j < PanoramiXNumScreens; j++)
-#define FOR_NSCREENS_FORWARD_SKIP(j) for(j = 1; j < PanoramiXNumScreens; j++)
-#define FOR_NSCREENS_BACKWARD(j) for(j = PanoramiXNumScreens - 1; j >= 0; j--)
+#define FOR_NSCREENS_FORWARD(j) for((j) = 0; (j) < PanoramiXNumScreens; (j)++)
+#define FOR_NSCREENS_FORWARD_SKIP(j) for((j) = 1; (j) < PanoramiXNumScreens; (j)++)
+#define FOR_NSCREENS_BACKWARD(j) for((j) = PanoramiXNumScreens - 1; (j) >= 0; (j)--)
 
 #define IS_SHARED_PIXMAP(r) (((r)->type == XRT_PIXMAP) && (r)->u.pix.shared)
 

--- a/Xext/saver/saver.c
+++ b/Xext/saver/saver.c
@@ -169,8 +169,8 @@ static DevPrivateKeyRec ScreenPrivateKeyRec;
 #define GetScreenPrivate(s) ((ScreenSaverScreenPrivatePtr) \
     dixLookupPrivate(&(s)->devPrivates, ScreenPrivateKey))
 #define SetScreenPrivate(s,v) \
-    dixSetPrivate(&(s)->devPrivates, ScreenPrivateKey, v);
-#define SetupScreen(s)	ScreenSaverScreenPrivatePtr pPriv = (s ? GetScreenPrivate(s) : NULL)
+    dixSetPrivate(&(s)->devPrivates, ScreenPrivateKey, (v));
+#define SetupScreen(s)	ScreenSaverScreenPrivatePtr pPriv = ((s) ? GetScreenPrivate((s)) : NULL)
 
 static void
 CheckScreenPrivate(ScreenPtr pScreen)

--- a/Xext/shm/shm.c
+++ b/Xext/shm/shm.c
@@ -76,28 +76,28 @@ in this Software without prior written authorization from The Open Group.
 /* Needed for Solaris cross-zone shared memory extension */
 #ifdef HAVE_SHMCTL64
 #include <sys/ipc_impl.h>
-#define SHMSTAT(id, buf)	shmctl64(id, IPC_STAT64, buf)
+#define SHMSTAT(id, buf)	shmctl64((id), IPC_STAT64, (buf))
 #define SHMSTAT_TYPE 		struct shmid_ds64
 #define SHMPERM_TYPE 		struct ipc_perm64
-#define SHM_PERM(buf) 		buf.shmx_perm
-#define SHM_SEGSZ(buf)		buf.shmx_segsz
-#define SHMPERM_UID(p)		p->ipcx_uid
-#define SHMPERM_CUID(p)		p->ipcx_cuid
-#define SHMPERM_GID(p)		p->ipcx_gid
-#define SHMPERM_CGID(p)		p->ipcx_cgid
-#define SHMPERM_MODE(p)		p->ipcx_mode
-#define SHMPERM_ZONEID(p)	p->ipcx_zoneid
+#define SHM_PERM(buf) 		(buf).shmx_perm
+#define SHM_SEGSZ(buf)		(buf).shmx_segsz
+#define SHMPERM_UID(p)		(p)->ipcx_uid
+#define SHMPERM_CUID(p)		(p)->ipcx_cuid
+#define SHMPERM_GID(p)		(p)->ipcx_gid
+#define SHMPERM_CGID(p)		(p)->ipcx_cgid
+#define SHMPERM_MODE(p)		(p)->ipcx_mode
+#define SHMPERM_ZONEID(p)	(p)->ipcx_zoneid
 #else
-#define SHMSTAT(id, buf) 	shmctl(id, IPC_STAT, buf)
+#define SHMSTAT(id, buf) 	shmctl((id), IPC_STAT, (buf))
 #define SHMSTAT_TYPE 		struct shmid_ds
 #define SHMPERM_TYPE 		struct ipc_perm
-#define SHM_PERM(buf) 		buf.shm_perm
-#define SHM_SEGSZ(buf)		buf.shm_segsz
-#define SHMPERM_UID(p)		p->uid
-#define SHMPERM_CUID(p)		p->cuid
-#define SHMPERM_GID(p)		p->gid
-#define SHMPERM_CGID(p)		p->cgid
-#define SHMPERM_MODE(p)		p->mode
+#define SHM_PERM(buf) 		(buf).shm_perm
+#define SHM_SEGSZ(buf)		(buf).shm_segsz
+#define SHMPERM_UID(p)		(p)->uid
+#define SHMPERM_CUID(p)		(p)->cuid
+#define SHMPERM_GID(p)		(p)->gid
+#define SHMPERM_CGID(p)		(p)->cgid
+#define SHMPERM_MODE(p)		(p)->mode
 #endif
 
 
@@ -135,27 +135,27 @@ static ShmFuncs fbFuncs = { fbShmCreatePixmap, NULL };
 #define VERIFY_SHMSEG(shmseg,shmdesc,client) \
 { \
     int tmprc; \
-    tmprc = dixLookupResourceByType((void **)&(shmdesc), shmseg, ShmSegType, \
-                                    client, DixReadAccess); \
+    tmprc = dixLookupResourceByType((void **)&(shmdesc), (shmseg), ShmSegType, \
+                                    (client), DixReadAccess); \
     if (tmprc != Success) \
 	return tmprc; \
 }
 
 #define VERIFY_SHMPTR(shmseg,offset,needwrite,shmdesc,client) \
 { \
-    VERIFY_SHMSEG(shmseg, shmdesc, client); \
-    if ((offset & 3) || (offset > shmdesc->size)) \
+    VERIFY_SHMSEG((shmseg), (shmdesc), (client)); \
+    if (((offset) & 3) || ((offset) > (shmdesc)->size)) \
     { \
-	client->errorValue = offset; \
+	(client)->errorValue = (offset); \
 	return BadValue; \
     } \
-    if (needwrite && !shmdesc->writable) \
+    if ((needwrite) && !(shmdesc)->writable) \
 	return BadAccess; \
 }
 
 #define VERIFY_SHMSIZE(shmdesc,offset,len,client) \
 { \
-    if ((offset + len) > shmdesc->size) \
+    if (((offset) + (len)) > (shmdesc)->size) \
     { \
 	return BadAccess; \
     } \

--- a/Xext/sync/sync.c
+++ b/Xext/sync/sync.c
@@ -101,7 +101,7 @@ static const char *WARN_INVALID_COUNTER_ALARM =
     "         the result of a programming error in the X server.\n";
 
 #define IsSystemCounter(pCounter) \
-    (pCounter && (pCounter->sync.client == NULL))
+    ((pCounter) && ((pCounter)->sync.client == NULL))
 
 /* these are all the alarm attributes that pertain to the alarm's trigger */
 #define XSyncCAAllTrigger \

--- a/Xext/xf86bigfont/xf86bigfont.c
+++ b/Xext/xf86bigfont/xf86bigfont.c
@@ -318,10 +318,10 @@ static inline void writeCharInfo(x_rpcbuf_t *rpcbuf, xCharInfo CI) {
 
 /* static CARD32 hashCI (xCharInfo *p); */
 #define hashCI(p) \
-	(CARD32)(((p->leftSideBearing << 27) + (p->leftSideBearing >> 5) + \
-	          (p->rightSideBearing << 23) + (p->rightSideBearing >> 9) + \
-	          (p->characterWidth << 16) + \
-	          (p->ascent << 11) + (p->descent << 6)) ^ p->attributes)
+	(CARD32)((((p)->leftSideBearing << 27) + ((p)->leftSideBearing >> 5) + \
+	          ((p)->rightSideBearing << 23) + ((p)->rightSideBearing >> 9) + \
+	          ((p)->characterWidth << 16) + \
+	          ((p)->ascent << 11) + ((p)->descent << 6)) ^ (p)->attributes)
 
 static int
 ProcXF86BigfontQueryFont(ClientPtr client)

--- a/Xext/xv/xvdix_priv.h
+++ b/Xext/xv/xvdix_priv.h
@@ -14,8 +14,8 @@
 
 #define VALIDATE_XV_PORT(portID, pPort, mode)\
     {\
-        int rc = dixLookupResourceByType((void **)&(pPort), portID,\
-                                         XvRTPort, client, mode);\
+        int rc = dixLookupResourceByType((void **)&(pPort), (portID),\
+                                         XvRTPort, client, (mode));\
         if (rc != Success)\
             return rc;\
     }

--- a/Xext/xv/xvmain.c
+++ b/Xext/xv/xvmain.c
@@ -105,7 +105,7 @@ SOFTWARE.
     dixLookupPrivate(&(pScreen)->devPrivates, &XvScreenKeyRec))->field)
 
 #define SCREEN_EPILOGUE(pScreen, field, wrapper)\
-    ((pScreen)->field = wrapper)
+    ((pScreen)->field = (wrapper))
 
 typedef struct _XvVideoNotifyRec {
     struct _XvVideoNotifyRec *next;
@@ -447,9 +447,9 @@ XvdiSendPortNotify(XvPortPtr pPort, Atom attribute, INT32 value)
 }
 
 #define CHECK_SIZE(dw, dh, sw, sh) {                                  \
-  if(!dw || !dh || !sw || !sh)  return Success;                       \
+  if(!(dw) || !(dh) || !(sw) || !(sh))  return Success;               \
   /* The region code will break these if they are too large */        \
-  if((dw > 32767) || (dh > 32767) || (sw > 32767) || (sh > 32767))    \
+  if(((dw) > 32767) || ((dh) > 32767) || ((sw) > 32767) || ((sh) > 32767)) \
         return BadValue;                                              \
 }
 


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
