### PR TITLE
xkb: add ToggleModifiersOnPress input option

### DIFF
--- a/Xext/xinput/xiproperty.c
+++ b/Xext/xinput/xiproperty.c
@@ -181,7 +181,8 @@ static struct dev_properties {
     {0, BTN_LABEL_PROP_BTN_TOOL_TRIPLETAP},
     {0, BTN_LABEL_PROP_BTN_GEAR_DOWN},
     {0, BTN_LABEL_PROP_BTN_GEAR_UP},
-    {0, XI_PROP_TRANSFORM}
+    {0, XI_PROP_TRANSFORM},
+    {0, XKB_PROP_LOCK_MODS_ON_PRESS}
 };
 
 static long XIPropHandlerID = 1;

--- a/Xext/xinput/xiproperty.c
+++ b/Xext/xinput/xiproperty.c
@@ -183,7 +183,8 @@ static struct dev_properties {
     {0, BTN_LABEL_PROP_BTN_TOOL_TRIPLETAP},
     {0, BTN_LABEL_PROP_BTN_GEAR_DOWN},
     {0, BTN_LABEL_PROP_BTN_GEAR_UP},
-    {0, XI_PROP_TRANSFORM}
+    {0, XI_PROP_TRANSFORM},
+    {0, XKB_PROP_LOCK_MODS_ON_PRESS}
 };
 
 static long XIPropHandlerID = 1;

--- a/Xext/xkeyboard/xkbActions.c
+++ b/Xext/xkeyboard/xkbActions.c
@@ -54,6 +54,8 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 DevPrivateKeyRec xkbDevicePrivateKeyRec;
 
+Bool xkbLockModsOnPress = FALSE;
+
 static void XkbFakePointerMotion(DeviceIntPtr dev, unsigned flags, int x,
                                  int y);
 
@@ -372,6 +374,10 @@ _XkbFilterLockState(XkbSrvInfoPtr xkbi,
             xkbi->state.locked_group += XkbSAGroup(&pAction->group);
         return 1;
     }
+    /* When xkbLockModsOnPress is set, a locking modifier such as CapsLock
+       toggles entirely on key press instead of locking on press and only
+       unlocking on the following key release like a mechanical typewriter.
+       Configured from the "ToggleModifiersOnPress" input option. */
     if (filter->keycode == 0) { /* initial press */
         filter->keycode = keycode;
         filter->active = 1;
@@ -379,15 +385,33 @@ _XkbFilterLockState(XkbSrvInfoPtr xkbi,
         filter->priv = xkbi->state.locked_mods & pAction->mods.mask;
         filter->filter = _XkbFilterLockState;
         filter->upAction = *pAction;
-        if (!(filter->upAction.mods.flags & XkbSA_LockNoLock))
-            xkbi->state.locked_mods |= pAction->mods.mask;
-        xkbi->setMods = pAction->mods.mask;
+
+        if (xkbLockModsOnPress) {
+            /* Toggle the whole lock now, on press, and leave the release a
+               no-op. base_mods (setMods/clearMods) is deliberately left
+               untouched so the indicator and the effective state flip
+               together, immediately. */
+            if (filter->priv) {
+                if (!(filter->upAction.mods.flags & XkbSA_LockNoUnlock))
+                    xkbi->state.locked_mods &= ~pAction->mods.mask;
+            }
+            else if (!(filter->upAction.mods.flags & XkbSA_LockNoLock)) {
+                xkbi->state.locked_mods |= pAction->mods.mask;
+            }
+        }
+        else {
+            if (!(filter->upAction.mods.flags & XkbSA_LockNoLock))
+                xkbi->state.locked_mods |= pAction->mods.mask;
+            xkbi->setMods = pAction->mods.mask;
+        }
     }
     else if (filter->keycode == keycode) {
         filter->active = 0;
-        xkbi->clearMods = filter->upAction.mods.mask;
-        if (!(filter->upAction.mods.flags & XkbSA_LockNoUnlock))
-            xkbi->state.locked_mods &= ~filter->priv;
+        if (!xkbLockModsOnPress) {
+            xkbi->clearMods = filter->upAction.mods.mask;
+            if (!(filter->upAction.mods.flags & XkbSA_LockNoUnlock))
+                xkbi->state.locked_mods &= ~filter->priv;
+        }
     }
     return 1;
 }

--- a/Xext/xkeyboard/xkbActions.c
+++ b/Xext/xkeyboard/xkbActions.c
@@ -55,6 +55,8 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 DevPrivateKeyRec xkbDevicePrivateKeyRec;
 
