### PR TITLE
(release/25.2) randr: fix heap overflow and size tracking in RRChangeProviderProperty

### DIFF
--- a/Xext/randr/rrproviderproperty.c
+++ b/Xext/randr/rrproviderproperty.c
@@ -183,7 +183,7 @@ RRChangeProviderProperty(RRProviderPtr provider, Atom property, Atom type,
             cleanupProperty(prop, add);
             return BadAlloc;
         }
-        new_value.size = len;
+        new_value.size = total_len;
         new_value.type = type;
         new_value.format = format;
 
@@ -200,7 +200,7 @@ RRChangeProviderProperty(RRProviderPtr provider, Atom property, Atom type,
         case PropModePrepend:
             new_data = new_value.data;
             old_data = (void *) (((char *) new_value.data) +
-                                  (prop_value->size * size_in_bytes));
+                                 (len * size_in_bytes));
             break;
         }
         if (new_data)


### PR DESCRIPTION
### Backport dashboard

Master: #3094 ✅ merged

| Branch | PR | Status |
|---|---|---|
| release/25.0 | #3099 | ⬜ open |
| release/25.1 | #3098 | ⬜ open |
| release/25.2 | #3097 | ⬜ open ← this PR |

<sub>Auto-generated backport dashboard — links the source master PR and sibling backports with their merge status.</sub>

---

**Backport of #3094** to `release/25.2`.

`release/25.2` carries the identical buggy code at the same path (`Xext/randr/rrproviderproperty.c`) — clean cherry-pick of the master fix.

---

In PropModePrepend mode, old_data was offset by prop_value->size * size_in_bytes instead of len * size_in_bytes, causing a heap buffer overflow whenever the existing property is larger than the new data being prepended.

Additionally, new_value.size was set to len instead of total_len in Append and Prepend modes, causing the stored property size to reflect only the new elements rather than the full property after the operation.

rrproperty.c (the RROutput equivalent) already has both correct forms, this brings rrproviderproperty.c in line with it.

Signed-off-by: Victor Lev <levvictor123@gmail.com>
(cherry picked from commit 826a3cc93de2d1c90e01f3b546bbcc2f3a81a170)
