### PR TITLE
kdrive/fbdev: Plug modesetting support into randr

### DIFF
--- a/hw/kdrive/ephyr/ephyr.c
+++ b/hw/kdrive/ephyr/ephyr.c
@@ -418,6 +418,9 @@ ephyrRandRGetInfo(ScreenPtr pScreen, Rotation * rotations)
     Rotation randr;
     int n = 0;
 
+    /* Dummy refresh rate so that new proton (>= 8) works */
+    int rate = 60;
+
     struct {
         int width, height;
     } sizes[] = {
@@ -446,12 +449,13 @@ ephyrRandRGetInfo(ScreenPtr pScreen, Rotation * rotations)
     if (!hostx_want_preexisting_window(screen)
         && !hostx_want_fullscreen()) {  /* only if no -parent switch */
         while (sizes[n].width != 0 && sizes[n].height != 0) {
-            RRRegisterSize(pScreen,
-                           sizes[n].width,
-                           sizes[n].height,
-                           (sizes[n].width * screen->width_mm) / screen->width,
-                           (sizes[n].height * screen->height_mm) /
-                           screen->height);
+            pSize = RRRegisterSize(pScreen,
+                                   sizes[n].width,
+                                   sizes[n].height,
+                                   (sizes[n].width * screen->width_mm) / screen->width,
+                                   (sizes[n].height * screen->height_mm) /
+                                   screen->height);
+            RRRegisterRate(pScreen, pSize, rate);
             n++;
         }
     }
@@ -462,7 +466,8 @@ ephyrRandRGetInfo(ScreenPtr pScreen, Rotation * rotations)
 
     randr = KdSubRotation(scrpriv->randr, screen->randr);
 
-    RRSetCurrentConfig(pScreen, randr, 0, pSize);
+    RRRegisterRate(pScreen, pSize, rate);
+    RRSetCurrentConfig(pScreen, randr, rate, pSize);
 
     return TRUE;
 }

--- a/hw/kdrive/fbdev/fbdev.c
+++ b/hw/kdrive/fbdev/fbdev.c
@@ -526,6 +526,20 @@ fbdevSetScreenSizes(ScreenPtr pScreen)
     }
 }
 
