### PR TITLE
(master) Xext: damage: fix missing include of windowstr.h

### DIFF
--- a/Xext/damage/damageext.c
+++ b/Xext/damage/damageext.c
@@ -30,6 +30,7 @@
 #include "dix/request_priv.h"
 #include "dix/screenint_priv.h"
 #include "include/pixmapstr.h"
+#include "include/windowstr.h"
 #include "miext/extinit_priv.h"
 #include "os/client_priv.h"
 #include "Xext/damage/damageext_priv.h"


### PR DESCRIPTION
damageext.c uses some type definitions from windowstr.h, so
that one needs to be included.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
