### PR TITLE
(release/25.1) Xi: zero feedback reply buffer in ProcXGetFeedbackControl

### DIFF
--- a/Xi/getfctl.c
+++ b/Xi/getfctl.c
@@ -297,7 +297,10 @@ ProcXGetFeedbackControl(ClientPtr client)
         return BadMatch;
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
-    char *buf = x_rpcbuf_reserve(&rpcbuf, total_length);
+    /* Use the zeroing variant: the CopySwap* helpers below do not write the
+     * internal pad bytes of the feedback state structs, which would otherwise
+     * leak uninitialized heap memory to the client. */
+    char *buf = x_rpcbuf_reserve0(&rpcbuf, total_length);
 
     for (k = dev->kbdfeed; k; k = k->next)
         CopySwapKbdFeedback(client, k, &buf);


### PR DESCRIPTION
The reply payload was allocated with the non-zeroing x_rpcbuf_reserve(), and
the CopySwapKbdFeedback/CopySwapPtrFeedback/CopySwapBellFeedback helpers
populate every field except the internal pad bytes of xKbdFeedbackState (1),
xPtrFeedbackState (2) and xBellFeedbackState (3). Those pad bytes were sent to
the client verbatim, disclosing uninitialized heap memory.

Use x_rpcbuf_reserve0() to zero the buffer, restoring the behaviour that the
earlier calloc()-based code provided before the x_rpcbuf conversion.

Fixes: 6413bd61d741 ("Xi: ProcXGetFeedbackControl(): use x_rpcbuf_t")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
