### PR TITLE
(master) xkb: bounds-check indicator index in ReadXkmIndicators

### DIFF
--- a/Xext/xkeyboard/xkmread.c
+++ b/Xext/xkeyboard/xkmread.c
@@ -644,6 +644,13 @@ ReadXkmIndicators(FILE * file, XkbDescPtr xkb, XkbChangesPtr changes)
             return -1;
         }
         nRead += tmp * SIZEOF(xkmIndicatorMapDesc);
+        /* wire.indicator is an untrusted CARD8 used as (indicator - 1) to
+         * index the fixed-size indicators[] and maps[] arrays; reject
+         * out-of-range values to avoid an out-of-bounds access. */
+        if (wire.indicator < 1 || wire.indicator > XkbNumIndicators) {
+            _XkbLibError(_XkbErrBadValue, "ReadXkmIndicators", wire.indicator);
+            return -1;
+        }
         if (xkb->names) {
             xkb->names->indicators[wire.indicator - 1] = name;
             if (changes)


### PR DESCRIPTION
ReadXkmIndicators() used the wire.indicator byte (CARD8, 0..255) as
indicators[wire.indicator - 1] and maps[wire.indicator - 1] without any range
check. Both arrays have XkbNumIndicators (32) entries, so indicator == 0
(index -1) or indicator > 32 wrote past the array bounds.

The parsed .xkm data is produced by the server's own xkbcomp on a stock
build, so this is hardening rather than a directly client-reachable bug, but
the sibling readers (ReadXkmKeycodes, ReadXkmKeyTypes) already validate their
indices and ReadXkmGeometry was fixed for the same class in 5d7e34fc9e.
Reject out-of-range indicator values.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>



---

### Backport dashboard

| Target branch | Backport PR | Status |
|---|---|---|
| `release/25.2` | #3109 | 🔄 Open |
| `release/25.1` | — | ✅ Already contained |
| `release/25.0` | — | ✅ Already contained |

<sub>🤖 Backport assessment by Claude Code on behalf of @metux. Only `release/25.2` was missing the fix; `25.1` and `25.0` already carry the equivalent guard (verified in their `Xi/`/`xkb/`/`Xext/` paths).</sub>
