### PR TITLE
(master) meson.build: build dpms extension unconditionally

### DIFF
--- a/Xext/dpms/meson.build
+++ b/Xext/dpms/meson.build
@@ -2,11 +2,8 @@ srcs_dpms = [
     'dpms.c',
 ]
 
-libxserver_dpms = []
-if build_dpms
-    libxserver_dpms = static_library('xserver_dpms',
-        srcs_dpms,
-        include_directories: inc,
-        dependencies: common_dep,
-    )
-endif
+libxserver_dpms = static_library('xserver_dpms',
+    srcs_dpms,
+    include_directories: inc,
+    dependencies: common_dep,
+)

--- a/Xext/meson.build
+++ b/Xext/meson.build
@@ -2,7 +2,6 @@ srcs_xext = [
     'xace.c',
 ]
 
-
 if build_hashtable
     srcs_xext += 'hashtable.c'
 endif

--- a/Xext/saver/saver.c
+++ b/Xext/saver/saver.c
@@ -60,9 +60,7 @@ in this Software without prior written authorization from the X Consortium.
 #include "cursorstr.h"
 #include "xace.h"
 #include "inputstr.h"
-#ifdef DPMSExtension
 #include <X11/extensions/dpmsconst.h>
-#endif
 #include "protocol-versions.h"
 
 Bool noScreenSaverExtension = FALSE;
@@ -373,11 +371,7 @@ ScreenSaverFreeSuspend(void *value, XID id)
 
         /* The screensaver could be active, since suspending it (by design)
            doesn't prevent it from being forcibly activated */
-#ifdef DPMSExtension
         if (screenIsSaved != SCREEN_SAVER_ON && DPMSPowerLevel == DPMSModeOn)
-#else
-        if (screenIsSaved != SCREEN_SAVER_ON)
-#endif
         {
             DeviceIntPtr dev;
             UpdateCurrentTimeIf();

--- a/dix/main.c
+++ b/dix/main.c
@@ -122,9 +122,7 @@ Equipment Corporation.
 #include "privates.h"
 #include "exevents.h"
 
-#ifdef DPMSExtension
 #include <X11/extensions/dpmsconst.h>
-#endif
 
 extern void Dispatch(void);
 

--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -32,9 +32,7 @@
 #include "os/cmdline.h"
 #include "os/ddx_priv.h"
 #include "os/osdep.h"
-#ifdef DPMSExtension
 #include "Xext/dpms/dpms_priv.h"
-#endif
 
 #include "kdrive.h"
 #include <dixstruct.h>

--- a/hw/xfree86/common/xf86Config.c
+++ b/hw/xfree86/common/xf86Config.c
@@ -55,9 +55,7 @@
 #include "os/log_priv.h"
 #include "os/osdep.h"
 #include "Xext/xkeyboard/xkbsrv_priv.h"
-#ifdef DPMSExtension
 #include "Xext/dpms/dpms_priv.h"
-#endif
 
 #include "xf86_priv.h"
 #include "xf86Modes.h"
@@ -934,7 +932,6 @@ configServerFlags(XF86ConfFlagsPtr flagsconf, XF86OptionPtr layoutopts)
         ErrorF("BlankTime value %d outside legal range of 0 - %d minutes\n",
                i, MAX_TIME_IN_MIN);
 
-#ifdef DPMSExtension
     i = -1;
     xf86GetOptValInteger(FlagOptions, FLAG_DPMS_STANDBYTIME, &i);
     if ((i >= 0) && (i < MAX_TIME_IN_MIN))
@@ -956,7 +953,6 @@ configServerFlags(XF86ConfFlagsPtr flagsconf, XF86OptionPtr layoutopts)
     else if (i != -1)
         ErrorF("OffTime value %d outside legal range of 0 - %d minutes\n",
                i, MAX_TIME_IN_MIN);
-#endif
 
 #ifdef XINERAMA
     from = X_DEFAULT;

--- a/hw/xfree86/common/xf86DPMS.c
+++ b/hw/xfree86/common/xf86DPMS.c
@@ -37,17 +37,11 @@
 #include "xf86Priv.h"
 #include "xf86Opt_priv.h"
 
-#ifdef DPMSExtension
 #include <X11/extensions/dpmsconst.h>
-#endif
-
-#ifdef DPMSExtension
 #include "Xext/dpms/dpms_priv.h"
-#endif
 
 #include "xf86VGAarbiter_priv.h"
 
-#ifdef DPMSExtension
 static void
 xf86DPMS(ScreenPtr pScreen, int level)
 {
@@ -58,12 +52,10 @@ xf86DPMS(ScreenPtr pScreen, int level)
         xf86VGAarbiterUnlock(pScrn);
     }
 }
