### PR TITLE
(release/25.1) Revert "xkb: unexport XkbGetCoreMap() and XkbSetRepeatKeys()"

### DIFF
--- a/Xi/getkmap.c
+++ b/Xi/getkmap.c
@@ -59,7 +59,6 @@ SOFTWARE.
 #include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
 #include "Xi/handlers.h"
-#include "xkb/xkbsrv_priv.h"
 
 #include "inputstr.h"           /* DeviceIntPtr      */
 #include "swaprep.h"

--- a/hw/xquartz/quartzKeyboard.c
+++ b/hw/xquartz/quartzKeyboard.c
@@ -44,10 +44,6 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <sys/stat.h>
-#include <assert.h>
-#include <pthread.h>
-
-#include "xkb/xkbsrv_priv.h"
 
 #include "quartz.h"
 #include "darwin.h"
@@ -56,6 +52,9 @@
 #include "quartzKeyboard.h"
 
 #include "X11Application.h"
+
+#include <assert.h>
+#include <pthread.h>
 
 #include "xkbsrv.h"
 #include "exevents.h"

--- a/include/xkbsrv.h
+++ b/include/xkbsrv.h
@@ -197,6 +197,9 @@ extern _X_EXPORT void XkbFreeKeyboard(XkbDescPtr /* xkb */ ,
                                       Bool      /* freeDesc */
     );
 
+extern _X_EXPORT KeySymsPtr XkbGetCoreMap(DeviceIntPtr  /* keybd */
+    );
+
 extern _X_EXPORT void XkbApplyMappingChange(DeviceIntPtr /* pXDev */ ,
                                             KeySymsPtr /* map */ ,
                                             KeyCode /* firstKey */ ,
@@ -208,6 +211,11 @@ extern _X_EXPORT void XkbApplyMappingChange(DeviceIntPtr /* pXDev */ ,
 extern _X_EXPORT void XkbDDXChangeControls(DeviceIntPtr /* dev */ ,
                                            XkbControlsPtr /* old */ ,
                                            XkbControlsPtr       /* new */
+    );
+
+extern _X_EXPORT void XkbSetRepeatKeys(DeviceIntPtr /* pXDev */ ,
+                                       int /* key */ ,
+                                       int      /* onoff */
     );
 
 extern _X_EXPORT void XkbGetRulesDflts(XkbRMLVOSet *    /* rmlvo */

--- a/xkb/xkbsrv_priv.h
+++ b/xkb/xkbsrv_priv.h
@@ -303,8 +303,4 @@ int XkbDDXUsesSoftRepeat(DeviceIntPtr dev);
 void XkbDDXKeybdCtrlProc(DeviceIntPtr dev, KeybdCtrl *ctrl);
 void XkbDDXUpdateDeviceIndicators(DeviceIntPtr dev, XkbSrvLedInfoPtr sli,
                                   CARD32 newState);
-
-KeySymsPtr XkbGetCoreMap(DeviceIntPtr keybd);
-void XkbSetRepeatKeys(DeviceIntPtr pXDev, int key, int onoff);
-
 #endif /* _XSERVER_XKBSRV_PRIV_H_ */


### PR DESCRIPTION
This reverts commit 25d99353eeb806f2929cf4423e481ff745ae4216. These symbols are required by the xorgxrdp driver.