### PR TITLE
(master) mi: mipoly.h: drop obsolete assert()

### DIFF
--- a/mi/mipoly.h
+++ b/mi/mipoly.h
@@ -162,7 +162,6 @@ typedef struct _ScanLineListBlock {
  *     The even-odd rule is in effect.
  */
 #define EVALUATEEDGEEVENODD(pAET, pPrevAET, y) { \
-   assert(pAET); \
    if (pAET->ymax == y) {          /* leaving this edge */ \
       pPrevAET->next = pAET->next; \
       pAET = pPrevAET->next; \


### PR DESCRIPTION
not hit for aeons now, not actually needed anymore.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