-#endif
 
 Bool
 xf86DPMSInit(ScreenPtr pScreen, DPMSSetProcPtr set, int flags)
 {
-#ifdef DPMSExtension
     ScrnInfoPtr pScrn = xf86ScreenToScrn(pScreen);
     void *DPMSOpt;
     MessageType enabled_from = X_DEFAULT;
@@ -85,7 +77,4 @@ xf86DPMSInit(ScreenPtr pScreen, DPMSSetProcPtr set, int flags)
         pScreen->DPMS = xf86DPMS;
     }
     return TRUE;
-#else
-    return FALSE;
-#endif
 }

--- a/hw/xfree86/common/xf86Events.c
+++ b/hw/xfree86/common/xf86Events.c
@@ -85,9 +85,7 @@
 #include "xkbsrv.h"
 #include "xkbstr.h"
 
-#ifdef DPMSExtension
 #include <X11/extensions/dpmsconst.h>
-#endif
 
 #include "../os-support/linux/systemd-logind.h"
 #include "seatd-libseat.h"
@@ -382,10 +380,8 @@ xf86VTLeave(void)
 
     DebugF("xf86VTSwitch: Leaving, xf86Exiting is %s\n",
            (dispatchException & DE_TERMINATE) ? "TRUE" : "FALSE");
-#ifdef DPMSExtension
     if (DPMSPowerLevel != DPMSModeOn)
         DPMSSet(serverClient, DPMSModeOn);