+static void
+fbdevClearFramebuffer(KdScreenInfo * screen)
+{
+#if 0 /* XXX Does not work reliably XXX */
+    FbdevPriv *priv = screen->card->driver;
+    memset(priv->fb_base, 0, priv->fix.smem_len);
+    volatile char *clear_me = (volatile char*)priv->fb_base;
+    for (int i = 0; i < priv->fix.smem_len; i++, clear_me[i] = 0);
+#else
+    kdOsFuncs->Disable();
+    kdOsFuncs->Enable();
+#endif
+}
+
 static Bool
 fbdevUnmapFramebuffer(KdScreenInfo * screen)
 {
@@ -640,12 +654,26 @@ fbdevSetShadow(ScreenPtr pScreen)
 
 #ifdef RANDR
 static Bool
+fbdevRandrModeSupported(ScreenPtr pScreen, const KdMonitorTiming *t)
+{
+    KdScreenPriv(pScreen);
+    KdScreenInfo *screen = pScreenPriv->screen;
+
+    return (t->horizontal <= screen->width) && (t->vertical <= screen->height);
+}
+
+static Bool
+fbdevRandrModeChangeSupported(ScreenPtr pScreen, const KdMonitorTiming *t)
+{
+    return TRUE;
+}
+
+static Bool
 fbdevRandRGetInfo(ScreenPtr pScreen, Rotation * rotations)
 {
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     FbdevScrPriv *scrpriv = screen->driver;
-    RRScreenSizePtr pSize;
     Rotation randr;
     int n;
 
@@ -657,15 +685,9 @@ fbdevRandRGetInfo(ScreenPtr pScreen, Rotation * rotations)
     if (n == pScreen->numDepths)
         return FALSE;
 
-    pSize = RRRegisterSize(pScreen,
-                           screen->width,
-                           screen->height, screen->width_mm, screen->height_mm);
-
     randr = KdSubRotation(scrpriv->randr, screen->randr);
 
-    RRSetCurrentConfig(pScreen, randr, 0, pSize);
-
-    return TRUE;
+    return KdRandRGetInfo(pScreen, randr, fbdevRandrModeSupported);
 }
 
 static Bool
@@ -677,6 +699,7 @@ fbdevRandRSetConfig(ScreenPtr pScreen,
     FbdevScrPriv *scrpriv = screen->driver;
     Bool wasEnabled = pScreenPriv->enabled;
     FbdevScrPriv oldscr;
+    const KdMonitorTiming *t;
     int oldwidth;
     int oldheight;
     int oldmmwidth;
@@ -718,6 +741,11 @@ fbdevRandRSetConfig(ScreenPtr pScreen,
 
     fbdevUnmapFramebuffer(screen);
 
+    t = KdRandRGetTiming(pScreen, fbdevRandrModeChangeSupported, rate, pSize);
+
+    if (!t || !fbdevSetMode(screen, t))
+        goto bail4;
+
     if (!fbdevMapFramebuffer(screen))
         goto bail4;
 
@@ -742,8 +770,11 @@ fbdevRandRSetConfig(ScreenPtr pScreen,
     /* set the subpixel order */
 
     KdSetSubpixelOrder(pScreen, scrpriv->randr);
-    if (wasEnabled)
+
+    if (wasEnabled) {
         KdEnableScreen(pScreen);
+        fbdevClearFramebuffer(screen);
+    }
 
     return TRUE;
 

--- a/hw/kdrive/fbdev/fbdev.c
+++ b/hw/kdrive/fbdev/fbdev.c
@@ -147,6 +147,31 @@ fbdevModeSupported(KdScreenInfo * screen, const KdMonitorTiming * t)
     return TRUE;
 }
 
+static int
+fbdevGetRefreshRate(const struct fb_var_screeninfo *var)
+{
+#define PICOS2HZ(a) (1.0e12/(a))
+    long scanline = var->left_margin + var->xres + var->right_margin + var->hsync_len;
+    long v_total = var->upper_margin + var->yres + var->lower_margin + var->vsync_len;
+    long vblank = v_total * scanline * var->pixclock;
+
+    long rate = vblank ? PICOS2HZ(vblank) : -1;
+
+    /* Make sure the rate is reasonable */
+    if (rate > 0 && rate <= 1000) {
+        return rate;
+    }
+
+    /**
+     * We could probe the refresh rate by doing FBIO_WAITFORVSYNC,
+     * measuring the time between them, and matching that to a list of common rates.
+     * However, if the rate reported by the driver is wrong, the driver probably doesn't care about
+     * refresh rates.
+     */
+    return 103;
+#undef PICOS2HZ
+}
+
 static void
 fbdevConvertMonitorTiming(const KdMonitorTiming * t,
                           struct fb_var_screeninfo *var)
@@ -177,14 +202,90 @@ fbdevConvertMonitorTiming(const KdMonitorTiming * t,
 }
 
 static Bool
+fbdevSetMode(KdScreenInfo *screen, const KdMonitorTiming *t)
+{
+    FbdevPriv *priv = screen->card->driver;
+    struct fb_var_screeninfo var = {0};
+    int depth;
+    int k;
+
+    k = ioctl(priv->fd, FBIOGET_VSCREENINFO, &var);
+
+    screen->rate = t->rate;
+    screen->width = t->horizontal;
+    screen->height = t->vertical;
+
+    if (k < 0 || (t->horizontal != var.xres) || (t->vertical != var.yres)) {
+        fbdevConvertMonitorTiming(t, &var);
+    }
+
+    var.activate = FB_ACTIVATE_NOW;
+    var.bits_per_pixel = screen->fb.depth;
+    var.nonstd = 0;
+    var.grayscale = 0;
+
+    k = ioctl(priv->fd, FBIOPUT_VSCREENINFO, &var);
+    if (k < 0) {
+        LogMessage(X_ERROR, "Xfbdev(%d): FBIOPUT_VSCREENINFO: %s\n",
+                   screen->card->mynum, strerror(errno));
+    }
+
+    /* Re-get the "fixed" parameters since they might have changed */
+    k = ioctl(priv->fd, FBIOGET_FSCREENINFO, &priv->fix);
+    if (k < 0) {
+        LogMessage(X_ERROR, "Xfbdev(%d): FBIOGET_FSCREENINFO: %s\n",
+                   screen->card->mynum, strerror(errno));
+    }
+
+    /* Now get the new screeninfo */
+    k = ioctl(priv->fd, FBIOGET_VSCREENINFO, &priv->var);
+    if (k >= 0) {
+        /* Just because the ioctl didn't fail, it doesn't mean we could set the mode */
+        LogMessage(X_INFO, "Xfbdev(%d): Current screen mode: width = %d, height = %d\n",
+                   screen->card->mynum, priv->var.xres, priv->var.yres);
+    }
+
+    depth = priv->var.bits_per_pixel;
+
+    /* Calculate fix.line_length if it's zero */
+    if (!priv->fix.line_length)
+        priv->fix.line_length = (priv->var.xres_virtual * depth + 7) / 8;
+
+    return (k >= 0) && (t->horizontal == priv->var.xres) && (t->vertical == var.yres);
+}
+
+static void
+fbdevConvertVarToTiming(const struct fb_var_screeninfo *var,
+                        KdMonitorTiming * t)
+{
+
+    t->horizontal = var->xres;
+    t->vertical = var->yres;
+    t->clock = var->pixclock ? 1000000000 / var->pixclock : 0;
+    t->hbp = var->left_margin;
+    t->hfp = var->right_margin;
+    t->vbp = var->upper_margin;
+    t->vfp = var->lower_margin;
+    t->hblank = var->hsync_len + t->hfp + t->hbp;
+    t->vblank = var->vsync_len + t->vfp + t->vbp;
+
+    t->rate = fbdevGetRefreshRate(var);
+
+    t->hpol = (var->sync & FB_SYNC_HOR_HIGH_ACT) ? KdSyncPositive : KdSyncNegative;
+    t->vpol = (var->sync & FB_SYNC_VERT_HIGH_ACT) ? KdSyncPositive : KdSyncNegative;
+}
+
+static Bool
 fbdevScreenInitialize(KdScreenInfo * screen, FbdevScrPriv * scrpriv)
 {
     FbdevPriv *priv = screen->card->driver;
     Pixel allbits;
     int depth;
+    int rate;
     Bool gray;
     struct fb_var_screeninfo var;
     const KdMonitorTiming *t;
+    KdMonitorTiming curr_mode = {0};
     int k;
 
     k = ioctl(priv->fd, FBIOGET_VSCREENINFO, &var);
@@ -193,12 +294,15 @@ fbdevScreenInitialize(KdScreenInfo * screen, FbdevScrPriv * scrpriv)
         if (k >= 0) {
             screen->width = var.xres;
             screen->height = var.yres;
-        }
-        else {
+            screen->rate = fbdevGetRefreshRate(&var);
+        } else {
             screen->width = 1024;
             screen->height = 768;
+            screen->rate = 103;
         }
-        screen->rate = 103;     /* FIXME: should get proper value from fb driver */
+    }
+    if (!screen->rate) {
+        screen->rate = (k >= 0) ? fbdevGetRefreshRate(&var) : 103;
     }
     if (!screen->fb.depth) {
         if (k >= 0)
@@ -207,51 +311,31 @@ fbdevScreenInitialize(KdScreenInfo * screen, FbdevScrPriv * scrpriv)
             screen->fb.depth = 16;
     }
 
-    if ((screen->width != var.xres) || (screen->height != var.yres)) {
-        t = KdFindMode(screen, fbdevModeSupported);
-        screen->rate = t->rate;
-        screen->width = t->horizontal;
-        screen->height = t->vertical;
-
-        /* Now try setting the mode */
-        if (k < 0 || (t->horizontal != var.xres || t->vertical != var.yres))
-            fbdevConvertMonitorTiming(t, &var);
+    rate = KdFindRate(screen, fbdevModeSupported);
+    if (k >= 0) {
+        /* Add the current framebuffer mode */
+        fbdevConvertVarToTiming(&var, &curr_mode);
+        KdAddMode(&curr_mode);
+        if (!rate) {
+            /* Add the desired framebuffer mode */
+            curr_mode.horizontal = screen->width;
+            curr_mode.vertical = screen->height;
+            KdAddMode(&curr_mode);
+        }
     }
 
-    var.activate = FB_ACTIVATE_NOW;
-    var.bits_per_pixel = screen->fb.depth;
-    var.nonstd = 0;
-    var.grayscale = 0;
-
-    LogMessage(X_INFO, "Xfbdev(%d): Desired screen mode: width = %d, height = %d\n",
-               screen->card->mynum, var.xres, var.yres);
-
-    k = ioctl(priv->fd, FBIOPUT_VSCREENINFO, &var);
-
-    if (k < 0) {
-        LogMessage(X_ERROR, "Xfbdev(%d): FBIOPUT_VSCREENINFO: %s\n",
-                   screen->card->mynum, strerror(errno));
-        return FALSE;
+    /* Fbdev rate isn't reliable, don't forbid modes based on it */
+    if (screen->rate < rate) {
+        screen->rate = rate;
     }
 
-    /* Re-get the "fixed" parameters since they might have changed */
-    k = ioctl(priv->fd, FBIOGET_FSCREENINFO, &priv->fix);
-    if (k < 0)
-        LogMessage(X_ERROR, "Xfbdev(%d): FBIOGET_FSCREENINFO: %s\n",
-                   screen->card->mynum, strerror(errno));
+    t = KdFindMode(screen, fbdevModeSupported);
 
-    /* Now get the new screeninfo */
-    ioctl(priv->fd, FBIOGET_VSCREENINFO, &priv->var);
+    /* Sets priv->fix, priv->var */
+    fbdevSetMode(screen, t);
+
     depth = priv->var.bits_per_pixel;
     gray = priv->var.grayscale;
-
-    /* Just because the ioctl didn't fail, it doesn't mean we could set the mode */
-    LogMessage(X_INFO, "Xfbdev(%d): Actual screen mode: width = %d, height = %d\n",
-               screen->card->mynum, priv->var.xres, priv->var.yres);
-
-    /* Calculate fix.line_length if it's zero */
-    if (!priv->fix.line_length)
-        priv->fix.line_length = (priv->var.xres_virtual * depth + 7) / 8;
 
     switch (priv->fix.visual) {
     case FB_VISUAL_MONO01:

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -521,6 +521,10 @@ void
 void KdRingBell(KdKeyboardInfo * ki, int volume, int pitch, int duration);
 
 /* kmode.c */
+int
+KdFindRate(KdScreenInfo * screen,
+           Bool (*supported) (KdScreenInfo *, const KdMonitorTiming *));
+
 const KdMonitorTiming *KdFindMode(KdScreenInfo * screen,
                                   Bool (*supported) (KdScreenInfo *,
                                                      const KdMonitorTiming *));

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -322,9 +322,6 @@ typedef struct _KdMonitorTiming {
     KdSyncPolarity vpol;        /* polarity */
 } KdMonitorTiming;
 
-extern const KdMonitorTiming kdMonitorTimings[];
-extern const int kdNumMonitorTimings;
-
 typedef struct _KdPointerMatrix {
     int matrix[2][3];
 } KdPointerMatrix;
@@ -527,6 +524,9 @@ void KdRingBell(KdKeyboardInfo * ki, int volume, int pitch, int duration);
 const KdMonitorTiming *KdFindMode(KdScreenInfo * screen,
                                   Bool (*supported) (KdScreenInfo *,
                                                      const KdMonitorTiming *));
+
+Bool
+KdAddMode(const KdMonitorTiming *new);
 
 Bool
 KdTuneMode(KdScreenInfo * screen,

--- a/hw/kdrive/src/kmode.c
+++ b/hw/kdrive/src/kmode.c
@@ -24,7 +24,16 @@
 #include <kdrive-config.h>
 #include "kdrive.h"
 
-const KdMonitorTiming kdMonitorTimings[] = {
+#include <string.h>
+
+/* If this is ever changed, update the mode list too */
+static const KdMonitorTiming kdDefaultTiming =
+    {800, 600, 72, 50000,       /* VESA */
+     56, 64, 240, KdSyncPositive,       /* 48.077 */
+     37, 23, 66, KdSyncPositive,        /* 72.188 */
+     };
+
+static KdMonitorTiming kdMonitorTimings[] = {
     /*  H       V       Hz      KHz */
     /*  FP      BP      BLANK   POLARITY */
 
@@ -85,8 +94,7 @@ const KdMonitorTiming kdMonitorTimings[] = {
      16, 160, 256, KdSyncPositive,      /* 46.875 */
      1, 21, 25, KdSyncPositive, /* 75.000 */
      },
-    /* DEFAULT */
-#define MONITOR_TIMING_DEFAULT	9
+    /* XXX DEFAULT XXX */
     {800, 600, 72, 50000,       /* VESA */
      56, 64, 240, KdSyncPositive,       /* 48.077 */
      37, 23, 66, KdSyncPositive,        /* 72.188 */
@@ -240,11 +248,16 @@ const KdMonitorTiming kdMonitorTimings[] = {
      128, 244, 680, KdSyncNegative,     /* 90.000 */
      1, 56, 60, KdSyncPositive, /* 60.000 */
      },
+
+    /* Space for extra modes */
+#define NUM_FREE_TIMINGS 4
+    {0}, {0}, {0}, {0},
 };
 
 #define NUM_MONITOR_TIMINGS (sizeof kdMonitorTimings/sizeof kdMonitorTimings[0])
 
-const int kdNumMonitorTimings = NUM_MONITOR_TIMINGS;
+static int kdNumFreeMonitorTimings = NUM_FREE_TIMINGS;
+static int kdNumMonitorTimings = NUM_MONITOR_TIMINGS - NUM_FREE_TIMINGS;
 
 const KdMonitorTiming *
 KdFindMode(KdScreenInfo * screen,
@@ -253,7 +266,7 @@ KdFindMode(KdScreenInfo * screen,
     int i;
     const KdMonitorTiming *t;
 
-    for (i = 0, t = kdMonitorTimings; i < NUM_MONITOR_TIMINGS; i++, t++) {
+    for (i = 0, t = kdMonitorTimings; i < kdNumMonitorTimings; i++, t++) {
         if ((*supported) (screen, t) &&
             t->horizontal == screen->width &&
             t->vertical == screen->height &&
@@ -262,7 +275,49 @@ KdFindMode(KdScreenInfo * screen,
         }
     }
     ErrorF("Warning: mode not found, using default\n");
-    return &kdMonitorTimings[MONITOR_TIMING_DEFAULT];
+    return &kdDefaultTiming;
+}
+
+Bool
+KdAddMode(const KdMonitorTiming *new)
+{
+    int i;
+    KdMonitorTiming *t;
+
+    for (i = kdNumMonitorTimings, t = kdMonitorTimings; i > 0; i--, t++) {
+        /* Look if the mode already exists */
+        if ((t->horizontal == new->horizontal) &&
+            (t->vertical == new->vertical) &&
+            (t->rate == new->rate)) {
+            return TRUE;
+        }
+
+        if (t->horizontal > new->horizontal) {
+            break;
+        }
+
+        if ((t->horizontal == new->horizontal) &&
+            (t->vertical > new->vertical)) {
+            break;
+        }
+
+        if ((t->horizontal == new->horizontal) &&
+            (t->vertical == new->vertical) &&
+            (t->rate < new->rate)) {
+            break;
+        }
+    }
+
+    if (!kdNumFreeMonitorTimings) {
+        return FALSE;
+    }
+
+    memmove(t + 1, t, i * sizeof(*t));
+    *t = *new;
+
+    kdNumFreeMonitorTimings--;
+    kdNumMonitorTimings++;
+    return TRUE;
 }
 
 static const KdMonitorTiming *
@@ -335,7 +390,7 @@ KdRandRGetInfo(ScreenPtr pScreen,
     int i;
     const KdMonitorTiming *t;
 
-    for (i = 0, t = kdMonitorTimings; i < NUM_MONITOR_TIMINGS; i++, t++) {
+    for (i = 0, t = kdMonitorTimings; i < kdNumMonitorTimings; i++, t++) {
         if ((*supported) (pScreen, t)) {
             RRScreenSizePtr pSize;
 
@@ -365,7 +420,7 @@ KdRandRGetTiming(ScreenPtr pScreen,
     int i;
     const KdMonitorTiming *t;
 
-    for (i = 0, t = kdMonitorTimings; i < NUM_MONITOR_TIMINGS; i++, t++) {
+    for (i = 0, t = kdMonitorTimings; i < kdNumMonitorTimings; i++, t++) {
         if (t->horizontal == pSize->width &&
             t->vertical == pSize->height &&
             t->rate == rate && (*supported) (pScreen, t))

--- a/hw/kdrive/src/kmode.c
+++ b/hw/kdrive/src/kmode.c
@@ -259,6 +259,24 @@ static KdMonitorTiming kdMonitorTimings[] = {
 static int kdNumFreeMonitorTimings = NUM_FREE_TIMINGS;
 static int kdNumMonitorTimings = NUM_MONITOR_TIMINGS - NUM_FREE_TIMINGS;
 
+int
+KdFindRate(KdScreenInfo * screen,
+           Bool (*supported) (KdScreenInfo *, const KdMonitorTiming *))
+{
+    int i;
+    const KdMonitorTiming *t;
+
+    for (i = 0, t = kdMonitorTimings; i < kdNumMonitorTimings; i++, t++) {
+        if ((*supported) (screen, t) &&
+            t->horizontal == screen->width &&
+            t->vertical == screen->height) {
+            return t->rate;
+        }
+    }
+
+    return 0;
+}
+
 const KdMonitorTiming *
 KdFindMode(KdScreenInfo * screen,
            Bool (*supported) (KdScreenInfo *, const KdMonitorTiming *))


### PR DESCRIPTION
Also gets modern proton working (version 8 and above).
My guess is modern proton really cares that the refresh rate reported through RandR is not 0.