### PR TITLE
(release/25.2) render: zero reply buffers in QueryPictFormats and QueryFilters

### DIFF
--- a/Xext/render/render.c
+++ b/Xext/render/render.c
@@ -244,7 +244,7 @@ ProcRenderQueryPictFormats(ClientPtr client)
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
-    xPictFormInfo *pictForm = x_rpcbuf_reserve(&rpcbuf, rlength);
+    xPictFormInfo *pictForm = x_rpcbuf_reserve0(&rpcbuf, rlength);
     if (!pictForm)
         return BadAlloc;
 
@@ -1531,7 +1531,7 @@ ProcRenderQueryFilters(ClientPtr client)
     total_bytes = (len << 2);
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
-    aliases = (INT16 *) x_rpcbuf_reserve(&rpcbuf, total_bytes);
+    aliases = (INT16 *) x_rpcbuf_reserve0(&rpcbuf, total_bytes);
     if (!aliases)
         return BadAlloc;
 


### PR DESCRIPTION
### Backport dashboard

Master: #2989 ✅ merged

| Branch | PR | Status |
|---|---|---|
| release/25.2 | #3100 | ⬜ open ← this PR |

<sub>Auto-generated backport dashboard — links the source master PR and sibling backports with their merge status.</sub>

---

**Backport of #2989** to `release/25.2`.

`release/25.2` carries the identical code at the same path (`Xext/render/render.c`): both `ProcRenderQueryPictFormats` and `ProcRenderQueryFilters` allocate their reply payloads with the non-zeroing `x_rpcbuf_reserve()`, and `x_rpcbuf_reserve0()` is available — so this is a clean cherry-pick of the master fix.

(25.1 already uses `x_rpcbuf_reserve0()` at both sites; 25.0 predates the `x_rpcbuf_t` rewrite and zero-allocs both buffers with `calloc`, so neither needs this fix.)

---

ProcRenderQueryPictFormats left the internal padding of xPictFormInfo (pad1)
and xPictDepth (pad1, pad2) unwritten, and ProcRenderQueryFilters left the
odd-count alias alignment slot and the filter-name alignment tail unwritten.
Both reply buffers were allocated with the non-zeroing x_rpcbuf_reserve(), so
those bytes disclosed uninitialized server heap to the client.

Use x_rpcbuf_reserve0() for both reply payloads.

Fixes: fe9fcfe98f3a ("render: ProcRenderQueryPictFormats(): use x_rpcbuf_t")
Fixes: 81f93d19a02a ("render: ProcRenderQueryFilters(): use x_rpcbuf_t")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit d6c0b230e85d2e525adcd99e00ffb74124f7610a)
