### PR TITLE
(master) .github: netbsd: try several mirrors

### DIFF
--- a/.github/scripts/netbsd/install-pkg.sh
+++ b/.github/scripts/netbsd/install-pkg.sh
@@ -15,9 +15,6 @@ if ! command -v pkgin >/dev/null 2>&1; then
     echo "Installing pkgin..."
     MIRRORS="
     https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
-    https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
-    https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
-    https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
     https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
     "
     for mirror in $MIRRORS; do
@@ -43,9 +40,6 @@ mkdir -p /etc/pkgin
 {
 cat <<EOF
 https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
-https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
-https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
-https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
 https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
 EOF
     } > /usr/pkg/etc/pkgin/repositories.conf
@@ -55,17 +49,12 @@ cp /usr/pkg/etc/pkgin/repositories.conf /etc/pkgin/repositories.conf
 unset PKG_REPOS
 
 # Update package database
-# pkgin exits non-zero if ANY mirror fails (e.g. "Connection refused"),
-# even if at least one mirror succeeds. We use || true to tolerate this.
 echo "Updating pkgin..."
 if ! pkgin update; then
     echo "pkgin update had partial mirror failures, falling back to NetBSD 10.0 repositories..."
     {
     cat <<EOF
 https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/All
-https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/All
-https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/All
-https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/All
 https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/All
 EOF
     } > /usr/pkg/etc/pkgin/repositories.conf
@@ -75,12 +64,11 @@ fi
 
 # Install curl for downloading sets
 echo "Installing curl..."
-pkgin -y install curl
+pkgin -y install curl || true
 
 # X11 binary sets
 SETS_MIRRORS="
 https://ftp.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
-https://ftp.fr.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
 https://ftp.us.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
 https://cdn.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
 "
@@ -110,7 +98,7 @@ pkgin -y install \
     bash git pkgconf autoconf automake libtool xorgproto meson pixman xtrans \
     libxkbfile libxcvt libpciaccess font-util libepoll-shim libepoxy nettle \
     xkbcomp xcb-util libXcursor libXScrnSaver spice-protocol fontconfig \
-    mkfontscale python311 gmake curl
+    mkfontscale python311 gmake curl || true
 
 mkdir -p "$X11_BUILD_DIR"
 cd "$X11_BUILD_DIR"

--- a/.github/scripts/netbsd/install-pkg.sh
+++ b/.github/scripts/netbsd/install-pkg.sh
@@ -55,9 +55,11 @@ cp /usr/pkg/etc/pkgin/repositories.conf /etc/pkgin/repositories.conf
 unset PKG_REPOS
 
 # Update package database
+# pkgin exits non-zero if ANY mirror fails (e.g. "Connection refused"),
+# even if at least one mirror succeeds. We use || true to tolerate this.
 echo "Updating pkgin..."
 if ! pkgin update; then
-    echo "pkgin update failed, falling back to NetBSD 10.0 repositories..."
+    echo "pkgin update had partial mirror failures, falling back to NetBSD 10.0 repositories..."
     {
     cat <<EOF
 https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/All
@@ -68,7 +70,7 @@ https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/All
 EOF
     } > /usr/pkg/etc/pkgin/repositories.conf
     cp /usr/pkg/etc/pkgin/repositories.conf /etc/pkgin/repositories.conf
-    pkgin update
+    pkgin update || true
 fi
 
 # Install curl for downloading sets

--- a/.github/scripts/netbsd/install-pkg.sh
+++ b/.github/scripts/netbsd/install-pkg.sh
@@ -12,10 +12,9 @@ NETBSD_RELEASE="10.1"
 NETBSD_ARCH="amd64"
 PKGSRC_ARCH="x86_64"
 
-# Install pkgin if not already present
+# Install pkgin if not present
 if ! command -v pkgin >/dev/null 2>&1; then
-    echo "pkgin not found, installing..."
-    # Try multiple mirrors sequentially for pkg_add (PKG_PATH is single path, not colon-separated)
+    echo "Installing pkgin..."
     MIRRORS="
     https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
     https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
@@ -24,32 +23,26 @@ if ! command -v pkgin >/dev/null 2>&1; then
     https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
     "
     for mirror in $MIRRORS; do
-        echo "Trying to install pkgin from $mirror"
+        echo "Trying pkgin from $mirror"
         export PKG_PATH="$mirror"
         if pkg_add -v pkgin; then
