### PR TITLE
(master) dix: fix missing includes of <assert.h>

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -99,6 +99,7 @@ Equipment Corporation.
 #include <dix-config.h>
 #include <version-config.h>
 
+#include <assert.h>
 #include <stddef.h>
 #include <X11/fonts/fontstruct.h>
 #include <X11/fonts/libxfont2.h>

--- a/dix/events.c
+++ b/dix/events.c
@@ -103,6 +103,7 @@ Equipment Corporation.
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <X11/X.h>
 #include <X11/extensions/ge.h>
 #include <X11/extensions/XKBproto.h>

--- a/dix/pixmap.c
+++ b/dix/pixmap.c
@@ -28,6 +28,7 @@ from The Open Group.
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <X11/X.h>
 #include <X11/extensions/render.h>
 

--- a/dix/privates.c
+++ b/dix/privates.c
@@ -50,6 +50,7 @@ from The Open Group.
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <stddef.h>
 
 #include "dix/colormap_priv.h"

--- a/dix/resource.c
+++ b/dix/resource.c
@@ -144,7 +144,6 @@ Equipment Corporation.
 #include "inputstr.h"
 #include "cursor.h"
 #include "xace.h"
-#include <assert.h>
 #include "gcstruct.h"
 
 #ifdef XSERVER_DTRACE


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
