### PR TITLE
(master) os: fix missing includes of <assert.h>

### DIFF
--- a/os/client.c
+++ b/os/client.c
@@ -52,6 +52,7 @@
  */
 #include <dix-config.h>
 
+#include <assert.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>

--- a/os/io.c
+++ b/os/io.c
@@ -53,6 +53,7 @@ SOFTWARE.
 
 #include <dix-config.h>
 
+#include <assert.h>
 #undef DEBUG_COMMUNICATION
 
 #include "dixstruct_priv.h"


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
