### PR TITLE
(master) xfree86: fix missing / obsolete includes of <assert.h>

### DIFF
--- a/hw/xfree86/common/xf86Bus.c
+++ b/hw/xfree86/common/xf86Bus.c
@@ -30,6 +30,7 @@
  */
 #include <xorg-config.h>
 
+#include <assert.h>
 #include <ctype.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/hw/xfree86/common/xf86Configure.c
+++ b/hw/xfree86/common/xf86Configure.c
@@ -24,6 +24,7 @@
  */
 #include <xorg-config.h>
 
+#include <assert.h>
 #include <errno.h>
 
 #include "os/ddx_priv.h"

--- a/hw/xfree86/common/xf86DGA.c
+++ b/hw/xfree86/common/xf86DGA.c
@@ -38,6 +38,7 @@
  */
 #include <xorg-config.h>
 
+#include <assert.h>
 #include <string.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>

--- a/hw/xfree86/common/xf86Events.c
+++ b/hw/xfree86/common/xf86Events.c
@@ -50,6 +50,7 @@
 /* [JCH-96/01/21] Extended std reverse map to four buttons. */
 #include <xorg-config.h>
 
+#include <assert.h>
 #include <errno.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>

--- a/hw/xfree86/common/xf86Helper.c
+++ b/hw/xfree86/common/xf86Helper.c
@@ -35,6 +35,7 @@
  */
 #include <xorg-config.h>
 
+#include <assert.h>
 #include <sys/stat.h>
 #include <X11/X.h>
 

--- a/hw/xfree86/common/xf86platformBus.c
+++ b/hw/xfree86/common/xf86platformBus.c
@@ -28,6 +28,7 @@
 #include <xorg-config.h>
 
 #ifdef XSERVER_PLATFORM_BUS
+#include <assert.h>
 #include <errno.h>
 
 #include <pciaccess.h>

--- a/hw/xfree86/dri/dri.c
+++ b/hw/xfree86/dri/dri.c
@@ -33,6 +33,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 #include <xorg-config.h>
 
+#include <assert.h>
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
@@ -2454,5 +2455,4 @@ DRIMoveBuffersHelper(ScreenPtr pScreen,
     }
     else
         *xdir = 1;
-
 }

--- a/hw/xfree86/drivers/input/inputtest/xf86-input-inputtest.c
+++ b/hw/xfree86/drivers/input/inputtest/xf86-input-inputtest.c
@@ -23,6 +23,7 @@
  */
 #include <xorg-config.h>
 
+#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -30,7 +31,6 @@
 #include <sys/stat.h>
 #include <sys/un.h>
 #include <stdbool.h>
-
 #include <X11/Xatom.h>
 
 #include "include/xorgVersion.h"

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -29,6 +29,7 @@
 
 #include "dix-config.h"
 
+#include <assert.h>
 #include <errno.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>

--- a/hw/xfree86/drivers/video/modesetting/present.c
+++ b/hw/xfree86/drivers/video/modesetting/present.c
@@ -22,7 +22,6 @@
 
 #include "dix-config.h"
 
-#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>

--- a/hw/xfree86/int10/vbe.c
+++ b/hw/xfree86/int10/vbe.c
@@ -9,8 +9,8 @@
  */
 #include <xorg-config.h>
 
+#include <assert.h>
 #include <string.h>
-
 #include <X11/extensions/dpmsconst.h>
 
 #include "xf86.h"

--- a/hw/xfree86/loader/loadmod.c
+++ b/hw/xfree86/loader/loadmod.c
@@ -47,6 +47,13 @@
  */
 #include <xorg-config.h>
 
+#include <assert.h>
+#include <dirent.h>
+#include <limits.h>
+#include <regex.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
 #include "dix.h"
 #include "os.h"
 #include "loaderProcs.h"
@@ -54,11 +61,6 @@
 #include "loader.h"
 #include "xf86Module_priv.h"
 
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <regex.h>
-#include <dirent.h>
-#include <limits.h>
 
 typedef struct _pattern {
     const char *pattern;

--- a/hw/xfree86/modes/xf86Crtc.c
+++ b/hw/xfree86/modes/xf86Crtc.c
@@ -22,6 +22,7 @@
  */
 #include <xorg-config.h>
 
+#include <assert.h>
 #include <stddef.h>
 #include <string.h>
 #include <stdio.h>

--- a/hw/xfree86/os-support/hurd/hurd_init.c
+++ b/hw/xfree86/os-support/hurd/hurd_init.c
@@ -38,7 +38,6 @@
 #include <errno.h>
 #include <sys/time.h>
 #include <sys/file.h>
-#include <assert.h>
 #include <mach.h>
 #include <hurd.h>
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
