### PR TITLE
(master) present: byte-swap notify list in sproc_present_pixmap_synced

### DIFF
--- a/Xext/present/present_request.c
+++ b/Xext/present/present_request.c
@@ -431,6 +431,10 @@ sproc_present_pixmap_synced(ClientPtr client)
     swapll(&stuff->target_msc);
     swapll(&stuff->divisor);
     swapll(&stuff->remainder);
+
+    /* Swap the trailing LISTofPRESENTNOTIFY, like sproc_present_pixmap(). */
+    SwapRestL(stuff);
+
     return proc_present_pixmap_synced(client);
 }
 #endif /* DRI3 */


### PR DESCRIPTION
sproc_present_pixmap_synced() swapped the fixed request header but, unlike
sproc_present_pixmap(), never byte-swapped the trailing LISTofPRESENTNOTIFY.
present_create_notifies() then read each notify window/serial in the wrong
byte order for swapped clients, so PresentPixmapSynced with notifies resolved
the wrong (or no) window. Bounds are enforced by req_len and dixLookupWindow()
so there was no memory-safety impact, only incorrect behaviour.

Add the missing SwapRestL(stuff).

Fixes: ac0bc0b3b6e6 ("Present: add PresentCapabilitySyncobj and PresentPixmapSynced")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>

---

### Backport dashboard

| Target branch | Backport PR | Status |
|----------------|-------------|--------|
| `release/25.2` | #3102 | 🔄 Open |
| `release/25.1` | — | ✅ Already contained |
| `release/25.0` | — | ✅ Already contained |

<sub>🤖 Backport assessment by Claude Code on behalf of @metux. **25.2** has `sproc_present_pixmap_synced()` with the header swaps but no trailing `SwapRestL()` — identical to master pre-fix (`Xext/present/present_request.c`) → clean cherry-pick. **25.1** and **25.0** already carry the `SwapRestL(stuff)` (same comment) in their `present/present_request.c`, so they're already fixed. (Behavioural bug for byte-swapped clients only; no memory-safety impact per the commit message.)</sub>
