### PR TITLE
Draft: WIP: nvidia driver instrumentation: check installed proc vectors and extensions

### DIFF
--- a/hw/xfree86/common/xf86Init.c
+++ b/hw/xfree86/common/xf86Init.c
@@ -76,6 +76,12 @@
 #include "xf86Module_priv.h"
 #include "xf86_priv.h"
 #include "xf86Priv.h"
+#ifdef PROC_VECTOR_MONITOR_ENABLED
+#include "hw/xfree86/compat/procvector_monitor.h"
+#endif
+#ifdef SCREENREC_MONITOR_ENABLED
+#include "hw/xfree86/compat/screenrec_monitor.h"
+#endif
 #include "xf86Config.h"
 #include "xf86_os_support.h"
 #include "xf86_OSlib.h"
@@ -712,6 +718,13 @@ InitOutput(int argc, char **argv)
 
     RegisterBlockAndWakeupHandlers((ServerBlockHandlerProcPtr) NoopDDA, xf86Wakeup,
                                    NULL);
+
+#ifdef PROC_VECTOR_MONITOR_ENABLED
+    ProcVectorMonitorInit();
+#endif
+#ifdef SCREENREC_MONITOR_ENABLED
+    ScreenRecMonitorInit();
+#endif
 }
 
 /**

--- a/hw/xfree86/compat/meson.build
+++ b/hw/xfree86/compat/meson.build
@@ -11,6 +11,13 @@ if get_option('legacy_nvidia_340x')
     srcs_xorg_compat += 'geeventinit.c'
 endif
 
+if get_option('procvector_monitor')
+    srcs_xorg_compat += 'procvector_monitor.c'
+endif
+if get_option('screenrec_monitor')
+    srcs_xorg_compat += 'screenrec_monitor.c'
+endif
+
 xorg_compat = static_library('xorg_compat',
     srcs_xorg_compat,
     dependencies: common_dep,

--- a/hw/xfree86/compat/procvector_monitor.c
+++ b/hw/xfree86/compat/procvector_monitor.c
@@ -1,0 +1,265 @@
+/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3
+ *
+ * Copyright © 2026 Enrico Weigelt, metux IT consult <info@metux.net>
+ *
+ * ProcVector modification monitor for detecting NVIDIA driver alterations.
+ * This is used for compatibility analysis and stability testing.
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <X11/X.h>
+#include "xf86.h"
+#include "xf86Module.h"
+#include "xf86Loader.h"
+#include "xf86Priv.h"
+#include "xf86Errors.h"
+#include <X11/Xproto.h>
+#include "dix/dix_priv.h"
+#include "dix/reqhandlers_priv.h"
+#include "dispatch.h"
+#include "os.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <signal.h>
+
+#define PROC_VECTOR_SIZE 256
+
+typedef struct {
+    uintptr_t proc_vector[PROC_VECTOR_SIZE];
+    uintptr_t swapped_proc_vector[PROC_VECTOR_SIZE];
+    unsigned long timestamp_ms;
+    Bool nvidia_module_loaded;
+    const char *module_name;
+} ProcVectorSnapshot;
+
+static ProcVectorSnapshot initial_snapshot;
+static ProcVectorSnapshot last_check;
+static Bool procvector_monitor_enabled = FALSE;
+static Bool monitor_setup_only = FALSE; /* Only check during module setup */
+static int procvector_monitor_interval_ms = 5000; /* Check every 5 seconds */
+static TimerPtr procvector_timer = NULL;
+static Bool mprotect_enabled = FALSE;
+static void *procvector_mprotect_base = NULL;
+static size_t procvector_mprotect_size = 0;
+static void *original_procvector_protection = NULL;
+
+/* File to log modifications */
+static const char *procvector_logfile = "/tmp/procvector_changes.log";
+static FILE *logfp = NULL;
+
+static void
+procvector_take_snapshot(ProcVectorSnapshot *snap, const char *module)
+{
+    int i;
+    if (!snap)
+        return;
+
+    for (i = 0; i < PROC_VECTOR_SIZE; i++) {
+        snap->proc_vector[i] = (uintptr_t)ProcVector[i];
+        snap->swapped_proc_vector[i] = (uintptr_t)SwappedProcVector[i];
+    }
+    snap->timestamp_ms = GetTimeInMillis();
+    snap->nvidia_module_loaded = FALSE; /* Will be set by caller if nvidia */
+    snap->module_name = module;
+}
+
+static void
+procvector_log_change(ProcVectorSnapshot *old, ProcVectorSnapshot *new,
+                      const char *reason)
+{
+    int i;
+    FILE *fp = logfp ? logfp : stderr;
+
+    fprintf(fp, "\n=== ProcVector/SwappedProcVector Modification Detected [%lu ms] ===\n",
+            new->timestamp_ms - old->timestamp_ms);
+    fprintf(fp, "Reason: %s\n", reason);
+    if (new->module_name)
+        fprintf(fp, "Module: %s\n", new->module_name);
+
+    for (i = 0; i < PROC_VECTOR_SIZE; i++) {
+        if (old->proc_vector[i] != new->proc_vector[i]) {
+            fprintf(fp, "  ProcVector[%3d] changed: 0x%016lx -> 0x%016lx\n",
+                    i, (unsigned long)old->proc_vector[i], (unsigned long)new->proc_vector[i]);
+        }
+        if (old->swapped_proc_vector[i] != new->swapped_proc_vector[i]) {
+            fprintf(fp, "  SwappedProcVector[%3d] changed: 0x%016lx -> 0x%016lx\n",
+                    i, (unsigned long)old->swapped_proc_vector[i], (unsigned long)new->swapped_proc_vector[i]);
+        }
+    }
+
+    fflush(fp);
+}
+
+static void
+procvector_check_and_log(const char *reason)
+{
+    ProcVectorSnapshot current;
+    procvector_take_snapshot(&current, NULL);
+
+    if (memcmp(&last_check, &current, sizeof(ProcVectorSnapshot)) != 0) {
+        procvector_log_change(&last_check, &current, reason);
+        last_check = current;
+    }
+}
+
+static CARD32
+procvector_timer_callback(OsTimerPtr timer, CARD32 now, pointer arg)
+{
+    if (!procvector_monitor_enabled)
+        return 0;
+
+    procvector_check_and_log("Periodic check");
+    return procvector_monitor_interval_ms;
+}
+
+/* Attempt to set memory protection to catch writes */
+static void
+procvector_setup_mprotect(void)
+{
+    /* Align to page boundary */
+    uintptr_t start = (uintptr_t)ProcVector;
+    uintptr_t end = (uintptr_t)SwappedProcVector + sizeof(SwappedProcVector);
+    uintptr_t page_size = getpagesize();
+
+    uintptr_t aligned_start = start & ~(page_size - 1);
+    uintptr_t aligned_end = (end + page_size - 1) & ~(page_size - 1);
+
+    procvector_mprotect_base = (void *)aligned_start;
+    procvector_mprotect_size = aligned_end - aligned_start;
+
+    if (mprotect(procvector_mprotect_base, procvector_mprotect_size, PROT_READ) == 0) {
+        LogMessage(X_INFO, "ProcVector monitor: mprotect enabled on 0x%lx size %lu\n",
+                   (unsigned long)procvector_mprotect_base, procvector_mprotect_size);
+        mprotect_enabled = TRUE;
+
+        /* Set up signal handler to catch writes */
+        struct sigaction sa;
+        sigemptyset(&sa.sa_mask);
+        sa.sa_flags = SA_SIGINFO | SA_RESTART;
+        sa.sa_sigaction = procvector_segv_handler;
+        if (sigaction(SIGSEGV, &sa, NULL) != 0) {
+            LogMessage(X_WARNING, "ProcVector monitor: failed to install SIGSEGV handler\n");
+        }
+    } else {
+        LogMessage(X_WARNING, "ProcVector monitor: mprotect failed (permissions?)\n");
+    }
+}
+
+/* Signal handler to catch SIGSEGV from mprotect */
+static void
+procvector_segv_handler(int sig, siginfo_t *info, void *ucontext)
+{
+    if (mprotect_enabled && info->si_addr >= procvector_mprotect_base &&
+        info->si_addr < (char *)procvector_mprotect_base + procvector_mprotect_size) {
+
+        /* Async-signal-safe logging */
+        const char *msg1 = "ProcVector: Detected write at ";
+        const char *msg2 = " - mprotect disabled, allowing write to proceed.\n";
+        write(STDERR_FILENO, msg1, strlen(msg1));
+
+        /* Simple hex output of address (async-signal-safe) */
+        uintptr_t addr = (uintptr_t)info->si_addr;
+        char hex[2];
+        const char *hexdigits = "0123456789abcdef";
+        /* Print in reverse order to buffer then write out correctly */
+        char buf[sizeof(void*) * 2 + 2];
+        int i = 0;
+        for (int nibble = sizeof(void*)*2 - 1; nibble >= 0; nibble--) {
+            buf[i++] = hexdigits[(addr >> (nibble * 4)) & 0xf];
+        }
+        buf[i] = '\n';
+        write(STDERR_FILENO, buf, i+1);
+
+        write(STDERR_FILENO, msg2, strlen(msg2));
+
+        /* Make the region writable so the instruction can complete */
+        mprotect(procvector_mprotect_base, procvector_mprotect_size, PROT_READ | PROT_WRITE);
+        mprotect_enabled = FALSE; /* Disable further mprotect trapping */
+    }
+}
+
+/* Enable monitoring - call from InitOutput or after ProcVector is initialized */
+void
+ProcVectorMonitorInit(void)
+{
+    const char *env = getenv("PROCVECTOR_MONITOR");
+    if (!env || strcmp(env, "1") != 0)
+        return;
+
+    /* Check if we should only monitor during driver setup (not periodically) */
+    if (getenv("PROCVECTOR_MONITOR_SETUP_ONLY"))
+        monitor_setup_only = TRUE;
+
+    procvector_monitor_enabled = TRUE;
+
+    logfp = fopen(procvector_logfile, "w");
+    if (!logfp)
+        LogMessage(X_WARNING, "ProcVector monitor: cannot open log file %s\n", procvector_logfile);
+
+    procvector_take_snapshot(&initial_snapshot, "initial");
+    last_check = initial_snapshot;
+
+    LogMessage(X_INFO, "ProcVector monitor: enabled, logging to %s\n", procvector_logfile);
+    if (monitor_setup_only)
+        LogMessage(X_INFO, "ProcVector monitor: setup-only mode (no periodic checks)\n");
+
+    /* Check immediately after initialization */
+    procvector_check_and_log("After initialization");
+
+    /* Set up periodic timer only if not in setup-only mode */
+    if (!monitor_setup_only) {
+        if (!procvector_timer) {
+            procvector_timer = TimerSet(procvector_timer, 0, procvector_monitor_interval_ms, procvector_timer_callback, NULL);
+        }
+    }
+
+    /* Optional mprotect-based detection */
+    if (getenv("PROCVECTOR_MPROTECT")) {
+        procvector_setup_mprotect();
+    }
+}
+
+/* Call this after loading a module (e.g., from LoaderLoadModule) */
+void
+ProcVectorMonitorCheckAfterModule(const char *module_name)
+{
+    if (!procvector_monitor_enabled)
+        return;
+
+    char reason[256];
+    snprintf(reason, sizeof(reason), "After loading module: %s", module_name);
+
+    ProcVectorSnapshot before_module = last_check;
+    procvector_check_and_log(reason);
+
+    if (memcmp(&before_module, &last_check, sizeof(ProcVectorSnapshot)) != 0) {
+        LogMessage(X_INFO, "ProcVector was modified by module: %s\n", module_name);
+    }
+}
+
+/* Explicit check for NVIDIA driver - call after nvidia module load */
+void
+ProcVectorMonitorCheckNVIDIA(void)
+{
+    ProcVectorMonitorCheckAfterModule("nvidia");
+}
+
+/* Disable monitoring (cleanup) */
+void
+ProcVectorMonitorFini(void)
+{
+    if (procvector_timer) {
+        TimerFree(procvector_timer);
+        procvector_timer = NULL;
+    }
+    if (logfp) {
+        fclose(logfp);
+        logfp = NULL;
+    }
+    procvector_monitor_enabled = FALSE;
+}

