### PR TITLE
os: Distribute target-specific code into its own subdirectories

### DIFF
--- a/os/apple/client.c
+++ b/os/apple/client.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies). All
+ * rights reserved.
+ * Copyright (c) 1993, 2010, Oracle and/or its affiliates.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <dix-config.h>
+#include "client_apple.h"
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "os.h"
+
+/* TODO: Have non libdispatch code as well */
+#include <dispatch/dispatch.h>
+
+#include <errno.h>
+#include <sys/sysctl.h>
+
+static void get_argmax_from_kern(void *arg) {
+        int *argmax = arg;
+        int mib[2];
+        size_t len;
+
+        mib[0] = CTL_KERN;
+        mib[1] = KERN_ARGMAX;
+
+        len = sizeof(int);
+        if (sysctl(mib, 2, argmax, &len, NULL, 0) == -1) {
+                ErrorF("Unable to dynamically determine kern.argmax, using ARG_MAX (%d)\n", ARG_MAX);
+                *argmax = ARG_MAX;
+        }
+}
+
+/*
+ * This is the libdispatch-based way to implement DetermineClientCmd. It only works on macOS 10.6 and later. 
+ * So TODO, have a version of this function without libdispatch (and wrap this in an ifdef to avoid compiling any libdispatch code)
+ * The code of this function was taken from the original DetermineClientCmd, written by Jeremy Huddleston Sequoia.
+*/
+static void determine_client_cmd_using_libdispatch(pid_t pid, const char **cmdname, const char **cmdargs) {
+        static dispatch_once_t once;
+        static int argmax;
+        dispatch_once_f(&once, &argmax, get_argmax_from_kern);
+
+        int mib[3];
+        size_t len = argmax;
+        int32_t argc = -1;
+
+        char * const procargs = calloc(1, len);
+        if (!procargs) {
+            ErrorF("Failed to allocate memory (%lu bytes) for KERN_PROCARGS2 result for pid %d: %s\n", len, pid, strerror(errno));
+            return;
+        }
+
+        mib[0] = CTL_KERN;
+        mib[1] = KERN_PROCARGS2;
+        mib[2] = pid;
+
+        if (sysctl(mib, 3, procargs, &len, NULL, 0) == -1) {
+            ErrorF("Failed to determine KERN_PROCARGS2 for pid %d: %s\n", pid, strerror(errno));
+            free(procargs);
+            return;
+        }
+
+        if (len < sizeof(argc) || len > argmax) {
+            ErrorF("Erroneous length returned when querying KERN_PROCARGS2 for pid %d: %zu\n", pid, len);
+            free(procargs);
+            return;
+        }
+
+        /* Ensure we have a failsafe NUL termination just in case the last entry
+         * was not actually NUL terminated.
+         */
+        procargs[len-1] = '\0';
+
+        /* Setup our iterator */
+        char *is = procargs;
+
+        /* The first element in the buffer is argc as a 32bit int. When using
+         * the older KERN_PROCARGS, this is omitted, and one needs to guess
+         * (usually by checking for an `=` character) when we start seeing
+         * envvars instead of arguments.
+         */
+        argc = *(int32_t *)is;
+        is += sizeof(argc);
+
+        /* The very next string is the executable path.  Skip over it since
+         * this function wants to return argv[0] and argv[1...n].
+         */
+        is += strlen(is) + 1;
+
+        /* Skip over extra NUL characters to get to the start of argv[0] */
+        for (; (is < &procargs[len]) && !(*is); is++);
+
+        if (! (is < &procargs[len])) {
+            ErrorF("Arguments were not returned when querying KERN_PROCARGS2 for pid %d: %zu\n", pid, len);
+            free(procargs);
+            return;
+        }
+
+        if (cmdname) {
+            *cmdname = strdup(is);
+        }
+
+        /* Jump over argv[0] and point to argv[1] */
+        is += strlen(is) + 1;
+
+        if (cmdargs && is < &procargs[len]) {
+            char *args = is;
+
+            /* Remove the NUL terminators except the last one */
+            for (int i = 1; i < argc - 1; i++) {
+                /* Advance to the NUL terminator */
+                is += strlen(is);
+
+                /* Change the NUL to a space, ensuring we don't accidentally remove the terminal NUL */
+                if (is < &procargs[len-1]) {
+                    *is = ' ';
+                }
+            }
+
+            *cmdargs = strdup(args);
+        }
+
+        free(procargs);
+}
+
+void DetermineClientCmdApple(pid_t pid, const char **cmdname, const char **cmdargs) {
+        /* There should be a check here for the macOS version.
+         * We are assuming that it's recent enough like the code previously did. */
+        determine_client_cmd_using_libdispatch(pid, cmdname, cmdargs);
+}

