### PR TITLE
(release/25.1) present: byte-swap notify list in sproc_present_pixmap_synced

### DIFF
--- a/present/present_request.c
+++ b/present/present_request.c
@@ -432,6 +432,10 @@ sproc_present_pixmap_synced(ClientPtr client)
     swapll(&stuff->target_msc);
     swapll(&stuff->divisor);
     swapll(&stuff->remainder);
+
+    /* Swap the trailing LISTofPRESENTNOTIFY, like sproc_present_pixmap(). */
+    SwapRestL(stuff);
+
     return proc_present_pixmap_synced(client);
 }
 #endif /* DRI3 */


### PR DESCRIPTION
sproc_present_pixmap_synced() swapped the fixed request header but, unlike
sproc_present_pixmap(), never byte-swapped the trailing LISTofPRESENTNOTIFY.
present_create_notifies() then read each notify window/serial in the wrong
byte order for swapped clients, so PresentPixmapSynced with notifies resolved
the wrong (or no) window. Bounds are enforced by req_len and dixLookupWindow()
so there was no memory-safety impact, only incorrect behaviour.

Add the missing SwapRestL(stuff).

Fixes: ac0bc0b3b6e6 ("Present: add PresentCapabilitySyncobj and PresentPixmapSynced")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