+Bool xkbLockModsOnPress = FALSE;
+
 static void XkbFakePointerMotion(DeviceIntPtr dev, unsigned flags, int x,
                                  int y);
 
@@ -373,6 +375,10 @@ _XkbFilterLockState(XkbSrvInfoPtr xkbi,
             xkbi->state.locked_group += XkbSAGroup(&pAction->group);
         return 1;
     }
+    /* When xkbLockModsOnPress is set, a locking modifier such as CapsLock
+       toggles entirely on key press instead of locking on press and only
+       unlocking on the following key release like a mechanical typewriter.
+       Configured from the "ToggleModifiersOnPress" input option. */
     if (filter->keycode == 0) { /* initial press */
         filter->keycode = keycode;
         filter->active = 1;
@@ -380,15 +386,33 @@ _XkbFilterLockState(XkbSrvInfoPtr xkbi,
         filter->priv = xkbi->state.locked_mods & pAction->mods.mask;
         filter->filter = _XkbFilterLockState;
         filter->upAction = *pAction;
-        if (!(filter->upAction.mods.flags & XkbSA_LockNoLock))
-            xkbi->state.locked_mods |= pAction->mods.mask;
-        xkbi->setMods = pAction->mods.mask;
+
+        if (xkbLockModsOnPress) {
+            /* Toggle the whole lock now, on press, and leave the release a
+               no-op. base_mods (setMods/clearMods) is deliberately left
+               untouched so the indicator and the effective state flip
+               together, immediately. */
+            if (filter->priv) {
+                if (!(filter->upAction.mods.flags & XkbSA_LockNoUnlock))
+                    xkbi->state.locked_mods &= ~pAction->mods.mask;
+            }
+            else if (!(filter->upAction.mods.flags & XkbSA_LockNoLock)) {
+                xkbi->state.locked_mods |= pAction->mods.mask;
+            }
+        }
+        else {
+            if (!(filter->upAction.mods.flags & XkbSA_LockNoLock))
+                xkbi->state.locked_mods |= pAction->mods.mask;
+            xkbi->setMods = pAction->mods.mask;
+        }
     }
     else if (filter->keycode == keycode) {
         filter->active = 0;
-        xkbi->clearMods = filter->upAction.mods.mask;
-        if (!(filter->upAction.mods.flags & XkbSA_LockNoUnlock))
-            xkbi->state.locked_mods &= ~filter->priv;
+        if (!xkbLockModsOnPress) {
+            xkbi->clearMods = filter->upAction.mods.mask;
+            if (!(filter->upAction.mods.flags & XkbSA_LockNoUnlock))
+                xkbi->state.locked_mods &= ~filter->priv;
+        }
     }
     return 1;
 }

--- a/Xext/xkeyboard/xkbInit.c
+++ b/Xext/xkeyboard/xkbInit.c
@@ -45,6 +45,8 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "os/cmdline.h"
 #include "os/log_priv.h"
 #include "xkbsrv_priv.h"
+#include "dix/exevents_priv.h"
+#include <xserver-properties.h>
 
 #include "inputstr.h"
 #include "opaque.h"
@@ -503,6 +505,40 @@ XkbInitOverlayState(XkbSrvInfoPtr xkbi)
     return Success;
 }
 
