### PR TITLE
(release/25.1) randr: zero provider info reply buffer in ProcRRGetProviderInfo

### DIFF
--- a/randr/rrprovider.c
+++ b/randr/rrprovider.c
@@ -160,7 +160,10 @@ ProcRRGetProviderInfo (ClientPtr client)
 
     extraLen = reply.length << 2;
     if (extraLen) {
-        extra = x_rpcbuf_reserve(&rpcbuf, extraLen);
+        /* Use the zeroing variant: the provider name is copied with its exact
+         * length, leaving the trailing alignment padding uninitialized, which
+         * would otherwise leak heap memory to the client. */
+        extra = x_rpcbuf_reserve0(&rpcbuf, extraLen);
         if (!extra)
             return BadAlloc;
     }


### PR DESCRIPTION
The reply "extra" buffer was allocated with the non-zeroing
x_rpcbuf_reserve(), and the provider name is copied with
memcpy(name, provider->name, reply.nameLength). Because the reserved length
rounds nameLength up to a 4-byte multiple, the up-to-3 trailing padding bytes
after the name were left uninitialized and sent to the client (e.g. for
"modesetting", nameLength 11), disclosing heap memory.

Use x_rpcbuf_reserve0() to zero the buffer.

Fixes: 36ef6a448b45 ("randr: ProcRRGetProviderInfo(): use x_rpcbuf_t")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