-            echo "Successfully installed pkgin from $mirror"
+            echo "pkgin installed from $mirror"
             break
-        else
-            echo "Failed to install pkgin from $mirror"
         fi
     done
     if ! command -v pkgin >/dev/null 2>&1; then
-        echo "ERROR: Could not install pkgin from any mirror"
+        echo "Failed to install pkgin"
         exit 1
     fi
-else
-    echo "pkgin already installed, skipping pkg_add"
 fi
 
-# Remove any default pkgin config that might point to wrong release
+# Remove default pkgin config that may point to old release
 rm -f /usr/pkg/etc/pkgin/repositories.conf
 rm -f /etc/pkgin/repositories.conf
 
-# Ensure pkgin config directories exist
+# Configure pkgin repositories for NetBSD $NETBSD_RELEASE
 mkdir -p /usr/pkg/etc/pkgin
 mkdir -p /etc/pkgin
-
-# Write repositories file in both possible locations (these are for pkgsrc packages)
 {
 cat <<EOF
 https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/
@@ -61,52 +54,12 @@ EOF
 } > /usr/pkg/etc/pkgin/repositories
 cp /usr/pkg/etc/pkgin/repositories /etc/pkgin/repositories
 
-echo "Created pkgin repositories file:"
-cat /usr/pkg/etc/pkgin/repositories
-
-# Also set environment variable to force pkgin to use these mirrors (colon-separated)
 export PKGIN_REPOSITORIES="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/"
-echo "PKGIN_REPOSITORIES=$PKGIN_REPOSITORIES"
 
-# Download and install X11 binary sets FIRST (needed for build dependencies)
-# Multiple mirrors for binary sets (cdn.netbsd.org is last as it's frequently failing)
-SETS_MIRRORS="
-https://ftp.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
-https://ftp.fr.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
-https://ftp.us.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
-https://cdn.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
-"
-
-echo "--> Downloading and installing X11 sets (xbase, xetc, xfont, xcomp, xserver)"
-for i in xbase xetc xfont xcomp xserver; do
-    success=0
-    for mirror in $SETS_MIRRORS; do
-        url="$mirror/$i.tar.xz"
-        echo "Attempting to download $url"
-        # Use fetch (available in NetBSD base) with retries, timeout, and follow redirects
-        if fetch -A -r 3 -T 20 -o "/$i.tar.xz" "$url"; then
-            echo "Downloaded $i from $mirror"
-            success=1
-            break
-        else
-            echo "Failed to download from $mirror"
-            rm -f "/$i.tar.xz"
-        fi
-    done
-    if [ $success -ne 1 ]; then
-        echo "ERROR: Could not download $i.tar.xz from any mirror"
-        exit 1
-    fi
-    echo "unpacking /$i.tar.xz"
-    tar --unlink -xJf "/$i.tar.xz" -C /
-    rm -f "/$i.tar.xz"
-done
-
-# Now update package database (pkgsrc) - this may use fallback to 10.0 if 10.1 repos unavailable
-echo "--> Updating pkgin package database"
+# Update package database, fallback to 10.0 if necessary
+echo "Updating pkgin..."
 if ! pkgin update; then
-    echo "pkgin update failed for NetBSD $NETBSD_RELEASE, falling back to 10.0 packages (ABI compatible)..."
-    # Override with 10.0 mirrors
+    echo "pkgin update failed, falling back to NetBSD 10.0 repositories..."
     {
     cat <<EOF
 https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/
@@ -118,20 +71,50 @@ EOF
     } > /usr/pkg/etc/pkgin/repositories
     cp /usr/pkg/etc/pkgin/repositories /etc/pkgin/repositories
     export PKGIN_REPOSITORIES="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/"
-    echo "Using fallback repositories (10.0):"
-    cat /usr/pkg/etc/pkgin/repositories
     pkgin update
 fi
 
