### PR TITLE
(master) os: rename __size_assert() into __SIZE_ASSERT()

### DIFF
--- a/Xext/randr/rrcrtc.c
+++ b/Xext/randr/rrcrtc.c
@@ -36,7 +36,7 @@
 #include "mipointer.h"
 
 /* xFixed is just `int`, so better check whether it's really 32bit */
-__size_assert(xFixed, sizeof(CARD32));
+__SIZE_ASSERT(xFixed, sizeof(CARD32));
 
 RESTYPE RRCrtcType = 0;
 

--- a/Xext/xv/xvdisp.c
+++ b/Xext/xv/xvdisp.c
@@ -37,6 +37,7 @@ SOFTWARE.
 #include "dix/screenint_priv.h"
 #include "include/shmint.h"
 #include "include/xvmcext.h"
+#include "os/osdep.h"
 #include "Xext/panoramiX/panoramiX.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
 #include "Xext/shm/shm_priv.h"
@@ -811,7 +812,7 @@ ProcXvShmPutImage(ClientPtr client)
 #endif /* CONFIG_MITSHM */
 }
 
-__size_assert(int, sizeof(INT32));
+__SIZE_ASSERT(int, sizeof(INT32));
 
 static int
 ProcXvQueryImageAttributes(ClientPtr client)

--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -41,11 +41,7 @@
     } while (0)
 
 /* static assert for protocol structure sizes */
-#ifndef __size_assert
-#define __size_assert(what, howmuch) \
-  typedef char what##_size_wrong_[( !!(sizeof(what) == howmuch) )*2-1 ]
-#endif
-#define XTYPE_SIZE_ASSERT(typename) __size_assert(typename,SIZEOF(typename))
+#define XTYPE_SIZE_ASSERT(typename) __SIZE_ASSERT(typename,SIZEOF(typename))
 
 /* server setting: maximum size for big requests */
 #define MAX_BIG_REQUEST_SIZE 4194303

--- a/hw/xnest/Keyboard.c
+++ b/hw/xnest/Keyboard.c
@@ -93,8 +93,8 @@ xnestChangeKeyboardControl(DeviceIntPtr pDev, KeybdCtrl * ctrl)
 }
 
 /* make sure that KeySym and xcb_keysym_t are both 32 bit */
-__size_assert(KeySym, 4);
-__size_assert(xcb_keysym_t, 4);
+__SIZE_ASSERT(KeySym, 4);
+__SIZE_ASSERT(xcb_keysym_t, 4);
 
 int
 xnestKeyboardProc(DeviceIntPtr pDev, int onoff)

--- a/os/osdep.h
+++ b/os/osdep.h
@@ -218,10 +218,8 @@ Ones(unsigned long mask)
 #endif
 
 /* static assert for protocol structure sizes */
-#ifndef __size_assert
-#define __size_assert(what, howmuch) \
+#define __SIZE_ASSERT(what, howmuch) \
   typedef char what##_size_wrong_[( !!(sizeof(what) == howmuch) )*2-1 ]
-#endif
 
 /*
  * like strlen(), but checking for NULL and return 0 in this case


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
