### PR TITLE
(master) xnest: no need for DISABLE_EXT_DPMS anymore

### DIFF
--- a/hw/xnest/meson.build
+++ b/hw/xnest/meson.build
@@ -45,7 +45,7 @@ executable(
         libxserver_xi_stubs,
         libxserver_xkb_stubs,
     ],
-    c_args: [ '-DHAVE_XNEST_CONFIG_H', '-DDISABLE_EXT_COMPOSITE', '-DDISABLE_EXT_DPMS', '-DISABLE_EXT_MITSHM' ],
+    c_args: [ '-DHAVE_XNEST_CONFIG_H', '-DDISABLE_EXT_COMPOSITE', '-DISABLE_EXT_MITSHM' ],
     install: true,
 )
 

--- a/mi/miinitext.c
+++ b/mi/miinitext.c
@@ -79,10 +79,6 @@ SOFTWARE.
 #endif
 
 /* some DDXes must explicitly prohibit some extensions */
-#ifdef DISABLE_EXT_DPMS
-#undef DPMSExtension
-#endif
-
 #ifdef DISABLE_EXT_MITSHM
 #undef MITSHM
 #undef CONFIG_MITSHM


### PR DESCRIPTION
All the other DDX'es (except xfree86) are already handling it the same
way: the extension is present, but the ScreenRec->DPMS() pointer left
NULL (callers already checking for that), so no need for any special
magic for Xnest.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
