### PR TITLE
(master) xquartz: remove unused variable 'i' in QuartzHide()

### DIFF
--- a/hw/xquartz/quartz.c
+++ b/hw/xquartz/quartz.c
@@ -471,8 +471,6 @@ QuartzShow(void)
 void
 QuartzHide(void)
 {
-    int i;
-
     if (XQuartzServerVisible) {
         DIX_FOR_EACH_SCREEN({ quartzProcs->SuspendScreen(walkScreen); });
     }


### PR DESCRIPTION
The variable 'i' was left over from before the DIX_FOR_EACH_SCREEN()
macro replaced the manual loop. Remove it to fix -Wunused-variable.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
