### PR TITLE
(master) xquartz: fix missing includes of <assert.h>

### DIFF
--- a/hw/xquartz/GL/visualConfigs.c
+++ b/hw/xquartz/GL/visualConfigs.c
@@ -30,6 +30,7 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include "dri.h"
 
 #include <OpenGL/OpenGL.h>

--- a/hw/xquartz/darwin.c
+++ b/hw/xquartz/darwin.c
@@ -30,6 +30,7 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <sys/stat.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>

--- a/hw/xquartz/mach-startup/stub.c
+++ b/hw/xquartz/mach-startup/stub.c
@@ -30,6 +30,7 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>

--- a/hw/xquartz/xpr/dri.c
+++ b/hw/xquartz/xpr/dri.c
@@ -36,6 +36,7 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include <sys/time.h>
 #include <unistd.h>
 

--- a/hw/xquartz/xpr/x-hook.c
+++ b/hw/xquartz/xpr/x-hook.c
@@ -32,7 +32,6 @@
 
 #include "x-hook.h"
 #include <stdlib.h>
-#include <assert.h>
 #include "os.h"
 
 #define CELL_NEW(f, d) X_PFX(list_prepend) ((x_list *)(f), (d))

--- a/hw/xquartz/xpr/xprFrame.c
+++ b/hw/xquartz/xpr/xprFrame.c
@@ -29,6 +29,7 @@
 
 #include <dix-config.h>
 
+#include <assert.h>
 #include "dix/dix_priv.h"
 #include "dix/property_priv.h"
 #include "dix/screenint_priv.h"


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