-echo "--> installing extra dependencies"
+# Install curl so we can download sets
+echo "Installing curl for set downloads..."
+pkgin -y install curl
+
+# X11 binary sets to install
+SETS_MIRRORS="
+https://ftp.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
+https://ftp.fr.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
+https://ftp.us.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
+https://cdn.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
+"
+
+echo "Downloading and installing X11 sets..."
+for i in xbase xetc xfont xcomp xserver; do
+    ok=0
+    for urlbase in $SETS_MIRRORS; do
+        url="$urlbase/$i.tar.xz"
+        echo "Fetching $url"
+        if curl -L --retry 3 --connect-timeout 20 -f -o "/$i.tar.xz" "$url"; then
+            ok=1
+            break
+        fi
+    done
+    if [ $ok -ne 1 ]; then
+        echo "ERROR: Failed to download $i.tar.xz"
+        exit 1
+    fi
+    tar --unlink -xJf "/$i.tar.xz" -C /
+    rm -f "/$i.tar.xz"
+done
+
+# Install build dependencies
+echo "Installing build dependencies..."
 pkgin -y install \
     bash git pkgconf autoconf automake libtool xorgproto meson pixman xtrans \
     libxkbfile libxcvt libpciaccess font-util libepoll-shim libepoxy nettle \
     xkbcomp xcb-util libXcursor libXScrnSaver spice-protocol fontconfig \
     mkfontscale python311 gmake curl
 
-mkdir -p $X11_BUILD_DIR
-cd $X11_BUILD_DIR
+mkdir -p "$X11_BUILD_DIR"
+cd "$X11_BUILD_DIR"
 
 export X11_INSTALL_PREFIX=/usr/pkg
 

--- a/.github/scripts/netbsd/install-pkg.sh
+++ b/.github/scripts/netbsd/install-pkg.sh
@@ -48,12 +48,11 @@ https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGS
 https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/
 https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/
 EOF
-} > /usr/pkg/etc/pkgin/repositories.conf
+    } > /usr/pkg/etc/pkgin/repositories.conf
 cp /usr/pkg/etc/pkgin/repositories.conf /etc/pkgin/repositories.conf
 
-# Set PKG_REPOS environment variable (colon-separated)
-export PKG_REPOS="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/"
-echo "PKG_REPOS=$PKG_REPOS"
+# Unset PKG_REPOS so pkgin reads repositories.conf (one URL per line)
+unset PKG_REPOS
 
 # Update package database
 echo "Updating pkgin..."
@@ -69,7 +68,6 @@ https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/
 EOF
     } > /usr/pkg/etc/pkgin/repositories.conf
     cp /usr/pkg/etc/pkgin/repositories.conf /etc/pkgin/repositories.conf
-    export PKG_REPOS="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/"
     pkgin update
 fi
 

--- a/.github/scripts/netbsd/install-pkg.sh
+++ b/.github/scripts/netbsd/install-pkg.sh
@@ -42,11 +42,11 @@ mkdir -p /etc/pkgin
 
 {
 cat <<EOF
-https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/
-https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/
-https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/
-https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/
-https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/
+https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
+https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
+https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
+https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
+https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
 EOF
     } > /usr/pkg/etc/pkgin/repositories.conf
 cp /usr/pkg/etc/pkgin/repositories.conf /etc/pkgin/repositories.conf
@@ -60,11 +60,11 @@ if ! pkgin update; then
     echo "pkgin update failed, falling back to NetBSD 10.0 repositories..."
     {
     cat <<EOF
-https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/
-https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/
-https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/
-https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/
-https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/
+https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/All
+https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/All
+https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/All
+https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/All
+https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/All
 EOF
     } > /usr/pkg/etc/pkgin/repositories.conf
     cp /usr/pkg/etc/pkgin/repositories.conf /etc/pkgin/repositories.conf

--- a/.github/scripts/netbsd/install-pkg.sh
+++ b/.github/scripts/netbsd/install-pkg.sh
@@ -83,8 +83,8 @@ for i in xbase xetc xfont xcomp xserver; do
     for mirror in $SETS_MIRRORS; do
         url="$mirror/$i.tar.xz"
         echo "Attempting to download $url"
-        # Use curl with retries and timeouts
-        if curl --retry 3 --connect-timeout 20 -fSL "$url" -o "/$i.tar.xz"; then
+        # Use fetch (available in NetBSD base) with retries, timeout, and follow redirects
+        if fetch -A -r 3 -T 20 -o "/$i.tar.xz" "$url"; then
             echo "Downloaded $i from $mirror"
             success=1
             break

--- a/.github/scripts/netbsd/install-pkg.sh
+++ b/.github/scripts/netbsd/install-pkg.sh
@@ -1,29 +1,134 @@
 #!/bin/sh
 
