### PR TITLE
(release/25.2) randr: zero name padding in GetScreenResources replies

### DIFF
--- a/Xext/randr/rrscreen.c
+++ b/Xext/randr/rrscreen.c
@@ -424,7 +424,7 @@ rrGetMultiScreenResources(ClientPtr client, Bool query, ScreenPtr pScreen)
 
     extraLen = reply.length << 2;
     if (extraLen) {
-        extra = x_rpcbuf_reserve(&rpcbuf, extraLen);
+        extra = x_rpcbuf_reserve0(&rpcbuf, extraLen);
         if (!extra) {
             return BadAlloc;
         }
@@ -542,7 +542,7 @@ rrGetScreenResources(ClientPtr client, Bool query)
         if (!extraLen)
             goto finish;
 
-        extra = x_rpcbuf_reserve(&rpcbuf, extraLen);
+        extra = x_rpcbuf_reserve0(&rpcbuf, extraLen);
         if (!extra) {
             free(modes);
             return BadAlloc;


### PR DESCRIPTION
### Backport dashboard

Master: #2991 ✅ merged

| Branch | PR | Status |
|---|---|---|
| release/25.2 | #3092 | ⬜ open ← this PR |

<sub>Auto-generated backport dashboard — links the source master PR and sibling backports with their merge status.</sub>

---

rrGetMultiScreenResources() and rrGetScreenResources() copy each mode name
with its exact length while the reply payload length rounds the total name
bytes up to a 4-byte multiple. The trailing alignment padding was left
uninitialized because the buffer was allocated with the non-zeroing
x_rpcbuf_reserve(), disclosing server heap to the client.

Use x_rpcbuf_reserve0() for both extra buffers.

Fixes: cbc4e91f02d1 ("randr: rrGetMultiScreenResources(): use x_rpcbuf_t")
Fixes: 26a1e5f7099c ("randr: rrGetScreenResources(): use x_rpcbuf_t")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit 88332a2a52b19df777cefc73ea46a6c2f6dcfac3)
