### PR TITLE
(release/25.0) randr: call correct handler from SProcRRGetOutputInfo

### DIFF
--- a/randr/rrsdispatch.c
+++ b/randr/rrsdispatch.c
@@ -129,7 +129,7 @@ SProcRRGetOutputInfo(ClientPtr client)
     REQUEST_SIZE_MATCH(xRRGetOutputInfoReq);
     swapl(&stuff->output);
     swapl(&stuff->configTimestamp);
-    return ProcRRGetScreenResources(client);
+    return ProcRRGetOutputInfo(client);
 }
 
 static int _X_COLD


### PR DESCRIPTION
SProcRRGetOutputInfo() swapped the RRGetOutputInfo request fields but then
dispatched to ProcRRGetScreenResources() instead of ProcRRGetOutputInfo().
The size check in the wrong handler rejected the request with BadLength, so
RRGetOutputInfo was broken for byte-swapped clients. It failed closed (no
memory-safety impact), but the dispatch is still wrong; call the correct
handler.

Fixes: ed172244034f ("randr: let SProc*'s call their Proc*'s directly")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
