### PR TITLE
randr: fix heap overflow and size tracking in RRChangeProviderProperty

### DIFF
--- a/Xext/randr/rrproviderproperty.c
+++ b/Xext/randr/rrproviderproperty.c
@@ -183,7 +183,7 @@ RRChangeProviderProperty(RRProviderPtr provider, Atom property, Atom type,
             cleanupProperty(prop, add);
             return BadAlloc;
         }
-        new_value.size = len;
+        new_value.size = total_len;
         new_value.type = type;
         new_value.format = format;
 
@@ -200,7 +200,7 @@ RRChangeProviderProperty(RRProviderPtr provider, Atom property, Atom type,
         case PropModePrepend:
             new_data = new_value.data;
             old_data = (void *) (((char *) new_value.data) +
-                                  (prop_value->size * size_in_bytes));
+                                 (len * size_in_bytes));
             break;
         }
         if (new_data)


### PR DESCRIPTION
In PropModePrepend mode, old_data was offset by prop_value->size * size_in_bytes instead of len * size_in_bytes, causing a heap buffer overflow whenever the existing property is larger than the new data being prepended.

Additionally, new_value.size was set to len instead of total_len in Append and Prepend modes, causing the stored property size to reflect only the new elements rather than the full property after the operation.

rrproperty.c (the RROutput equivalent) already has both correct forms, this brings rrproviderproperty.c in line with it.

Signed-off-by: Victor Lev <levvictor123@gmail.com>

---

### Backport dashboard

| Target branch | Backport PR | Status |
|----------------|-------------|--------|
| `release/25.2` | #3097 | 🔄 Open |
| `release/25.1` | #3098 | 🔄 Open |
| `release/25.0` | #3099 | 🔄 Open |

<sub>🤖 Backport assessment by Claude Code on behalf of @metux. All three maintained lines carry the identical bug. **25.2** keeps the file at `Xext/randr/rrproviderproperty.c` (clean cherry-pick); **25.1** and **25.0** keep it at the pre-reorg `randr/rrproviderproperty.c`, so the same 2-line change was applied path-adapted.</sub>