--- a/os/apple/client_apple.h
+++ b/os/apple/client_apple.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3
+ *
+ * Copyright © 2026 Aggelos Tselios <aggelostselios777@gmail.com>
+ */
+ 
+#pragma once
+
+#ifndef OS_APPLE_CLIENT_H
+#define OS_APPLE_CLIENT_H 1
+
+#include <sys/types.h> /* pid_t */
+
+/* Implementation of DetermineClientCmd for Apple targets. */
+void DetermineClientCmdApple(pid_t pid, const char **cmdname, const char **cmdargs);
+
+#endif /* OS_APPLE_CLIENT_H */

--- a/os/client.c
+++ b/os/client.c
@@ -63,17 +63,11 @@
 #include "os.h"
 
 #ifdef __sun
-#include <errno.h>
-#include <procfs.h>
+#include "solaris/client_solaris.h"
 #endif
 
 #ifdef __OpenBSD__
-#include <sys/param.h>
-#include <sys/sysctl.h>
-#include <sys/types.h>
-
-#include <kvm.h>
-#include <limits.h>
+#include "openbsd/client_openbsd.h"
 #endif
 
 #ifdef __APPLE__

--- a/os/client.c
+++ b/os/client.c
@@ -53,14 +53,14 @@
 #include <dix-config.h>
 
 #include <assert.h>
-#include <sys/stat.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "os/client_priv.h"
 
-#include "os.h"
 #include "dixstruct.h"
+#include "os.h"
 
 #ifdef __sun
 #include <errno.h>
@@ -77,12 +77,11 @@
 #endif
 
 #ifdef __APPLE__
-#include "apple/client.h"
+#include "apple/client_apple.h"
 #endif /* __APPLE__ */
 
 #if defined(__DragonFly__) || defined(__FreeBSD__)
-#include <sys/sysctl.h>
-#include <errno.h>
+#include "freebsd/client_freebsd.h"
 #endif
 
 #include "os/auth.h"
@@ -165,60 +164,7 @@ DetermineClientCmd(pid_t pid, const char **cmdname, const char **cmdargs)
     if (pid == -1)
         return;
 #if defined(__DragonFly__) || defined(__FreeBSD__)
