### PR TITLE
(master) test: xtest.c: fix missing include of <assert.h>

### DIFF
--- a/test/xtest.c
+++ b/test/xtest.c
@@ -24,6 +24,7 @@
 /* Test relies on assert() */
 #undef NDEBUG
 
+#include <assert.h>
 #include <dix-config.h>
 
 #include <stdint.h>


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
