### PR TITLE
(master) kdrive: parentheses around macro argument symbols

### DIFF
--- a/hw/kdrive/fbdev/fbdev.c
+++ b/hw/kdrive/fbdev/fbdev.c
@@ -374,7 +374,7 @@ fbdevScreenInitialize(KdScreenInfo * screen, FbdevScrPriv * scrpriv)
     case FB_VISUAL_TRUECOLOR:
     case FB_VISUAL_DIRECTCOLOR:
         screen->fb.visuals = (1 << TrueColor);
-#define Mask(o,l)   (((1 << l) - 1) << o)
+#define Mask(o,l)   (((1 << (l)) - 1) << (o))
         screen->fb.redMask = Mask (priv->var.red.offset, priv->var.red.length);
         screen->fb.greenMask =
             Mask (priv->var.green.offset, priv->var.green.length);

--- a/hw/kdrive/linux/evdev/evdev.c
+++ b/hw/kdrive/linux/evdev/evdev.c
@@ -35,10 +35,10 @@
 
 #define BITS_PER_LONG (sizeof(long) * 8)
 #define NBITS(x) ((((x)-1)/BITS_PER_LONG)+1)
-#define ISBITSET(x,y) ((x)[LONG(y)] & BIT(y))
+#define ISBITSET(x,y) ((x)[LONG((y))] & BIT((y)))
 #define OFF(x)   ((x)%BITS_PER_LONG)
 #define LONG(x)  ((x)/BITS_PER_LONG)
-#define BIT(x)         (1 << OFF(x))
+#define BIT(x)         (1 << OFF((x)))
 
 typedef struct _kevdev {
     /* current device state */

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -348,8 +348,8 @@ extern const KdOsFuncs *kdOsFuncs;
 #define KdGetScreenPriv(pScreen) ((KdPrivScreenPtr) \
     dixLookupPrivate(&(pScreen)->devPrivates, kdScreenPrivateKey))
 #define KdSetScreenPriv(pScreen,v) \
-    dixSetPrivate(&(pScreen)->devPrivates, kdScreenPrivateKey, v)
-#define KdScreenPriv(pScreen) KdPrivScreenPtr pScreenPriv = KdGetScreenPriv(pScreen)
+    dixSetPrivate(&(pScreen)->devPrivates, kdScreenPrivateKey, (v))
+#define KdScreenPriv(pScreen) KdPrivScreenPtr pScreenPriv = KdGetScreenPriv((pScreen))
 
 /* kcmap.c */
 void

--- a/hw/kdrive/src/kinput.c
+++ b/hw/kdrive/src/kinput.c
@@ -65,7 +65,7 @@
 #define DEV_INPUT_EVENT_PREFIX_LEN (sizeof(DEV_INPUT_EVENT_PREFIX) - 1)
 #endif
 
-#define AtomFromName(x) MakeAtom(x, strlen(x), 1)
+#define AtomFromName(x) MakeAtom((x), strlen((x)), 1)
 
 #define KD_KEY_COUNT    248
 #define KD_MIN_KEYCODE  8
@@ -2120,7 +2120,7 @@ KdWakeupHandler(ScreenPtr pScreen, int result)
         KdProcessSwitch();
 }
 
-#define KdScreenOrigin(pScreen) (&(KdGetScreenPriv(pScreen)->screen->origin))
+#define KdScreenOrigin(pScreen) (&(KdGetScreenPriv((pScreen))->screen->origin))
 
 static Bool
 KdCursorOffScreen(ScreenPtr *ppScreen, int *x, int *y)

--- a/hw/kdrive/src/kxv.c
+++ b/hw/kdrive/src/kxv.c
@@ -106,7 +106,7 @@ static unsigned long PortResource = 0;
     dixLookupPrivate(&(pScreen)->devPrivates, KdXvScreenKey))
 
 #define GET_KDXV_SCREEN(pScreen) \
-    ((KdXVScreenPtr)(dixGetPrivate(&pScreen->devPrivates, &KdXVScreenPrivateKey)))
+    ((KdXVScreenPtr)(dixGetPrivate(&(pScreen)->devPrivates, &KdXVScreenPrivateKey)))
 
 #define GET_KDXV_WINDOW(pWin) ((KdXVWindowPtr) \
     dixLookupPrivate(&(pWin)->devPrivates, KdXVWindowKey))


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
