### PR TITLE
(master) xquartz: parentheses around macro argument symbols

### DIFF
--- a/hw/xquartz/GL/capabilities.c
+++ b/hw/xquartz/GL/capabilities.c
@@ -321,8 +321,8 @@ handleDepthModes(struct glCapabilitiesConfig *c, GLint dmodes)
 {
     int offset = 0;
 #define DEPTH(flag, value) do { \
-        if (dmodes & flag) { \
-            c->depth_buffers[offset++] = value; \
+        if (dmodes & (flag)) { \
+            c->depth_buffers[offset++] = (value); \
         } \
 } while (0)
 

--- a/hw/xquartz/GL/indirect.c
+++ b/hw/xquartz/GL/indirect.c
@@ -52,7 +52,7 @@
 
 #include "darwin.h"
 #define GLAQUA_DEBUG_MSG(msg, args ...) ASL_LOG(ASL_LEVEL_DEBUG, "GLXAqua", \
-                                                msg, \
+                                                (msg), \
                                                 ## args)
 
 __GLXprovider *

--- a/hw/xquartz/applewm.c
+++ b/hw/xquartz/applewm.c
@@ -59,8 +59,8 @@
 #include "protocol-versions.h"
 
 #define DEFINE_ATOM_HELPER(func, atom_name)                      \
-    static Atom func(void) {                                       \
-        return dixAddAtom(atom_name);                           \
+    static Atom (func)(void) {                                   \
+        return dixAddAtom((atom_name));                          \
     }
 
 DEFINE_ATOM_HELPER(xa_native_screen_origin, "_NATIVE_SCREEN_ORIGIN")

--- a/hw/xquartz/darwin.h
+++ b/hw/xquartz/darwin.h
@@ -46,7 +46,7 @@ DarwinParseModifierList(const char *constmodifiers, int separatelr);
 void DarwinAdjustScreenOrigins(void);
 
 #define SCREEN_PRIV(pScreen) ((DarwinFramebufferPtr) \
-                              dixLookupPrivate(&pScreen->devPrivates, \
+                              dixLookupPrivate(&(pScreen)->devPrivates, \
                                                darwinScreenKey))
 
 /*
@@ -87,13 +87,13 @@ xq_asl_log(int level, const char *subsystem, const char *file,
            const char *function, int line, const char *fmt,
            ...);
 
-#define ASL_LOG(level, subsystem, msg, args ...) xq_asl_log(level, subsystem, \
+#define ASL_LOG(level, subsystem, msg, args ...) xq_asl_log((level), (subsystem), \
                                                             __FILE__, \
                                                             __func__, \
-                                                            __LINE__, msg, \
+                                                            __LINE__, (msg), \
                                                             ## args)
 #define DEBUG_LOG(msg, args ...)                 ASL_LOG(ASL_LEVEL_DEBUG, \
-                                                         "XQuartz", msg, \
+                                                         "XQuartz", (msg), \
                                                          ## args)
 #define TRACE()                                  DEBUG_LOG("TRACE")
 

--- a/hw/xquartz/darwinfb.h
+++ b/hw/xquartz/darwinfb.h
@@ -49,7 +49,7 @@ typedef struct {
 
 #define MASK_LH(l, h)       (((1 << (1 + (h) - (l))) - 1) << (l))
 #define BM_ARGB(a, r, g, b) MASK_LH(0, (b) - 1)
-#define GM_ARGB(a, r, g, b) MASK_LH(b, (b) + (g) - 1)
+#define GM_ARGB(a, r, g, b) MASK_LH((b), (b) + (g) - 1)
 #define RM_ARGB(a, r, g, b) MASK_LH((b) + (g), (b) + (g) + (r) - 1)
 #define AM_ARGB(a, r, g, b) MASK_LH((b) + (g) + (r), \
                                     (b) + (g) + (r) + (a) - 1)

--- a/hw/xquartz/mach-startup/bundle-main.c
+++ b/hw/xquartz/mach-startup/bundle-main.c
@@ -82,9 +82,6 @@ extern Bool noCompositeExtension;
 #define DEFAULT_STARTX X11BINDIR "/startx -- " X11BINDIR "/Xquartz"
 #define DEFAULT_SHELL  "/bin/sh"
 
-#define _STRINGIZE(s) #s
-#define STRINGIZE(s) _STRINGIZE(s)
-
 #ifndef XSERVER_VERSION
 #define XSERVER_VERSION "?"
 #endif

--- a/hw/xquartz/pbproxy/pbproxy.h
+++ b/hw/xquartz/pbproxy/pbproxy.h
@@ -87,13 +87,13 @@ xq_asl_log(int level, const char *subsystem, const char *file,
            const char *function, int line, const char *fmt,
            ...);
 
-#define ASL_LOG(level, subsystem, msg, args ...) xq_asl_log(level, subsystem, \
+#define ASL_LOG(level, subsystem, msg, args ...) xq_asl_log((level), (subsystem), \
                                                             __FILE__, \
                                                             __func__, \
-                                                            __LINE__, msg, \
+                                                            __LINE__, (msg), \
                                                             ## args)
 #define DebugF(msg, args ...)                    ASL_LOG(ASL_LEVEL_DEBUG, \
-                                                         "xpbproxy", msg, \
+                                                         "xpbproxy", (msg), \
                                                          ## args)
 #define TRACE()                                  DebugF("TRACE")
 

--- a/hw/xquartz/quartzRandR.h
+++ b/hw/xquartz/quartzRandR.h
@@ -52,7 +52,7 @@ typedef struct {
 } QuartzScreenRec, *QuartzScreenPtr;
 
 #define QUARTZ_PRIV(pScreen) \
-    ((QuartzScreenPtr)dixLookupPrivate(&pScreen->devPrivates, quartzScreenKey))
+    ((QuartzScreenPtr)dixLookupPrivate(&(pScreen)->devPrivates, quartzScreenKey))
 
 void
 QuartzCopyDisplayIDs(ScreenPtr pScreen, int displayCount,

--- a/hw/xquartz/xpr/driWrap.c
+++ b/hw/xquartz/xpr/driWrap.c
@@ -65,12 +65,12 @@ static DevPrivateKeyRec driWrapScreenKeyRec;
 static GCOps driGCOps;
 
 #define wrap(priv, real, member, func) { \
-        priv->member = real->member; \
-        real->member = func; \
+        (priv)->member = (real)->member; \
+        (real)->member = (func); \
 }
 
 #define unwrap(priv, real, member)     { \
-        real->member = priv->member; \
+        (real)->member = (priv)->member; \
 }
 
 static DRIGCRec *

--- a/hw/xquartz/xpr/dristruct.h
+++ b/hw/xquartz/xpr/dristruct.h
@@ -69,7 +69,7 @@ typedef struct _DRIDrawablePrivRec {
 #define DRI_SCREEN_PRIV_FROM_INDEX(screenIndex) ((DRIScreenPrivPtr) \
                                                  dixLookupPrivate(&screenInfo \
                                                                   .screens[ \
-                                                                      screenIndex \
+                                                                      (screenIndex) \
                                                                   ]-> \
                                                                   devPrivates, \
                                                                   DRIScreenPrivKey))

--- a/hw/xquartz/xpr/x-hash.c
+++ b/hw/xquartz/xpr/x-hash.c
@@ -48,7 +48,7 @@ struct x_hash_table_struct {
     x_destroy_fun *destroy_value;
 };
 
-#define ITEM_NEW(k, v) X_PFX(list_prepend) ((x_list *)(k), v)
+#define ITEM_NEW(k, v) X_PFX(list_prepend) ((x_list *)(k), (v))
 #define ITEM_FREE(i)   X_PFX(list_free_1) (i)
 #define ITEM_KEY(i)    ((void *)(i)->next)
 #define ITEM_VALUE(i)  ((i)->data)

--- a/hw/xquartz/xpr/xpr.h
+++ b/hw/xquartz/xpr/xpr.h
@@ -37,7 +37,7 @@
 #include "darwin.h"
 
 #undef DEBUG_LOG
-#define DEBUG_LOG(msg, args ...) ASL_LOG(ASL_LEVEL_DEBUG, "xpr", msg, ## args)
+#define DEBUG_LOG(msg, args ...) ASL_LOG(ASL_LEVEL_DEBUG, "xpr", (msg), ## args)
 
 Bool
 QuartzModeBundleInit(void);

--- a/hw/xquartz/xpr/xprCursor.c
+++ b/hw/xquartz/xpr/xprCursor.c
@@ -60,7 +60,7 @@ static DevPrivateKeyRec darwinCursorScreenKeyRec;
 #define darwinCursorScreenKey (&darwinCursorScreenKeyRec)
 
 #define CURSOR_PRIV(pScreen) ((QuartzCursorScreenPtr) \
-                              dixLookupPrivate(&pScreen->devPrivates, \
+                              dixLookupPrivate(&(pScreen)->devPrivates, \
                                                darwinCursorScreenKey))
 
 static Bool

--- a/hw/xquartz/xpr/xprFrame.c
+++ b/hw/xquartz/xpr/xprFrame.c
@@ -54,8 +54,8 @@
 #endif
 
 #define DEFINE_ATOM_HELPER(func, atom_name)                      \
-    static Atom func(void) {                                       \
-        return dixAddAtom(atom_name);                           \
+    static Atom (func)(void) {                                   \
+        return dixAddAtom((atom_name));                          \
     }
 
 DEFINE_ATOM_HELPER(xa_native_window_id, "_NATIVE_WINDOW_ID")


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
