### PR TITLE
(release/25.1) glx: fix integer overflow in CreateContextAttribsARB length check

### DIFF
--- a/glx/createcontext.c
+++ b/glx/createcontext.c
@@ -114,7 +114,16 @@ __glXDisp_CreateContextAttribsARB(__GLXclientState * cl, GLbyte * pc)
 
     /* Verify that the size of the packet matches the size inferred from the
      * sizes specified for the various fields.
+     *
+     * Clamp numAttribs first: the size computation below multiplies it by 8
+     * in 32-bit arithmetic, so without this guard a value such as 0x20000000
+     * overflows to 0, lets a minimal request pass the length check, and then
+     * the attribute-parsing loop reads far out of bounds.  This mirrors the
+     * UINT32_MAX >> 3 clamp used by the other GLX context handlers.
      */
+    if (req->numAttribs > (UINT32_MAX >> 3))
+        return BadLength;
+
     const unsigned expected_size = (sizeof(xGLXCreateContextAttribsARBReq)
                                     + (req->numAttribs * 8)) / 4;
 


### PR DESCRIPTION
__glXDisp_CreateContextAttribsARB() computed

    expected_size = (sizeof(req) + req->numAttribs * 8) / 4

in 32-bit unsigned arithmetic with no clamp on the attacker-controlled
numAttribs. A value such as 0x20000000 makes numAttribs * 8 wrap to 0, so a
minimal 28-byte request satisfies "req->length != expected_size", after which
the loop "for (i = 0; i < req->numAttribs; i++)" reads attribs[i*2] far past
the end of the request buffer (out-of-bounds read / crash).

Add the same "numAttribs > (UINT32_MAX >> 3)" clamp the other GLX context
handlers already use before the size computation.

Fixes: b840ba5f54de ("glx: Implement protocol for glXCreateContextAttribsARB")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
