### PR TITLE
(release/25.1) glx: fix out-of-bounds read in RenderLarge variable-size dispatch

### DIFF
--- a/glx/glxcmds.c
+++ b/glx/glxcmds.c
@@ -2107,7 +2107,20 @@ __glXDisp_RenderLarge(__GLXclientState * cl, GLbyte * pc)
              ** If it's a variable-size command (a command whose length must
              ** be computed from its parameters), all the parameters needed
              ** will be in the 1st request, so it's okay to do this.
+             **
+             ** The varsize() handlers dereference the fixed-size command
+             ** header at fixed offsets without bounds-checking their reqlen
+             ** argument, so the fixed header (entry.bytes, plus the extra 4
+             ** bytes of the larger RenderLarge header) must actually be
+             ** present in this first request.  Without this check a short
+             ** first request (e.g. dataBytes == __GLX_RENDER_LARGE_HDR_SIZE)
+             ** lets varsize() read past the end of the request buffer.
+             ** The non-large __glXDisp_Render path performs the equivalent
+             ** "cmdlen < entry.bytes" check before calling varsize().
              */
+            if (left < entry.bytes + 4) {
+                return BadLength;
+            }
             extra = (*entry.varsize) (pc + __GLX_RENDER_LARGE_HDR_SIZE,
                                       client->swapped,
                                       left - __GLX_RENDER_LARGE_HDR_SIZE);


### PR DESCRIPTION
__glXDisp_RenderLarge() invoked entry.varsize() (the per-command size
function) for the first request of a multi-request RenderLarge command after
only checking that dataBytes >= __GLX_RENDER_LARGE_HDR_SIZE (8). The
entry.bytes consistency check happens afterwards, too late.

The variable-size handlers (e.g. __glXTexImage3DReqSize,
__glXTexSubImage3DReqSize, __glXMap2dReqSize, __glXSeparableFilter2DReqSize)
read fixed-offset header fields up to ~80 bytes into the command and ignore
their reqlen argument. A client sending GLXRenderLarge with dataBytes == 8 and
a variable-size sub-opcode therefore caused varsize() to read well past the
end of the request buffer.

The non-large __glXDisp_Render() path guards this with "cmdlen < entry.bytes"
before calling varsize(); add the equivalent guard to the RenderLarge first-
request path, ensuring the fixed command header (entry.bytes plus the extra 4
bytes of the larger RenderLarge header) is contained in this request before
varsize() runs.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
