### PR TITLE
(master) test: fix <assert.h> includes

### DIFF
--- a/test/fixes.c
+++ b/test/fixes.c
@@ -26,6 +26,7 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <X11/X.h>

--- a/test/hashtabletest.c
+++ b/test/hashtabletest.c
@@ -1,8 +1,10 @@
 #include <dix-config.h>
 
-#include <misc.h>
+#include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
+
+#include <misc.h>
 #include "hashtable.h"
 #include "resource.h"
 

--- a/test/input.c
+++ b/test/input.c
@@ -26,6 +26,7 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <stdint.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>
@@ -47,7 +48,6 @@
 #include "inputstr.h"
 #include "Xext/xinput/exglobals.h"
 #include "eventstr.h"
-#include "assert.h"
 
 #include "tests-common.h"
 

--- a/test/misc.c
+++ b/test/misc.c
@@ -26,6 +26,7 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <stdint.h>
 
 #include "dix/input_priv.h"

--- a/test/signal-logging.c
+++ b/test/signal-logging.c
@@ -26,13 +26,13 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <stdint.h>
 #include <unistd.h>
 
 #include "os/fmt.h"
 #include "os/log_priv.h"
 
-#include "assert.h"
 #include "misc.h"
 
 #include "tests-common.h"

--- a/test/sync/sync.c
+++ b/test/sync/sync.c
@@ -21,7 +21,6 @@
  * IN THE SOFTWARE.
  */
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>

--- a/test/touch.c
+++ b/test/touch.c
@@ -26,13 +26,13 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <stdint.h>
 
 #include "dix/atom_priv.h"
 #include "dix/input_priv.h"
 
 #include "inputstr.h"
-#include "assert.h"
 #include "scrnintstr.h"
 #include "tests-common.h"
 

--- a/test/xi1/protocol-xchangedevicecontrol.c
+++ b/test/xi1/protocol-xchangedevicecontrol.c
@@ -26,6 +26,8 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
+
 /*
  * Protocol testing for ChangeDeviceControl request.
  */

--- a/test/xi2/protocol-common.c
+++ b/test/xi2/protocol-common.c
@@ -26,6 +26,7 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <errno.h>
 #include <stdint.h>
 #include <X11/extensions/XI2.h>

--- a/test/xi2/protocol-eventconvert.c
+++ b/test/xi2/protocol-eventconvert.c
@@ -25,6 +25,7 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <stdint.h>
 #include <X11/extensions/XI2proto.h>
 

--- a/test/xi2/protocol-xigetclientpointer.c
+++ b/test/xi2/protocol-xigetclientpointer.c
@@ -26,6 +26,8 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
+
 /*
  * Protocol testing for XIGetClientPointer request.
  */

--- a/test/xi2/protocol-xigetselectedevents.c
+++ b/test/xi2/protocol-xigetselectedevents.c
@@ -26,6 +26,8 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
+
 /*
  * Protocol testing for XIGetSelectedEvents request.
  *

--- a/test/xi2/protocol-xipassivegrabdevice.c
+++ b/test/xi2/protocol-xipassivegrabdevice.c
@@ -26,6 +26,8 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
+
 /*
  * Protocol testing for XIPassiveGrab request.
  */

--- a/test/xi2/protocol-xiquerydevice.c
+++ b/test/xi2/protocol-xiquerydevice.c
@@ -26,6 +26,7 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <stdint.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>

--- a/test/xi2/protocol-xiquerypointer.c
+++ b/test/xi2/protocol-xiquerypointer.c
@@ -29,6 +29,7 @@
 /*
  * Protocol testing for XIQueryPointer request.
  */
+#include <assert.h>
 #include <stdint.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>

--- a/test/xi2/protocol-xiqueryversion.c
+++ b/test/xi2/protocol-xiqueryversion.c
@@ -37,6 +37,7 @@
  * Client version less than 2 must return BadValue.
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>

--- a/test/xi2/protocol-xiselectevents.c
+++ b/test/xi2/protocol-xiselectevents.c
@@ -48,6 +48,7 @@
  *
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>

--- a/test/xi2/protocol-xisetclientpointer.c
+++ b/test/xi2/protocol-xisetclientpointer.c
@@ -35,6 +35,7 @@
  * Success for window None.
  * BadWindow for invalid windows.
  */
+#include <assert.h>
 #include <stdint.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>

--- a/test/xi2/protocol-xiwarppointer.c
+++ b/test/xi2/protocol-xiwarppointer.c
@@ -29,6 +29,7 @@
 /*
  * Protocol testing for XIWarpPointer request.
  */
+#include <assert.h>
 #include <stdint.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>

--- a/test/xi2/xi2.c
+++ b/test/xi2/xi2.c
@@ -26,12 +26,12 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <stdint.h>
 
 #include "dix/inpututils_priv.h"
 
 #include "inputstr.h"
-#include "assert.h"
 
 #include "protocol-common.h"
 


### PR DESCRIPTION
Lots of places missed to include it, some do but don't need it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
