### PR TITLE
(master) xvfb: parentheses around macro argument symbols

### DIFF
--- a/hw/vfb/InitOutput.c
+++ b/hw/vfb/InitOutput.c
@@ -161,12 +161,12 @@ static char *render_node = NULL;
 #endif
 
 #define swapcopy16(_dst, _src) \
-    if (needswap) { CARD16 _s = _src; cpswaps(_s, _dst); } \
-    else _dst = _src;
+    if (needswap) { CARD16 _s = (_src); cpswaps(_s, (_dst)); } \
+    else (_dst) = (_src);
 
 #define swapcopy32(_dst, _src) \
-    if (needswap) { CARD32 _s = _src; cpswapl(_s, _dst); } \
-    else _dst = _src;
+    if (needswap) { CARD32 _s = (_src); cpswapl(_s, (_dst)); } \
+    else (_dst) = (_src);
 
 static void
 vfbAddCrtcInfo(vfbScreenInfoPtr screen, int numCrtcs)


### PR DESCRIPTION
For safety, add extra parantheses on each used macro argument.
In most cases not strictly necessary, but better have some strict
and automatically enforcable policy here than wasting time on
judging individual cases.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
