### PR TITLE
(release/25.1) xfixes: swap nbytes before validating request length

### DIFF
--- a/xfixes/cursor.c
+++ b/xfixes/cursor.c
@@ -410,12 +410,17 @@ ProcXFixesSetCursorName(ClientPtr client)
     REQUEST(xXFixesSetCursorNameReq);
     Atom atom;
 
+    /* nbytes must be swapped before REQUEST_FIXED_SIZE validates the request
+     * length against it, otherwise a swapped client can pass a small wire-order
+     * nbytes that satisfies the length check while MakeAtom() below reads the
+     * large host-order value out of bounds. */
+    if (client->swapped)
+        swaps(&stuff->nbytes);
+
     REQUEST_FIXED_SIZE(xXFixesSetCursorNameReq, stuff->nbytes);
 
-    if (client->swapped) {
+    if (client->swapped)
         swapl(&stuff->cursor);
-        swaps(&stuff->nbytes);
-    }
 
     VERIFY_CURSOR(pCursor, stuff->cursor, client, DixSetAttrAccess);
     tchar = (char *) &stuff[1];
@@ -667,12 +672,17 @@ ProcXFixesChangeCursorByName(ClientPtr client)
     char *tchar;
 
     REQUEST(xXFixesChangeCursorByNameReq);
+
+    /* nbytes must be swapped before REQUEST_FIXED_SIZE validates the request
+     * length against it (see ProcXFixesSetCursorName); otherwise MakeAtom()
+     * below reads the host-order value out of bounds for a swapped client. */
+    if (client->swapped)
+        swaps(&stuff->nbytes);
+
     REQUEST_FIXED_SIZE(xXFixesChangeCursorByNameReq, stuff->nbytes);
 
-    if (client->swapped) {
+    if (client->swapped)
         swapl(&stuff->source);
-        swaps(&stuff->nbytes);
-    }
 
     VERIFY_CURSOR(pSource, stuff->source, client,
                   DixReadAccess | DixGetAttrAccess);


### PR DESCRIPTION
ProcXFixesSetCursorName() and ProcXFixesChangeCursorByName() called
REQUEST_FIXED_SIZE(..., stuff->nbytes) while stuff->nbytes was still in wire
byte order for a swapped client; the swaps(&stuff->nbytes) happened afterwards.
MakeAtom() then used the host-order (swapped) value.

A byte-swapped client could choose a wire-order nbytes that passes the length
check (e.g. 0x0001) whose swapped value is large (0x0100), making MakeAtom()
read several hundred bytes past the end of the request buffer and fold that
adjacent heap memory into the atom table (disclosed via GetCursorName) or
crash the server.

Swap nbytes before REQUEST_FIXED_SIZE so the validated value is the one
MakeAtom() consumes. This restores the ordering that existed before the
request swapping was inlined into the Proc handlers (commit 8336ad8e6f).

Fixes: 8336ad8e6f3a ("xfixes: inline request swapping")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
