### PR TITLE
(master) include: extnsionst.h: drop unnecessary includes

### DIFF
--- a/include/extnsionst.h
+++ b/include/extnsionst.h
@@ -48,11 +48,7 @@ SOFTWARE.
 #define EXTENSIONSTRUCT_H
 
 #include "xlibre_ptrtypes.h"
-#include "dix.h"
-#include "misc.h"
-#include "screenint.h"
 #include "extension.h"
-#include "gc.h"
 #include "privates.h"
 
 typedef struct _ExtensionEntry {


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