-#endif
     for (i = 0; i < xf86NumScreens; i++) {
         if (!(dispatchException & DE_TERMINATE))
             if (xf86Screens[i]->EnableDisableFBAccess)

--- a/hw/xfree86/common/xf86Init.c
+++ b/hw/xfree86/common/xf86Init.c
@@ -59,9 +59,7 @@
 #include "os/ddx_priv.h"
 #include "os/log_priv.h"
 #include "os/osdep.h"
-#ifdef DPMSExtension
 #include "Xext/dpms/dpms_priv.h"
-#endif
 #include "Xext/randr/randrstr_priv.h"
 
 #include "servermd.h"
@@ -90,9 +88,7 @@
 #include "globals.h"
 #include "xserver-properties.h"
 
-#ifdef DPMSExtension
 #include <X11/extensions/dpmsconst.h>
-#endif
 
 #ifdef __linux__
 #include <linux/major.h>
@@ -813,10 +809,9 @@ ddxGiveUp(enum ExitCode error)
         input_lock();
 
         /* try to restore the original video state */
-#ifdef DPMSExtension            /* Turn screens back on */
+        /* Turn screens back on */
         if (DPMSPowerLevel != DPMSModeOn)
             DPMSSet(serverClient, DPMSModeOn);
-#endif
         if (xf86Screens) {
             for (i = 0; i < xf86NumScreens; i++)
                 if (xf86Screens[i]->vtSema) {

--- a/hw/xnest/Args.c
+++ b/hw/xnest/Args.c
@@ -57,9 +57,7 @@ ddxProcessArgument(int argc, char *argv[], int i)
 
     noCompositeExtension = TRUE;
 
-#ifdef DPMSExtension
     noDPMSExtension = TRUE;
-#endif
 
     if (!strcmp(argv[i], "-display")) {
         if (++i < argc) {

--- a/hw/xwin/InitOutput.c
+++ b/hw/xwin/InitOutput.c
@@ -39,9 +39,7 @@ from The Open Group.
 #include "os/log_priv.h"
 #include "os/osdep.h"
 #include "Xext/xkeyboard/xkbsrv_priv.h"
-#ifdef DPMSExtension
 #include "Xext/dpms/dpms_priv.h"
-#endif
 #include "Xext/pseudoramiX/pseudoramiX.h"
 
 #include "winmsg.h"

--- a/include/meson.build
+++ b/include/meson.build
@@ -226,7 +226,6 @@ conf_data.set('COMPOSITE', '1')
 conf_data.set('DAMAGE', '1')
 conf_data.set('DBE', '1')
 conf_data.set('DGA', build_dga ? '1' : false)
-conf_data.set('DPMSExtension', build_dpms ? '1' : false)
 conf_data.set('DRI2', build_dri2 ? '1' : false)
 conf_data.set('DRI3', build_dri3 ? '1' : false)
 if build_glx

--- a/meson.build
+++ b/meson.build
@@ -117,7 +117,7 @@ xf86bigfontproto_dep = dependency('xf86bigfontproto', version: '>= 1.2.0', fallb
 xf86vidmodeproto_dep = dependency('xf86vidmodeproto', version: '>= 2.2.99.1', fallback: ['xorgproto', 'ext_xorgproto'])
 applewmproto_dep = dependency('applewmproto', version: '>= 1.4', fallback: ['xorgproto', 'ext_xorgproto'], required: false)
 xshmfence_dep = dependency('xshmfence', version: xshmfence_req, required: false)
-dpmsproto_dep = dependency('dpmsproto', version: '>= 1.2', required: get_option('dpms'))
+dpmsproto_dep = dependency('dpmsproto', version: '>= 1.2')
 
 pixman_dep = dependency('pixman-1')
 libbsd_dep = dependency('libbsd-overlay', required: false)
@@ -574,11 +574,6 @@ if get_option('vgahw') == 'auto'
     endif
 else
     build_vgahw = get_option('vgahw') == 'true'
-endif
-
-build_dpms = get_option('dpms')
-if build_xquartz
-    build_dpms = false
 endif
 
 build_xf86bigfont = get_option('xf86bigfont')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -91,8 +91,6 @@ option('seatd_libseat', type: 'combo', choices: ['true', 'false', 'auto'], value
 
 option('vgahw', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
        description: 'Xorg VGA access module')
-option('dpms', type: 'boolean', value: true,
-       description: 'Xorg DPMS extension')
 option('xf86bigfont', type: 'boolean', value: false,
        description: 'XF86 Big Font extension')
 option('screensaver', type: 'boolean', value: true,

--- a/mi/mieq.c
+++ b/mi/mieq.c
@@ -60,9 +60,7 @@ in this Software without prior written authorization from The Open Group.
 #include   "scrnintstr.h"
 #include   "eventstr.h"
 
-#ifdef DPMSExtension
 #include <X11/extensions/dpmsconst.h>
-#endif
 
 /* Maximum size should be initial size multiplied by a power of 2 */
 #define QUEUE_INITIAL_SIZE                 512
@@ -560,13 +558,11 @@ mieqProcessInputEvents(void)
 
         if (screenIsSaved == SCREEN_SAVER_ON)
             dixSaveScreens(serverClient, SCREEN_SAVER_OFF, ScreenSaverReset);
-#ifdef DPMSExtension
         else if (DPMSPowerLevel != DPMSModeOn)
             SetScreenSaverTimer();
 
         if (DPMSPowerLevel != DPMSModeOn)
             DPMSSet(serverClient, DPMSModeOn);
-#endif
 
         mieqProcessDeviceEvent(dev, &event, screen);
 

--- a/os/WaitFor.c
+++ b/os/WaitFor.c
@@ -92,9 +92,7 @@ SOFTWARE.
 #define GetErrno() errno
 #endif
 
-#ifdef DPMSExtension
 #include <X11/extensions/dpmsconst.h>
-#endif
 
 struct _OsTimerRec {
     struct xorg_list list;
@@ -388,8 +386,6 @@ TimerInit(void)
     }
 }
 
-#ifdef DPMSExtension
-
 #define DPMS_CHECK_MODE(mode,time)\
     if (time > 0 && DPMSPowerLevel < mode && timeout >= time)\
 	DPMSSet(serverClient, mode);
@@ -419,7 +415,6 @@ NextDPMSTimeout(INT32 timeout)
         return 0;
     }
 }
-#endif                          /* DPMSExtension */
 
 static CARD32
 ScreenSaverTimeoutExpire(OsTimerPtr timer, CARD32 now, void *arg)
@@ -427,7 +422,6 @@ ScreenSaverTimeoutExpire(OsTimerPtr timer, CARD32 now, void *arg)
     INT32 timeout = now - LastEventTime(XIAllDevices).milliseconds;
     CARD32 nextTimeout = 0;
 
-#ifdef DPMSExtension
     /*
      * Check each mode lowest to highest, since a lower mode can
      * have the same timeout as a higher one.
@@ -446,7 +440,6 @@ ScreenSaverTimeoutExpire(OsTimerPtr timer, CARD32 now, void *arg)
      */
     if (DPMSPowerLevel != DPMSModeOn)
         return nextTimeout;
-#endif                          /* DPMSExtension */
 
     if (!ScreenSaverTime)
         return nextTimeout;
@@ -484,7 +477,6 @@ SetScreenSaverTimer(void)
 {
     CARD32 timeout = 0;
 
-#ifdef DPMSExtension
     if (DPMSEnabled) {
         /*
          * A higher DPMS level has a timeout that's either less
@@ -499,7 +491,6 @@ SetScreenSaverTimer(void)
         else if (DPMSOffTime > 0)
             timeout = DPMSOffTime;
     }
-#endif
 
     if (ScreenSaverTime > 0) {
         timeout = timeout > 0 ? min(ScreenSaverTime, timeout) : ScreenSaverTime;

--- a/os/utils.c
+++ b/os/utils.c
@@ -279,9 +279,7 @@ UseMsg(void)
     ErrorF("-core                  generate core dump on fatal error\n");
     ErrorF("-displayfd fd          file descriptor to write display number to when ready to connect\n");
     ErrorF("-dpi int               screen resolution in dots per inch\n");
-#ifdef DPMSExtension
     ErrorF("-dpms                  disables VESA DPMS monitor control\n");
-#endif
     ErrorF
         ("-deferglyphs [none|all|16] defer loading of [no|all|16-bit] glyphs\n");
     ErrorF("-f #                   bell base (0-100)\n");
@@ -513,12 +511,10 @@ ProcessCommandLine(int argc, char *argv[])
             else
                 UseMsg();
         }
-#ifdef DPMSExtension
         else if (strcmp(argv[i], "dpms") == 0)
             /* ignored for compatibility */ ;
         else if (strcmp(argv[i], "-dpms") == 0)
             DPMSDisabledSwitch = TRUE;
-#endif
         else if (strcmp(argv[i], "-deferglyphs") == 0) {
             if (++i >= argc || !xfont2_parse_glyph_caching_mode(argv[i]))
                 UseMsg();


### PR DESCRIPTION
There's no practical use in having extra build-time switch for
disabling DPMS extension and corresponding ifdef-zoo.

Those DDX'es not supporting it just continue leaving the ScreenProc->DPMS
empty (NULL), thus leaving to the extension to be run-time disabled.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
