### PR TITLE
(master) test: parentheses around macro argument symbols

### DIFF
--- a/test/input.c
+++ b/test/input.c
@@ -1826,7 +1826,7 @@ _mieq_test_generate_events(uint32_t start, uint32_t count)
     }
 }
 
-#define mieq_test_generate_events(c) { _mieq_test_generate_events(next, c); next += c; }
+#define mieq_test_generate_events(c) { _mieq_test_generate_events(next, (c)); next += (c); }
 
 static void
 mieq_test(void)

--- a/test/misc.c
+++ b/test/misc.c
@@ -93,10 +93,10 @@ dix_update_desktop_dimensions(void)
 
 #define assert_dimensions(_x, _y, _w, _h) \
     update_desktop_dimensions();          \
-    assert(screenInfo.x == _x);           \
-    assert(screenInfo.y == _y);           \
-    assert(screenInfo.width == _w);       \
-    assert(screenInfo.height == _h);
+    assert(screenInfo.x == (_x));         \
+    assert(screenInfo.y == (_y));         \
+    assert(screenInfo.width == (_w));     \
+    assert(screenInfo.height == (_h));
 
     /* single screen */
     screenInfo.numScreens = 1;

--- a/test/signal-logging.c
+++ b/test/signal-logging.c
@@ -193,12 +193,12 @@ static void logging_format(void)
     free(fname);
 
 #define read_log_msg(msg) do {                                  \
-        msg = fgets(read_buf, sizeof(read_buf), f);             \
-        assert(msg != NULL);                                   \
-        msg = strchr(read_buf, ']');                            \
-        assert(msg != NULL);                                    \
-        assert(strlen(msg) > 2);                                \
-        msg = msg + 2; /* advance past [time.stamp] */          \
+        (msg) = fgets(read_buf, sizeof(read_buf), f);           \
+        assert((msg) != NULL);                                  \
+        (msg) = strchr(read_buf, ']');                          \
+        assert((msg) != NULL);                                  \
+        assert(strlen((msg)) > 2);                              \
+        (msg) = (msg) + 2; /* advance past [time.stamp] */      \
     } while (0)
 
     /* boring test message */


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
