### PR TITLE
(release/25.1) Xext: xvmc: guard against NULL screen private in ProcXvMCGetDRInfo

### DIFF
--- a/Xext/xvmc.c
+++ b/Xext/xvmc.c
@@ -611,6 +611,12 @@ ProcXvMCGetDRInfo(ClientPtr client)
     pScreen = pPort->pAdaptor->pScreen;
     pScreenPriv = XVMC_GET_PRIVATE(pScreen);
 
+    /* The port may live on a screen that never initialized XvMC, in which case
+     * the per-screen private is NULL. Match the other port-taking handlers and
+     * reject it instead of dereferencing NULL. */
+    if (!pScreenPriv)
+        return BadMatch;
+
     int nameLen = strlen(pScreenPriv->clientDriverName) + 1;
     int busIDLen = strlen(pScreenPriv->busID) + 1;
 


### PR DESCRIPTION
ProcXvMCGetDRInfo() fetched the per-screen XvMC private with
XVMC_GET_PRIVATE() and immediately dereferenced it
(strlen(pScreenPriv->clientDriverName)). The private is NULL for any screen on
which XvMCScreenInit() was never called, while the extension and its private
key become available globally as soon as any screen enables XvMC.

A local client owning a valid Xv port on a non-XvMC screen (e.g. a multi-GPU
setup where only one screen has XvMC) could thus crash the server. The three
other port-taking XvMC handlers already check for NULL; do the same here and
return BadMatch.

Fixes: 3b0dce3620e4 ("lib/XvMC/Imake Added support for automatic loading of the correct hardware XvMC driver.")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
