### PR TITLE
(release/25.2) present: byte-swap notify list in sproc_present_pixmap_synced

### DIFF
--- a/Xext/present/present_request.c
+++ b/Xext/present/present_request.c
@@ -431,6 +431,10 @@ sproc_present_pixmap_synced(ClientPtr client)
     swapll(&stuff->target_msc);
     swapll(&stuff->divisor);
     swapll(&stuff->remainder);
+
+    /* Swap the trailing LISTofPRESENTNOTIFY, like sproc_present_pixmap(). */
+    SwapRestL(stuff);
+
     return proc_present_pixmap_synced(client);
 }
 #endif /* DRI3 */


### PR DESCRIPTION
### Backport dashboard

Master: #2983 ✅ merged

| Branch | PR | Status |
|---|---|---|
| release/25.2 | #3102 | ⬜ open ← this PR |

<sub>Auto-generated backport dashboard — links the source master PR and sibling backports with their merge status.</sub>

---

**Backport of #2983** to `release/25.2`.

`release/25.2` has `sproc_present_pixmap_synced()` (in `Xext/present/present_request.c`) with the fixed-header swaps but no trailing `SwapRestL()` — identical to master pre-fix → clean cherry-pick.

(25.1 and 25.0 already carry `SwapRestL(stuff)` in their `present/present_request.c`, so neither needs this fix.)

---

sproc_present_pixmap_synced() swapped the fixed request header but, unlike
sproc_present_pixmap(), never byte-swapped the trailing LISTofPRESENTNOTIFY.
present_create_notifies() then read each notify window/serial in the wrong
byte order for swapped clients, so PresentPixmapSynced with notifies resolved
the wrong (or no) window. Bounds are enforced by req_len and dixLookupWindow()
so there was no memory-safety impact, only incorrect behaviour.

Add the missing SwapRestL(stuff).

Fixes: ac0bc0b3b6e6 ("Present: add PresentCapabilitySyncobj and PresentPixmapSynced")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit 16d7c7944553e05620fa0574e742d8c632e07ce9)
