### PR TITLE
Xi: fix ProcX*ChangeDeviceProperty swapping

### DIFF
--- a/Xi/xiproperty.c
+++ b/Xi/xiproperty.c
@@ -874,17 +874,17 @@ ProcXChangeDeviceProperty(ClientPtr client)
         swapl(&stuff->property);
         swapl(&stuff->type);
         swapl(&stuff->nUnits);
-    }
 
-    switch (stuff->format) {
-    case 8:
-        break;
-    case 16:
-        SwapRestS(stuff);
-        break;
-    case 32:
-        SwapRestL(stuff);
-        break;
+        switch (stuff->format) {
+        case 8:
+            break;
+        case 16:
+            SwapRestS(stuff);
+            break;
+        case 32:
+            SwapRestL(stuff);
+            break;
+        }
     }
 
     DeviceIntPtr dev;
@@ -1065,17 +1065,17 @@ ProcXIChangeProperty(ClientPtr client)
         swapl(&stuff->property);
         swapl(&stuff->type);
         swapl(&stuff->num_items);
-    }
 
-    switch (stuff->format) {
-    case 8:
-        break;
-    case 16:
-        SwapRestS(stuff);
-        break;
-    case 32:
-        SwapRestL(stuff);
-        break;
+        switch (stuff->format) {
+        case 8:
+            break;
+        case 16:
+            SwapRestS(stuff);
+            break;
+        case 32:
+            SwapRestL(stuff);
+            break;
+        }
     }
 
     int rc;


### PR DESCRIPTION
The SwapRest* functions swaps data unconditionally, improve code to perform check if client is swap and only then perform swapping

Fixes:  https://github.com/X11Libre/xserver/issues/3079

note: it not necessary for master, there check in macro