### PR TITLE
(release/25.1) randr: zero name padding in GetScreenResources replies

### DIFF
--- a/randr/rrscreen.c
+++ b/randr/rrscreen.c
@@ -426,7 +426,7 @@ rrGetMultiScreenResources(ClientPtr client, Bool query, ScreenPtr pScreen)
 
     extraLen = reply.length << 2;
     if (extraLen) {
-        extra = x_rpcbuf_reserve(&rpcbuf, extraLen);
+        extra = x_rpcbuf_reserve0(&rpcbuf, extraLen);
         if (!extra) {
             return BadAlloc;
         }
@@ -544,7 +544,7 @@ rrGetScreenResources(ClientPtr client, Bool query)
         if (!extraLen)
             goto finish;
 
-        extra = x_rpcbuf_reserve(&rpcbuf, extraLen);
+        extra = x_rpcbuf_reserve0(&rpcbuf, extraLen);
         if (!extra) {
             free(modes);
             return BadAlloc;


### PR DESCRIPTION
rrGetMultiScreenResources() and rrGetScreenResources() copy each mode name
with its exact length while the reply payload length rounds the total name
bytes up to a 4-byte multiple. The trailing alignment padding was left
uninitialized because the buffer was allocated with the non-zeroing
x_rpcbuf_reserve(), disclosing server heap to the client.

Use x_rpcbuf_reserve0() for both extra buffers.

Fixes: cbc4e91f02d1 ("randr: rrGetMultiScreenResources(): use x_rpcbuf_t")
Fixes: 26a1e5f7099c ("randr: rrGetScreenResources(): use x_rpcbuf_t")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