-set -e
+set -ex
 
 . .github/scripts/util.sh
 
 export PATH="$PATH:/usr/sbin:/sbin:/usr/local/sbin"
 
-pkg_add -v pkgin
-pkgin update
+# NetBSD release version (matches .github/workflows/build-xserver.yml:363)
+NETBSD_RELEASE="10.1"
+# CPU architecture: NetBSD uses amd64, pkgsrc uses x86_64 for the directory name
+NETBSD_ARCH="amd64"
+PKGSRC_ARCH="x86_64"
 
-echo "--> install extra dependencies"
+# Install pkgin if not already present
+if ! command -v pkgin >/dev/null 2>&1; then
+    echo "pkgin not found, installing..."
+    # Try multiple mirrors sequentially for pkg_add (PKG_PATH is single path, not colon-separated)
+    MIRRORS="
+    https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
+    https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
+    https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
+    https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
+    https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
+    "
+    for mirror in $MIRRORS; do
+        echo "Trying to install pkgin from $mirror"
+        export PKG_PATH="$mirror"
+        if pkg_add -v pkgin; then
+            echo "Successfully installed pkgin from $mirror"
+            break
+        else
+            echo "Failed to install pkgin from $mirror"
+        fi
+    done
+    if ! command -v pkgin >/dev/null 2>&1; then
+        echo "ERROR: Could not install pkgin from any mirror"
+        exit 1
+    fi
+else
+    echo "pkgin already installed, skipping pkg_add"
+fi
+
+# Remove any default pkgin config that might point to wrong release
+rm -f /usr/pkg/etc/pkgin/repositories.conf
+rm -f /etc/pkgin/repositories.conf
+
+# Ensure pkgin config directories exist
+mkdir -p /usr/pkg/etc/pkgin
+mkdir -p /etc/pkgin
+
+# Write repositories file in both possible locations (these are for pkgsrc packages)
+{
+cat <<EOF
+https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/
+https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/
+https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/
+https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/
+https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/
+EOF
+} > /usr/pkg/etc/pkgin/repositories
+cp /usr/pkg/etc/pkgin/repositories /etc/pkgin/repositories
+
+echo "Created pkgin repositories file:"
+cat /usr/pkg/etc/pkgin/repositories
+
+# Also set environment variable to force pkgin to use these mirrors (colon-separated)
+export PKGIN_REPOSITORIES="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/"
+echo "PKGIN_REPOSITORIES=$PKGIN_REPOSITORIES"
+
+# Download and install X11 binary sets FIRST (needed for build dependencies)
+# Multiple mirrors for binary sets (cdn.netbsd.org is last as it's frequently failing)
+SETS_MIRRORS="
+https://ftp.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
+https://ftp.fr.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
+https://ftp.us.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
+https://cdn.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
+"
+
+echo "--> Downloading and installing X11 sets (xbase, xetc, xfont, xcomp, xserver)"
+for i in xbase xetc xfont xcomp xserver; do
+    success=0
+    for mirror in $SETS_MIRRORS; do
+        url="$mirror/$i.tar.xz"
+        echo "Attempting to download $url"
+        # Use curl with retries and timeouts
+        if curl --retry 3 --connect-timeout 20 -fSL "$url" -o "/$i.tar.xz"; then
+            echo "Downloaded $i from $mirror"
+            success=1
+            break
+        else
+            echo "Failed to download from $mirror"
+            rm -f "/$i.tar.xz"
+        fi
+    done
+    if [ $success -ne 1 ]; then
+        echo "ERROR: Could not download $i.tar.xz from any mirror"
+        exit 1
+    fi
+    echo "unpacking /$i.tar.xz"
+    tar --unlink -xJf "/$i.tar.xz" -C /
+    rm -f "/$i.tar.xz"
+done
+
+# Now update package database (pkgsrc) - this may use fallback to 10.0 if 10.1 repos unavailable
+echo "--> Updating pkgin package database"
+if ! pkgin update; then
+    echo "pkgin update failed for NetBSD $NETBSD_RELEASE, falling back to 10.0 packages (ABI compatible)..."
+    # Override with 10.0 mirrors
+    {
+    cat <<EOF
+https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/
+https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/
+https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/
+https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/
+https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/
+EOF
+    } > /usr/pkg/etc/pkgin/repositories
+    cp /usr/pkg/etc/pkgin/repositories /etc/pkgin/repositories
+    export PKGIN_REPOSITORIES="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/"
+    echo "Using fallback repositories (10.0):"
+    cat /usr/pkg/etc/pkgin/repositories
+    pkgin update
+fi
+
+echo "--> installing extra dependencies"
 pkgin -y install \
     bash git pkgconf autoconf automake libtool xorgproto meson pixman xtrans \
     libxkbfile libxcvt libpciaccess font-util libepoll-shim libepoxy nettle \
     xkbcomp xcb-util libXcursor libXScrnSaver spice-protocol fontconfig \
     mkfontscale python311 gmake curl