--- a/hw/xfree86/compat/procvector_monitor.h
+++ b/hw/xfree86/compat/procvector_monitor.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3
+ *
+ * Copyright © 2026 Enrico Weigelt, metux IT consult <info@metux.net>
+ *
+ * ProcVector monitoring interface.
+ */
+
+#ifndef PROCVECTOR_MONITOR_H
+#define PROCVECTOR_MONITOR_H
+
+extern void ProcVectorMonitorInit(void);
+extern void ProcVectorMonitorFini(void);
+extern void ProcVectorMonitorCheckAfterModule(const char *module_name);
+extern void ProcVectorMonitorCheckNVIDIA(void);
+
+#endif /* PROCVECTOR_MONITOR_H */

--- a/hw/xfree86/compat/screenrec_monitor.c
+++ b/hw/xfree86/compat/screenrec_monitor.c
@@ -1,0 +1,473 @@
+/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3
+ *
+ * Copyright © 2026 Enrico Weigelt, metux IT consult <info@metux.net>
+ *
+ * ScreenRec modification monitor for detecting NVIDIA driver alterations.
+ * Tracks changes to screen structures during driver setup.
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <X11/X.h>
+#include "xf86.h"
+#include "xf86Module.h"
+#include "xf86Loader.h"
+#include "xf86Priv.h"
+#include "xf86Errors.h"
+#include "xorg-server.h"
+#include <X11/X.h>  /* for MAXFORMATS */
+#include "screenint.h"
+#include "scrnintstr.h"
+#include "os.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <signal.h>
+#include <stddef.h>
+#include "privates.h"
+
+#define MAX_SCREENS 256  /* Arbitrary limit */
+
+typedef struct {
+    int screen_count;
+    ScreenRec *screens[MAX_SCREENS];
+    size_t *struct_sizes;  /* size of each ScreenRec */
+    unsigned char **snapshots;  /* raw snapshots, one per screen */
+    unsigned long timestamp_ms;
+    const char *module_name;
+} ScreenRecSnapshot;
+
+static ScreenRecSnapshot initial_snap;
+static ScreenRecSnapshot last_check;
+static Bool screenrec_monitor_enabled = FALSE;
+static Bool monitor_setup_only = FALSE;
+static int screenrec_monitor_interval_ms = 5000;
+static TimerPtr screenrec_timer = NULL;
+static Bool mprotect_enabled = FALSE;
+static void **screenrec_mprotect_bases = NULL;
+static size_t screenrec_mprotect_count = 0;
+
+static const char *screenrec_logfile = "/tmp/screenrec_changes.log";
+static FILE *logfp = NULL;
+
+/* Field metadata for ScreenRec */
+typedef struct {
+    const char *name;
+    size_t offset;
+    size_t size;
+    int array_count;  /* >1 if it's an array, 0 for variable-length */
+} ScreenField;
+
+/* Fields to monitor - defined in order of appearance in ScreenRec */
+static const ScreenField screen_fields[] = {
+    {"myNum", offsetof(ScreenRec, myNum), sizeof(int), 0},
+    {"id", offsetof(ScreenRec, id), sizeof(ATOM), 0},
+    {"x", offsetof(ScreenRec, x), sizeof(short), 0},
+    {"y", offsetof(ScreenRec, y), sizeof(short), 0},
+    {"width", offsetof(ScreenRec, width), sizeof(short), 0},
+    {"height", offsetof(ScreenRec, height), sizeof(short), 0},
+    {"mmWidth", offsetof(ScreenRec, mmWidth), sizeof(short), 0},
+    {"mmHeight", offsetof(ScreenRec, mmHeight), sizeof(short), 0},
+    {"numDepths", offsetof(ScreenRec, numDepths), sizeof(short), 0},
+    {"rootDepth", offsetof(ScreenRec, rootDepth), sizeof(unsigned char), 0},
+    {"allowedDepths", offsetof(ScreenRec, allowedDepths), sizeof(DepthPtr), 0},
+    {"rootVisual", offsetof(ScreenRec, rootVisual), sizeof(unsigned long), 0},
+    {"defColormap", offsetof(ScreenRec, defColormap), sizeof(unsigned long), 0},
+    {"minInstalledCmaps", offsetof(ScreenRec, minInstalledCmaps), sizeof(short), 0},
+    {"maxInstalledCmaps", offsetof(ScreenRec, maxInstalledCmaps), sizeof(short), 0},
+    {"backingStoreSupport", offsetof(ScreenRec, backingStoreSupport), sizeof(char), 0},
+    {"saveUnderSupport", offsetof(ScreenRec, saveUnderSupport), sizeof(char), 0},
+    {"whitePixel", offsetof(ScreenRec, whitePixel), sizeof(unsigned long), 0},
+    {"blackPixel", offsetof(ScreenRec, blackPixel), sizeof(unsigned long), 0},
+    {"GCperDepth", offsetof(ScreenRec, GCperDepth), sizeof(GCPtr), MAXFORMATS+1},
+    {"defaultStipple", offsetof(ScreenRec, defaultStipple), sizeof(PixmapPtr), 0},
+    {"devPrivate", offsetof(ScreenRec, devPrivate), sizeof(void*), 0},
+    {"numVisuals", offsetof(ScreenRec, numVisuals), sizeof(short), 0},
+    {"visuals", offsetof(ScreenRec, visuals), sizeof(VisualPtr), 0},
+    {"root", offsetof(ScreenRec, root), sizeof(WindowPtr), 0},
+    /* Skip screenSaverStuffRec (pointer complicated) */
+    {"screenSpecificPrivates", offsetof(ScreenRec, screenSpecificPrivates), sizeof(PrivateRec[PRIVATE_LAST]), PRIVATE_LAST},
+    /* function pointers - we'll monitor selected ones */
+    {"CloseScreen", offsetof(ScreenRec, CloseScreen), sizeof(CloseScreenProcPtr), 0},
+    {"QueryBestSize", offsetof(ScreenRec, QueryBestSize), sizeof(QueryBestSizeProcPtr), 0},
+    {"SaveScreen", offsetof(ScreenRec, SaveScreen), sizeof(SaveScreenProcPtr), 0},
+    {"GetImage", offsetof(ScreenRec, GetImage), sizeof(GetImageProcPtr), 0},
+    {"CreateWindow", offsetof(ScreenRec, CreateWindow), sizeof(CreateWindowProcPtr), 0},
+    {"DestroyWindow", offsetof(ScreenRec, DestroyWindow), sizeof(DestroyWindowProcPtr), 0},
+    {"MapWindow", offsetof(ScreenRec, MapWindow), sizeof(MapWindowProcPtr), 0},
+    {"UnmapWindow", offsetof(ScreenRec, UnmapWindow), sizeof(UnmapWindowProcPtr), 0},
+    {"CreatePixmap", offsetof(ScreenRec, CreatePixmap), sizeof(CreatePixmapProcPtr), 0},
+    {"DestroyPixmap", offsetof(ScreenRec, DestroyPixmap), sizeof(DestroyPixmapProcPtr), 0},
+    {"CreateGC", offsetof(ScreenRec, CreateGC), sizeof(CreateGCProcPtr), 0},
+    {"InstallColormap", offsetof(ScreenRec, InstallColormap), sizeof(InstallColormapProcPtr), 0},
+    {"StoreColors", offsetof(ScreenRec, StoreColors), sizeof(StoreColorsProcPtr), 0},
+    {"canDoBGNoneRoot", offsetof(ScreenRec, canDoBGNoneRoot), sizeof(Bool), 0},
+    {"isGPU", offsetof(ScreenRec, isGPU), sizeof(Bool), 0},
+#ifdef CONFIG_LEGACY_NVIDIA_PADDING
+    {"reserved_for_nvidia_470_and_390", offsetof(ScreenRec, reserved_for_nvidia_470_and_390), sizeof(void*), 0},
+#endif
+    {"totalPixmapSize", offsetof(ScreenRec, totalPixmapSize), sizeof(unsigned int), 0},
+    {"BitmapToRegion", offsetof(ScreenRec, BitmapToRegion), sizeof(BitmapToRegionProcPtr), 0},
+    {"BlockHandler", offsetof(ScreenRec, BlockHandler), sizeof(ScreenBlockHandlerProcPtr), 0},
+    {"WakeupHandler", offsetof(ScreenRec, WakeupHandler), sizeof(ScreenWakeupHandlerProcPtr), 0},
+    {"CreateScreenResources", offsetof(ScreenRec, CreateScreenResources), sizeof(CreateScreenResourcesProcPtr), 0},
+    {"DPMS", offsetof(ScreenRec, DPMS), sizeof(DPMSProcPtr), 0},
+};
+
+static void
+screenrec_take_snapshot(ScreenRecSnapshot *snap)
+{
+    int i;
+    if (!snap)
+        return;
+
+    snap->screen_count = screenInfo.numScreens;
+    for (i = 0; i < screenInfo.numScreens && i < MAX_SCREENS; i++) {
+        ScreenRec *scr = screenInfo.screens[i];
+        if (!scr) continue;
+        snap->screens[i] = scr;
+        /* We'll allocate snapshots lazily */
+    }
+    snap->timestamp_ms = GetTimeInMillis();
+}
+
+static void
+screenrec_alloc_snapshots(ScreenRecSnapshot *snap)
+{
+    int i;
+    if (!snap) return;
+
+    /* Free existing snapshots if any */
+    if (snap->struct_sizes) {
+        free(snap->struct_sizes);
+        snap->struct_sizes = NULL;
+    }
+    if (snap->snapshots) {
+        for (i = 0; i < snap->screen_count; i++) {
+            if (snap->snapshots[i])
+                free(snap->snapshots[i]);
+        }
+        free(snap->snapshots);
+        snap->snapshots = NULL;
+    }
+
+    if (snap->screen_count == 0)
+        return;
+
+    snap->struct_sizes = calloc(snap->screen_count, sizeof(size_t));
+    snap->snapshots = calloc(snap->screen_count, sizeof(unsigned char*));
+    if (!snap->struct_sizes || !snap->snapshots) {
+        LogMessage(X_WARNING, "ScreenRec monitor: out of memory allocating snapshots\n");
+        return;
+    }
+
+    for (i = 0; i < snap->screen_count; i++) {
+        if (snap->screens[i]) {
+            snap->struct_sizes[i] = sizeof(ScreenRec);  /* Could be dynamic if future changes */
+            snap->snapshots[i] = malloc(snap->struct_sizes[i]);
+            if (snap->snapshots[i]) {
+                memcpy(snap->snapshots[i], snap->screens[i], snap->struct_sizes[i]);
+            }
+        }
+    }
+}
+
+static void
+screenrec_free_snapshots(ScreenRecSnapshot *snap)
+{
+    if (!snap) return;
+    if (snap->struct_sizes) {
+        free(snap->struct_sizes);
+        snap->struct_sizes = NULL;
+    }
+    if (snap->snapshots) {
+        for (int i = 0; i < snap->screen_count; i++) {
+            if (snap->snapshots[i])
+                free(snap->snapshots[i]);
+        }
+        free(snap->snapshots);
+        snap->snapshots = NULL;
+    }
+}
+
+static void
+screenrec_log_change(ScreenRecSnapshot *old, ScreenRecSnapshot *new,
+                     const char *reason)
+{
+    FILE *fp = logfp ? logfp : stderr;
+
+    fprintf(fp, "\n=== ScreenRec Modification Detected [%lu ms] ===\n",
+            new->timestamp_ms - old->timestamp_ms);
+    fprintf(fp, "Reason: %s\n", reason);
+    if (new->module_name)
+        fprintf(fp, "Module: %s\n", new->module_name);
+
+    for (int s = 0; s < new->screen_count && s < old->screen_count; s++) {
+        ScreenRec *new_scr = new->screens[s];
+        ScreenRec *old_scr = old->screens[s];
+        unsigned char *old_snap = old->snapshots[s];
+        unsigned char *new_snap = new->snapshots[s];
+
+        if (!new_scr || !old_scr || !old_snap || !new_snap)
+            continue;
+
+        if (memcmp(old_snap, new_snap, sizeof(ScreenRec)) != 0) {
+            fprintf(fp, "\nScreen %d changes:\n", s);
+
+            /* Compare each monitored field */
+            for (size_t i = 0; i < sizeof(screen_fields)/sizeof(screen_fields[0]); i++) {
+                const ScreenField *f = &screen_fields[i];
+                void *old_field = (unsigned char*)old_scr + f->offset;
+                void *new_field = (unsigned char*)new_scr + f->offset;
+
+                if (f->array_count > 1) {
+                    size_t total = f->size * f->array_count;
+                    if (memcmp(old_field, new_field, total) != 0) {
+                        fprintf(fp, "  %s[]: array of %zu elements changed\n", f->name, f->array_count);
+                        /* Could dump individual elements if needed */
+                    }
+                } else {
+                    if (memcmp(old_field, new_field, f->size) != 0) {
+                        if (f->size == sizeof(void*)) {
+                            fprintf(fp, "  %s: 0x%016lx -> 0x%016lx\n",
+                                    f->name,
+                                    (unsigned long)*(void**)old_field,
+                                    (unsigned long)*(void**)new_field);
+                        } else if (f->size == sizeof(int)) {
+                            fprintf(fp, "  %s: %d -> %d\n",
+                                    f->name,
+                                    *(int*)old_field,
+                                    *(int*)new_field);
+                        } else if (f->size == sizeof(short)) {
+                            fprintf(fp, "  %s: %hd -> %hd\n",
+                                    f->name,
+                                    *(short*)old_field,
+                                    *(short*)new_field);
+                        } else if (f->size == sizeof(unsigned char)) {
+                            fprintf(fp, "  %s: %u -> %u\n",
+                                    f->name,
+                                    *(unsigned char*)old_field,
+                                    *(unsigned char*)new_field);
+                        } else if (f->size == sizeof(unsigned long)) {
+                            fprintf(fp, "  %s: 0x%016lx -> 0x%016lx\n",
+                                    f->name,
+                                    *(unsigned long*)old_field,
+                                    *(unsigned long*)new_field);
+                        } else if (f->size == sizeof(Bool)) {
+                            fprintf(fp, "  %s: %s -> %s\n",
+                                    f->name,
+                                    *(Bool*)old_field ? "true" : "false",
+                                    *(Bool*)new_field ? "true" : "false");
+                        } else {
+                            fprintf(fp, "  %s: size %zu bytes changed\n", f->name, f->size);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fflush(fp);
+}
+
+static void
+screenrec_check_and_log(const char *reason)
+{
+    ScreenRecSnapshot current;
+    memset(&current, 0, sizeof(current));
+    screenrec_take_snapshot(&current);
+    screenrec_alloc_snapshots(&current);
+
+    if (memcmp(&last_check, &current, sizeof(ScreenRecSnapshot)) != 0) {
+        screenrec_log_change(&last_check, &current, reason);
+    }
+
+    /* Update last_check with new snapshots */
+    screenrec_free_snapshots(&last_check);
+    last_check = current;
+}
+
+static CARD32
+screenrec_timer_callback(OsTimerPtr timer, CARD32 now, pointer arg)
+{
+    if (!screenrec_monitor_enabled)
+        return 0;
+
+    screenrec_check_and_log("Periodic check");
+    return screenrec_monitor_interval_ms;
+}
+
+static void
+screenrec_segv_handler(int sig, siginfo_t *info, void *ucontext)
+{
+    if (!mprotect_enabled)
+        return;
+
+    for (int i = 0; i < screenrec_mprotect_count; i++) {
+        if (screenrec_mprotect_bases[i] &&
+            info->si_addr >= screenrec_mprotect_bases[i] &&
+            info->si_addr < (char*)screenrec_mprotect_bases[i] + getpagesize()) {
+            const char *msg = "ScreenRec: Detected write at ";
+            write(STDERR_FILENO, msg, strlen(msg));
+            char buf[32];
+            int len = snprintf(buf, sizeof(buf), "%p - allowing write\n", info->si_addr);
+            if (len > 0)
+                write(STDERR_FILENO, buf, len);
+            /* Make all pages writable and disable further trapping */
+            for (int j = 0; j < screenrec_mprotect_count; j++) {
+                if (screenrec_mprotect_bases[j])
+                    mprotect(screenrec_mprotect_bases[j], getpagesize(), PROT_READ | PROT_WRITE);
+            }
+            mprotect_enabled = FALSE;
+            return;
+        }
+    }
+}
+
+static void
+screenrec_setup_mprotect(void)
+{
+    /* For each screen, mprotect its ScreenRec */
+    screenrec_mprotect_count = screenInfo.numScreens;
+    if (screenrec_mprotect_count == 0)
+        return;
+
+    screenrec_mprotect_bases = calloc(screenrec_mprotect_count, sizeof(void*));
+    if (!screenrec_mprotect_bases)
+        return;
+
+    uintptr_t page_size = getpagesize();
+
+    for (int i = 0; i < screenInfo.numScreens; i++) {
+        ScreenRec *scr = screenInfo.screens[i];
+        if (!scr)
+            continue;
+
+        uintptr_t start = (uintptr_t)scr;
+        uintptr_t end = start + sizeof(ScreenRec);
+        uintptr_t aligned_start = start & ~(page_size - 1);
+        uintptr_t aligned_end = (end + page_size - 1) & ~(page_size - 1);
+
+        void *base = (void*)aligned_start;
+        size_t size = aligned_end - aligned_start;
+
+        if (mprotect(base, size, PROT_READ) == 0) {
+            screenrec_mprotect_bases[i] = base;
+            LogMessage(X_INFO, "ScreenRec monitor: mprotect enabled for screen %d at 0x%lx size %lu\n",
+                       i, (unsigned long)base, size);
+        }
+    }
+
+    if (screenrec_mprotect_bases[0]) {
+        mprotect_enabled = TRUE;
+        /* Install signal handler */
+        struct sigaction sa;
+        sigemptyset(&sa.sa_mask);
+        sa.sa_flags = SA_SIGINFO | SA_RESTART;
+        sa.sa_sigaction = screenrec_segv_handler;
+        if (sigaction(SIGSEGV, &sa, NULL) != 0) {
+            LogMessage(X_WARNING, "ScreenRec monitor: failed to install SIGSEGV handler\n");
+        }
+    }
+}
+
+/* Global signal handler for ScreenRec writes */
+static void
+screenrec_segv_handler(int sig, siginfo_t *info, void *ucontext)
+{
+    if (!mprotect_enabled)
+        return;
+
+    for (int i = 0; i < screenrec_mprotect_count; i++) {
+        if (screenrec_mprotect_bases[i] &&
+            info->si_addr >= screenrec_mprotect_bases[i] &&
+            info->si_addr < (char*)screenrec_mprotect_bases[i] + getpagesize()) {
+            const char *msg = "ScreenRec: Detected write at ";
+            write(STDERR_FILENO, msg, strlen(msg));
+            char buf[32];
+            int len = snprintf(buf, sizeof(buf), "%p - allowing write\n", info->si_addr);
+            if (len > 0)
+                write(STDERR_FILENO, buf, len);
+            /* Make all pages writable and disable further trapping */
+            for (int j = 0; j < screenrec_mprotect_count; j++) {
+                if (screenrec_mprotect_bases[j])
+                    mprotect(screenrec_mprotect_bases[j], getpagesize(), PROT_READ | PROT_WRITE);
+            }
+            mprotect_enabled = FALSE;
+            return;
+        }
+    }
+}
+
+void
+ScreenRecMonitorInit(void)
+{
+    const char *env = getenv("SCREENREC_MONITOR");
+    if (!env || strcmp(env, "1") != 0)
+        return;
+
+    if (getenv("SCREENREC_MONITOR_SETUP_ONLY"))
+        monitor_setup_only = TRUE;
+
+    screenrec_monitor_enabled = TRUE;
+
+    logfp = fopen(screenrec_logfile, "w");
+    if (!logfp)
+        LogMessage(X_WARNING, "ScreenRec monitor: cannot open log file %s\n", screenrec_logfile);
+
+    screenrec_take_snapshot(&initial_snap);
+    screenrec_alloc_snapshots(&initial_snap);
+    last_check = initial_snap;  /* deep copy */
+
+    LogMessage(X_INFO, "ScreenRec monitor: enabled, logging to %s\n", screenrec_logfile);
+    if (monitor_setup_only)
+        LogMessage(X_INFO, "ScreenRec monitor: setup-only mode\n");
+
+    screenrec_check_and_log("After initialization");
+
+    if (!monitor_setup_only) {
+        screenrec_timer = TimerSet(screenrec_timer, 0, screenrec_monitor_interval_ms, screenrec_timer_callback, NULL);
+    }
+
+    if (getenv("SCREENREC_MPROTECT")) {
+        screenrec_setup_mprotect();
+    }
+}
+
+void
+ScreenRecMonitorCheckAfterModule(const char *module_name)
+{
+    if (!screenrec_monitor_enabled)
+        return;
+
+    ScreenRecSnapshot before_module = last_check;
+    screenrec_check_and_log("After module load");
+
+    if (memcmp(&before_module, &last_check, sizeof(ScreenRecSnapshot)) != 0) {
+        LogMessage(X_INFO, "ScreenRec was modified by module: %s\n", module_name);
+    }
+}
+
+void
+ScreenRecMonitorFini(void)
+{
+    if (screenrec_timer) {
+        TimerCancel(screenrec_timer);
+        TimerFree(screenrec_timer);
+        screenrec_timer = NULL;
+    }
+    if (logfp) {
+        fclose(logfp);
+        logfp = NULL;
+    }
+    screenrec_free_snapshots(&initial_snap);
+    screenrec_free_snapshots(&last_check);
+    if (screenrec_mprotect_bases) {
+        free(screenrec_mprotect_bases);
+        screenrec_mprotect_bases = NULL;
+    }
+    screenrec_monitor_enabled = FALSE;
+}

--- a/hw/xfree86/compat/screenrec_monitor.h
+++ b/hw/xfree86/compat/screenrec_monitor.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3
+ *
+ * Copyright © 2026 Enrico Weigelt, metux IT consult <info@metux.net>
+ *
+ * ScreenRec monitoring interface.
+ */
+
+#ifndef SCREENREC_MONITOR_H
+#define SCREENREC_MONITOR_H
+
+extern void ScreenRecMonitorInit(void);
+extern void ScreenRecMonitorFini(void);
+extern void ScreenRecMonitorCheckAfterModule(const char *module_name);
+
+#endif /* SCREENREC_MONITOR_H */

--- a/hw/xfree86/loader/loadmod.c
+++ b/hw/xfree86/loader/loadmod.c
@@ -54,6 +54,13 @@
 #include "loader.h"
 #include "xf86Module_priv.h"
 
+#ifdef PROC_VECTOR_MONITOR_ENABLED
+#include "hw/xfree86/compat/procvector_monitor.h"
+#endif
+#ifdef SCREENREC_MONITOR_ENABLED
+#include "hw/xfree86/compat/screenrec_monitor.h"
+#endif
+
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <regex.h>
@@ -977,7 +984,15 @@ LoadModule(const char *module, void *options, const XF86ModReqInfo *modreq,
     ret = NULL;
 
  LoadModule_exit:
-    FreePatterns(patterns);
+#ifdef PROC_VECTOR_MONITOR_ENABLED
+    if (ret)
+        ProcVectorMonitorCheckAfterModule(m);
+#endif
+#ifdef SCREENREC_MONITOR_ENABLED
+    if (ret)
+        ScreenRecMonitorCheckAfterModule(m);
+#endif
+     FreePatterns(patterns);
     free(found);
     free(name);
     free(p);

--- a/meson.build
+++ b/meson.build
@@ -637,6 +637,13 @@ endif
 
 legacy_nvidia_padding = get_option('legacy_nvidia_padding')
 
+if get_option('procvector_monitor')
+    add_project_arguments('-DPROC_VECTOR_MONITOR_ENABLED', language: 'c')
+endif
+if get_option('screenrec_monitor')
+    add_project_arguments('-DSCREENREC_MONITOR_ENABLED', language: 'c')
+endif
+
 m_dep = cc.find_library('m', required : false)
 dl_dep = cc.find_library('dl', required : false)
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -169,6 +169,12 @@ option('legacy_nvidia_padding', type: 'boolean', value: false,
         description: 'EXPERT ONLY: Add a padding to ScreenRec to match an older ABI for legacy NVidia drivers')
 option('legacy_nvidia_340x', type: 'boolean', value: true,
         description: 'Extra entrypoints for old Nvidia 340x proprietary driver')
+option('procvector_monitor', type: 'boolean', value: false,
+        description: 'Monitor ProcVector for modifications (for compatibility testing)')
+option('screenrec_monitor', type: 'boolean', value: false,
+        description: 'Monitor ScreenRec for modifications (for compatibility testing)')
+option('procvector_monitor', type: 'boolean', value: false,
+        description: 'Monitor ProcVector for modifications (for compatibility testing)')
 
 # testsuite fine tuning - some things might not run everywhere
 option('test_rendercheck_triangles', type: 'boolean', value: false,


### PR DESCRIPTION
This is a work in progress.

Add some (optional) instrumentation around proprietary Nvidia driver - checking which ProcVector's it hooks up, which extensions it installs, etc.
Hopefully it can give us more insights into how it's actually interacting with the Xserver - which are important for further refactoring.

Anybody running NVidia cards with the proprietary driver(s), feel free to play around with it and report back what you've found out.