### PR TITLE
 kdrive/fbdev: Use KdTuneMode to probe for a screen mode that works

### DIFF
--- a/hw/kdrive/fbdev/fbdev.c
+++ b/hw/kdrive/fbdev/fbdev.c
@@ -311,8 +311,14 @@ fbdevScreenInitialize(KdScreenInfo * screen, FbdevScrPriv * scrpriv)
             screen->fb.depth = 16;
     }
 
+    scrpriv->max_width = 0;
+    scrpriv->max_height = 0;
+
     rate = KdFindRate(screen, fbdevModeSupported);
     if (k >= 0) {
+        scrpriv->max_width = var.xres;
+        scrpriv->max_height = var.yres;
+
         /* Add the current framebuffer mode */
         fbdevConvertVarToTiming(&var, &curr_mode);
         KdAddMode(&curr_mode);
@@ -333,6 +339,14 @@ fbdevScreenInitialize(KdScreenInfo * screen, FbdevScrPriv * scrpriv)
 
     /* Sets priv->fix, priv->var */
     KdTuneMode(screen, t, fbdevSetMode, fbdevModeSupported);
+
+    if (scrpriv->max_width < screen->width) {
+        scrpriv->max_width = screen->width;
+    }
+
+    if (scrpriv->max_height < screen->height) {
+        scrpriv->max_height = screen->height;
+    }
 
     depth = priv->var.bits_per_pixel;
     gray = priv->var.grayscale;
@@ -658,8 +672,9 @@ fbdevRandrModeSupported(ScreenPtr pScreen, const KdMonitorTiming *t)
 {
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
+    FbdevScrPriv *scrpriv = screen->driver;
 
-    return (t->horizontal <= screen->width) && (t->vertical <= screen->height);
+    return (t->horizontal <= scrpriv->max_width) && (t->vertical <= scrpriv->max_height);
 }
 
 static Bool

--- a/hw/kdrive/fbdev/fbdev.c
+++ b/hw/kdrive/fbdev/fbdev.c
@@ -337,8 +337,18 @@ fbdevScreenInitialize(KdScreenInfo * screen, FbdevScrPriv * scrpriv)
 
     t = KdFindMode(screen, fbdevModeSupported);
 
-    /* Sets priv->fix, priv->var */
+
+    /**
+     * XXX The only way we can check what modes are supported is by actually setting them.
+     *
+     * We save the video card mode, probe the mode by setting it, and restore the video card mode.
+     * The probed video move will be set by fbdevEnable.
+     */
+
+    /* KdTuneMode calls fbdevSetMode, which sets priv->fix, priv->var */
+    fbdevPreserve(screen->card);
     KdTuneMode(screen, t, fbdevSetMode, fbdevModeSupported);
+    fbdevRestore(screen->card);
 
     if (scrpriv->max_width < screen->width) {
         scrpriv->max_width = screen->width;
@@ -906,6 +916,13 @@ fbdevCreateResources(ScreenPtr pScreen)
 void
 fbdevPreserve(KdCardInfo * card)
 {
+    FbdevPriv *priv = card->driver;
+    memset(&priv->saved_var, 0, sizeof(priv->saved_var));
+    if (ioctl(priv->fd, FBIOGET_VSCREENINFO, &priv->saved_var) < 0) {
+        LogMessage(X_INFO, "Xfbdev(%d): Failed to save the video card mode: %s\n",
+                   card->mynum, strerror(errno));
+        memset(&priv->saved_var, 0, sizeof(priv->saved_var));
+    }
 }
 
 static int
@@ -997,6 +1014,12 @@ fbdevDisable(ScreenPtr pScreen)
 void
 fbdevRestore(KdCardInfo * card)
 {
+    FbdevPriv *priv = card->driver;
+    if (priv->saved_var.xres &&
+        (ioctl(priv->fd, FBIOPUT_VSCREENINFO, &priv->saved_var) < 0)) {
+        LogMessage(X_INFO, "Xfbdev(%d): Failed to restore the video card mode: %s\n",
+                   card->mynum, strerror(errno));
+    }
 }
 
 void

--- a/hw/kdrive/fbdev/fbdev.c
+++ b/hw/kdrive/fbdev/fbdev.c
@@ -332,7 +332,7 @@ fbdevScreenInitialize(KdScreenInfo * screen, FbdevScrPriv * scrpriv)
     t = KdFindMode(screen, fbdevModeSupported);
 
     /* Sets priv->fix, priv->var */
-    fbdevSetMode(screen, t);
+    KdTuneMode(screen, t, fbdevSetMode, fbdevModeSupported);
 
     depth = priv->var.bits_per_pixel;
     gray = priv->var.grayscale;

--- a/hw/kdrive/fbdev/fbdev.h
+++ b/hw/kdrive/fbdev/fbdev.h
@@ -34,6 +34,7 @@
 #endif
 
 typedef struct _fbdevPriv {
+    struct fb_var_screeninfo saved_var;
     struct fb_var_screeninfo var;
     struct fb_fix_screeninfo fix;
     __u16 red[256];

--- a/hw/kdrive/fbdev/fbdev.h
+++ b/hw/kdrive/fbdev/fbdev.h
@@ -47,6 +47,8 @@ typedef struct _fbdevPriv {
 typedef struct _fbdevScrPriv {
     Rotation randr;
     Bool shadow;
+    int max_width;
+    int max_height;
 #ifdef GLAMOR
     int dri_fd;
 #endif

--- a/hw/kdrive/src/kdrive.h
+++ b/hw/kdrive/src/kdrive.h
@@ -533,8 +533,8 @@ Bool
 KdAddMode(const KdMonitorTiming *new);
 
 Bool
-KdTuneMode(KdScreenInfo * screen,
-           Bool (*usable) (KdScreenInfo *),
+KdTuneMode(KdScreenInfo * screen, const KdMonitorTiming *m,
+           Bool (*usable) (KdScreenInfo *, const KdMonitorTiming *),
            Bool (*supported) (KdScreenInfo *, const KdMonitorTiming *));
 
 #ifdef RANDR

--- a/hw/kdrive/src/kmode.c
+++ b/hw/kdrive/src/kmode.c
@@ -341,7 +341,7 @@ KdAddMode(const KdMonitorTiming *new)
 static const KdMonitorTiming *
 kdFindPrevSize(const KdMonitorTiming * old)
 {
-    const KdMonitorTiming *new, *prev;
+    const KdMonitorTiming *new;
 
     if (old == kdMonitorTimings)
         return 0;
@@ -356,17 +356,19 @@ kdFindPrevSize(const KdMonitorTiming * old)
             break;
         }
     }
+#if 0
     /*
      * Match the refresh rate (<=)
      */
     while (new != kdMonitorTimings) {
-        prev = new - 1;
+        const KdMonitorTiming *prev = new - 1;
         if (prev->horizontal == new->horizontal &&
             prev->vertical == new->vertical && prev->rate > old->rate) {
             break;
         }
         new--;
     }
+#endif
     return new;
 }
 

--- a/hw/kdrive/src/kmode.c
+++ b/hw/kdrive/src/kmode.c
@@ -371,13 +371,18 @@ kdFindPrevSize(const KdMonitorTiming * old)
 }
 
 Bool
-KdTuneMode(KdScreenInfo * screen,
-           Bool (*usable) (KdScreenInfo *),
+KdTuneMode(KdScreenInfo * screen, const KdMonitorTiming *m,
+           Bool (*usable) (KdScreenInfo *, const KdMonitorTiming *),
            Bool (*supported) (KdScreenInfo *, const KdMonitorTiming *))
 {
-    const KdMonitorTiming *t;
+    const KdMonitorTiming *t = m;
+    int depth = screen->fb.depth;
 
-    while (!(*usable) (screen)) {
+    screen->width = t->horizontal;
+    screen->height = t->vertical;
+    screen->rate = t->rate;
+
+    while (!(*usable) (screen, t)) {
         /*
          * Fix requested depth and geometry until it works
          */
@@ -386,6 +391,7 @@ KdTuneMode(KdScreenInfo * screen,
         else if (screen->fb.depth > 8)
             screen->fb.depth = 8;
         else {
+            screen->fb.depth = depth;
             t = kdFindPrevSize(KdFindMode(screen, supported));
             if (!t)
                 return FALSE;

--- a/hw/kdrive/src/kmode.c
+++ b/hw/kdrive/src/kmode.c
@@ -380,9 +380,11 @@ KdTuneMode(KdScreenInfo * screen, const KdMonitorTiming *m,
     const KdMonitorTiming *t = m;
     int depth = screen->fb.depth;
 
-    screen->width = t->horizontal;
-    screen->height = t->vertical;
-    screen->rate = t->rate;
+    if (t) {
+        screen->width = t->horizontal;
+        screen->height = t->vertical;
+        screen->rate = t->rate;
+    }
 
     while (!(*usable) (screen, t)) {
         /*


### PR DESCRIPTION
Also allow RandR to set modes higher than the initial selected mode, if we know they are supported.