### PR TITLE
(master) Xext: composite: drop unused include of <assert.h>

### DIFF
--- a/Xext/composite/compint.h
+++ b/Xext/composite/compint.h
@@ -66,7 +66,6 @@
 #include "damage.h"
 #include <X11/extensions/compositeproto.h>
 #include "compositeext.h"
-#include <assert.h>
 
 typedef struct _CompClientWindow {
     struct _CompClientWindow *next;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
