### PR TITLE
kdrive/fbdev: Add some config examples to the man page

### DIFF
--- a/hw/kdrive/fbdev/Xfbdev.man
+++ b/hw/kdrive/fbdev/Xfbdev.man
@@ -73,6 +73,55 @@ tells the X server to only use embedded GLES contexts.
 .B -noxv
 disables X-Video support.
 
+.SH CONFIGURATION
+.
+Like all kdrive X servers,
+.B Xfbdev
+doesn't read any configuration file.
+Instead, all configuration is done via command-line arguments.
+
+.B Xfbdev
+is intended to provide a reasonable configuration out-of-the-box, with no special configuration.
+Simply running
+.B xinit -- /path/to/Xfbdev
+should provide a default configuration that is able to provide a usable display.
+This default configuration is rather simplistic, with the aim of working
+almost anywhere, while sacrificing performance.
+
+For regular use, a shell script or similar can be created to invoke xinit and pass all the necessary command-line arguments.
+
+In the most general form, the configuration of
+.B Xfbdev
+looks like this:
+.B xinit -- /path/to/Xfbdev [server_args] [screen_0_args] -screen [geom] [screen_1_args] -screen [geom] ... [screen_n_args] -screen [geom] [screen_n_args]
+
+Arguments whose effect is intended to affect the entire X server instead of a particular screen (e.g. +xinerama) can be added anywhere,
+but they are usually added before the arguments of the first screen.
+
+If a single X11 screen is desired, with no special geometry,
+.B Xfbdev
+supports using an implicit first screen, like so:
+.B xinit -- /path/to/Xfbdev [server_args] [screen_args]
+
+Below are listed some example configurations, intended to serve as a guide for configuring
+.B Xfbdev.
+
+A single X11 screen with DRI3 running on a different card than the framebuffer, with an explicit glvendor and with only OpenGL ES contexts allowed:
+.B xinit  --  /usr/bin/Xfbdev :1 -fb /dev/fb0 -glvendor nvidia -dri /dev/dri/card1 -force-es
+
+A single X11 screen with automatic DRI3 and explicit screen geometry:
+.B xinit -- /usr/bin/Xfbdev -fb /dev/fb1 -dri auto -screen 1200x1000
+.B xinit -- /usr/bin/Xfbdev -screen 1200x1000 -fb /dev/fb1 -dri auto
+
+Two X11 screens with DRI3 support, with the first screen on the left, the second screen on the right:
+.B xinit -- /usr/bin/Xfbdev -dri /dev/dri/card1 -fb /dev/fb0 -screen 1920x1080 -fb /dev/fb1 -dri /dev/dri/card1 -screen 1920x1080
+
+Two X11 screens with DRI3 support, with the first screen on the left, the second screen on the right, using xinerama:
+.B xinit -- /usr/bin/Xfbdev +xinerama -dri /dev/dri/card1 -fb /dev/fb0 -screen 1920x1080 -fb /dev/fb1 -dri /dev/dri/card1 -screen 1920x1080
+
+Two X11 screens, the first one below the second one:
+.B xinit -- /usr/bin/Xfbdev -fb /dev/fb0 -origin 0,1080 -screen 1920x1080 -fb /dev/fb1 -origin 0,0 -screen 1920x1080
+
 .SH KEYBOARD
 .B Xfbdev
 supports the common special key combinations of the Xkdrive family of servers.  Please

--- a/hw/kdrive/src/kinput.c
+++ b/hw/kdrive/src/kinput.c
@@ -2186,12 +2186,12 @@ KdCursorOffScreen(ScreenPtr *ppScreen, int *x, int *y)
 
     if (*x < 0)
         *x += pNewScreen->width;
+    else if (*x >= pScreen->width)
+        *x -= pScreen->width;
+
     if (*y < 0)
         *y += pNewScreen->height;
-
-    if (*x >= pScreen->width)
-        *x -= pScreen->width;
-    if (*y >= pScreen->height)
+    else if (*y >= pScreen->height)
         *y -= pScreen->height;
 
     *ppScreen = pNewScreen;


### PR DESCRIPTION
We had no info on how to pass multi-screen config options to Xfbdev.

We also had no example configs to guide people interested in
configuring Xfbdev.

--------------------------------------------------------------------------------------------------

kdrive: Don't fixup the cursor position twice in `KdCursorOffScreen`

The intent of the code is to take the coordinates of the cursor
and adjust them so that they are where they are supposed to be on
the new screen.

If we're moving up on a screen with a larger height that the one
we are on, *y < 0, so we fix it by adding the new screen's height.
Since the height is larger, and the code was lacking an else branch,
it thinks that we are now moving down, so it incorrectly subtracts
the old screen height, making the cursor end up somewhere it's not
supposed to be.