### PR TITLE
(release/25.2) render: fix swapping and additional length check in ProcRenderSetPictureFilter()

### DIFF
--- a/Xext/render/render.c
+++ b/Xext/render/render.c
@@ -2894,6 +2894,22 @@ ProcRenderSetPictureFilter(ClientPtr client)
         swaps(&stuff->nbytes);
     }
 
+    const size_t namelen = pad_to_int32(stuff->nbytes);
+    REQUEST_AT_LEAST_EXTRA_SIZE(xRenderSetPictureFilterReq, namelen);
+
+    const size_t packet_len = stuff->length * 4;
+    const size_t remaining =
+        (packet_len - sizeof(xRenderSetPictureFilterReq) - namelen);
+    const size_t nparams = remaining / 4;
+    if ((nparams * 4) != remaining) {
+        return BadLength;
+    }
+
+    if (client->swapped) {
+        CARD32 *params = (CARD32*)((char*)(stuff + 1) + namelen);
+        SwapLongs(params, nparams);
+    }
+
 #ifdef XINERAMA
     return (usePanoramiX ? PanoramiXRenderSetPictureFilter(client, stuff)
                          : SingleRenderSetPictureFilter(client, stuff));


### PR DESCRIPTION
### Backport dashboard

Master: #2395 ✅ merged

| Branch | PR | Status |
|---|---|---|
| release/25.2 | #3096 | ⬜ open ← this PR |

<sub>Auto-generated backport dashboard — links the source master PR and sibling backports with their merge status.</sub>

---

**Backport of #2395** to `release/25.2`.

`release/25.2` uses the same post-refactor inline-swap model as master and was missing both the trailing-param byte-swap and the length/overflow check — i.e. it carried the identical vulnerability. This cherry-picks the master fix verbatim.

---

* correctly swap the parameters, which are coming after the filter name block
  (those are treated as CARD32's)
* additional length checks for malicious packets (protect from buffer overflow)

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit 92430c900830eb74d5af010a3e20c517096c1d27)
