### PR TITLE
(master) include: inputstr.h: drop assert()

### DIFF
--- a/include/inputstr.h
+++ b/include/inputstr.h
@@ -660,7 +660,6 @@ extern EventSyncInfoRec syncEvents;
 static inline WindowPtr
 DeepestSpriteWin(SpritePtr sprite)
 {
-    assert(sprite->spriteTraceGood > 0);
     return sprite->spriteTrace[sprite->spriteTraceGood - 1];
 }
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