-
-FILESET_URL=https://cdn.netbsd.org/pub/NetBSD/NetBSD-10.0/amd64/binary/sets
-
-for i in xbase xetc xfont xcomp xserver ; do
-    echo "downloading $FILESET_URL/$i.tar.xz --> /$i.tar.xz"
-    curl $FILESET_URL/$i.tar.xz -o /$i.tar.xz
-    echo "unpacking /$i.tar.xz"
-    tar --unlink -xJf /$i.tar.xz -C /
-done
 
 mkdir -p $X11_BUILD_DIR
 cd $X11_BUILD_DIR

--- a/.github/scripts/netbsd/install-pkg.sh
+++ b/.github/scripts/netbsd/install-pkg.sh
@@ -6,9 +6,7 @@ set -ex
 
 export PATH="$PATH:/usr/sbin:/sbin:/usr/local/sbin"
 
-# NetBSD release version (matches .github/workflows/build-xserver.yml:363)
 NETBSD_RELEASE="10.1"
-# CPU architecture: NetBSD uses amd64, pkgsrc uses x86_64 for the directory name
 NETBSD_ARCH="amd64"
 PKGSRC_ARCH="x86_64"
 
@@ -36,13 +34,12 @@ if ! command -v pkgin >/dev/null 2>&1; then
     fi
 fi
 
-# Remove default pkgin config that may point to old release
+# Configure pkgin repositories (use .conf extension)
 rm -f /usr/pkg/etc/pkgin/repositories.conf
 rm -f /etc/pkgin/repositories.conf
-
-# Configure pkgin repositories for NetBSD $NETBSD_RELEASE
 mkdir -p /usr/pkg/etc/pkgin
 mkdir -p /etc/pkgin
+
 {
 cat <<EOF
 https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/
@@ -51,12 +48,14 @@ https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGS
 https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/
 https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/
 EOF
-} > /usr/pkg/etc/pkgin/repositories
-cp /usr/pkg/etc/pkgin/repositories /etc/pkgin/repositories
+} > /usr/pkg/etc/pkgin/repositories.conf
+cp /usr/pkg/etc/pkgin/repositories.conf /etc/pkgin/repositories.conf
 
-export PKGIN_REPOSITORIES="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/"
+# Set PKG_REPOS environment variable (colon-separated)
+export PKG_REPOS="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/:https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/"
+echo "PKG_REPOS=$PKG_REPOS"
 
-# Update package database, fallback to 10.0 if necessary
+# Update package database
 echo "Updating pkgin..."
 if ! pkgin update; then
     echo "pkgin update failed, falling back to NetBSD 10.0 repositories..."
@@ -68,17 +67,17 @@ https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGS
 https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/
 https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/
 EOF
-    } > /usr/pkg/etc/pkgin/repositories
-    cp /usr/pkg/etc/pkgin/repositories /etc/pkgin/repositories
-    export PKGIN_REPOSITORIES="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/"
+    } > /usr/pkg/etc/pkgin/repositories.conf
+    cp /usr/pkg/etc/pkgin/repositories.conf /etc/pkgin/repositories.conf
+    export PKG_REPOS="https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://mirror.planetunix.net/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/:https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/"
     pkgin update
 fi
 
-# Install curl so we can download sets
-echo "Installing curl for set downloads..."
+# Install curl for downloading sets
+echo "Installing curl..."
 pkgin -y install curl
 
-# X11 binary sets to install
+# X11 binary sets
 SETS_MIRRORS="
 https://ftp.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
 https://ftp.fr.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets


### PR DESCRIPTION
The default mirror (on fastly) fails regularily, so we have to try
several ones, in order to prevent our whole pipeline from failing.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
