### PR TITLE
(master) xquartz: osxcompat.h: guard HAS_LIBDISPATCH to avoid -Wmacro-redefined

### DIFF
--- a/hw/xquartz/osxcompat.h
+++ b/hw/xquartz/osxcompat.h
@@ -31,7 +31,9 @@
 #include <AvailabilityMacros.h>
 
 #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
+#ifndef HAS_LIBDISPATCH
 #define HAS_LIBDISPATCH
+#endif
 #endif
 
 #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1080


### PR DESCRIPTION
The header defines HAS_LIBDISPATCH (empty value) while the build system
passes -DHAS_LIBDISPATCH on the command line, which Clang expands to

Add an #ifndef guard and explicit value so both definitions agree.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
