### PR TITLE
(release/25.1) Xi: zero device/pointer/state reply buffers

### DIFF
--- a/Xi/listdev.c
+++ b/Xi/listdev.c
@@ -361,7 +361,7 @@ ProcXListInputDevices(ClientPtr client)
 
     /* allocate space for reply */
     total_length = numdevs * sizeof(xDeviceInfo) + size + namesize;
-    char *devbuf = x_rpcbuf_reserve(&rpcbuf, total_length);
+    char *devbuf = x_rpcbuf_reserve0(&rpcbuf, total_length);
     if (!devbuf) {
         free(skip);
         return BadAlloc;

--- a/Xi/queryst.c
+++ b/Xi/queryst.c
@@ -99,7 +99,7 @@ ProcXQueryDeviceState(ClientPtr client)
     }
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
-    char *buf = x_rpcbuf_reserve(&rpcbuf, total_length);
+    char *buf = x_rpcbuf_reserve0(&rpcbuf, total_length);
     if (!buf)
         return BadAlloc;
 

--- a/Xi/xiquerydevice.c
+++ b/Xi/xiquerydevice.c
@@ -102,7 +102,7 @@ ProcXIQueryDevice(ClientPtr client)
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
-    info = x_rpcbuf_reserve(&rpcbuf, len);
+    info = x_rpcbuf_reserve0(&rpcbuf, len);
     if (!info) {
         free(skip);
         return BadAlloc;

--- a/Xi/xiquerypointer.c
+++ b/Xi/xiquerypointer.c
@@ -143,7 +143,7 @@ ProcXIQueryPointer(ClientPtr client)
 
         const int buttons_size = bits_to_bytes(256); /* button map up to 255 */
         reply.buttons_len = bytes_to_int32(buttons_size);
-        char *buttons = x_rpcbuf_reserve(&rpcbuf, buttons_size);
+        char *buttons = x_rpcbuf_reserve0(&rpcbuf, buttons_size);
         if (!buttons)
             return BadAlloc;
 


### PR DESCRIPTION
Several XInput reply handlers built their payloads in buffers allocated with
the non-zeroing x_rpcbuf_reserve() and left bytes uninitialized that were then
sent to the client:

  * ProcXListInputDevices - xDeviceInfo.attached and xKeyInfo pad bytes.
  * ProcXIQueryPointer - the 32-byte button bitmask was only OR'ed with the
    down buttons via SetBit(), never zero-initialized.
  * ProcXIQueryDevice - pad bytes of xXIDeviceInfo, xXIValuatorInfo,
    xXIScrollInfo and xXIGestureInfo.
  * ProcXQueryDeviceState - xKeyState.pad1 and xButtonState.pad1.

Allocate all four reply payloads with x_rpcbuf_reserve0().

Fixes: 8c90875c3d7d ("Xi: ProcXListInputDevices(): use x_rpcbuf_t")
Fixes: 528102426175 ("Xi: ProcXIQueryPointer(): use x_rpcbuf_t")
Fixes: a7a48427f5b3 ("Xi: ProcXIQueryDevice(): use x_rpcbuf_t")
Fixes: 68b709817395 ("Xi: ProcXQueryDeviceState(): use x_rpcbuf_t")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
