### PR TITLE
release/25.0: README.md: update for one year of XLibre

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,128 +1,81 @@
-XLibre Xserver
-===============
+# XLibre Xserver
 
-Xlibre is a fork of the [Xorg Xserver](https://gitlab.freedesktop.org/xorg/xserver)
-with lots of code cleanups and enhanced functionality.
+The XLibre Xserver is the community-managed display server for the [X Window System Protocol Version 11 (Wikipedia)](https://en.wikipedia.org/wiki/X_Window_System_core_protocol), in short, X11.
 
-This fork was necessary since toxic elements within Xorg projects, moles
-from BigTech, are boycotting any substantial work on Xorg, in order to
-destroy the project, to eliminate competition of their own products.
-Classic "embrace, extend, extinguish" tactics.
+<p>
+    <figure><a href="https://github.com/orgs/X11Libre/discussions/504#discussioncomment-17195498"><img src="https://github.com/X11Libre/website/blob/eb05723185647561390dade472edea5938333113/build/img/xlibre-one-year.jpg" alt="1 year of XLibre screenshot"></a><figcaption>One Year of XLibre. See more <a href="https://github.com/orgs/X11Libre/discussions/211">liberated screens here</a>.</figcaption>
+    </figure>
+</p>
 
-Right after journalists first began covering the planned fork Xlibre,
-on June 6th 2025, Redhat employees started a purge on the Xlibre founder's
-GitLab account on freedesktop.org: deleted the git repo, tickets, merge
-requests, etc, and so fired the shot that the whole world heard.
+## Selected Features
 
-This is an independent project, not at all affiliated with BigTech or any
-of their subsidiaries or tax evasion tools, nor any political activists
-groups, state actors, etc. It's explicitly free of any "DEI" or similar
-discriminatory policies. Anybody who's treating others nicely is welcomed.
+* All the good things from [X.Org Server](https://en.wikipedia.org/wiki/X.Org_Server), including its unreleased features
+* [TearFree modesetting](https://github.com/X11Libre/xserver/commit/0dacee6c5149b63a563e9bed63502da2e9f1ac1f) by default and optionally [atomic modesetting](https://github.com/X11Libre/xserver/commit/461411c798c263f70daa96f7136614dfefda6adc)
+* Support for the Nvidia drivers 340, 390, 470, 570, and newer
+* [Xnamespace extension](https://github.com/X11Libre/xserver/blob/master/doc/Xnamespace.md) for separating X clients
+* Support for seat management via [seatd](https://sr.ht/~kennylevinsen/seatd) besides [systemd-logind](https://www.freedesktop.org/software/systemd/man/latest/systemd-logind.service.html)
+* [Xfbdev](https://github.com/X11Libre/xserver/tree/master/hw/kdrive), the generic framebuffer Xserver for Linux
+* CI builds for several BSDs, Linux, MacOS, and Microsoft Windows
+* Active community, cleanups, fixes, and development based on merit
 
-It doesn't matter which country you're coming from, your political views,
-your race, your sex, your age, your food menu, whether you wear boots or
-heels, whether you're furry or fairy, Conan or McKay, comic character, a
-small furry creature from Alpha Centauri, or just a boring average person.
-Anybody who's interested in bringing X forward is welcome.
-
-Together we'll make X great again!
-
-Upgrade notice
---------------
-
-* Module ABIs have changed - drivers MUST be recompiled against this Xserver
-  version, otherwise the Xserver can crash or fail to start up correctly.
-
-* If your console is locked up (no input possible, not even VT switch), then
-  most likely the input driver couldn't be loaded due to a version mismatch.
-  When unsure, it's best to be prepared to ssh into your machine from another one
-  or set a timer that's calling `chvt 1` after certain time, so you don't
-  need a cold reboot.
-  Or, make sure that you have magic `SysRq` key enabled (`Alt+PrtSc`)
-  via sysctl (`kernel.sysrq=1`), then press following combination depending on keyboard
-  layout to make kernel regain control over keyboard to make VT switching work:
-  - QWERTY/AZERTY keyboard layout: `SysRq + R`
-  - Dvorak/Colemak keyboard layout: `SysRq + P`
-
-* Proprietary Nvidia drivers might break: they still haven't managed to do
-  even simple cleanups to catch up with Xorg master for about a year.
-  All attempts to get into direct mail contact have failed. We're trying to
-  work around this, but cannot give any guarantees. But you can make it work
-  by adding `Option "IgnoreABI" "1"` line to `ServerFlags` section in Xorg config.
-
-* Most Xorg drivers should run as-is (once recompiled!), with some exceptions.
-  See `.gitlab-ci.yml` for the versions/branches built along with Xlibre.
+To learn more about the features and mission of XLibre, please [visit our homepage](https://xlibre.net).
 
 
-Driver repositories
--------------------
+## Switching to XLibre
 
-Since Redhat had deleted and banned all X11Libre repositories from freedesktop.org,
-the driver repositories are now moved to GitHub:
-
-| Driver | Git repository | Release tag |
-| --- | --- | --- |
-| xf86-input-elographics:   | https://github.com/X11Libre/xf86-input-elographics    | xlibre-xf86-input-elographics-1.4.4.1    |
-| xf86-input-evdev:         | https://github.com/X11Libre/xf86-input-evdev          | xlibre-xf86-input-evdev-2.11.0.1         |
-| xf86-input-void:          | https://github.com/X11Libre/xf86-input-void           | xlibre-xf86-input-void-1.4.2.1           |
-| xf86-input-joystick:      | https://github.com/X11Libre/xf86-input-joystick       | xlibre-xf86-input-joystick-1.6.4.1       |
-| xf86-input-keyboard:      | https://github.com/X11Libre/xf86-input-keyboard       | xlibre-xf86-input-keyboard-2.1.0.1       |
-| xf86-input-libinput:      | https://github.com/X11Libre/xf86-input-libinput       | xlibre-xf86-input-libinput-1.5.0.1       |
-| xf86-input-mouse:         | https://github.com/X11Libre/xf86-input-mouse          | xlibre-xf86-input-mouse-1.9.5.1          |
-| xf86-input-synaptics:     | https://github.com/X11Libre/xf86-input-synaptics      | xlibre-xf86-input-synaptics-1.10.0.1     |
-| xf86-input-vmmouse:       | https://github.com/X11Libre/xf86-input-vmmouse        | xlibre-xf86-input-vmmouse-13.2.0.1       |
-| xf86-input-wacom:         | https://github.com/X11Libre/xf86-input-wacom          | xlibre-xf86-input-wacom-1.2.3.1          |
-| xf86-video-amdgpu:        | https://github.com/X11Libre/xf86-video-amdgpu         | xlibre-xf86-video-amdgpu-23.0.0.2        |
-| xf86-video-apm:           | https://github.com/X11Libre/xf86-video-apm            | xlibre-xf86-video-apm-1.3.0.1            |
-| xf86-video-ark:           | https://github.com/X11Libre/xf86-video-ark            | xfree-xf86-video-ark-0.7.6.1             |
-| xf86-video-ast:           | https://github.com/X11Libre/xf86-video-ast            | xlibre-xf86-video-ast-1.2.0              |
-| xf86-video-ati:           | https://github.com/X11Libre/xf86-video-ati            | xfree-xf86-video-ati-22.0.0.1            |
-| xf86-video-chips:         | https://github.com/X11Libre/xf86-video-chips          | xlibre-xf86-video-chips-1.5.0.1          |
-| xf86-video-cirrus:        | https://github.com/X11Libre/xf86-video-cirrus         | xlibre-xf86-video-cirrus-1.6.0.1         |
-| xf86-video-dummy:         | https://github.com/X11Libre/xf86-video-dummy          | xlibre-xf86-video-dummy-0.4.1.1          |
-| xf86-video-fbdev:         | https://github.com/X11Libre/xf86-video-fbdev          | xlibre-xf86-video-fbdev-0.5.1.1          |
-| xf86-video-freedreno:     | https://github.com/X11Libre/xf86-video-freedreno      | xlibre-xf86-video-freedreno-1.4.0.1      |
-| xf86-video-geode:         | https://github.com/X11Libre/xf86-video-geode          | xlibre-xf86-video-geode-2.18.1.1         |
-| xf86-video-i128:          | https://github.com/X11Libre/xf86-video-i128           | xlibre-xf86-video-i128-1.4.1.1           |
-| xf86-video-i740:          | https://github.com/X11Libre/xf86-video-i740           | xlibre-xf86-video-i740-1.4.0.1           |
-| xf86-video-intel:         | https://github.com/X11Libre/xf86-video-intel          | xlibre-xf86-video-intel-3.0.0.1          |
-| xf86-video-mach64:        | https://github.com/X11Libre/xf86-video-mach64         | xlibre-xf86-video-mach64-6.10.0.1        |
-| xf86-video-mga:           | https://github.com/X11Libre/xf86-video-mga            | xlibre-xf86-video-mga-2.1.0.1            |
-| xf86-video-neomagic:      | https://github.com/X11Libre/xf86-video-neomagic       | xlibre-xf86-video-neomagic-1.3.1.1       |
-| xf86-video-nested:        | https://github.com/X11Libre/xf86-video-nested         | xlibre-xf86-video-nested-1.0.0.1         |
-| xf86-video-nouveau:       | https://github.com/X11Libre/xf86-video-nouveau        | xlibre-xf86-video-nouveau-1.0.18.1       |
-| xf86-video-nv:            | https://github.com/X11Libre/xf86-video-nv             | xlibre-xf86-video-nv-2.1.23.1            |
-| xf86-video-omap:          | https://github.com/X11Libre/xf86-video-omap           | xlibre-xf86-video-omap-0.4.5.1           |
-| xf86-video-qxl:           | https://github.com/X11Libre/xf86-video-qxl            | xlibre-xf86-video-qxl-0.1.6.1            |
-| xf86-video-r128:          | https://github.com/X11Libre/xf86-video-r128           | xlibre-xf86-video-r128-6.13.0.1          |
-| xf86-video-rendition:     | https://github.com/X11Libre/xf86-video-rendition      | xlibre-xf86-video-rendition-4.2.7.1      |
-| xf86-video-s3virge:       | https://github.com/X11Libre/xf86-video-s3virge        | xlibre-xf86-video-s3virge-1.11.1.1       |
-| xf86-video-savage:        | https://github.com/X11Libre/xf86-video-savage         | xlibre-xf86-video-savage-2.4.1.1         |
-| xf86-video-siliconmotion: | https://github.com/X11Libre/xf86-video-siliconmotion  | xlibre-xf86-video-siliconmotion-1.7.10.1 |
-| xf86-video-sis:           | https://github.com/X11Libre/xf86-video-sis            | xlibre-xf86-video-sis-0.12.0.1           |
-| xf86-video-sisusb:        | https://github.com/X11Libre/xf86-video-sisusb         | xlibre-xf86-video-sisusb-0.9.7.1         |
-| xf86-video-suncg14:       | https://github.com/X11Libre/xf86-video-suncg14        | xlibre-xf86-video-suncg14-1.2.0          |
-| xf86-video-suncg3:        | https://github.com/X11Libre/xf86-video-suncg3         | xlibre-xf86-video-suncg3-1.1.3.0         |
-| xf86-video-suncg6:        | https://github.com/X11Libre/xf86-video-suncg6         | xlibre-xf86-video-suncg6-1.1.3.1         |
-| xf86-video-sunffb:        | https://github.com/X11Libre/xf86-video-sunffb         | xlibre-xf86-video-sunffb-1.2.3.1         |
-| xf86-video-sunleo:        | https://github.com/X11Libre/xf86-video-sunleo         | xlibre-xf86-video-sunleo-1.2.3.1         |
-| xf86-video-suntcx:        | https://github.com/X11Libre/xf86-video-suntcx         | xlibre-xf86-video-suntcx-1.1.3.1         |
-| xf86-video-tdfx:          | https://github.com/X11Libre/xf86-video-tdfx           | xlibre-xf86-video-tdfx-1.5.0.1           |
-| xf86-video-trident:       | https://github.com/X11Libre/xf86-video-trident        | xlibre-xf86-video-trident-1.4.0.1        |
-| xf86-video-vbox:          | https://github.com/X11Libre/xf86-video-vbox           | xlibre-xf86-video-vbox-1.0.1.1           |
-| xf86-video-v4l:           | https://github.com/X11Libre/xf86-video-v4l            | xlibre-xf86-video-v4l-0.3.0.1            |
-| xf86-video-vesa:          | https://github.com/X11Libre/xf86-video-vesa           | xlibre-xf86-video-vesa-2.6.0.1           |
-| xf86-video-vmware:        | https://github.com/X11Libre/xf86-video-vmware         | xlibre-xf86-video-vmware-13.4.0.1        |
-| xf86-video-voodoo:        | https://github.com/X11Libre/xf86-video-voodoo         | xlibre-xf86-video-voodoo-1.2.6.1         |
-| xf86-video-wsfb:          | https://github.com/X11Libre/xf86-video-wsfb           | xlibre-xf86-video-wsfb-0.4.1.1           |
-| xf86-video-xgi:           | https://github.com/X11Libre/xf86-video-xgi            | xlibre-xf86-video-xgi-1.6.1.1            |
+The easiest way to install and run XLibre is to use your distribution's provided packages. Please see the [Are We XLibre Yet? - (X11Libre/xserver Wiki)](https://github.com/X11Libre/xserver/wiki/Are-We-XLibre-Yet%3F) page for a list of the available options. If there is no option, then go on with building and installing XLibre from source.
 
 
-Contact
--------
+### Building XLibre
 
-|  |  |
-| --- | --- |
-| Mailing list:                     | https://www.freelists.org/list/xlibre |
-| Telegram channel:                 | https://t.me/x11dev |
-| Matrix space (mirror of tg group): | https://matrix.to/#/#xlibredev:matrix.org |
+After cloning the [Xserver repository](https://github.com/X11Libre/xserver.git) or unpacking the sources and installing the dependencies, change into the source directory and run the [Meson](https://mesonbuild.com) build tool:
+
+```shell
+cd "<source dir of xserver>"
+meson setup <prefix> build <meson_options>
+ninja -C build install
+```
+
+You may specify the install `<prefix>` with, for example, `--prefix="$(pwd)/image"` and add build time [`<meson_options>`](https://github.com/X11Libre/xserver/blob/master/meson_options.txt) like so: `-Dxnest=false`. You may also want to build and install some graphics and input drivers. Please refer to the [Building XLibre (X11Libre/xserver Wiki)](https://github.com/X11Libre/xserver/wiki/Building-XLibre) page for more details.
+
+
+### Configuring XLibre
+
+Until XLibre releases its own, you can find a detailed description of the configuration on the [Configuration - Xorg (ArchWiki)](https://wiki.archlinux.org/title/Xorg#Configuration) page. If you have built and installed XLibre yourself, then change into the `<prefix>` directory with `cd <prefix>` and create a directory `etc/X11` with a file `xorg.conf` and adjust it accordingly.
+
+Starting with version 25.0.0.16, the proprietary Nvidia driver is autodetected and handled internally without any special configuration. Please see the [Compatibility of XLibre (X11Libre/xserver Wiki)](https://github.com/X11Libre/xserver/wiki/Compatibility-of-XLibre) page for [more details on the Nvidia driver](https://github.com/X11Libre/xserver/wiki/Compatibility-of-XLibre#nvidia-proprietary-driver) and compatibility in general.
+
+
+### Running XLibre
+
+If you installed XLibre using your distribution's provided packages, then the Xserver is usually started by [init (Wikipedia)](https://en.wikipedia.org/wiki/Init) on system start. On other systems it should be possible to manually start XLibre with user permissions by invoking `startx`. Please refer to [`man startx`](https://linux.die.net/man/1/startx) for how to use it.
+
+If you have built and installed XLibre yourself, then you may want to shutdown other Xservers, change into the `<prefix>` directory, and create a simple `testx.sh` file with the following contents:
+
+```shell
+#!/bin/sh
+./bin/X :1 vt8 -logfile /dev/stdout &
+_pid=$!
+sleep 10 && kill $_pid
+```
+
+You can adjust the `:1 vt8` and other options in the `testx.sh` file as detailed in [`man Xorg`](https://linux.die.net/man/1/xorg). Make the `testx.sh` executable and run it:
+
+```shell
+chmod 0770 testx.sh
+./testx.sh
+```
+
+This should give you 10 glorious seconds of a black and beautiful and empty screen. Afterwards the Xserver complains about being killed, but there should be no other critical errors for a "test passed." For more details, please see [Building XLibre (X11Libre/xserver Wiki)](https://github.com/X11Libre/xserver/wiki/Building-XLibre).
+
+
+## I want to help!
+
+That's great; there's enough to do for everyone. You may consider [one](https://github.com/orgs/X11Libre/discussions/categories/1-new-ideas) of the [many](https://github.com/orgs/X11Libre/discussions/categories/2-rfcs-of-the-core-team) [ideas](https://github.com/orgs/X11Libre/discussions/categories/3-ideas-soon-to-be-addressed) and [feature requests](https://github.com/X11Libre/xserver/issues?q=is%3Aissue%20state%3Aopen%20label%3Aenhancement) out there. To help in testing, you may consider becoming an [XLibre Test Driver](https://github.com/X11Libre/xserver/wiki/XLibre-Test-Drivers). Please also have a look at the [good first](https://github.com/X11Libre/xserver/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22) and [help wanted](https://github.com/X11Libre/xserver/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) issues and the [Liberated Screens](https://github.com/orgs/X11Libre/discussions/211).
+
+If you want to work on anything, just let us know. If you have any questions, [just ask](https://github.com/orgs/X11Libre/discussions/categories/q-a). Thank you!
+
+
+## Contact
+
+[XLibre Discussions at GitHub](https://github.com/orgs/X11Libre/discussions) | [XLibre mailing list at FreeLists](https://www.freelists.org/list/xlibre) | [@x11dev channel at Telegram](https://t.me/x11dev) | [#xlibredev space at Matrix](https://matrix.to/#/#xlibredev:matrix.org) | [XLibre security contact at GitHub](https://github.com/X11Libre/xserver/security/policy)


### PR DESCRIPTION
Backport the current README from master to release/25.0.

Backport-of: 50981f161ab8176013d7efec584ce33963548225
Signed-off-by: callmetango <callmetango@users.noreply.github.com>
