### PR TITLE
(master) exa: fix missing includes of <assert.h>

### DIFF
--- a/exa/exa.c
+++ b/exa/exa.c
@@ -30,6 +30,7 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <stdlib.h>
 
 #include "dix/screen_hooks_priv.h"

--- a/exa/exa_glyphs.c
+++ b/exa/exa_glyphs.c
@@ -42,6 +42,7 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <stdlib.h>
 
 #include "include/mipict.h"

--- a/exa/exa_render.c
+++ b/exa/exa_render.c
@@ -23,6 +23,7 @@
  */
 #include <dix-config.h>
 
+#include <assert.h>
 #include <stdlib.h>
 
 #include "include/mipict.h"


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
