### PR TITLE
(release/25.0) Xi: fix NULL pointer dereference in ProcXIChangeCursor

### DIFF
--- a/Xi/xichangecursor.c
+++ b/Xi/xichangecursor.c
@@ -83,11 +83,12 @@ ProcXIChangeCursor(ClientPtr client)
     if (!InputDevIsMaster(pDev) || !IsPointerDevice(pDev))
         return BadDevice;
 
-    if (stuff->win != None) {
-        rc = dixLookupWindow(&pWin, stuff->win, client, DixSetAttrAccess);
-        if (rc != Success)
-            return rc;
-    }
+    /* A window is required: pWin is dereferenced unconditionally below (and in
+     * ChangeWindowDeviceCursor), so do not allow win == None to leave it NULL.
+     * dixLookupWindow() rejects None with BadWindow. */
+    rc = dixLookupWindow(&pWin, stuff->win, client, DixSetAttrAccess);
+    if (rc != Success)
+        return rc;
 
     if (stuff->cursor == None) {
         if (pWin == pWin->drawable.pScreen->root)


### PR DESCRIPTION
When a client sent XIChangeCursor with win == None, the window was never
looked up and pWin stayed NULL, after which "pWin == pWin->drawable.pScreen->
root" (or ChangeWindowDeviceCursor()) dereferenced NULL and crashed the
server. Any client with a valid master-pointer device could trigger this.

A valid window is required for this request, so look the window up
unconditionally; dixLookupWindow() rejects None with BadWindow.

Fixes: 95e1a88050dd ("Xi: Adding ChangeDeviceCursor request")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
