### PR TITLE
(master) xkb: zero padding in GetMap reply wire descriptors

### DIFF
--- a/Xext/xkeyboard/xkb.c
+++ b/Xext/xkeyboard/xkb.c
@@ -1091,7 +1091,7 @@ static void XkbWriteKeyTypes(XkbDescPtr xkb, CARD8 firstType, CARD8 nTypes,
 {
     XkbKeyTypePtr type = &xkb->map->types[firstType];
     for (int i = 0; i < nTypes; i++, type++) {
-        xkbKeyTypeWireDesc *wire = x_rpcbuf_reserve(rpcbuf, sizeof(xkbKeyTypeWireDesc));
+        xkbKeyTypeWireDesc *wire = x_rpcbuf_reserve0(rpcbuf, sizeof(xkbKeyTypeWireDesc));
         wire->mask = type->mods.mask;
         wire->realMods = type->mods.real_mods;
         wire->virtualMods = type->mods.vmods;
@@ -1103,7 +1103,7 @@ static void XkbWriteKeyTypes(XkbDescPtr xkb, CARD8 firstType, CARD8 nTypes,
         }
 
         if (type->map_count > 0) {
-            void *space = x_rpcbuf_reserve(
+            void *space = x_rpcbuf_reserve0(
                 rpcbuf, sizeof(xkbKTMapEntryWireDesc) * type->map_count);
             xkbKTMapEntryWireDesc *ewire = space;
             XkbKTMapEntryPtr entry = type->map;
@@ -1235,7 +1235,7 @@ XkbSizeKeyActions(XkbDescPtr xkb, xkbGetMapReply * rep)
 static void XkbWriteKeyActions(XkbDescPtr xkb, KeyCode firstKeyAct,
                                CARD8 nKeyActs, x_rpcbuf_t *rpcbuf)
 {
-    CARD8 *numDesc = x_rpcbuf_reserve(rpcbuf, XkbPaddedSize(nKeyActs));
+    CARD8 *numDesc = x_rpcbuf_reserve0(rpcbuf, XkbPaddedSize(nKeyActs));
 
     for (int i = 0; i < nKeyActs; i++) {
         if (xkb->server->key_acts[i + firstKeyAct] == 0)
@@ -1283,7 +1283,7 @@ static void XkbWriteKeyBehaviors(XkbDescPtr xkb, KeyCode firstKeyBehavior,
     XkbBehavior *pBhvr = &xkb->server->behaviors[firstKeyBehavior];
     for (int i = 0; i < nKeyBehaviors; i++, pBhvr++) {
         if (pBhvr->type != XkbKB_Default) {
-            xkbBehaviorWireDesc *wire = x_rpcbuf_reserve(rpcbuf, sizeof(xkbBehaviorWireDesc));
+            xkbBehaviorWireDesc *wire = x_rpcbuf_reserve0(rpcbuf, sizeof(xkbBehaviorWireDesc));
             wire->key = i + firstKeyBehavior;
             wire->type = pBhvr->type;
             wire->data = pBhvr->data;
@@ -1326,7 +1326,7 @@ static void XkbWriteExplicit(XkbDescPtr xkb, KeyCode firstKeyExplicit,
     }
 
     /* reserve buffer space (with padding) */
-    char *buf = x_rpcbuf_reserve(rpcbuf, XkbPaddedSize(count * 2));
+    char *buf = x_rpcbuf_reserve0(rpcbuf, XkbPaddedSize(count * 2));
 
     /* copy over the active entries */
     for (int i = 0; i < nKeyExplicit; i++) {
@@ -1401,7 +1401,7 @@ static void XkbWriteVirtualModMap(XkbDescPtr xkb, KeyCode firstVModMapKey,
     unsigned short *pMap = &xkb->server->vmodmap[firstVModMapKey];
     for (int i = 0; i < nVModMapKeys; i++, pMap++) {
         if (*pMap != 0) {
-            xkbVModMapWireDesc *wire = x_rpcbuf_reserve(rpcbuf, sizeof(xkbVModMapWireDesc));
+            xkbVModMapWireDesc *wire = x_rpcbuf_reserve0(rpcbuf, sizeof(xkbVModMapWireDesc));
             wire->key = i + firstVModMapKey;
             wire->vmods = *pMap;
         }


### PR DESCRIPTION
The XkbGetMap reply builders left padding bytes unwritten in buffers allocated
with the non-zeroing x_rpcbuf_reserve(), disclosing uninitialized server heap
to the client:

  * xkbKeyTypeWireDesc.pad and xkbKTMapEntryWireDesc.pad (XkbWriteKeyTypes)
  * xkbBehaviorWireDesc.pad (XkbWriteKeyBehaviors)
  * xkbVModMapWireDesc.pad (XkbWriteVirtualModMap)
  * the XkbPaddedSize() rounding tail of the key-action count array
    (XkbWriteKeyActions) and the explicit-component array (XkbWriteExplicit)

Use x_rpcbuf_reserve0() for these reservations.

Fixes: 742443ea7379 ("xkb: pass x_rpcbuf_t into XkbAssembleMap()")
Fixes: bee50daecae5 ("xkb: use x_rpcbuf_t in XkbWriteKeyActions()")
Fixes: 316e5e431a3a ("xkb: use x_rpcbuf_t in XkbWriteKeyBehaviors()")
Fixes: e5d91b49e5e9 ("xkb: use x_rpcbuf_t in XkbWriteExplicit()")
Fixes: c3052dbc392e ("xkb: use x_rpcbuf_t in XkbWriteVirtualModMap()")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