+static int
+XkbSetLockModsOnPressProperty(DeviceIntPtr dev, Atom atom,
+                              XIPropertyValuePtr val, BOOL checkOnly)
+{
+    int nelem = 1;
+    int v;
+    int *ptr = &v;
+
+    if (atom != XIGetKnownProperty(XKB_PROP_LOCK_MODS_ON_PRESS))
+        return Success;
+
+    if (XIPropToInt(val, &nelem, &ptr))
+        return BadValue;
+    if (v != 0 && v != 1)
+        return BadValue;
+
+    if (!checkOnly)
+        xkbLockModsOnPress = v;
+
+    return Success;
+}
+
+static void
+XkbInitLockModsOnPressProperty(DeviceIntPtr dev)
+{
+    Atom prop = XIGetKnownProperty(XKB_PROP_LOCK_MODS_ON_PRESS);
+    CARD8 val = xkbLockModsOnPress;
+
+    XIChangeDeviceProperty(dev, prop, XA_INTEGER, 8,
+                           PropModeReplace, 1, &val, FALSE);
+    XISetDevicePropertyDeletable(dev, prop, FALSE);
+    XIRegisterPropertyHandler(dev, XkbSetLockModsOnPressProperty, NULL, NULL);
+}
+
 static Bool
 InitKeyboardDeviceStructInternal(DeviceIntPtr dev, XkbRMLVOSet * rmlvo,
                                  const char *keymap, int keymap_length,
@@ -638,6 +674,9 @@ InitKeyboardDeviceStructInternal(DeviceIntPtr dev, XkbRMLVOSet * rmlvo,
         XkbSetRulesUsed(rmlvo);
     }
     XkbFreeRMLVOSet(&rmlvo_dflts, FALSE);
+
+    if (InputDevIsMaster(dev))
+        XkbInitLockModsOnPressProperty(dev);
 
     return TRUE;
 

--- a/hw/xfree86/common/xf86Xinput.c
+++ b/hw/xfree86/common/xf86Xinput.c
@@ -367,10 +367,13 @@ ApplyXkbToggleTiming(DeviceIntPtr dev)
     /* This toggle is server-global (see xkbsrv.h): a key event is processed
      * by both the originating slave keyboard and the master keyboard, each
      * with its own XkbSrvInfo, so a per-device flag would only reach one of
-     * the two paths. Sticky/opt-in: once any configured keyboard enables the
-     * quirk it stays on; nothing here turns it back off. */
+     * the two paths. Propagate via the master keyboard's xinput property
+     * so the value remains readable and writable at runtime */
     if (xf86SetBoolOption(pInfo->options, "ToggleModifiersOnPress", FALSE)) {
-        xkbLockModsOnPress = TRUE;
+        CARD8 val = 1;
+        XIChangeDeviceProperty(inputInfo.keyboard,
+                               XIGetKnownProperty(XKB_PROP_LOCK_MODS_ON_PRESS),
+                               XA_INTEGER, 8, PropModeReplace, 1, &val, TRUE);
         LogMessageVerb(X_CONFIG, 1, "%s: locking modifiers toggle on press\n",
                        pInfo->name);
     }

--- a/hw/xfree86/common/xf86Xinput.c
+++ b/hw/xfree86/common/xf86Xinput.c
@@ -356,6 +356,26 @@ ApplyAutoRepeat(DeviceIntPtr dev)
     xkbi->desc->ctrls->repeat_interval = 1000 / rate;
 }
 
+static void
+ApplyXkbToggleTiming(DeviceIntPtr dev)
+{
+    InputInfoPtr pInfo = (InputInfoPtr) dev->public.devicePrivate;
+
+    if (!dev->key)
+        return;
+
+    /* This toggle is server-global (see xkbsrv.h): a key event is processed
+     * by both the originating slave keyboard and the master keyboard, each
+     * with its own XkbSrvInfo, so a per-device flag would only reach one of
+     * the two paths. Sticky/opt-in: once any configured keyboard enables the
+     * quirk it stays on; nothing here turns it back off. */
+    if (xf86SetBoolOption(pInfo->options, "ToggleModifiersOnPress", FALSE)) {
+        xkbLockModsOnPress = TRUE;
+        LogMessageVerb(X_CONFIG, 1, "%s: locking modifiers toggle on press\n",
+                       pInfo->name);
+    }
+}
+
 /***********************************************************************
  *
  * xf86ProcessCommonOptions --
@@ -893,6 +913,7 @@ xf86InputDevicePostInit(DeviceIntPtr dev)
     ApplyAccelerationSettings(dev);
     ApplyTransformationMatrix(dev);
     ApplyAutoRepeat(dev);
+    ApplyXkbToggleTiming(dev);
     return Success;
 }
 

--- a/hw/xfree86/common/xf86Xinput.c
+++ b/hw/xfree86/common/xf86Xinput.c
@@ -357,6 +357,26 @@ ApplyAutoRepeat(DeviceIntPtr dev)
     xkbi->desc->ctrls->repeat_interval = 1000 / rate;
 }
 
+static void
+ApplyXkbToggleTiming(DeviceIntPtr dev)
+{
+    InputInfoPtr pInfo = (InputInfoPtr) dev->public.devicePrivate;
+
+    if (!dev->key)
+        return;
+
+    /* This toggle is server-global (see xkbsrv.h): a key event is processed
+     * by both the originating slave keyboard and the master keyboard, each
+     * with its own XkbSrvInfo, so a per-device flag would only reach one of
+     * the two paths. Sticky/opt-in: once any configured keyboard enables the
+     * quirk it stays on; nothing here turns it back off. */
+    if (xf86SetBoolOption(pInfo->options, "ToggleModifiersOnPress", FALSE)) {
+        xkbLockModsOnPress = TRUE;
+        LogMessageVerb(X_CONFIG, 1, "%s: locking modifiers toggle on press\n",
+                       pInfo->name);
+    }
+}
+
 /***********************************************************************
  *
  * xf86ProcessCommonOptions --
@@ -894,6 +914,7 @@ xf86InputDevicePostInit(DeviceIntPtr dev)
     ApplyAccelerationSettings(dev);
     ApplyTransformationMatrix(dev);
     ApplyAutoRepeat(dev);
+    ApplyXkbToggleTiming(dev);
     return Success;
 }
 

--- a/hw/xfree86/common/xf86Xinput.c
+++ b/hw/xfree86/common/xf86Xinput.c
@@ -368,10 +368,13 @@ ApplyXkbToggleTiming(DeviceIntPtr dev)
     /* This toggle is server-global (see xkbsrv.h): a key event is processed
      * by both the originating slave keyboard and the master keyboard, each
      * with its own XkbSrvInfo, so a per-device flag would only reach one of
-     * the two paths. Sticky/opt-in: once any configured keyboard enables the
-     * quirk it stays on; nothing here turns it back off. */
+     * the two paths. Propagate via the master keyboard's xinput property
+     * so the value remains readable and writable at runtime */
     if (xf86SetBoolOption(pInfo->options, "ToggleModifiersOnPress", FALSE)) {
-        xkbLockModsOnPress = TRUE;
+        CARD8 val = 1;
+        XIChangeDeviceProperty(inputInfo.keyboard,
+                               XIGetKnownProperty(XKB_PROP_LOCK_MODS_ON_PRESS),
+                               XA_INTEGER, 8, PropModeReplace, 1, &val, TRUE);
         LogMessageVerb(X_CONFIG, 1, "%s: locking modifiers toggle on press\n",
                        pInfo->name);
     }