-    /* on DragonFly and FreeBSD use KERN_PROC_ARGS */
-    {
-        int mib[] = {
-            CTL_KERN,
-            KERN_PROC,
-            KERN_PROC_ARGS,
-            pid,
-        };
-
-        /* Determine exact size instead of relying on kern.argmax */
-        size_t len;
-        if (sysctl(mib, ARRAY_SIZE(mib), NULL, &len, NULL, 0) != 0) {
-            ErrorF("Failed to query KERN_PROC_ARGS length for PID %d: %s\n", pid, strerror(errno));
-            return;
-        }
-
-        /* Read KERN_PROC_ARGS contents. Similar to /proc/pid/cmdline
-         * the process name and each argument are separated by NUL byte. */
-        char *const procargs = calloc(1, len);
-        if (!procargs) {
-            ErrorF("Failed to allocate memory (%zu bytes) for KERN_PROC_ARGS result for pid %d: %s\n", len, pid, strerror(errno));
-            return;
-        }
-
-        if (sysctl(mib, ARRAY_SIZE(mib), procargs, &len, NULL, 0) != 0) {
-            ErrorF("Failed to get KERN_PROC_ARGS for PID %d: %s\n", pid, strerror(errno));
-            free(procargs);
-            return;
-        }
-
-        /* Construct the process name without arguments. */
-        if (cmdname) {
-            *cmdname = strdup(procargs);
-        }
-
-        /* Construct the arguments for client process. */
-        if (cmdargs) {
-            size_t cmdsize = strlen(procargs) + 1;
-            size_t argsize = len - cmdsize;
-            char *args = NULL;
-
-            if (argsize > 0)
-                args = procargs + cmdsize;
-            if (args) {
-                /* Replace NUL with space except terminating NUL */
-                for (size_t i = 0; i < (argsize - 1); i++) {
-                    if (args[i] == '\0')
-                        args[i] = ' ';
-                }
-                *cmdargs = strdup(args);
-            }
-        }
-        free(procargs);
-    }
+    DetermineClientCmdFreeBSD(pid, cmdname, cmdargs);
 #elif defined(__OpenBSD__)
     /* on OpenBSD use kvm_getargv() */
     {

--- a/os/client.c
+++ b/os/client.c
@@ -76,15 +76,13 @@
 #include <limits.h>
 #endif
 
+#ifdef __APPLE__
+#include "apple/client.h"
+#endif /* __APPLE__ */
+
 #if defined(__DragonFly__) || defined(__FreeBSD__)
 #include <sys/sysctl.h>
 #include <errno.h>
-#endif
-
-#ifdef __APPLE__
-#include <dispatch/dispatch.h>
-#include <errno.h>
-#include <sys/sysctl.h>
 #endif
 
 #include "os/auth.h"
@@ -123,24 +121,7 @@ DetermineClientPid(struct _Client * client)
     return pid;
 }
 
-#ifdef __APPLE__ /* only required on macOS */
-static void
-get_argmax_from_kern(void *arg)
-{
-    int *argmax = arg;
-    int mib[2];
-    size_t len;
 
-    mib[0] = CTL_KERN;
-    mib[1] = KERN_ARGMAX;
-
-    len = sizeof(int);
-    if (sysctl(mib, 2, argmax, &len, NULL, 0) == -1) {
-        ErrorF("Unable to dynamically determine kern.argmax, using ARG_MAX (%d)\n", ARG_MAX);
-        *argmax = ARG_MAX;
-    }
-}
-#endif
 
 /**
  * Try to determine a command line string for a client based on its
@@ -166,7 +147,11 @@ get_argmax_from_kern(void *arg)
 void
 DetermineClientCmd(pid_t pid, const char **cmdname, const char **cmdargs)
 {
-#if !defined(__APPLE__) && !defined(__DragonFly__) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+#ifdef __APPLE__
+    DetermineClientCmdApple(pid, cmdname, cmdargs);
+#endif /* __APPLE__ */
+
+#if !defined(__DragonFly__) && !defined(__FreeBSD__)
     char path[PATH_MAX + 1];
     int totsize = 0;
     int fd = 0;
@@ -179,96 +164,7 @@ DetermineClientCmd(pid_t pid, const char **cmdname, const char **cmdargs)
 
     if (pid == -1)
         return;
