### PR TITLE
(master) kdrive: fix missing includes of <assert.h>

### DIFF
--- a/hw/kdrive/ephyr/ephyr.c
+++ b/hw/kdrive/ephyr/ephyr.c
@@ -25,6 +25,7 @@
 
 #include <kdrive-config.h>
 
+#include <assert.h>
 #include <xcb/xcb_keysyms.h>
 #include <X11/keysym.h>
 

--- a/hw/kdrive/ephyr/ephyr_draw.c
+++ b/hw/kdrive/ephyr/ephyr_draw.c
@@ -27,6 +27,8 @@
 
 #include <kdrive-config.h>
 
+#include <assert.h>
+
 #include "ephyr.h"
 #include "exa_priv.h"
 #include "fbpict.h"

--- a/hw/kdrive/ephyr/ephyr_glamor.c
+++ b/hw/kdrive/ephyr/ephyr_glamor.c
@@ -30,6 +30,7 @@
 #define MESA_EGL_NO_X11_HEADERS
 #define EGL_NO_X11
 
+#include <assert.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <xcb/xcb.h>


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
