### PR TITLE
(master) .github: switch arch build job to callmetango's archlinux-build-package-action

### DIFF
--- a/.github/arch/PKGBUILD
+++ b/.github/arch/PKGBUILD
@@ -29,9 +29,7 @@ export _builddir="${_sourcedir}/build"    # temporary build directory for meson
 export _pkgsrc="$(pwd)"                   # directory of PKGBUILD file
 
 pkgver() {
-    (
-        cat ../GIT_VERSION
-    )
+    cat "${_sourcedir}/.github/arch/GIT_VERSION"
 }
 
 build() {

--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -423,21 +423,15 @@ jobs:
 
     xserver-build-arch:
         runs-on: ubuntu-latest
-        container:
-            image: archlinux
-            options: --privileged
         steps:
-          - run:  pacman -Sy --noconfirm git
           - uses: actions/checkout@v6
             with: # needed for `git describe` to work
                 fetch-tags: true
                 fetch-depth: 0
-          - name: disable git safe.directory for running in chroot
-            run:  git config --global --add safe.directory '*'
           - name: determine pkg version from git
             run:  git describe | sed -e 's~^xlibre-xserver-~~; s~-[0-9a-z]*$~~' | tr '-' '.' > .github/arch/GIT_VERSION
           - name: build arch package
-            uses: metux/archlinux-build-package-action@HEAD
+            uses: callmetango/archlinux-build-package-action@v0.6.0
             with:
                 path: .github/arch
                 makepkg-opts: -cfse --noconfirm


### PR DESCRIPTION
My onwn fork isn't needed anymore, switch to upstream.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
