### PR TITLE
(master) glamor: fix missing includes of <assert.h>

### DIFF
--- a/glamor/glamor_core.c
+++ b/glamor/glamor_core.c
@@ -32,6 +32,7 @@
  */
 #include <dix-config.h>
 
+#include <assert.h>
 #include <stdlib.h>
 
 #include "os/bug_priv.h"

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -28,6 +28,7 @@
  */
 #include <dix-config.h>
 
+#include <assert.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>

--- a/glamor/glamor_vbo.c
+++ b/glamor/glamor_vbo.c
@@ -28,6 +28,7 @@
  */
 #include <dix-config.h>
 
+#include <assert.h>
 #include "glamor_priv.h"
 
 /** Default size of the VBO, in bytes.

--- a/glamor/glamor_xv.c
+++ b/glamor/glamor_xv.c
@@ -33,8 +33,6 @@
  */
 #include <dix-config.h>
 
-#include <assert.h>
-
 #include "dix/dix_priv.h"
 #include "os/bug_priv.h"
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