-
-#if defined (__APPLE__)
-    {
-        static dispatch_once_t once;
-        static int argmax;
-        dispatch_once_f(&once, &argmax, get_argmax_from_kern);
-
-        int mib[3];
-        size_t len = argmax;
-        int32_t argc = -1;
-
-        char * const procargs = calloc(1, len);
-        if (!procargs) {
-            ErrorF("Failed to allocate memory (%lu bytes) for KERN_PROCARGS2 result for pid %d: %s\n", len, pid, strerror(errno));
-            return;
-        }
-
-        mib[0] = CTL_KERN;
-        mib[1] = KERN_PROCARGS2;
-        mib[2] = pid;
-
-        if (sysctl(mib, 3, procargs, &len, NULL, 0) == -1) {
-            ErrorF("Failed to determine KERN_PROCARGS2 for pid %d: %s\n", pid, strerror(errno));
-            free(procargs);
-            return;
-        }
-
-        if (len < sizeof(argc) || len > argmax) {
-            ErrorF("Erroneous length returned when querying KERN_PROCARGS2 for pid %d: %zu\n", pid, len);
-            free(procargs);
-            return;
-        }
-
-        /* Ensure we have a failsafe NUL termination just in case the last entry
-         * was not actually NUL terminated.
-         */
-        procargs[len-1] = '\0';
-
-        /* Setup our iterator */
-        char *is = procargs;
-
-        /* The first element in the buffer is argc as a 32bit int. When using
-         * the older KERN_PROCARGS, this is omitted, and one needs to guess
-         * (usually by checking for an `=` character) when we start seeing
-         * envvars instead of arguments.
-         */
-        argc = *(int32_t *)is;
-        is += sizeof(argc);
-
-        /* The very next string is the executable path.  Skip over it since
-         * this function wants to return argv[0] and argv[1...n].
-         */
-        is += strlen(is) + 1;
-
-        /* Skip over extra NUL characters to get to the start of argv[0] */
-        for (; (is < &procargs[len]) && !(*is); is++);
-
-        if (! (is < &procargs[len])) {
-            ErrorF("Arguments were not returned when querying KERN_PROCARGS2 for pid %d: %zu\n", pid, len);
-            free(procargs);
-            return;
-        }
-
-        if (cmdname) {
-            *cmdname = strdup(is);
-        }
-
-        /* Jump over argv[0] and point to argv[1] */
-        is += strlen(is) + 1;
-
-        if (cmdargs && is < &procargs[len]) {
-            char *args = is;
-
-            /* Remove the NUL terminators except the last one */
-            for (int i = 1; i < argc - 1; i++) {
-                /* Advance to the NUL terminator */
-                is += strlen(is);
-
-                /* Change the NUL to a space, ensuring we don't accidentally remove the terminal NUL */
-                if (is < &procargs[len-1]) {
-                    *is = ' ';
-                }
-            }
-
-            *cmdargs = strdup(args);
-        }
-
-        free(procargs);
-    }
-#elif defined(__DragonFly__) || defined(__FreeBSD__)
+#if defined(__DragonFly__) || defined(__FreeBSD__)
     /* on DragonFly and FreeBSD use KERN_PROC_ARGS */
     {
         int mib[] = {

--- a/os/freebsd/client.c
+++ b/os/freebsd/client.c
@@ -59,6 +59,11 @@ void DetermineClientCmdFreeBSD(pid_t pid, const char **cmdname,
         /* Read KERN_PROC_ARGS contents. Similar to /proc/pid/cmdline
          * the process name and each argument are separated by NUL byte. */
         char *const procargs = calloc(1, len);
+        if (!procargs) {
+                ErrorF("Failed to allocate memory (%zu bytes) for KERN_PROC_ARGS result for pid %d: %s\n", len, pid, strerror(errno));
+                return;
+        }
+                
         if (sysctl(mib, ARRAY_SIZE(mib), procargs, &len, NULL, 0) != 0) {
                 ErrorF("Failed to get KERN_PROC_ARGS for PID %d: %s\n", pid,
                        strerror(errno));

--- a/os/freebsd/client.c
+++ b/os/freebsd/client.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies). All
+ * rights reserved.
+ * Copyright (c) 1993, 2010, Oracle and/or its affiliates.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <dix-config.h>
+#include "client_freebsd.h"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "dix.h"
+#include "os.h"
+#include <errno.h>
+#include <sys/sysctl.h>
+
+/*
+ * Originally implemented by Jan Beich. This implementation is also compatible with DragonflyBSD. 
+ */
+void DetermineClientCmdFreeBSD(pid_t pid, const char **cmdname,
+                               const char **cmdargs) {
+        int mib[] = {
+            CTL_KERN,
+            KERN_PROC,
+            KERN_PROC_ARGS,
+            pid,
+        };
+
+        /* Determine exact size instead of relying on kern.argmax */
+        size_t len;
+        if (sysctl(mib, ARRAY_SIZE(mib), NULL, &len, NULL, 0) != 0) {
+                ErrorF("Failed to query KERN_PROC_ARGS length for PID %d: %s\n",
+                       pid, strerror(errno));
+                return;
+        }
+
+        /* Read KERN_PROC_ARGS contents. Similar to /proc/pid/cmdline
+         * the process name and each argument are separated by NUL byte. */
+        char *const procargs = calloc(1, len);
+        if (sysctl(mib, ARRAY_SIZE(mib), procargs, &len, NULL, 0) != 0) {
+                ErrorF("Failed to get KERN_PROC_ARGS for PID %d: %s\n", pid,
+                       strerror(errno));
+                free(procargs);
+                return;
+        }
+
+        /* Construct the process name without arguments. */
+        if (cmdname) {
+                *cmdname = strdup(procargs);
+        }
+
+        /* Construct the arguments for client process. */
+        if (cmdargs) {
+                size_t cmdsize = strlen(procargs) + 1;
+                size_t argsize = len - cmdsize;
+                char *args = NULL;
+
+                if (argsize > 0)
+                        args = procargs + cmdsize;
+                if (args) {
+                        /* Replace NUL with space except terminating NUL */
+                        for (size_t i = 0; i < (argsize - 1); i++) {
+                                if (args[i] == '\0')
+                                        args[i] = ' ';
+                        }
+                        *cmdargs = strdup(args);
+                }
+        }
+        free(procargs);
+}

--- a/os/freebsd/client_freebsd.h
+++ b/os/freebsd/client_freebsd.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3
+ *
+ * Copyright © 2026 Aggelos Tselios <aggelostselios777@gmail.com>
+ */
+
+#pragma once
+
+#ifndef OS_FREEBSD_CLIENT_H
+#define OS_FREEBSD_CLIENT_H 1
+
+#include <sys/types.h> /* pid_t */
+
+/* Implementation of DetermineClientCmd for FreeBSD based operating systems */
+void DetermineClientCmdFreeBSD(pid_t pid, const char **cmdname, const char **cmdargs);
+
+#endif /* OS_FREEBSD_CLIENT_H */

--- a/os/meson.build
+++ b/os/meson.build
@@ -75,6 +75,7 @@ if host_machine.system() == 'sunos'
     os_c_args += '-D__EXTENSIONS__'
     os_dep += cc.find_library('socket')
     os_dep += cc.find_library('nsl')
+    srcs_os += 'solaris/client.c'
 elif host_machine.system() == 'darwin'
     srcs_os += 'apple/client.c'
 elif host_machine.system() == 'freebsd'

--- a/os/meson.build
+++ b/os/meson.build
@@ -75,10 +75,13 @@ if host_machine.system() == 'sunos'
     os_c_args += '-D__EXTENSIONS__'
     os_dep += cc.find_library('socket')
     os_dep += cc.find_library('nsl')
-endif
-
-if host_machine.system() == 'darwin'
+elif host_machine.system() == 'darwin'
     srcs_os += 'apple/client.c'
+elif host_machine.system() == 'freebsd'
+    srcs_os += 'freebsd/client.c'
+elif host_machine.system() == 'dragonfly'
+    # See os/client.c:161
+    srcs_os += 'freebsd/client.c'
 endif
 
 if get_option('xres')

--- a/os/meson.build
+++ b/os/meson.build
@@ -77,8 +77,16 @@ if host_machine.system() == 'sunos'
     os_dep += cc.find_library('nsl')
 endif
 
-if host_machine.system() == 'openbsd'
-    os_dep += cc.find_library('kvm')
+if host_machine.system() == 'darwin'
+    srcs_os += 'apple/client.c'
+endif
+
+if get_option('xres')
+    # Only the XRes extension cares about the client ID.
+    os_c_args += '-DCLIENTIDS'
+    if host_machine.system() == 'openbsd'
+        os_dep += cc.find_library('kvm')
+    endif
 endif
 
 libxlibc = []

--- a/os/meson.build
+++ b/os/meson.build
@@ -83,6 +83,8 @@ elif host_machine.system() == 'freebsd'
 elif host_machine.system() == 'dragonfly'
     # See os/client.c:161
     srcs_os += 'freebsd/client.c'
+elif host_machine.system() == 'openbsd'
+    srcs_os += 'openbsd/client.c'
 endif
 
 if get_option('xres')

--- a/os/meson.build
+++ b/os/meson.build
@@ -84,15 +84,8 @@ elif host_machine.system() == 'dragonfly'
     # See os/client.c:161
     srcs_os += 'freebsd/client.c'
 elif host_machine.system() == 'openbsd'
+    os_dep += cc.find_library('kvm')
     srcs_os += 'openbsd/client.c'
-endif
-
-if get_option('xres')
-    # Only the XRes extension cares about the client ID.
-    os_c_args += '-DCLIENTIDS'
-    if host_machine.system() == 'openbsd'
-        os_dep += cc.find_library('kvm')
-    endif
 endif
 
 libxlibc = []

--- a/os/meson.build
+++ b/os/meson.build
@@ -81,7 +81,8 @@ elif host_machine.system() == 'darwin'
 elif host_machine.system() == 'freebsd'
     srcs_os += 'freebsd/client.c'
 elif host_machine.system() == 'dragonfly'
-    # See os/client.c:161
+    # The FreeBSD implementation also works on DragonFlyBSD. To avoid code duplication, we can
+    # just reuse the same implementation for both operating systems.
     srcs_os += 'freebsd/client.c'
 elif host_machine.system() == 'openbsd'
     os_dep += cc.find_library('kvm')

--- a/os/openbsd/client.c
+++ b/os/openbsd/client.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies). All
+ * rights reserved.
+ * Copyright (c) 1993, 2010, Oracle and/or its affiliates.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <dix-config.h>
+#include "client_openbsd.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <sys/param.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+
+#include <kvm.h>
+#include <limits.h>
+
+void DetermineClientCmdOpenBSD(pid_t pid, const char **cmdname,
+                               const char **cmdargs) {
+        kvm_t *kd;
+        char errbuf[_POSIX2_LINE_MAX];
+        char **argv;
+        struct kinfo_proc *kp;
+        size_t len = 0;
+        int i, n;
+
+        kd = kvm_open(NULL, NULL, NULL, KVM_NO_FILES, errbuf);
+        if (kd == NULL)
+                return;
+        kp =
+            kvm_getprocs(kd, KERN_PROC_PID, pid, sizeof(struct kinfo_proc), &n);
+        if (n != 1)
+                goto done_kvm;
+        argv = kvm_getargv(kd, kp, 0);
+        if (argv == NULL)
+                goto done_kvm;
+        if (cmdname) {
+                if (argv[0] == NULL)
+                        goto done_kvm;
+                else
+                        *cmdname = strdup(argv[0]);
+        }
+        if (cmdargs) {
+                i = 1;
+                while (argv[i] != NULL) {
+                        len += strlen(argv[i]) + 1;
+                        i++;
+                }
+                *cmdargs = calloc(1, len);
+                if (*cmdargs) {
+                        i = 1;
+                        while (argv[i] != NULL) {
+                                strlcat(*(char **)cmdargs, argv[i], len);
+                                strlcat(*(char **)cmdargs, " ", len);
+                                i++;
+                        }
+                }
+        }
+done_kvm:
+        kvm_close(kd);
+}

--- a/os/openbsd/client_openbsd.h
+++ b/os/openbsd/client_openbsd.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3
+ *
+ * Copyright © 2026 Aggelos Tselios <aggelostselios777@gmail.com>
+ */
+
+#pragma once
+
+#ifndef OS_OPENBSD_CLIENT_H
+#define OS_OPENBSD_CLIENT_H 1
+
+#include <sys/types.h> /* pid_t */
+
+/* Implementation of DetermineClientCmd for OpenBSD */
+void DetermineClientCmdOpenBSD(pid_t pid, const char **cmdname, const char **cmdargs);
+
+#endif /* OS_OPENBSD_CLIENT_H */

--- a/os/solaris/client.c
+++ b/os/solaris/client.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies). All
+ * rights reserved.
+ * Copyright (c) 1993, 2010, Oracle and/or its affiliates.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <dix-config.h>
+#include "client_solaris.h"
+#include "os.h"
+#include <errno.h>
+
+#include <fcntl.h>
+#include <procfs.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <limits.h>
+#include <unistd.h>
+
+static void determine_client_cmd_using_cmdline(char *path, int fd, const char **cmdname,
+                                               const char **cmdargs) {
+        /* Read the contents of /proc/pid/cmdline. It should contain the
+         * process name and arguments. */
+        ssize_t totsize = read(fd, path, PATH_MAX + 1);
+        if (totsize <= 0)
+                return;
+        path[totsize - 1] = '\0';
+
+        /* Construct the process name without arguments. */
+        if (cmdname) {
+                *cmdname = strdup(path);
+        }
+
+        /* Construct the arguments for client process. */
+        if (cmdargs) {
+                size_t cmdsize = strlen(path) + 1;
+                size_t argsize = totsize - cmdsize;
+                char *args = NULL;
+
+                if (argsize > 0)
+                        args = calloc(1, argsize);
+                if (args) {
+                        int i = 0;
+
+                        for (i = 0; i < (argsize - 1); ++i) {
+                                const char c = path[cmdsize + i];
+
+                                args[i] = (c == '\0') ? ' ' : c;
+                        }
+                        args[argsize - 1] = '\0';
+                        *cmdargs = args;
+                }
+        }
+}
+
+/* Solaris prior to 11.3.5 does not support /proc/pid/cmdline, but
+ * makes information similar to what ps shows available in a binary
+ * structure in the /proc/pid/psinfo file. */
+static void determine_client_cmd_using_psinfo(const char *path, const char **cmdname,
+                                              const char **cmdargs) {
+        int fd = open(path, O_RDONLY);
+        if (fd < 0) {
+                ErrorF("Failed to open %s: %s\n", path, strerror(errno));
+                return;
+        } else {
+                psinfo_t psinfo = {0};
+
+                ssize_t totsize = read(fd, &psinfo, sizeof(psinfo_t));
+                close(fd);
+                if (totsize <= 0)
+                        return;
+
+                /* pr_psargs is the first PRARGSZ (80) characters of the command
+                 * line string - assume up to the first space is the command
+                 * name, since it's not delimited.   While there is also
+                 * pr_fname, that's more limited, giving only the first 16 chars
+                 * of the basename of the file that was exec'ed, thus cutting
+                 * off many long gnome command names, or returning
+                 * "isapython2.6" for all python scripts.
+                 */
+                psinfo.pr_psargs[PRARGSZ - 1] = '\0';
+                char *sp = strchr(psinfo.pr_psargs, ' ');
+                if (sp)
+                        *sp++ = '\0';
+
+                if (cmdname)
+                        *cmdname = strdup(psinfo.pr_psargs);
+
+                if (cmdargs && sp)
+                        *cmdargs = strdup(sp);
+        }
+}
+
+void DetermineClientCmdSolaris(pid_t pid, const char **cmdname,
+                               const char **cmdargs) {
+        /*
+         * see comment in determine_client_cmd_using_psinfo
+         * to avoid allocating the same path twice, we are
+         * formatting it here and passing it to the function that will actually
+         * be used
+         */
+        char path[PATH_MAX + 1] = { 0 };
+        if (snprintf(path, sizeof(path), "/proc/%d/cmdline", pid) < 0)
+                return;
+        int fd = open(path, O_RDONLY);
+        if (fd < 0) {
+                if (snprintf(path, sizeof(path), "/proc/%d/psinfo", pid) >= 0)
+                        determine_client_cmd_using_psinfo(path, cmdname, cmdargs);
+        } else {
+                determine_client_cmd_using_cmdline(path, fd, cmdname, cmdargs);
+                close(fd);
+        }
+}

--- a/os/solaris/client_solaris.h
+++ b/os/solaris/client_solaris.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3
+ *
+ * Copyright © 2026 Aggelos Tselios <aggelostselios777@gmail.com>
+ */
+
+#pragma once
+
+#ifndef OS_SOLARIS_CLIENT_H
+#define OS_SOLARIS_CLIENT_H 1
+
+#include <sys/types.h> /* pid_t */
+
+/* Implementation of DetermineClientCmd for Solaris/SunOS systems */
+void DetermineClientCmdSolaris(pid_t pid, const char **cmdname, const char **cmdargs);
+
+#endif /* OS_SOLARIS_CLIENT_H */


### PR DESCRIPTION
Discussed in #1743 and #2951, the code under os/client.c (and other files under the `os/` directory) is full of `#ifdefs` and massive functions depending on the target platform. Moving it to separate files is cleaner and a better solution long term.

Signed-off-by: Aggelos Tselios <aggelostselios777@gmail.com>