### PR TITLE
(master) dri3: parentheses around macro argument symbols

### DIFF
--- a/Xext/dri3/dri3_priv.h
+++ b/Xext/dri3/dri3_priv.h
@@ -56,10 +56,10 @@ typedef struct dri3_screen_priv {
 
 #define VERIFY_DRI3_SYNCOBJ(id, ptr, a)\
     do {\
-        int rc = dixLookupResourceByType((void **)&(ptr), id,\
-                                         dri3_syncobj_type, client, a);\
+        int rc = dixLookupResourceByType((void **)&(ptr), (id),\
+                                         dri3_syncobj_type, client, (a));\
         if (rc != Success) {\
-            client->errorValue = id;\
+            client->errorValue = (id);\
             return rc;\
         }\
     } while (0);


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
