### PR TITLE
(release/25.0) Xi: fix double length scaling in ProcXIPassiveGrabDevice mask copy

### DIFF
--- a/Xi/xipassivegrab.c
+++ b/Xi/xipassivegrab.c
@@ -140,7 +140,7 @@ ProcXIPassiveGrabDevice(ClientPtr client)
 
     mask_len = min(xi2mask_mask_size(mask.xi2mask), stuff->mask_len * 4);
     xi2mask_set_one_mask(mask.xi2mask, stuff->deviceid,
-                         (unsigned char *) &stuff[1], mask_len * 4);
+                         (unsigned char *) &stuff[1], mask_len);
 
     memset(&param, 0, sizeof(param));
     param.grabtype = XI2;


### PR DESCRIPTION
mask_len is already a byte count (min of the target mask size and
stuff->mask_len * 4), but it was passed to xi2mask_set_one_mask() as
"mask_len * 4", scaling by 4 a second time. With stuff->mask_len == 1 this
made the helper copy 5 bytes from the 4-byte request mask region, a 1-byte
over-read.

Pass mask_len directly, matching the sibling ProcXIGrabDevice().

Fixes: 59a6d7d47890 ("Xi: don't overrun memory for grab masks.")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
