### PR TITLE
(master) os: parentheses around macro argument symbols

### DIFF
--- a/os/WaitFor.c
+++ b/os/WaitFor.c
@@ -391,12 +391,12 @@ TimerInit(void)
 #ifdef DPMSExtension
 
 #define DPMS_CHECK_MODE(mode,time)\
-    if (time > 0 && DPMSPowerLevel < mode && timeout >= time)\
-	DPMSSet(serverClient, mode);
+    if ((time) > 0 && DPMSPowerLevel < (mode) && timeout >= (time))\
+	DPMSSet(serverClient, (mode));
 
 #define DPMS_CHECK_TIMEOUT(time)\
-    if (time > 0 && (time - timeout) > 0)\
-	return time - timeout;
+    if ((time) > 0 && ((time) - timeout) > 0)\
+	return (time) - timeout;
 
 static CARD32
 NextDPMSTimeout(INT32 timeout)

--- a/os/Xtransutil.c
+++ b/os/Xtransutil.c
@@ -226,7 +226,7 @@ int _XSERVTransConvertAddress(int *familyp, int *addrlenp, Xtransaddr **addrp)
 
 #if !defined(S_IFLNK) && !defined(S_ISLNK)
 #undef lstat
-#define lstat(a,b) stat(a,b)
+#define lstat(a,b) stat((a),(b))
 #endif
 
 #define FAIL_IF_NOMODE  1

--- a/os/access.c
+++ b/os/access.c
@@ -190,7 +190,7 @@ Bool defeatAccessControl = FALSE;
 #define addrEqual(fam, address, length, host) \
 			 ((fam) == (host)->family &&\
 			  (length) == (host)->len &&\
-			  !memcmp (address, (host)->addr, length))
+			  !memcmp ((address), (host)->addr, (length)))
 
 static int ConvertAddr(struct sockaddr * /*saddr */ ,
                        int * /*len */ ,
@@ -221,11 +221,11 @@ typedef struct _host {
 } HOST;
 
 #define MakeHost(h,l)	(h)=calloc(1, sizeof *(h)+(l));\
-			if (h) { \
+			if ((h)) { \
 			   (h)->addr=(unsigned char *) ((h) + 1);\
 			   (h)->requested = FALSE; \
 			}
-#define FreeHost(h)	free(h)
+#define FreeHost(h)	free((h))
 static HOST *selfhosts = NULL;
 static HOST *validhosts = NULL;
 static int AccessEnabled = TRUE;
@@ -526,9 +526,9 @@ DefineSelf(int fd)
 
 #ifdef VARIABLE_IFREQ
 #define ifr_size(p) (sizeof (struct ifreq) + \
-		     (p->ifr_addr.sa_len > sizeof (p->ifr_addr) ? \
-		      p->ifr_addr.sa_len - sizeof (p->ifr_addr) : 0))
-#define ifraddr_size(a) (a.sa_len)
+		     ((p)->ifr_addr.sa_len > sizeof ((p)->ifr_addr) ? \
+		      (p)->ifr_addr.sa_len - sizeof ((p)->ifr_addr) : 0))
+#define ifraddr_size(a) ((a).sa_len)
 #else
 #define ifr_size(p) (sizeof (ifr_type))
 #define ifraddr_size(a) (sizeof (a))

--- a/os/bug_priv.h
+++ b/os/bug_priv.h
@@ -14,20 +14,20 @@
         xorg_backtrace();                                             \
     } } while(0)
 
-#define BUG_WARN_MSG(cond, ...) __BUG_WARN_MSG(cond, 1, __VA_ARGS__)
+#define BUG_WARN_MSG(cond, ...) __BUG_WARN_MSG((cond), 1, __VA_ARGS__)
 
-#define BUG_WARN(cond)  __BUG_WARN_MSG(cond, 0, NULL)
+#define BUG_WARN(cond)  __BUG_WARN_MSG((cond), 0, NULL)
 
 #define BUG_RETURN(cond) \
-    do { if (cond) { __BUG_WARN_MSG(cond, 0, NULL); return; } } while(0)
+    do { if (cond) { __BUG_WARN_MSG((cond), 0, NULL); return; } } while(0)
 
 #define BUG_RETURN_MSG(cond, ...) \
-    do { if (cond) { __BUG_WARN_MSG(cond, 1, __VA_ARGS__); return; } } while(0)
+    do { if (cond) { __BUG_WARN_MSG((cond), 1, __VA_ARGS__); return; } } while(0)
 
 #define BUG_RETURN_VAL(cond, val) \
-    do { if (cond) { __BUG_WARN_MSG(cond, 0, NULL); return (val); } } while(0)
+    do { if (cond) { __BUG_WARN_MSG((cond), 0, NULL); return (val); } } while(0)
 
 #define BUG_RETURN_VAL_MSG(cond, val, ...) \
-    do { if (cond) { __BUG_WARN_MSG(cond, 1, __VA_ARGS__); return (val); } } while(0)
+    do { if (cond) { __BUG_WARN_MSG((cond), 1, __VA_ARGS__); return (val); } } while(0)
 
 #endif /* _XSERVER_OS_BUG_H_ */

--- a/os/cmdline.h
+++ b/os/cmdline.h
@@ -8,7 +8,7 @@
 #include "include/os.h"
 
 #define CHECK_FOR_REQUIRED_ARGUMENTS(num)  \
-    do if (((i + num) >= argc) || (!argv[i + num])) {                   \
+    do if (((i + (num)) >= argc) || (!argv[i + (num)])) {                   \
         UseMsg();                                                       \
         FatalError("Required argument to %s not specified\n", argv[i]); \
     } while (0)

--- a/os/xdmauth.c
+++ b/os/xdmauth.c
@@ -115,9 +115,9 @@ XdmAuthenticationAddAuth(int name_len, const char *name,
     return ret;
 }
 
-#define atox(c)	('0' <= c && c <= '9' ? c - '0' : \
-		 'a' <= c && c <= 'f' ? c - 'a' + 10 : \
-		 'A' <= c && c <= 'F' ? c - 'A' + 10 : -1)
+#define atox(c)	('0' <= (c) && (c) <= '9' ? (c) - '0' : \
+		 'a' <= (c) && (c) <= 'f' ? (c) - 'a' + 10 : \
+		 'A' <= (c) && (c) <= 'F' ? (c) - 'A' + 10 : -1)
 
 static int
 HexToBinary(const char *in, char *out, int len)

--- a/os/xserver_poll.h
+++ b/os/xserver_poll.h
@@ -31,7 +31,7 @@
 
 #ifdef HAVE_POLL
 #include <poll.h>
-#define xserver_poll(fds, nfds, timeout) poll(fds, nfds, timeout)
+#define xserver_poll(fds, nfds, timeout) poll((fds), (nfds), (timeout))
 #else
 
 #ifdef WIN32


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
