### PR TITLE
(master) Xi: fix NULL pointer dereference in ProcXQueryDeviceState

### DIFF
--- a/Xext/xinput/queryst.c
+++ b/Xext/xinput/queryst.c
@@ -76,6 +76,13 @@ ProcXQueryDeviceState(ClientPtr client)
     if (rc != Success && rc != BadAccess)
         return rc;
 
+    /* dixLookupDevice() leaves dev NULL on anything other than Success,
+     * including BadAccess. The code below intentionally continues on
+     * BadAccess to blank out the state, but it cannot do so without a valid
+     * device, so bail out rather than dereferencing NULL. */
+    if (!dev)
+        return rc;
+
     v = dev->valuator;
     if (v != NULL && v->motionHintWindow != NULL)
         MaybeStopDeviceHint(dev, client);


### PR DESCRIPTION
The handler deliberately continues when dixLookupDevice() returns BadAccess
(to emit class headers with the device state blanked out). However
dixLookupDevice() leaves *pDev == NULL on any non-Success return, so the
subsequent "v = dev->valuator" dereferenced NULL and crashed the server.

This is reachable when an XACE/SELinux hook denies the client's DixReadAccess
to the device. Bail out when dev is NULL instead of dereferencing it.

Fixes: 8502c06e19a4 ("xace: Fake return values on denials in input polling requests.")
Fixes: 5c03d131815c ("xace: add new hooks + access controls: XInput extension.")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>



---

### Backport dashboard

| Target branch | Backport PR | Status |
|---|---|---|
| `release/25.2` | #3110 | 🔄 Open |
| `release/25.1` | — | ✅ Already contained |
| `release/25.0` | — | ✅ Already contained |

<sub>🤖 Backport assessment by Claude Code on behalf of @metux. Only `release/25.2` was missing the fix; `25.1` and `25.0` already carry the equivalent guard (verified in their `Xi/`/`xkb/`/`Xext/` paths).</sub>
