### PR TITLE
(release/25.2) Xext: xvideo: zero padding in ProcXvListImageFormats reply

### DIFF
--- a/Xext/xv/xvdisp.c
+++ b/Xext/xv/xvdisp.c
@@ -905,18 +905,20 @@ ProcXvListImageFormats(ClientPtr client)
         x_rpcbuf_write_CARD32(&rpcbuf, pImage->id);
         x_rpcbuf_write_CARD8(&rpcbuf, pImage->type);
         x_rpcbuf_write_CARD8(&rpcbuf, pImage->byte_order);
-        x_rpcbuf_reserve(&rpcbuf, sizeof(CARD16)); /* pad1; */
+        x_rpcbuf_write_CARD16(&rpcbuf, 0); /* pad1 */
         x_rpcbuf_write_binary_pad(&rpcbuf, pImage->guid, 16);
         x_rpcbuf_write_CARD8(&rpcbuf, pImage->bits_per_pixel);
         x_rpcbuf_write_CARD8(&rpcbuf, pImage->num_planes);
-        x_rpcbuf_reserve(&rpcbuf, sizeof(CARD16)); /* pad2; */
+        x_rpcbuf_write_CARD16(&rpcbuf, 0); /* pad2 */
         x_rpcbuf_write_CARD8(&rpcbuf, pImage->depth);
-        x_rpcbuf_reserve(&rpcbuf, sizeof(CARD8)+sizeof(CARD16)); /* pad3, pad4 */
+        x_rpcbuf_write_CARD8(&rpcbuf, 0);  /* pad3 */
+        x_rpcbuf_write_CARD16(&rpcbuf, 0); /* pad4 */
         x_rpcbuf_write_CARD32(&rpcbuf, pImage->red_mask);
         x_rpcbuf_write_CARD32(&rpcbuf, pImage->green_mask);
         x_rpcbuf_write_CARD32(&rpcbuf, pImage->blue_mask);
         x_rpcbuf_write_CARD8(&rpcbuf, pImage->format);
-        x_rpcbuf_reserve(&rpcbuf, sizeof(CARD8)+sizeof(CARD16)); /* pad5, pad6 */
+        x_rpcbuf_write_CARD8(&rpcbuf, 0);  /* pad5 */
+        x_rpcbuf_write_CARD16(&rpcbuf, 0); /* pad6 */
         x_rpcbuf_write_CARD32(&rpcbuf, pImage->y_sample_bits);
         x_rpcbuf_write_CARD32(&rpcbuf, pImage->u_sample_bits);
         x_rpcbuf_write_CARD32(&rpcbuf, pImage->v_sample_bits);
@@ -928,7 +930,10 @@ ProcXvListImageFormats(ClientPtr client)
         x_rpcbuf_write_CARD32(&rpcbuf, pImage->vert_v_period);
         x_rpcbuf_write_binary_pad(&rpcbuf, pImage->component_order, 32);
         x_rpcbuf_write_CARD8(&rpcbuf, pImage->scanline_order);
-        x_rpcbuf_reserve(&rpcbuf, sizeof(CARD8)+sizeof(CARD16)+(sizeof(CARD32)*2)); /* pad7, pad8, pad9, pad10 */
+        x_rpcbuf_write_CARD8(&rpcbuf, 0);  /* pad7 */
+        x_rpcbuf_write_CARD16(&rpcbuf, 0); /* pad8 */
+        x_rpcbuf_write_CARD32(&rpcbuf, 0); /* pad9 */
+        x_rpcbuf_write_CARD32(&rpcbuf, 0); /* pad10 */
     }
 
     /* use rpc.wpos here, in order to get how much we've really written */


### PR DESCRIPTION
### Backport dashboard

Master: #2985 ✅ merged

| Branch | PR | Status |
|---|---|---|
| release/25.2 | #3101 | ⬜ open ← this PR |

<sub>Auto-generated backport dashboard — links the source master PR and sibling backports with their merge status.</sub>

---

**Backport of #2985** to `release/25.2`.

`release/25.2` carries the identical code at the same path (`Xext/xv/xvdisp.c`): `ProcXvListImageFormats` reserves the `xvImageFormatInfo` padding with the non-zeroing `x_rpcbuf_reserve()` and never writes it — so this is a clean cherry-pick of the master fix.

(25.1 already writes the pads as explicit zeros; 25.0 predates the `x_rpcbuf_t` rewrite and builds the reply from a zero-initialized `xvImageFormatInfo info = { 0 }`, so neither needs this fix.)

---

The xvImageFormatInfo records in the ProcXvListImageFormats reply left the
inter-field padding (pad1..pad10, ~18 bytes per format) uninitialized: it was
reserved with the non-zeroing x_rpcbuf_reserve() and never written, so those
bytes were sent to the client as uninitialized server heap.

Write the padding fields explicitly as zero with x_rpcbuf_write_CARD8/16/32(),
matching the field-by-field construction of the rest of the record.

Fixes: 2d66d11caf89 ("Xext: xv: ProcXvListImageFormats(): use x_rpcbuf_t for reply payload assembly")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit 92e1be28ec6d895f032dbe7d2168744cea8fa2a3)
