### PR TITLE
README: add seatd operation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ chmod 0770 testx.sh
 
 This should give you 10 glorious seconds of a black and beautiful and empty screen. Afterwards the Xserver complains about being killed, but there should be no other critical errors for a "test passed." For more details, please see [Building XLibre (X11Libre/xserver Wiki)](https://github.com/X11Libre/xserver/wiki/Building-XLibre).
 
+If you are using seatd for rootless operation instead of (e)logind, create the following file named `.xserverrc` in your home directory:
+```shell
+#!/bin/sh
+exec X -keeptty "$@"
+```
+Then, run `chmod +x ~/.xserverrc`.
+
 
 ## I want to help!
 


### PR DESCRIPTION
As seatd operation is now supported, we should document how to use it, as the error message is a vague, unhelpful permission denied error if this is not set. On top of this, Xorg configuration documentation on the internet of course does not document this as (e)logind does not require this.