--- a/hw/xfree86/man/xorg.conf.man
+++ b/hw/xfree86/man/xorg.conf.man
@@ -1251,6 +1251,16 @@ entries.
 This optional entry specifies that the device should be ignored entirely,
 and not added to the server. This can be useful when the device is handled
 by another program and no X events should be generated.
+.TP 7
+.BI "Option \*qToggleModifiersOnPress\*q \*q" boolean \*q
+When enabled, a locking modifier such as CapsLock or NumLock toggles
+entirely on key press instead of locking on press and unlocking only on the
+subsequent release (as on a mechanical typewriter).
+This sets the server default behavior and can be adjusted at runtime by
+.I "Toggle Lock Modifiers On Press"
+xinput property on any master keyboard.
+The default is
+.B off.
 .SH "OUTPUTCLASS SECTION"
 The config file may have multiple
 .B OutputClass

--- a/include/xkbsrv.h
+++ b/include/xkbsrv.h
@@ -146,6 +146,12 @@ typedef struct _XkbSrvInfo {
     char overlay_perkey_state[256/8]; /* bitfield */
 } XkbSrvInfoRec, *XkbSrvInfoPtr;
 
+/* Server-wide lock-key timing quirk, configured from an input option.
+ * Global rather than per-device because key events are processed by both
+ * the originating slave keyboard and the master keyboard, each with its
+ * own XkbSrvInfo; a global is read identically on both paths. */
+extern Bool xkbLockModsOnPress;     /* toggle locking mods on press */
+
 typedef struct _XkbSrvLedInfo {
     CARD16 flags;
     CARD16 class;

--- a/include/xserver-properties.h
+++ b/include/xserver-properties.h
@@ -62,6 +62,11 @@
 /* FLOAT, format 32 */
 #define ACCEL_PROP_VELOCITY_SCALING "Device Accel Velocity Scaling"
 
+/* XKB lock-key timing quirk
+ * CARD8, 1 value, 0 = standard X11 behaviour, 1 = toggle entirely on press.
+ * Set on master keyboard devices. */
+#define XKB_PROP_LOCK_MODS_ON_PRESS "Toggle Lock Modifiers On Press"
+
 /* Axis labels */
 #define AXIS_LABEL_PROP "Axis Labels"
 


### PR DESCRIPTION
For a long time people talk about a delay when using Caps Lock, causing them to write two upper case letters when only one was intended. There are some hacks to work around, but I think an option to solve it directly in the xserver would be better.

I hope this code is good enough to work for others across different system configurations, as it works for me.
And because it would be cool if XLibre have more options for users who want them :)

I listed Claude as assistant in both commits because it also wrote the in-code comments in correct English, but I don't know if it is necessary, as there are no rules yet for AI assisted or generated contributions in the guidelines :/

Fixes https://github.com/X11Libre/xserver/issues/285