### PR TITLE
(master) xwin: fix missing includes of <assert.h>

### DIFF
--- a/hw/xwin/glx/dri_helpers.c
+++ b/hw/xwin/glx/dri_helpers.c
@@ -22,6 +22,7 @@
  */
 #include <xwin-config.h>
 
+#include <assert.h>
 #include <X11/extensions/windowsdriconst.h>
 
 #include "Xext/glx/glxserver.h"

--- a/hw/xwin/winmultiwindowwindow.c
+++ b/hw/xwin/winmultiwindowwindow.c
@@ -33,6 +33,8 @@
  */
 #include <xwin-config.h>
 
+#include <assert.h>
+
 #include "dix/resource_priv.h"
 #include "mi/mi_priv.h"
 

--- a/hw/xwin/winshadgdi.c
+++ b/hw/xwin/winshadgdi.c
@@ -29,6 +29,8 @@
  */
 #include <xwin-config.h>
 
+#include <assert.h>
+
 #include "win.h"
 
 #include "dix/colormap_priv.h"


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
