### PR TITLE
(master) xnest: parentheses around macro argument symbols

### DIFF
--- a/hw/xnest/Color.c
+++ b/hw/xnest/Color.c
@@ -45,7 +45,7 @@ static DevPrivateKeyRec cmapScrPrivateKeyRec;
 #define cmapScrPrivateKey (&cmapScrPrivateKeyRec)
 
 #define GetInstalledColormap(s) ((ColormapPtr) dixLookupPrivate(&(s)->devPrivates, cmapScrPrivateKey))
-#define SetInstalledColormap(s,c) (dixSetPrivate(&(s)->devPrivates, cmapScrPrivateKey, c))
+#define SetInstalledColormap(s,c) (dixSetPrivate(&(s)->devPrivates, cmapScrPrivateKey, (c)))
 
 static Bool load_colormap(ColormapPtr pCmap, int ncolors, uint32_t *colors)
 {

--- a/hw/xnest/Color.h
+++ b/hw/xnest/Color.h
@@ -42,7 +42,7 @@ extern DevPrivateKeyRec xnestColormapPrivateKeyRec;
 #define xnestColormapPriv(pCmap) \
   ((xnestPrivColormap *) dixLookupPrivate(&(pCmap)->devPrivates, &xnestColormapPrivateKeyRec))
 
-#define xnestColormap(pCmap) (xnestColormapPriv(pCmap)->colormap)
+#define xnestColormap(pCmap) (xnestColormapPriv((pCmap))->colormap)
 
 #define xnestPixel(pixel) (pixel)
 

--- a/hw/xnest/Drawable.h
+++ b/hw/xnest/Drawable.h
@@ -20,7 +20,7 @@ is" without express or implied warranty.
 
 #define xnestDrawable(pDrawable) \
   (WindowDrawable((pDrawable)->type) ?	\
-   xnestWindow((WindowPtr)pDrawable) : \
-   xnestPixmap((PixmapPtr)pDrawable))
+   xnestWindow((WindowPtr)(pDrawable)) : \
+   xnestPixmap((PixmapPtr)(pDrawable)))
 
 #endif                          /* XNESTDRAWABLE_H */

--- a/hw/xnest/XNCursor.h
+++ b/hw/xnest/XNCursor.h
@@ -37,14 +37,14 @@ extern DevScreenPrivateKeyRec xnestScreenCursorPrivKeyRec;
 
 #define xnestGetCursorPriv(pCursor, pScreen) ((xnestPrivCursor *) \
     dixLookupScreenPrivate(&(pCursor)->devPrivates, \
-                           &xnestScreenCursorPrivKeyRec, pScreen))
+                           &xnestScreenCursorPrivKeyRec, (pScreen)))
 
 #define xnestSetCursorPriv(pCursor, pScreen, v) \
     dixSetScreenPrivate(&(pCursor)->devPrivates, \
-                        &xnestScreenCursorPrivKeyRec, pScreen, v)
+                        &xnestScreenCursorPrivKeyRec, (pScreen), (v))
 
 #define xnestCursor(pCursor, pScreen) \
-  (xnestGetCursorPriv(pCursor, pScreen)->cursor)
+  (xnestGetCursorPriv((pCursor), (pScreen))->cursor)
 
 Bool xnestRealizeCursor(DeviceIntPtr pDev,
                         ScreenPtr pScreen, CursorPtr pCursor);

--- a/hw/xnest/XNFont.h
+++ b/hw/xnest/XNFont.h
@@ -22,7 +22,7 @@ is" without express or implied warranty.
 extern int xnestFontPrivateIndex;
 
 #define xnestFontPriv(pFont) \
-  ((xnestPrivFont *)FontGetPrivate(pFont, xnestFontPrivateIndex))
+  ((xnestPrivFont *)FontGetPrivate((pFont), xnestFontPrivateIndex))
 
 Bool xnestRealizeFont(ScreenPtr pScreen, FontPtr pFont);
 Bool xnestUnrealizeFont(ScreenPtr pScreen, FontPtr pFont);

--- a/hw/xnest/XNGC.h
+++ b/hw/xnest/XNGC.h
@@ -31,7 +31,7 @@ extern DevPrivateKeyRec xnestGCPrivateKeyRec;
 #define xnestGCPriv(pGC) ((xnestPrivGC *) \
     dixLookupPrivate(&(pGC)->devPrivates, xnestGCPrivateKey))
 
-#define xnestGC(pGC) (xnestGCPriv(pGC)->gc)
+#define xnestGC(pGC) (xnestGCPriv((pGC))->gc)
 
 Bool xnestCreateGC(GCPtr pGC);
 void xnestValidateGC(GCPtr pGC, unsigned long changes, DrawablePtr pDrawable);

--- a/hw/xnest/XNPixmap.h
+++ b/hw/xnest/XNPixmap.h
@@ -28,7 +28,7 @@ typedef struct {
 #define xnestPixmapPriv(pPixmap) ((xnestPrivPixmap *) \
     dixLookupPrivate(&(pPixmap)->devPrivates, xnestPixmapPrivateKey))
 
-#define xnestPixmap(pPixmap) (xnestPixmapPriv(pPixmap)->pixmap)
+#define xnestPixmap(pPixmap) (xnestPixmapPriv((pPixmap))->pixmap)
 
 #define xnestSharePixmap(pPixmap) ((pPixmap)->refcnt++)
 

--- a/hw/xnest/XNWindow.h
+++ b/hw/xnest/XNWindow.h
@@ -43,12 +43,12 @@ extern DevPrivateKeyRec xnestWindowPrivateKeyRec;
 #define xnestWindowPriv(pWin) ((xnestPrivWin *) \
     dixLookupPrivate(&(pWin)->devPrivates, xnestWindowPrivateKey))
 
-#define xnestWindow(pWin) (xnestWindowPriv(pWin)->window)
+#define xnestWindow(pWin) (xnestWindowPriv((pWin))->window)
 
 #define xnestWindowParent(pWin) \
   ((pWin)->parent ? \
    xnestWindow((pWin)->parent) : \
-   xnestDefaultWindows[pWin->drawable.pScreen->myNum])
+   xnestDefaultWindows[(pWin)->drawable.pScreen->myNum])
 
 #define xnestWindowSiblingAbove(pWin) \
   ((pWin)->prevSib ? xnestWindow((pWin)->prevSib) : XCB_WINDOW_NONE)

--- a/hw/xnest/xcb.c
+++ b/hw/xnest/xcb.c
@@ -495,9 +495,9 @@ do { \
 
 #define XN_CI_GET_DEFAULT_INFO_2D(font,cs) \
 do { \
-    unsigned int r = (font->font_reply->default_char >> 8); \
-    unsigned int c = (font->font_reply->default_char & 0xff); \
-    XN_CI_GET_CHAR_INFO_2D (font, r, c, NULL, cs); \
+    unsigned int r = ((font)->font_reply->default_char >> 8); \
+    unsigned int c = ((font)->font_reply->default_char & 0xff); \
+    XN_CI_GET_CHAR_INFO_2D ((font), r, c, NULL, (cs)); \
 } while (0)
 
 #define XN_CI_GET_ROWZERO_CHAR_INFO_2D(font,col,def,cs) \


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
