### PR TITLE
(release/25.1) render: zero reply buffers in QueryPictFormats and QueryFilters

### DIFF
--- a/render/render.c
+++ b/render/render.c
@@ -244,7 +244,7 @@ ProcRenderQueryPictFormats(ClientPtr client)
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
-    xPictFormInfo *pictForm = x_rpcbuf_reserve(&rpcbuf, rlength);
+    xPictFormInfo *pictForm = x_rpcbuf_reserve0(&rpcbuf, rlength);
     if (!pictForm)
         return BadAlloc;
 
@@ -1531,7 +1531,7 @@ ProcRenderQueryFilters(ClientPtr client)
     total_bytes = (len << 2);
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
-    aliases = (INT16 *) x_rpcbuf_reserve(&rpcbuf, total_bytes);
+    aliases = (INT16 *) x_rpcbuf_reserve0(&rpcbuf, total_bytes);
     if (!aliases)
         return BadAlloc;
 


### PR DESCRIPTION
ProcRenderQueryPictFormats left the internal padding of xPictFormInfo (pad1)
and xPictDepth (pad1, pad2) unwritten, and ProcRenderQueryFilters left the
odd-count alias alignment slot and the filter-name alignment tail unwritten.
Both reply buffers were allocated with the non-zeroing x_rpcbuf_reserve(), so
those bytes disclosed uninitialized server heap to the client.

Use x_rpcbuf_reserve0() for both reply payloads.

Fixes: fe9fcfe98f3a ("render: ProcRenderQueryPictFormats(): use x_rpcbuf_t")
Fixes: 81f93d19a02a ("render: ProcRenderQueryFilters(): use x_rpcbuf_t")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
