### PR TITLE
(master) dix: zero padding in ProcQueryColors reply

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -3015,7 +3015,7 @@ ProcQueryColors(ClientPtr client)
             bytes_to_int32((client->req_len << 2) - sizeof(xQueryColorsReq));
 
         x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
-        xrgb *prgbs = x_rpcbuf_reserve(&rpcbuf, count * sizeof(xrgb));
+        xrgb *prgbs = x_rpcbuf_reserve0(&rpcbuf, count * sizeof(xrgb));
         if (!prgbs && count)
             return BadAlloc;
         if ((rc =


### PR DESCRIPTION
QueryColors() fills the red/green/blue fields of each xrgb entry but never
writes the trailing 2-byte pad field. Because the reply buffer was allocated
with the non-zeroing x_rpcbuf_reserve(), those pad bytes leaked uninitialized
server heap to the client (and were even byte-swapped on the swapped path).

Use x_rpcbuf_reserve0() for the xrgb array.

Fixes: 15340ce053d4 ("dix: ProcQueryColors(): use x_rpcbuf_t")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
