### PR TITLE
(release/25.1) xfree86: vidmode: zero gamma ramp reply padding

### DIFF
--- a/hw/xfree86/xext/vidmode.c
+++ b/hw/xfree86/xext/vidmode.c
@@ -1679,7 +1679,7 @@ ProcVidModeGetGammaRamp(ClientPtr client)
 
     if (stuff->size) {
         size_t ramplen = length * 3 * sizeof(CARD16);
-        CARD16 *ramp = x_rpcbuf_reserve(&rpcbuf, ramplen);
+        CARD16 *ramp = x_rpcbuf_reserve0(&rpcbuf, ramplen);
         if (!ramp)
             return BadAlloc;
 


### PR DESCRIPTION
ProcVidModeGetGammaRamp reserves length = (size + 1) & ~1 entries per channel
but GetGammaRamp() only fills stuff->size entries. When size is odd, the last
CARD16 of each of the three channels was left uninitialized and sent to the
client. The buffer used the non-zeroing x_rpcbuf_reserve().

Use x_rpcbuf_reserve0() for the ramp buffer.

Fixes: 0bf7d613d5c4 ("xf86vidmode: ProcVidModeSetGammaRamp(): use x_rpcbuf_t")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
