### PR TITLE
(master) os: drop ifdef on CLIENTIDS

### DIFF
--- a/os/client.c
+++ b/os/client.c
@@ -462,7 +462,6 @@ DetermineClientCmd(pid_t pid, const char **cmdname, const char **cmdargs)
 void
 ReserveClientIds(struct _Client *client)
 {
-#ifdef CLIENTIDS
     if (client == NULL)
         return;
 
@@ -482,7 +481,6 @@ ReserveClientIds(struct _Client *client)
            (unsigned long) client->clientAsMask,
            client->clientIds->cmdname ? client->clientIds->cmdname : "NULL",
            client->clientIds->cmdargs ? client->clientIds->cmdargs : "NULL");
-#endif                          /* CLIENTIDS */
 }
 
 /**
@@ -494,7 +492,6 @@ ReserveClientIds(struct _Client *client)
 void
 ReleaseClientIds(struct _Client *client)
 {
-#ifdef CLIENTIDS
     if (client == NULL)
         return;
 
@@ -512,7 +509,6 @@ ReleaseClientIds(struct _Client *client)
     free((void *) client->clientIds->cmdargs);  /* const char * */
     free(client->clientIds);
     client->clientIds = NULL;
-#endif                          /* CLIENTIDS */
 }
 
 /**

--- a/os/meson.build
+++ b/os/meson.build
@@ -77,12 +77,8 @@ if host_machine.system() == 'sunos'
     os_dep += cc.find_library('nsl')
 endif
 
-if get_option('xres')
-    # Only the XRes extension cares about the client ID.
-    os_c_args += '-DCLIENTIDS'
-    if host_machine.system() == 'openbsd'
-        os_dep += cc.find_library('kvm')
-    endif
+if host_machine.system() == 'openbsd'
+    os_dep += cc.find_library('kvm')
 endif
 
 libxlibc = []


### PR DESCRIPTION
it's especially needed for xres, which is always enabled anyways.
no need for the extra complexity here.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
