### PR TITLE
Xnamespace protocol extension (prototype)

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -122,6 +122,70 @@ jobs:
                       __BUILD/meson-logs/*
                       __BUILD/test/piglit-results/*
 
+            # X-NAMESPACE conformance: exercise the management extension end to
+            # end against the Xvfb we just built (namespace is on by default),
+            # using the TAP test tool + runner from go-x11proto.
+            - name: check out go-x11proto (conformance tests)
+              uses: actions/checkout@v4
+              with:
+                  repository: X11Libre/go-x11proto
+                  ref: master
+                  path: go-x11proto
+
+            - name: install Go toolchain
+              uses: actions/setup-go@v5
+              with:
+                  go-version-file: go-x11proto/go.mod
+
+            - name: X-NAMESPACE conformance test (Xvfb)
+              env:
+                  XNS_XSERVER: ${{ github.workspace }}/__BUILD/hw/vfb/Xvfb
+                  XNS_TEST_FLAGS: -v
+              run: |
+                  export LD_LIBRARY_PATH="$X11_PREFIX/lib/$MACHINE:$X11_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+                  ./go-x11proto/contrib/xnamespace/run-xnamespace-test.sh
+
+            # The nested servers (Xephyr, Xnest) need a parent X display; reuse
+            # the Xvfb we just built as that parent. Xfbdev is skipped: it needs
+            # a real /dev/fb0, which CI runners don't have.
+            - name: X-NAMESPACE conformance test (Xephyr, Xnest)
+              env:
+                  XNS_TEST_FLAGS: -v
+              run: |
+                  export LD_LIBRARY_PATH="$X11_PREFIX/lib/$MACHINE:$X11_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+                  build="$PWD/__BUILD"
+                  runner=./go-x11proto/contrib/xnamespace/run-xnamespace-test.sh
+
+                  # bring up the parent display (-ac so the nested servers may
+                  # connect without an auth cookie) and wait for its socket.
+                  "$build/hw/vfb/Xvfb" :99 -ac -screen 0 1280x1024x24 \
+                      >/tmp/xvfb-parent.log 2>&1 &
+                  parent=$!
+                  trap 'kill "$parent" 2>/dev/null || true' EXIT
+                  for _ in $(seq 1 100); do
+                      [ -S /tmp/.X11-unix/X99 ] && break
+                      kill -0 "$parent" 2>/dev/null || {
+                          echo "parent Xvfb exited before becoming ready:" >&2
+                          cat /tmp/xvfb-parent.log >&2; exit 1; }
+                      sleep 0.1
+                  done
+                  export DISPLAY=:99
+
+                  # each nested server takes its own geometry syntax; the runner
+                  # supplies -displayfd/-namespace/+byteswappedclients itself.
+                  rc=0
+                  echo "::group::Xephyr"
+                  XNS_XSERVER="$build/hw/kdrive/ephyr/Xephyr" \
+                  XNS_XSERVER_ARGS="-screen 1280x1024x24" \
+                      "$runner" || rc=1
+                  echo "::endgroup::"
+                  echo "::group::Xnest"
+                  XNS_XSERVER="$build/hw/xnest/Xnest" \
+                  XNS_XSERVER_ARGS="-geometry 1280x1024" \
+                      "$runner" || rc=1
+                  echo "::endgroup::"
+                  exit "$rc"
+
     abi-changes-check:
         runs-on: ubuntu-latest
         outputs:

--- a/Xext/namespace/config.c
+++ b/Xext/namespace/config.c
@@ -6,8 +6,11 @@
 
 #include "os/auth.h"
 #include "include/os.h"
+#include "include/dix.h"
+#include "dix/dix_priv.h"
 
 #include "namespace.h"
+#include "namespaceproto.h"
 
 struct Xnamespace ns_root = {
     .allowMouseMotion = TRUE,
@@ -274,4 +277,264 @@ int XnsAddToken(struct Xnamespace *ns, const char *proto, size_t protolen,
     if (handleOut)
         *handleOut = t->handle;
     return Success;
+}
+
+/**
+ * @brief Validate a namespace name coming off the wire.
+ *
+ * Config-file input is trusted and does not go through this. Rejects empty
+ * or over-long names and any non-printable, whitespace, '#' (comment) or '/'
+ * (reserved for future nesting) characters, so a protocol-created name stays
+ * expressible in the config file.
+ *
+ * @param name pointer to the name bytes
+ * @param len  number of bytes
+ * @return Success if acceptable, else BadName
+ */
+static int validateName(const char *name, size_t len)
+{
+    if (len == 0 || len > XNS_NAME_MAX)
+        return BadName;
+    for (size_t i = 0; i < len; i++) {
+        unsigned char c = (unsigned char) name[i];
+        /* printable, no whitespace/control, no '#' (comment) or '/' (reserved
+           for future nesting) - keeps protocol names config-file expressible */
+        if (c <= ' ' || c == 0x7f || c == '#' || c == '/')
+            return BadName;
+    }
+    return Success;
+}
+
+/**
+ * @brief Apply a capability bitmask to a namespace's individual flag fields.
+ * @param ns   the namespace to update
+ * @param caps capability bitmask (XNS_CAPABILITY_*)
+ */
+static void capsToFields(struct Xnamespace *ns, CARD32 caps)
+{
+    ns->allowMouseMotion  = !!(caps & XNS_CAPABILITY_MOUSE_MOTION);
+    ns->allowShape        = !!(caps & XNS_CAPABILITY_SHAPE);
+    ns->allowTransparency = !!(caps & XNS_CAPABILITY_TRANSPARENCY);
+    ns->allowXInput       = !!(caps & XNS_CAPABILITY_INPUT);
+    ns->allowXKeyboard    = !!(caps & XNS_CAPABILITY_KEYBOARD);
+    ns->superPower        = !!(caps & XNS_CAPABILITY_ADMIN);
+}
+
+/**
+ * @brief Build the capability bitmask describing a namespace.
+ * @param ns the namespace to inspect
+ * @return the XNS_CAPABILITY_* bitmask of its enabled capabilities
+ */
+CARD32 XnsCaps(const struct Xnamespace *ns)
+{
+    return (ns->allowMouseMotion  ? XNS_CAPABILITY_MOUSE_MOTION : 0)
+         | (ns->allowShape        ? XNS_CAPABILITY_SHAPE        : 0)
+         | (ns->allowTransparency ? XNS_CAPABILITY_TRANSPARENCY : 0)
+         | (ns->allowXInput       ? XNS_CAPABILITY_INPUT        : 0)
+         | (ns->allowXKeyboard    ? XNS_CAPABILITY_KEYBOARD     : 0)
+         | (ns->superPower        ? XNS_CAPABILITY_ADMIN        : 0);
+}
+
+/**
+ * @brief Build the attribute bitmask describing a namespace.
+ * @param ns the namespace to inspect
+ * @return the XNS_ATTR_* bitmask (e.g. immutable, transient)
+ */
+CARD32 XnsAttrs(const struct Xnamespace *ns)
+{
+    return (ns->builtin    ? XNS_ATTR_IMMUTABLE : 0)
+         | (ns->autoRemove ? XNS_ATTR_TRANSIENT : 0);
+}
+
+/**
+ * @brief Atomically update a subset of a namespace's capability bits.
+ *
+ * Computes @c (old & ~mask) | (values & mask), so several managers can change
+ * disjoint bits without read-modify-write races.
+ *
+ * @param ns     the namespace to update
+ * @param mask   which capability bits to apply
+ * @param values new values for the masked bits
+ * @return Success, or BadValue if @p mask contains reserved bits
+ */
+int XnsSetCaps(struct Xnamespace *ns, CARD32 mask, CARD32 values)
+{
+    if (mask & ~XNS_CAPABILITY_ALL)
+        return BadValue;
+    CARD32 newcaps = (XnsCaps(ns) & ~mask) | (values & mask);
+    capsToFields(ns, newcaps);
+    return Success;
+}
+
+/**
+ * @brief Count the auth tokens currently registered in a namespace.
+ * @param ns the namespace to inspect
+ * @return the number of auth tokens
+ */
+CARD32 XnsCountTokens(struct Xnamespace *ns)
+{
+    CARD32 n = 0;
+    struct auth_token *at;
+    xorg_list_for_each_entry(at, &ns->auth_tokens, entry)
+        n++;
+    return n;
+}
+
+/**
+ * @brief Create a new namespace (the runtime equivalent of a config
+ *        @c namespace stanza).
+ *
+ * Validates the name, rejects duplicates, and initialises capabilities and
+ * attributes. The name is copied; the caller's buffer need not persist.
+ *
+ * @param name    pointer to the name bytes (need not be NUL-terminated)
+ * @param namelen number of name bytes
+ * @param caps    initial capability bitmask (XNS_CAPABILITY_*)
+ * @param attrs   initial attribute bitmask (XNS_ATTR_*; only TRANSIENT honored)
+ * @param[out] err set to Success, or BadName / BadAlloc on failure
+ * @return the new namespace, or NULL on failure (see @p err)
+ */
+struct Xnamespace *XnsCreate(const char *name, size_t namelen,
+                             CARD32 caps, CARD32 attrs, int *err)
+{
+    int rc = validateName(name, namelen);
+    if (rc != Success) {
+        *err = rc;
+        return NULL;
+    }
+    if (XnsLookup(name, namelen)) {     /* duplicate */
+        *err = BadName;
+        return NULL;
+    }
+
+    struct Xnamespace *ns = calloc(1, sizeof(*ns));
+    if (!ns) {
+        *err = BadAlloc;
+        return NULL;
+    }
+    ns->name = strndup(name, namelen);
+    if (!ns->name) {
+        free(ns);
+        *err = BadAlloc;
+        return NULL;
+    }
+    xorg_list_init(&ns->auth_tokens);
+    capsToFields(ns, caps);
+    ns->autoRemove = !!(attrs & XNS_ATTR_TRANSIENT);
+    xorg_list_append(&ns->entry, &ns_list);
+
+    *err = Success;
+    return ns;
+}
+
+/**
+ * @brief Unregister and free a single auth token.
+ *
+ * Revokes the underlying authorization, unlinks the token from its namespace
+ * and frees it.
+ *
+ * @param at the token to remove (must be linked into a namespace)
+ */
+static void freeToken(struct auth_token *at)
+{
+    if (at->authId)
+        RemoveAuthorization(at->authProto ? (unsigned short) strlen(at->authProto) : 0,
+                            at->authProto,
+                            (unsigned short) at->authTokenLen, at->authTokenData);
+    xorg_list_del(&at->entry);
+    free(at->authProto);
+    free(at->authTokenData);
+    free(at);
+}
+
+/**
+ * @brief Tear down a namespace: free its tokens and the namespace itself.
+ *
+ * Built-in namespaces are never destroyed. Any client still pointing at @p ns
+ * is detached first so that its later teardown cannot dereference freed
+ * memory. Does not touch refcnt (it is discarded along with the namespace).
+ *
+ * @param ns the namespace to destroy (NULL and built-ins are ignored)
+ */
+void XnsDestroyNamespace(struct Xnamespace *ns)
+{
+    if (!ns || ns->builtin)
+        return;
+
+    /* detach any clients still pointing here so their later teardown does not
+       dereference freed memory (refcnt is being discarded with the namespace) */
+    for (int i = 1; i < currentMaxClients; i++) {
+        if (!clients[i])
+            continue;
+        struct XnamespaceClientPriv *p = XnsClientPriv(clients[i]);
+        if (p && p->ns == ns)
+            p->ns = NULL;
+    }
+
+    struct auth_token *at, *tmp;
+    xorg_list_for_each_entry_safe(at, tmp, &ns->auth_tokens, entry)
+        freeToken(at);
+
+    xorg_list_del(&ns->entry);
+    free((void *) ns->name);
+    free(ns);
+}
+
+/**
+ * @brief Delete a namespace, optionally terminating its clients first.
+ *
+ * Built-in namespaces cannot be deleted. A non-empty namespace is only
+ * removed when @p onClients is XNS_DELETE_KILL_CLIENTS, in which case every
+ * client in it is forcibly closed before the namespace is destroyed.
+ *
+ * @param ns        the namespace to delete
+ * @param onClients XNS_DELETE_FAIL_IF_BUSY or XNS_DELETE_KILL_CLIENTS
+ * @return Success, or BadAccess (built-in, or busy without the kill flag)
+ */
+int XnsDelete(struct Xnamespace *ns, CARD8 onClients)
+{
+    if (ns->builtin)
+        return BadAccess;
+
+    if (ns->refcnt > 0) {
+        if (onClients != XNS_DELETE_KILL_CLIENTS)
+            return BadAccess;       /* busy */
+
+        /* keep the last client's exit from auto-destroying ns under us */
+        ns->autoRemove = FALSE;
+        for (int i = 1; i < currentMaxClients; i++) {
+            if (!clients[i])
+                continue;
+            struct XnamespaceClientPriv *p = XnsClientPriv(clients[i]);
+            if (p && p->ns == ns) {
+                /* force full teardown even for RetainPermanent clients, so
+                   ClientDestroyCallback fires (refcnt--, priv->ns cleared)
+                   and no client is left pointing at the freed namespace.
+                   Mirrors KillAllClients() in dix/dispatch.c. */
+                clients[i]->closeDownMode = DestroyAll;
+                CloseDownClient(clients[i]);
+            }
+        }
+    }
+
+    XnsDestroyNamespace(ns);
+    return Success;
+}
+
+/**
+ * @brief Remove an auth token from a namespace by its handle.
+ * @param ns     the namespace to remove from
+ * @param handle the token handle returned by XnsAddToken()
+ * @return Success, or BadMatch if no token with that handle exists
+ */
+int XnsRemoveToken(struct Xnamespace *ns, CARD32 handle)
+{
+    struct auth_token *at, *tmp;
+    xorg_list_for_each_entry_safe(at, tmp, &ns->auth_tokens, entry) {
+        if (at->handle == handle) {
+            freeToken(at);
+            return Success;
+        }
+    }
+    return BadMatch;
 }

--- a/Xext/namespace/config.c
+++ b/Xext/namespace/config.c
@@ -31,11 +31,9 @@ char *namespaceConfigFile = NULL;
 
 static struct Xnamespace* select_ns(const char* name)
 {
-    struct Xnamespace *walk;
-    xorg_list_for_each_entry(walk, &ns_list, entry) {
-        if (strcmp(walk->name, name)==0)
-            return walk;
-    }
+    struct Xnamespace *ns = XnsLookup(name, strlen(name));
+    if (ns)
+        return ns;
 
     struct Xnamespace *newns = calloc(1, sizeof(struct Xnamespace));
     newns->name = strdup(name);
@@ -199,11 +197,28 @@ Bool XnsLoadConfig(void)
     return TRUE;
 }
 
-struct Xnamespace *XnsFindByName(const char* name) {
+/**
+ * @brief Look up a namespace by name, comparing exactly @p namelen bytes.
+ *
+ * Length-aware so it can be called with names that are not NUL-terminated
+ * (e.g. straight out of a request buffer).
+ *
+ * @param name    pointer to the name bytes (need not be NUL-terminated)
+ * @param namelen number of bytes to compare
+ * @return the matching namespace, or NULL if none matches
+ */
+struct Xnamespace *XnsLookup(const char *name, size_t namelen)
+{
     struct Xnamespace *walk;
     xorg_list_for_each_entry(walk, &ns_list, entry) {
-        if (strcmp(walk->name, name)==0)
+        if (strlen(walk->name) == namelen &&
+            memcmp(walk->name, name, namelen) == 0)
             return walk;
     }
     return NULL;
+}
+
+struct Xnamespace *XnsFindByName(const char* name) {
+    /* the (NUL-terminated) name path is just the length-aware lookup */
+    return XnsLookup(name, strlen(name));
 }

--- a/Xext/namespace/config.c
+++ b/Xext/namespace/config.c
@@ -421,6 +421,18 @@ struct Xnamespace *XnsCreate(const char *name, size_t namelen,
     xorg_list_init(&ns->auth_tokens);
     capsToFields(ns, caps);
     ns->autoRemove = !!(attrs & XNS_ATTR_TRANSIENT);
+
+    /* namespaces known at boot get their virtual root from
+       hookInitRootWindow(); one created here, well after that one-shot
+       callback already ran, has no other chance to get one. */
+    ns->rootWindow = XnsCreateVirtualRoot(ns_root.rootWindow, ns->name);
+    if (!ns->rootWindow) {
+        free((void *)ns->name);
+        free(ns);
+        *err = BadAlloc;
+        return NULL;
+    }
+
     xorg_list_append(&ns->entry, &ns_list);
 
     *err = Success;

--- a/Xext/namespace/config.c
+++ b/Xext/namespace/config.c
@@ -1,9 +1,11 @@
 #include <dix-config.h>
 
+#include <stdlib.h>
 #include <string.h>
 #include <X11/Xdefs.h>
 
 #include "os/auth.h"
+#include "include/os.h"
 
 #include "namespace.h"
 
@@ -37,6 +39,7 @@ static struct Xnamespace* select_ns(const char* name)
 
     struct Xnamespace *newns = calloc(1, sizeof(struct Xnamespace));
     newns->name = strdup(name);
+    xorg_list_init(&newns->auth_tokens);
     xorg_list_append(&newns->entry, &ns_list);
     return newns;
 }
@@ -99,32 +102,30 @@ static void parseLine(char *line, struct Xnamespace **walk_ns)
 
     if (strcmp(token, "auth") == 0)
     {
-        token = strtok(NULL, " \t");
-        if (token == NULL)
+        char *proto = strtok(NULL, " \t");
+        if (proto == NULL)
             return;
 
-        struct auth_token *new_token = calloc(1, sizeof(struct auth_token));
-        if (new_token == NULL)
+        char *hex = strtok(NULL, " ");
+        if (hex == NULL)
+            return;
+
+        size_t binlen = strlen(hex) / 2;
+        char *bin = calloc(1, binlen ? binlen : 1);
+        if (bin == NULL)
             FatalError("Xnamespace: failed allocating token\n");
 
-        new_token->authProto = strdup(token);
-        token = strtok(NULL, " ");
-
-        new_token->authTokenLen = strlen(token)/2;
-        new_token->authTokenData = calloc(1, new_token->authTokenLen);
-        if (!new_token->authTokenData) {
-            free(new_token->authProto);
-            free(new_token);
+        if (!hex2bin(hex, bin)) {
+            XNS_LOG("invalid hex auth data, ignoring\n");
+            free(bin);
             return;
         }
-        hex2bin(token, new_token->authTokenData);
 
-        new_token->authId = AddAuthorization(strlen(new_token->authProto),
-                                             new_token->authProto,
-                                             new_token->authTokenLen,
-                                             new_token->authTokenData);
-
-        xorg_list_append(&new_token->entry, &curr->auth_tokens);
+        /* the config file stores the key hex-encoded; the model stores it
+           binary. Registration itself is shared with the protocol path. */
+        if (XnsAddToken(curr, proto, strlen(proto), bin, binlen, NULL) != Success)
+            XNS_LOG("failed to add auth token for namespace \"%s\"\n", curr->name);
+        free(bin);
         return;
     }
 
@@ -161,6 +162,8 @@ Bool XnsLoadConfig(void)
 {
     xorg_list_append_ndup(&ns_root.entry, &ns_list);
     xorg_list_append_ndup(&ns_anon.entry, &ns_list);
+    xorg_list_init(&ns_root.auth_tokens);
+    xorg_list_init(&ns_anon.auth_tokens);
 
     if (!namespaceConfigFile) {
         XNS_LOG("no namespace config given - Xnamespace disabled\n");
@@ -221,4 +224,54 @@ struct Xnamespace *XnsLookup(const char *name, size_t namelen)
 struct Xnamespace *XnsFindByName(const char* name) {
     /* the (NUL-terminated) name path is just the length-aware lookup */
     return XnsLookup(name, strlen(name));
+}
+
+/**
+ * @brief Register an authentication token and map it into a namespace.
+ *
+ * Copies the protocol name and key, registers the authorization with the OS
+ * layer and assigns a per-namespace handle for later removal. The single
+ * code path for adding tokens, shared by the config loader and (later) the
+ * management protocol.
+ *
+ * @param ns       the namespace to add the token to
+ * @param proto    auth protocol name bytes (e.g. "MIT-MAGIC-COOKIE-1")
+ * @param protolen length of @p proto
+ * @param data     raw key bytes (may be NULL when @p datalen is 0)
+ * @param datalen  length of @p data
+ * @param[out] handleOut if non-NULL, set to the new token's handle
+ * @return Success, or BadAlloc on allocation failure
+ */
+int XnsAddToken(struct Xnamespace *ns, const char *proto, size_t protolen,
+                const char *data, size_t datalen, CARD32 *handleOut)
+{
+    struct auth_token *t = calloc(1, sizeof(*t));
+    if (!t)
+        return BadAlloc;
+
+    t->authProto = strndup(proto, protolen);
+    if (!t->authProto) {
+        free(t);
+        return BadAlloc;
+    }
+
+    t->authTokenLen = datalen;
+    if (datalen) {
+        t->authTokenData = malloc(datalen);
+        if (!t->authTokenData) {
+            free(t->authProto);
+            free(t);
+            return BadAlloc;
+        }
+        memcpy(t->authTokenData, data, datalen);
+    }
+
+    t->authId = AddAuthorization((unsigned int) protolen, t->authProto,
+                                 (unsigned int) datalen, t->authTokenData);
+    t->handle = ++ns->tokenHandleSeq;   /* 1-based; 0 is never a valid handle */
+    xorg_list_append(&t->entry, &ns->auth_tokens);
+
+    if (handleOut)
+        *handleOut = t->handle;
+    return Success;
 }

--- a/Xext/namespace/hook-ext-access.c
+++ b/Xext/namespace/hook-ext-access.c
@@ -8,6 +8,7 @@
 #include "Xext/xacestr.h"
 
 #include "namespace.h"
+#include "namespaceproto.h"
 #include "hooks.h"
 
 /* called on X_QueryExtension */
@@ -18,6 +19,11 @@ void hookExtAccess(CallbackListPtr *pcbl, void *unused, void *calldata)
     /* root NS has super powers */
     if (subj->ns->superPower)
         goto pass;
+
+    /* the namespace management extension is invisible to non-superPower
+       clients - they must not even learn it exists */
+    if (streq(param->ext->name, XNS_EXTENSION_NAME))
+        goto reject;
 
     switch (param->ext->index + EXTENSION_BASE) {
         /* unrestricted access */

--- a/Xext/namespace/hook-ext-dispatch.c
+++ b/Xext/namespace/hook-ext-dispatch.c
@@ -16,6 +16,7 @@
 #include "Xext/xacestr.h"
 
 #include "namespace.h"
+#include "namespaceproto.h"
 #include "hooks.h"
 
 void hookExtDispatch(CallbackListPtr *pcbl, void *unused, void *calldata)
@@ -25,6 +26,11 @@ void hookExtDispatch(CallbackListPtr *pcbl, void *unused, void *calldata)
     /* root NS has super powers */
     if (subj->ns->superPower)
         goto pass;
+
+    /* never dispatch the namespace management extension to non-superPower
+       clients (defence in depth; they cannot see it via QueryExtension) */
+    if (streq(param->ext->name, XNS_EXTENSION_NAME))
+        goto reject;
 
     switch (client->majorOp) {
         /* unrestricted access to these */

--- a/Xext/namespace/hook-init-rootwindow.c
+++ b/Xext/namespace/hook-init-rootwindow.c
@@ -17,6 +17,50 @@ static inline int setWinStrProp(WindowPtr pWin, Atom name, const char *text) {
                                    8, PropModeReplace, strlen(text), text, TRUE);
 }
 
+/**
+ * @brief Create a namespace's virtual root window, parented to the real root.
+ *
+ * Used both at boot (for namespaces known from the config file, one pass
+ * over ns_list from hookInitRootWindow below) and at runtime (for a
+ * namespace created later via the CreateNamespace protocol request, which
+ * has no other opportunity to get a virtual root - PostInitRootWindowCallback
+ * only ever fires once, before any client can reach the extension).
+ *
+ * @param realRoot the screen's actual root window to parent the new window to
+ * @param name     the namespace's name, used only for the window's WM_NAME
+ * @return the new window, or NULL on failure
+ */
+WindowPtr XnsCreateVirtualRoot(WindowPtr realRoot, const char *name)
+{
+    int rc = 0;
+    WindowPtr pWin = dixCreateWindow(
+        FakeClientID(0), realRoot, 0, 0, 23, 23,
+        0, /* bw */
+        InputOutput,
+        0, /* vmask */
+        NULL, /* vlist */
+        0, /* depth */
+        serverClient,
+        wVisual(realRoot), /* visual */
+        &rc);
+
+    if (!pWin)
+        return NULL;
+
+    Mask mask = pWin->eventMask;
+    pWin->eventMask = 0;    /* subterfuge in case AddResource fails */
+    if (!AddResource(pWin->drawable.id, X11_RESTYPE_WINDOW, (void *) pWin))
+        return NULL;
+    pWin->eventMask = mask;
+
+    // set window name
+    char buf[PATH_MAX] = { 0 };
+    snprintf(buf, sizeof(buf)-1, "XNS-ROOT:%s", name);
+    setWinStrProp(pWin, XA_WM_NAME, buf);
+
+    return pWin;
+}
+
 void hookInitRootWindow(CallbackListPtr *pcbl, void *data, void *screen)
 {
     ScreenPtr pScreen = (ScreenPtr)screen;
@@ -39,33 +83,9 @@ void hookInitRootWindow(CallbackListPtr *pcbl, void *data, void *screen)
             continue;
         }
 
-        int rc = 0;
-        WindowPtr pWin = dixCreateWindow(
-            FakeClientID(0), realRoot, 0, 0, 23, 23,
-            0, /* bw */
-            InputOutput,
-            0, /* vmask */
-            NULL, /* vlist */
-            0, /* depth */
-            serverClient,
-            wVisual(realRoot), /* visual */
-            &rc);
-
-        if (!pWin)
+        walk->rootWindow = XnsCreateVirtualRoot(realRoot, walk->name);
+        if (!walk->rootWindow)
             FatalError("hookInitRootWindow: cant create per-namespace root window for %s\n", walk->name);
-
-        Mask mask = pWin->eventMask;
-        pWin->eventMask = 0;    /* subterfuge in case AddResource fails */
-        if (!AddResource(pWin->drawable.id, X11_RESTYPE_WINDOW, (void *) pWin))
-            FatalError("hookInitRootWindow: cant add per-namespace root window as resource\n");
-        pWin->eventMask = mask;
-
-        walk->rootWindow = pWin;
-
-        // set window name
-        char buf[PATH_MAX] = { 0 };
-        snprintf(buf, sizeof(buf)-1, "XNS-ROOT:%s", walk->name);
-        setWinStrProp(pWin, XA_WM_NAME, buf);
 
         XNS_LOG("<%s> virtual root 0x%0llx\n", walk->name, (unsigned long long)walk->rootWindow->drawable.id);
     }

--- a/Xext/namespace/hook-resource.c
+++ b/Xext/namespace/hook-resource.c
@@ -28,6 +28,10 @@ void hookResourceAccess(CallbackListPtr *pcbl, void *unused, void *calldata)
     if (param->client == serverClient)
         goto pass;
 
+    // no restriction on super power
+    if (subj->ns->superPower)
+        goto pass;
+
     // special filtering for windows: block transparency for untrusted clients
     if (param->rtype == X11_RESTYPE_WINDOW) {
         WindowPtr pWindow = (WindowPtr) param->res;

--- a/Xext/namespace/hook-resource.c
+++ b/Xext/namespace/hook-resource.c
@@ -73,6 +73,7 @@ void hookResourceAccess(CallbackListPtr *pcbl, void *unused, void *calldata)
 
                 case X_CreateGC:
                 case X_CreatePixmap:
+                case X_CreateColormap:
                     if (checkAllowed(param->access_mode, DixGetAttrAccess))
                         goto pass;
                 break;

--- a/Xext/namespace/meson.build
+++ b/Xext/namespace/meson.build
@@ -16,6 +16,7 @@ libxserver_namespace = static_library(
 		'hook-server.c',
 		'hook-windowproperty.c',
 		'namespace.c',
+		'proto.c',
 	],
 	include_directories: inc,
 	dependencies: common_dep,

--- a/Xext/namespace/namespace.c
+++ b/Xext/namespace/namespace.c
@@ -54,17 +54,39 @@ NamespaceExtensionInit(void)
     struct XnamespaceClientPriv *srv = XnsClientPriv(serverClient);
     *srv = (struct XnamespaceClientPriv) { .isServer = TRUE };
     XnamespaceAssignClient(srv, &ns_root);
+
+    /* register the runtime management protocol extension. It is gated to
+       superPower clients in hookExtAccess()/hookExtDispatch(), so it stays
+       invisible and unreachable to namespaced clients. */
+    XnsProtoExtensionInit();
 }
 
+/**
+ * @brief Assign a client to a namespace, maintaining reference counts.
+ *
+ * Decrements the old namespace's refcount and increments the new one's. If the
+ * old namespace is transient (XNS_ATTR_TRANSIENT) and its last client just
+ * left, it is destroyed.
+ *
+ * @param priv  the client's namespace private (may already reference a namespace)
+ * @param newns the namespace to move the client into (NULL to detach)
+ */
 void XnamespaceAssignClient(struct XnamespaceClientPriv *priv, struct Xnamespace *newns)
 {
-    if (priv->ns != NULL)
-        priv->ns->refcnt--;
+    struct Xnamespace *oldns = priv->ns;
+
+    if (oldns != NULL)
+        oldns->refcnt--;
 
     priv->ns = newns;
 
     if (newns != NULL)
         newns->refcnt++;
+
+    /* a transient namespace vanishes once its last client has left */
+    if (oldns != NULL && oldns != newns && oldns->refcnt == 0 &&
+        oldns->autoRemove && !oldns->builtin)
+        XnsDestroyNamespace(oldns);
 }
 
 void XnamespaceAssignClientByName(struct XnamespaceClientPriv *priv, const char *name)

--- a/Xext/namespace/namespace.h
+++ b/Xext/namespace/namespace.h
@@ -29,6 +29,7 @@ struct Xnamespace {
     Bool allowXInput;
     Bool allowXKeyboard;
     Bool superPower;
+    Bool autoRemove;           /* destroy when the last client exits */
     struct xorg_list auth_tokens;
     CARD32 tokenHandleSeq;      /* monotonic per-namespace handle counter */
     size_t refcnt;
@@ -51,10 +52,22 @@ struct XnamespaceClientPriv {
 extern DevPrivateKeyRec namespaceClientPrivKeyRec;
 
 Bool XnsLoadConfig(void);
+void XnsProtoExtensionInit(void);
 struct Xnamespace *XnsFindByName(const char* name);
 struct Xnamespace *XnsLookup(const char *name, size_t namelen);
 int XnsAddToken(struct Xnamespace *ns, const char *proto, size_t protolen,
                 const char *data, size_t datalen, CARD32 *handleOut);
+
+/* namespace-model setter layer (config.c), shared with the protocol handlers */
+struct Xnamespace *XnsCreate(const char *name, size_t namelen,
+                             CARD32 caps, CARD32 attrs, int *err);
+void XnsDestroyNamespace(struct Xnamespace *ns);
+int  XnsDelete(struct Xnamespace *ns, CARD8 onClients);
+int  XnsSetCaps(struct Xnamespace *ns, CARD32 mask, CARD32 values);
+int  XnsRemoveToken(struct Xnamespace *ns, CARD32 handle);
+CARD32 XnsCountTokens(struct Xnamespace *ns);
+CARD32 XnsCaps(const struct Xnamespace *ns);
+CARD32 XnsAttrs(const struct Xnamespace *ns);
 struct Xnamespace* XnsFindByAuth(size_t szAuthProto, const char* authProto, size_t szAuthToken, const char* authToken);
 void XnamespaceAssignClient(struct XnamespaceClientPriv *priv, struct Xnamespace *ns);
 void XnamespaceAssignClientByName(struct XnamespaceClientPriv *priv, const char *name);

--- a/Xext/namespace/namespace.h
+++ b/Xext/namespace/namespace.h
@@ -53,6 +53,7 @@ extern DevPrivateKeyRec namespaceClientPrivKeyRec;
 
 Bool XnsLoadConfig(void);
 void XnsProtoExtensionInit(void);
+WindowPtr XnsCreateVirtualRoot(WindowPtr realRoot, const char *name);
 struct Xnamespace *XnsFindByName(const char* name);
 struct Xnamespace *XnsLookup(const char *name, size_t namelen);
 int XnsAddToken(struct Xnamespace *ns, const char *proto, size_t protolen,

--- a/Xext/namespace/namespace.h
+++ b/Xext/namespace/namespace.h
@@ -50,6 +50,7 @@ extern DevPrivateKeyRec namespaceClientPrivKeyRec;
 
 Bool XnsLoadConfig(void);
 struct Xnamespace *XnsFindByName(const char* name);
+struct Xnamespace *XnsLookup(const char *name, size_t namelen);
 struct Xnamespace* XnsFindByAuth(size_t szAuthProto, const char* authProto, size_t szAuthToken, const char* authToken);
 void XnamespaceAssignClient(struct XnamespaceClientPriv *priv, struct Xnamespace *ns);
 void XnamespaceAssignClientByName(struct XnamespaceClientPriv *priv, const char *name);

--- a/Xext/namespace/namespace.h
+++ b/Xext/namespace/namespace.h
@@ -16,6 +16,7 @@ struct auth_token {
     char *authTokenData;
     size_t authTokenLen;
     XID authId;
+    CARD32 handle;              /* per-namespace token handle */
 };
 
 struct Xnamespace {
@@ -29,6 +30,7 @@ struct Xnamespace {
     Bool allowXKeyboard;
     Bool superPower;
     struct xorg_list auth_tokens;
+    CARD32 tokenHandleSeq;      /* monotonic per-namespace handle counter */
     size_t refcnt;
     WindowPtr rootWindow;
 };
@@ -51,6 +53,8 @@ extern DevPrivateKeyRec namespaceClientPrivKeyRec;
 Bool XnsLoadConfig(void);
 struct Xnamespace *XnsFindByName(const char* name);
 struct Xnamespace *XnsLookup(const char *name, size_t namelen);
+int XnsAddToken(struct Xnamespace *ns, const char *proto, size_t protolen,
+                const char *data, size_t datalen, CARD32 *handleOut);
 struct Xnamespace* XnsFindByAuth(size_t szAuthProto, const char* authProto, size_t szAuthToken, const char* authToken);
 void XnamespaceAssignClient(struct XnamespaceClientPriv *priv, struct Xnamespace *ns);
 void XnamespaceAssignClientByName(struct XnamespaceClientPriv *priv, const char *name);

--- a/Xext/namespace/namespaceproto.h
+++ b/Xext/namespace/namespaceproto.h
@@ -1,0 +1,291 @@
+/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3
+ *
+ * Xnamespace management extension - protocol definitions (DRAFT v1.0)
+ *
+ * See doc/Xnamespace-protocol.md for the specification.
+ *
+ * This header is the on-the-wire contract: it would normally live in
+ * xorgproto (as Xnamespaceproto.h) and be shared with client bindings
+ * (e.g. go-x11proto). It is kept here for now while the design is in flux.
+ */
+#ifndef _XSERVER_NAMESPACEPROTO_H
+#define _XSERVER_NAMESPACEPROTO_H
+
+#include <X11/Xmd.h>
+#include <X11/Xproto.h>
+
+#define XNS_EXTENSION_NAME      "X-NAMESPACE"
+#define XNS_MAJOR_VERSION       1
+#define XNS_MINOR_VERSION       0
+
+/* maximum namespace name length (keeps names config-file expressible) */
+#define XNS_NAME_MAX            255
+
+/* request opcodes (minor) */
+#define X_XnsQueryVersion       0
+#define X_XnsListNamespaces     1
+#define X_XnsCreateNamespace    2
+#define X_XnsDeleteNamespace    3
+#define X_XnsQueryNamespace     4
+#define X_XnsSetNamespaceFlags  5
+#define X_XnsAddAuthToken       6
+#define X_XnsRemoveAuthToken    7
+#define X_XnsListAuthTokens     8
+#define X_XnsGetClientNamespace 9
+#define XnsNumberRequests       10
+
+/* capability bits (see struct Xnamespace allow* / superPower) */
+#define XNS_CAPABILITY_MOUSE_MOTION     (1u << 0)
+#define XNS_CAPABILITY_SHAPE            (1u << 1)
+#define XNS_CAPABILITY_TRANSPARENCY     (1u << 2)
+#define XNS_CAPABILITY_INPUT            (1u << 3)
+#define XNS_CAPABILITY_KEYBOARD         (1u << 4)
+#define XNS_CAPABILITY_ADMIN            (1u << 5)
+#define XNS_CAPABILITY_ALL              0x0000003fu
+
+/* namespace attribute bits */
+#define XNS_ATTR_IMMUTABLE              (1u << 0)   /* read-only (root/anon) */
+#define XNS_ATTR_TRANSIENT              (1u << 1)   /* drop when last client exits */
+#define XNS_ATTR_ALL                    0x00000003u
+
+/* values for xXnsDeleteNamespaceReq.onClients */
+#define XNS_DELETE_FAIL_IF_BUSY         0   /* BadAccess if any client present */
+#define XNS_DELETE_KILL_CLIENTS         1   /* terminate clients, then delete */
+
+/* ------------------------------------------------------------------ *
+ *  Requests
+ *
+ *  Every variable-length field carries its byte length in a *Len field
+ *  of the fixed struct; the payloads follow in declared order, each
+ *  padded to a 4-byte boundary. This matches the xcb/xgb codegen idiom
+ *  (length field + char-list) and the X_REQUEST_VAR_* parsing macros.
+ * ------------------------------------------------------------------ */
+
+typedef struct {
+    CARD8   reqType;            /* extension major opcode */
+    CARD8   xnsReqType;         /* X_XnsQueryVersion */
+    CARD16  length;
+    CARD16  clientMajorVersion;
+    CARD16  clientMinorVersion;
+} xXnsQueryVersionReq;
+#define sz_xXnsQueryVersionReq 8
+
+typedef struct {
+    CARD8   reqType;
+    CARD8   xnsReqType;         /* X_XnsListNamespaces */
+    CARD16  length;
+} xXnsListNamespacesReq;
+#define sz_xXnsListNamespacesReq 4
+
+typedef struct {
+    CARD8   reqType;
+    CARD8   xnsReqType;         /* X_XnsCreateNamespace */
+    CARD16  length;
+    CARD32  capabilities;
+    CARD32  attributes;         /* XNS_ATTR_TRANSIENT honored; IMMUTABLE rejected */
+    CARD16  nameLen;
+    CARD16  pad0;
+    /* CARD8 name[nameLen], padded */
+} xXnsCreateNamespaceReq;
+#define sz_xXnsCreateNamespaceReq 16
+
+typedef struct {
+    CARD8   reqType;
+    CARD8   xnsReqType;         /* X_XnsDeleteNamespace */
+    CARD16  length;
+    CARD8   onClients;          /* XNS_DELETE_* */
+    CARD8   pad0;
+    CARD16  nameLen;
+    /* CARD8 name[nameLen], padded */
+} xXnsDeleteNamespaceReq;
+#define sz_xXnsDeleteNamespaceReq 8
+
+typedef struct {
+    CARD8   reqType;
+    CARD8   xnsReqType;         /* X_XnsQueryNamespace */
+    CARD16  length;
+    CARD16  nameLen;
+    CARD16  pad0;
+    /* CARD8 name[nameLen], padded */
+} xXnsQueryNamespaceReq;
+#define sz_xXnsQueryNamespaceReq 8
+
+typedef struct {
+    CARD8   reqType;
+    CARD8   xnsReqType;         /* X_XnsSetNamespaceFlags */
+    CARD16  length;
+    CARD32  valueMask;          /* which capability bits to apply */
+    CARD32  values;             /* new values for masked bits */
+    CARD16  nameLen;
+    CARD16  pad0;
+    /* CARD8 name[nameLen], padded */
+} xXnsSetNamespaceFlagsReq;
+#define sz_xXnsSetNamespaceFlagsReq 16
+
+typedef struct {
+    CARD8   reqType;
+    CARD8   xnsReqType;         /* X_XnsAddAuthToken */
+    CARD16  length;
+    CARD16  nameLen;
+    CARD16  protoLen;
+    CARD16  dataLen;
+    CARD16  pad0;
+    /* CARD8 name[nameLen], proto[protoLen], data[dataLen]; each padded */
+} xXnsAddAuthTokenReq;
+#define sz_xXnsAddAuthTokenReq 12
+
+typedef struct {
+    CARD8   reqType;
+    CARD8   xnsReqType;         /* X_XnsRemoveAuthToken */
+    CARD16  length;
+    CARD32  tokenHandle;
+    CARD16  nameLen;
+    CARD16  pad0;
+    /* CARD8 name[nameLen], padded */
+} xXnsRemoveAuthTokenReq;
+#define sz_xXnsRemoveAuthTokenReq 12
+
+typedef struct {
+    CARD8   reqType;
+    CARD8   xnsReqType;         /* X_XnsListAuthTokens */
+    CARD16  length;
+    CARD16  nameLen;
+    CARD16  pad0;
+    /* CARD8 name[nameLen], padded */
+} xXnsListAuthTokensReq;
+#define sz_xXnsListAuthTokensReq 8
+
+typedef struct {
+    CARD8   reqType;
+    CARD8   xnsReqType;         /* X_XnsGetClientNamespace */
+    CARD16  length;
+    CARD32  clientResource;     /* 0 = the calling client */
+} xXnsGetClientNamespaceReq;
+#define sz_xXnsGetClientNamespaceReq 8
+
+/* ------------------------------------------------------------------ *
+ *  Replies (all 32-byte aligned header; variable tails via rpcbuf)
+ * ------------------------------------------------------------------ */
+
+typedef struct {
+    BYTE    type;               /* X_Reply */
+    CARD8   pad0;
+    CARD16  sequenceNumber;
+    CARD32  length;
+    CARD16  majorVersion;
+    CARD16  minorVersion;
+    CARD32  pad1;
+    CARD32  pad2;
+    CARD32  pad3;
+    CARD32  pad4;
+    CARD32  pad5;
+} xXnsQueryVersionReply;
+#define sz_xXnsQueryVersionReply 32
+
+/* ListNamespaces reply: header + `count` NAMESPACEINFO records (rpcbuf).
+   each record: capabilities, attributes, refcnt, numTokens (CARD32 x4),
+   nameLen (CARD16), pad (CARD16), name bytes (padded). */
+typedef struct {
+    BYTE    type;
+    CARD8   pad0;
+    CARD16  sequenceNumber;
+    CARD32  length;             /* size of trailing records, in 4-byte units */
+    CARD32  count;              /* number of namespaces */
+    CARD32  pad1;
+    CARD32  pad2;
+    CARD32  pad3;
+    CARD32  pad4;
+    CARD32  pad5;
+} xXnsListNamespacesReply;
+#define sz_xXnsListNamespacesReply 32
+
+typedef struct {
+    BYTE    type;
+    CARD8   pad0;
+    CARD16  sequenceNumber;
+    CARD32  length;             /* 0 - empty ack */
+    CARD32  pad1;
+    CARD32  pad2;
+    CARD32  pad3;
+    CARD32  pad4;
+    CARD32  pad5;
+    CARD32  pad6;
+} xXnsAckReply;                 /* Create / Delete / RemoveAuthToken */
+#define sz_xXnsAckReply 32
+
+typedef struct {
+    BYTE    type;
+    CARD8   pad0;
+    CARD16  sequenceNumber;
+    CARD32  length;             /* 0 */
+    CARD32  capabilities;
+    CARD32  attributes;
+    CARD32  refcnt;
+    CARD32  numTokens;
+    CARD32  pad1;
+    CARD32  pad2;
+} xXnsQueryNamespaceReply;
+#define sz_xXnsQueryNamespaceReply 32
+
+typedef struct {
+    BYTE    type;
+    CARD8   pad0;
+    CARD16  sequenceNumber;
+    CARD32  length;             /* 0 */
+    CARD32  capabilities;       /* resulting capabilities */
+    CARD32  pad1;
+    CARD32  pad2;
+    CARD32  pad3;
+    CARD32  pad4;
+    CARD32  pad5;
+} xXnsSetNamespaceFlagsReply;
+#define sz_xXnsSetNamespaceFlagsReply 32
+
+typedef struct {
+    BYTE    type;
+    CARD8   pad0;
+    CARD16  sequenceNumber;
+    CARD32  length;             /* 0 */
+    CARD32  tokenHandle;
+    CARD32  pad1;
+    CARD32  pad2;
+    CARD32  pad3;
+    CARD32  pad4;
+    CARD32  pad5;
+} xXnsAddAuthTokenReply;
+#define sz_xXnsAddAuthTokenReply 32
+
+/* ListAuthTokens reply: header + `count` records (rpcbuf).
+   each record: tokenHandle (CARD32), protoLen (CARD16), pad (CARD16),
+   proto bytes (padded). NO key material. */
+typedef struct {
+    BYTE    type;
+    CARD8   pad0;
+    CARD16  sequenceNumber;
+    CARD32  length;
+    CARD32  count;
+    CARD32  pad1;
+    CARD32  pad2;
+    CARD32  pad3;
+    CARD32  pad4;
+    CARD32  pad5;
+} xXnsListAuthTokensReply;
+#define sz_xXnsListAuthTokensReply 32
+
+/* GetClientNamespace reply: header + namespace name (rpcbuf) */
+typedef struct {
+    BYTE    type;
+    CARD8   isServer;
+    CARD16  sequenceNumber;
+    CARD32  length;             /* size of trailing name, in 4-byte units */
+    CARD16  nameLen;
+    CARD16  pad0;
+    CARD32  pad1;
+    CARD32  pad2;
+    CARD32  pad3;
+    CARD32  pad4;
+    CARD32  pad5;
+} xXnsGetClientNamespaceReply;
+#define sz_xXnsGetClientNamespaceReply 32
+
+#endif /* _XSERVER_NAMESPACEPROTO_H */

--- a/Xext/namespace/proto.c
+++ b/Xext/namespace/proto.c
@@ -1,0 +1,382 @@
+/* SPDX-License-Identifier: MIT OR X11
+ *
+ * Xnamespace management extension - protocol dispatch (DRAFT SKELETON)
+ *
+ * See doc/Xnamespace-protocol.md. Request parsing uses the X_REQUEST_*
+ * macros (including the X_REQUEST_VAR_* helpers); the namespace-model
+ * mutations go through the shared setter layer in config.c, which is also
+ * used by the config loader so both share one code path.
+ *
+ * Access control is NOT done here: the extension is made unreachable to
+ * non-superPower clients in hook-ext-access.c / hook-ext-dispatch.c, so
+ * every handler below may assume its caller is superPower.
+ */
+#include <dix-config.h>
+
+#include <X11/Xmd.h>
+#include <X11/Xproto.h>
+
+#include "dix/dix_priv.h"
+#include "dix/request_priv.h"
+#include "dix/rpcbuf_priv.h"
+#include "include/dixstruct.h"
+#include "include/os.h"
+#include "miext/extinit_priv.h"
+
+#include "namespace.h"
+#include "namespaceproto.h"
+
+static unsigned char XnsReqCode = 0;
+
+/* The namespace-model setters (XnsCreate/XnsDelete/XnsSetCaps/XnsAddToken/
+   XnsRemoveToken/XnsLookup/XnsCaps/XnsAttrs/XnsCountTokens) live in config.c
+   and are shared with the config loader - declared in namespace.h. */
+
+/* ------------------------------------------------------------------ *
+ *  Requests
+ * ------------------------------------------------------------------ */
+
+/** @brief Negotiate the extension (major, minor) version. */
+static int
+ProcXnsQueryVersion(ClientPtr client)
+{
+    X_REQUEST_HEAD_STRUCT(xXnsQueryVersionReq);
+    X_REQUEST_FIELD_CARD16(clientMajorVersion);
+    X_REQUEST_FIELD_CARD16(clientMinorVersion);
+
+    xXnsQueryVersionReply reply = {
+        .majorVersion = XNS_MAJOR_VERSION,
+        .minorVersion = (stuff->clientMajorVersion < XNS_MAJOR_VERSION)
+                            ? stuff->clientMinorVersion : XNS_MINOR_VERSION,
+    };
+    X_REPLY_FIELD_CARD16(majorVersion);
+    X_REPLY_FIELD_CARD16(minorVersion);
+    return X_SEND_REPLY_SIMPLE(client, reply);
+}
+
+/** @brief Create a namespace with the requested capabilities/attributes. */
+static int
+ProcXnsCreateNamespace(ClientPtr client)
+{
+    X_REQUEST_HEAD_AT_LEAST(xXnsCreateNamespaceReq);
+    X_REQUEST_FIELD_CARD32(capabilities);
+    X_REQUEST_FIELD_CARD32(attributes);
+    X_REQUEST_FIELD_CARD16(nameLen);
+
+    const char *name;
+    X_REQUEST_VAR_BEGIN();
+    X_REQUEST_VAR_FIELD(name, stuff->nameLen);
+    X_REQUEST_VAR_END();
+
+    if (stuff->capabilities & ~XNS_CAPABILITY_ALL)
+        return BadValue;
+    if (stuff->attributes & (~XNS_ATTR_ALL | XNS_ATTR_IMMUTABLE))
+        return BadValue;       /* IMMUTABLE is server-set only */
+
+    int err = Success;
+    if (!XnsCreate(name, stuff->nameLen, stuff->capabilities,
+                   stuff->attributes, &err))
+        return err;            /* BadName / BadAlloc */
+
+    xXnsAckReply reply = { 0 };
+    return X_SEND_REPLY_SIMPLE(client, reply);
+}
+
+/** @brief Delete a namespace, optionally killing its clients first. */
+static int
+ProcXnsDeleteNamespace(ClientPtr client)
+{
+    X_REQUEST_HEAD_AT_LEAST(xXnsDeleteNamespaceReq);
+    X_REQUEST_FIELD_CARD16(nameLen);
+
+    const char *name;
+    X_REQUEST_VAR_BEGIN();
+    X_REQUEST_VAR_FIELD(name, stuff->nameLen);
+    X_REQUEST_VAR_END();
+
+    if (stuff->onClients != XNS_DELETE_FAIL_IF_BUSY &&
+        stuff->onClients != XNS_DELETE_KILL_CLIENTS)
+        return BadValue;
+
+    struct Xnamespace *ns = XnsLookup(name, stuff->nameLen);
+    if (!ns)
+        return BadName;
+    if (XnsAttrs(ns) & XNS_ATTR_IMMUTABLE)
+        return BadAccess;
+
+    /* refuse to delete the namespace the caller itself belongs to: killing
+       our own client mid-request would free `client` under us (UAF on the
+       reply path). A manager lives in a separate superPower namespace. */
+    struct XnamespaceClientPriv *self = XnsClientPriv(client);
+    if (self && self->ns == ns)
+        return BadAccess;
+
+    int rc = XnsDelete(ns, stuff->onClients);
+    if (rc != Success)
+        return rc;             /* BadAccess if busy && FAIL_IF_BUSY */
+
+    xXnsAckReply reply = { 0 };
+    return X_SEND_REPLY_SIMPLE(client, reply);
+}
+
+/** @brief Report a namespace's capabilities, attributes, refcount and token count. */
+static int
+ProcXnsQueryNamespace(ClientPtr client)
+{
+    X_REQUEST_HEAD_AT_LEAST(xXnsQueryNamespaceReq);
+    X_REQUEST_FIELD_CARD16(nameLen);
+
+    const char *name;
+    X_REQUEST_VAR_BEGIN();
+    X_REQUEST_VAR_FIELD(name, stuff->nameLen);
+    X_REQUEST_VAR_END();
+
+    struct Xnamespace *ns = XnsLookup(name, stuff->nameLen);
+    if (!ns)
+        return BadName;
+
+    xXnsQueryNamespaceReply reply = {
+        .capabilities = XnsCaps(ns),
+        .attributes   = XnsAttrs(ns),
+        .refcnt       = (CARD32) ns->refcnt,
+        .numTokens    = XnsCountTokens(ns),
+    };
+    X_REPLY_FIELD_CARD32(capabilities);
+    X_REPLY_FIELD_CARD32(attributes);
+    X_REPLY_FIELD_CARD32(refcnt);
+    X_REPLY_FIELD_CARD32(numTokens);
+    return X_SEND_REPLY_SIMPLE(client, reply);
+}
+
+/** @brief Apply a masked capability update to a namespace. */
+static int
+ProcXnsSetNamespaceFlags(ClientPtr client)
+{
+    X_REQUEST_HEAD_AT_LEAST(xXnsSetNamespaceFlagsReq);
+    X_REQUEST_FIELD_CARD32(valueMask);
+    X_REQUEST_FIELD_CARD32(values);
+    X_REQUEST_FIELD_CARD16(nameLen);
+
+    const char *name;
+    X_REQUEST_VAR_BEGIN();
+    X_REQUEST_VAR_FIELD(name, stuff->nameLen);
+    X_REQUEST_VAR_END();
+
+    if (stuff->valueMask & ~XNS_CAPABILITY_ALL)
+        return BadValue;
+
+    struct Xnamespace *ns = XnsLookup(name, stuff->nameLen);
+    if (!ns)
+        return BadName;
+    if (XnsAttrs(ns) & XNS_ATTR_IMMUTABLE)
+        return BadAccess;
+
+    int rc = XnsSetCaps(ns, stuff->valueMask, stuff->values);
+    if (rc != Success)
+        return rc;
+
+    xXnsSetNamespaceFlagsReply reply = { .capabilities = XnsCaps(ns) };
+    X_REPLY_FIELD_CARD32(capabilities);
+    return X_SEND_REPLY_SIMPLE(client, reply);
+}
+
+/** @brief Register an auth token in a namespace; reply with its handle. */
+static int
+ProcXnsAddAuthToken(ClientPtr client)
+{
+    X_REQUEST_HEAD_AT_LEAST(xXnsAddAuthTokenReq);
+    X_REQUEST_FIELD_CARD16(nameLen);
+    X_REQUEST_FIELD_CARD16(protoLen);
+    X_REQUEST_FIELD_CARD16(dataLen);
+
+    /* three variable-length fields, peeled off in declared order */
+    const char *name, *proto, *data;
+    X_REQUEST_VAR_BEGIN();
+    X_REQUEST_VAR_FIELD(name,  stuff->nameLen);
+    X_REQUEST_VAR_FIELD(proto, stuff->protoLen);
+    X_REQUEST_VAR_FIELD(data,  stuff->dataLen);
+    X_REQUEST_VAR_END();
+
+    if (stuff->protoLen == 0)
+        return BadValue;
+
+    struct Xnamespace *ns = XnsLookup(name, stuff->nameLen);
+    if (!ns)
+        return BadName;
+    if (XnsAttrs(ns) & XNS_ATTR_IMMUTABLE)
+        return BadAccess;
+
+    CARD32 handle = 0;
+    int rc = XnsAddToken(ns, proto, stuff->protoLen, data, stuff->dataLen,
+                         &handle);
+    if (rc != Success)
+        return rc;             /* BadAlloc */
+
+    xXnsAddAuthTokenReply reply = { .tokenHandle = handle };
+    X_REPLY_FIELD_CARD32(tokenHandle);
+    return X_SEND_REPLY_SIMPLE(client, reply);
+}
+
+/** @brief Remove an auth token from a namespace by handle. */
+static int
+ProcXnsRemoveAuthToken(ClientPtr client)
+{
+    X_REQUEST_HEAD_AT_LEAST(xXnsRemoveAuthTokenReq);
+    X_REQUEST_FIELD_CARD32(tokenHandle);
+    X_REQUEST_FIELD_CARD16(nameLen);
+
+    const char *name;
+    X_REQUEST_VAR_BEGIN();
+    X_REQUEST_VAR_FIELD(name, stuff->nameLen);
+    X_REQUEST_VAR_END();
+
+    struct Xnamespace *ns = XnsLookup(name, stuff->nameLen);
+    if (!ns)
+        return BadName;
+    if (XnsAttrs(ns) & XNS_ATTR_IMMUTABLE)
+        return BadAccess;
+
+    int rc = XnsRemoveToken(ns, stuff->tokenHandle);
+    if (rc != Success)
+        return rc;             /* BadMatch */
+
+    xXnsAckReply reply = { 0 };
+    return X_SEND_REPLY_SIMPLE(client, reply);
+}
+
+/** @brief List every namespace with its capabilities, attributes and counts. */
+static int
+ProcXnsListNamespaces(ClientPtr client)
+{
+    X_REQUEST_HEAD_STRUCT(xXnsListNamespacesReq);
+
+    x_rpcbuf_t buf = { .swapped = client->swapped, .err_clear = TRUE };
+    CARD32 count = 0;
+
+    struct Xnamespace *ns;
+    xorg_list_for_each_entry(ns, &ns_list, entry) {
+        x_rpcbuf_write_CARD32(&buf, XnsCaps(ns));
+        x_rpcbuf_write_CARD32(&buf, XnsAttrs(ns));
+        x_rpcbuf_write_CARD32(&buf, (CARD32) ns->refcnt);
+        x_rpcbuf_write_CARD32(&buf, XnsCountTokens(ns));
+        x_rpcbuf_write_CARD16(&buf, (CARD16) strlen(ns->name));
+        x_rpcbuf_write_CARD16(&buf, 0 /* pad */);
+        x_rpcbuf_write_string_pad(&buf, ns->name);
+        count++;
+    }
+
+    xXnsListNamespacesReply reply = { .count = count };
+    X_REPLY_FIELD_CARD32(count);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, buf);
+}
+
+/** @brief List a namespace's auth tokens (handle + protocol name; no key data). */
+static int
+ProcXnsListAuthTokens(ClientPtr client)
+{
+    X_REQUEST_HEAD_AT_LEAST(xXnsListAuthTokensReq);
+    X_REQUEST_FIELD_CARD16(nameLen);
+
+    const char *name;
+    X_REQUEST_VAR_BEGIN();
+    X_REQUEST_VAR_FIELD(name, stuff->nameLen);
+    X_REQUEST_VAR_END();
+
+    struct Xnamespace *ns = XnsLookup(name, stuff->nameLen);
+    if (!ns)
+        return BadName;
+
+    x_rpcbuf_t buf = { .swapped = client->swapped, .err_clear = TRUE };
+    CARD32 count = 0;
+    struct auth_token *at;
+    xorg_list_for_each_entry(at, &ns->auth_tokens, entry) {
+        x_rpcbuf_write_CARD32(&buf, at->handle);
+        x_rpcbuf_write_CARD16(&buf, (CARD16)(at->authProto ? strlen(at->authProto) : 0));
+        x_rpcbuf_write_CARD16(&buf, 0 /* pad */);
+        x_rpcbuf_write_string_pad(&buf, at->authProto);
+        /* deliberately NOT writing authTokenData - no key exfiltration */
+        count++;
+    }
+
+    xXnsListAuthTokensReply reply = { .count = count };
+    X_REPLY_FIELD_CARD32(count);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, buf);
+}
+
+/** @brief Report which namespace a given client (0 = caller) belongs to. */
+static int
+ProcXnsGetClientNamespace(ClientPtr client)
+{
+    X_REQUEST_HEAD_STRUCT(xXnsGetClientNamespaceReq);
+    X_REQUEST_FIELD_CARD32(clientResource);
+
+    ClientPtr target = client;
+    if (stuff->clientResource != 0) {
+        int rc = dixLookupResourceOwner(&target, stuff->clientResource, client,
+                                        DixGetAttrAccess);
+        if (rc != Success)
+            return rc;
+    }
+
+    struct XnamespaceClientPriv *priv = XnsClientPriv(target);
+    const char *nsname = (priv && priv->ns) ? priv->ns->name : "";
+
+    x_rpcbuf_t buf = { .swapped = client->swapped, .err_clear = TRUE };
+    x_rpcbuf_write_string_pad(&buf, nsname);
+
+    xXnsGetClientNamespaceReply reply = {
+        .isServer = (priv && priv->isServer) ? TRUE : FALSE,
+        .nameLen  = (CARD16) strlen(nsname),
+    };
+    X_REPLY_FIELD_CARD16(nameLen);
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, buf);
+}
+
+/* ------------------------------------------------------------------ *
+ *  Dispatch (registered for both proc and sproc - all field swapping
+ *  happens inside the handlers via the X_REQUEST_* macros, like DPMS)
+ * ------------------------------------------------------------------ */
+
+/**
+ * @brief Extension request entry point (used for both swapped and unswapped
+ *        clients; each handler does its own field swapping via the
+ *        X_REQUEST_* macros).
+ * @param client the requesting client
+ * @return an X11 status code
+ */
+static int
+ProcXnsDispatch(ClientPtr client)
+{
+    REQUEST(xReq);
+
+    switch (stuff->data) {
+    case X_XnsQueryVersion:        return ProcXnsQueryVersion(client);
+    case X_XnsListNamespaces:      return ProcXnsListNamespaces(client);
+    case X_XnsCreateNamespace:     return ProcXnsCreateNamespace(client);
+    case X_XnsDeleteNamespace:     return ProcXnsDeleteNamespace(client);
+    case X_XnsQueryNamespace:      return ProcXnsQueryNamespace(client);
+    case X_XnsSetNamespaceFlags:   return ProcXnsSetNamespaceFlags(client);
+    case X_XnsAddAuthToken:        return ProcXnsAddAuthToken(client);
+    case X_XnsRemoveAuthToken:     return ProcXnsRemoveAuthToken(client);
+    case X_XnsListAuthTokens:      return ProcXnsListAuthTokens(client);
+    case X_XnsGetClientNamespace:  return ProcXnsGetClientNamespace(client);
+    default:                       return BadRequest;
+    }
+}
+
+/**
+ * @brief Register the namespace management extension.
+ *
+ * Called from NamespaceExtensionInit() once a namespace config has loaded.
+ * Access is gated to superPower clients by the Xace extension hooks, so the
+ * extension is invisible and unreachable to namespaced clients.
+ */
+void
+XnsProtoExtensionInit(void)
+{
+    ExtensionEntry *ext = AddExtension(XNS_EXTENSION_NAME, 0, 0,
+                                       ProcXnsDispatch, ProcXnsDispatch,
+                                       NULL, StandardMinorOpcode);
+    if (ext)
+        XnsReqCode = (unsigned char) ext->base;
+}

--- a/dix/request_priv.h
+++ b/dix/request_priv.h
@@ -158,6 +158,108 @@ static inline int __write_reply_hdr_simple(
     do { if (client->swapped) SwapLongs(request_rest, (count)); } while (0) \
 
 /*
+ * macros for walking variable-length fields (strings / binary blobs) that
+ * follow the fixed request struct.
+ *
+ * These complement the X_REQUEST_FIELD_* macros: where the latter handle the
+ * fixed part, these let multiple variable-length fields be peeled off, one
+ * after another, in the same stacked style - while keeping a single source of
+ * truth for the length (the request's own length field) so an embedded length
+ * can never make a handler read past the request.
+ *
+ * Usage (after X_REQUEST_HEAD_AT_LEAST() and swapping the *_len fields):
+ *
+ *     X_REQUEST_VAR_BEGIN();
+ *     X_REQUEST_VAR_FIELD(name,  stuff->name_len);
+ *     X_REQUEST_VAR_FIELD(proto, stuff->proto_len);
+ *     X_REQUEST_VAR_FIELD(data,  stuff->data_len);
+ *     X_REQUEST_VAR_END();
+ *
+ * Each field is padded to a 4-byte boundary on the wire; X_REQUEST_VAR_END()
+ * requires the request to be fully consumed (strict, no trailing smuggling).
+ * Any inconsistency returns BadLength, like the other request macros.
+ *
+ * Note: the *_len fields must already be byte-swapped (via X_REQUEST_FIELD_*)
+ * before they are passed here.
+ */
+
+/* set up the cursor right after the fixed struct.
+   X_REQUEST_HEAD_AT_LEAST() must have run first (sizeof(*stuff) <= req_len). */
+#define X_REQUEST_VAR_BEGIN() \
+    char *_xreq_ptr = (char *)(&stuff[1]); \
+    size_t _xreq_left = ((size_t)client->req_len << 2) - sizeof(*stuff)
+
+/* bind (ptr) to a byte/string field of (n) bytes, advance past its padding */
+#define X_REQUEST_VAR_FIELD(ptr, n) \
+    do { \
+        uint64_t _xreq_n = (uint64_t)(n); \
+        if (_xreq_n > _xreq_left) return (BadLength); \
+        size_t _xreq_adv = pad_to_int32((int)_xreq_n); \
+        if (_xreq_adv > _xreq_left) return (BadLength); \
+        (ptr) = _xreq_ptr; \
+        _xreq_ptr += _xreq_adv; \
+        _xreq_left -= _xreq_adv; \
+    } while (0)
+
+/* bind (ptr) to an array of (count) CARD16, swap them in place if necessary */
+#define X_REQUEST_VAR_FIELD_CARD16(ptr, count) \
+    do { \
+        uint64_t _xreq_n = (uint64_t)(count) * sizeof(CARD16); \
+        if (_xreq_n > _xreq_left) return (BadLength); \
+        size_t _xreq_adv = pad_to_int32((int)_xreq_n); \
+        if (_xreq_adv > _xreq_left) return (BadLength); \
+        (ptr) = (CARD16 *)_xreq_ptr; \
+        if (client->swapped) SwapShorts((short *)(ptr), (count)); \
+        _xreq_ptr += _xreq_adv; \
+        _xreq_left -= _xreq_adv; \
+    } while (0)
+
+/* bind (ptr) to an array of (count) CARD32, swap them in place if necessary */
+#define X_REQUEST_VAR_FIELD_CARD32(ptr, count) \
+    do { \
+        uint64_t _xreq_n = (uint64_t)(count) * sizeof(CARD32); \
+        if (_xreq_n > _xreq_left) return (BadLength); \
+        size_t _xreq_adv = pad_to_int32((int)_xreq_n); \
+        if (_xreq_adv > _xreq_left) return (BadLength); \
+        (ptr) = (CARD32 *)_xreq_ptr; \
+        if (client->swapped) SwapLongs((CARD32 *)(ptr), (count)); \
+        _xreq_ptr += _xreq_adv; \
+        _xreq_left -= _xreq_adv; \
+    } while (0)
+
+/* bind (ptr) to a trailing array of fixed-size elements whose count is
+   *implied by the request length*, not carried in a header field, and store
+   that count in (count_out). The remaining bytes must divide evenly by
+   (elemsize) (e.g. sizeof(xRectangle), sizeof(xColorItem)), else BadLength.
+   Consumes the rest of the request - so this must be the last variable field.
+
+   Element byte-swapping is the caller's job (per-field, element-type
+   specific); this macro only validates the count and delimits the array. */
+#define X_REQUEST_VAR_ARRAY(ptr, count_out, elemsize) \
+    do { \
+        if ((elemsize) == 0 || (_xreq_left % (size_t)(elemsize)) != 0) \
+            return (BadLength); \
+        (count_out) = _xreq_left / (size_t)(elemsize); \
+        (ptr) = (void *)_xreq_ptr; \
+        _xreq_ptr += _xreq_left; \
+        _xreq_left = 0; \
+    } while (0)
+
+/* bind (ptr)/(len) to whatever bytes remain - for a single trailing string
+   whose length is implied by the request length (no embedded length field) */
+#define X_REQUEST_VAR_REST(ptr, len) \
+    do { \
+        (ptr) = _xreq_ptr; \
+        (len) = _xreq_left; \
+        _xreq_ptr += _xreq_left; \
+        _xreq_left = 0; \
+    } while (0)
+
+/* require the variable part to be fully consumed */
+#define X_REQUEST_VAR_END() \
+    do { if (_xreq_left != 0) return (BadLength); } while (0)
+
+/*
  * macros for request handlers
  *
  * these are handling reply struct field byte-swapping if necessary

--- a/doc/Xnamespace-protocol.md
+++ b/doc/Xnamespace-protocol.md
@@ -1,0 +1,440 @@
+Xnamespace protocol extension — design v0.1 (DRAFT)
+===================================================
+
+This document specifies an X11 protocol extension for the Xnamespace
+feature. Its purpose is to let an authorized management client
+**dynamically manage namespaces at runtime** — the settings that today can
+only be provisioned statically from the `namespace.conf` file at server
+startup (see `doc/Xnamespace.md` and `Xext/namespace/config.c`).
+
+The expected user is a container/session manager: it creates a namespace
+when a container starts and deletes it when the container finishes. Traffic
+is very low, so requests are kept simple and synchronous (round-tripped)
+rather than optimised for throughput — many X11 packets are needlessly
+complex and this extension deliberately avoids that.
+
+The wire protocol mirrors the existing in-memory model (`struct Xnamespace`
+in `Xext/namespace/namespace.h`) so the extension stays a thin, auditable
+layer over data the server already maintains.
+
+Status: DESIGN DRAFT. Opcodes, encodings and the capability bit layout are
+not yet frozen.
+
+
+1. Goals and non-goals
+----------------------
+
+Goals:
+
+ * Enumerate namespaces and their settings.
+ * Create and delete namespaces at runtime.
+ * Query and modify per-namespace capability flags
+   (`mouse-motion`, `shape`, `transparency`, `xinput`, `xkeyboard`,
+   `superpower`).
+ * Add, list and remove authentication tokens that map clients into a
+   namespace (the `auth` lines in the config file today).
+ * Auto-remove a namespace when its last client exits (transient
+   namespaces for transient containers).
+
+Non-goals (decided, not just deferred):
+
+ * **No persistence.** Xservers never persist state; runtime changes live
+   only in memory. The config file remains the boot-time seed and is never
+   rewritten. There is no `SaveConfig`/`ReloadConfig`.
+ * **No client reassignment.** A client's namespace is fixed at connect
+   time by its auth token. There is no `AssignClient` request. A namespace
+   is emptied by terminating its clients, not by moving them.
+ * **No namespace hierarchy yet.** A name delimiter is reserved for future
+   nesting (section 3), but inheritance semantics are undefined and using
+   the delimiter now is an error.
+ * **No events yet.** With a single synchronous manager there is no
+   multi-manager consistency problem to solve. A `NamespaceNotify` event
+   may be added later if a use case appears.
+
+
+2. Security model (the load-bearing part)
+-----------------------------------------
+
+The entire point of namespaces is isolation, and a management protocol is a
+direct path to subverting it. So the access rule is simple and absolute:
+
+> **The whole extension is reachable only by clients in a `superPower`
+> namespace** (today only the built-in `root`, plus any namespace
+> explicitly granted `superpower`). To every other client the extension
+> does not exist.
+
+This is enforced exactly where the existing code already enforces the same
+boundary for `SECURITY`, `RECORD` and `XTEST` — the two Xace extension
+hooks, both of which already gate on `subj->ns->superPower`:
+
+ * `hook-ext-access.c` (fires on `QueryExtension`): non-superPower clients
+   get `BadAccess`, so the extension is **invisible** — it reports as not
+   present. A sandboxed client cannot even discover it exists.
+ * `hook-ext-dispatch.c` (fires on every request to the extension):
+   non-superPower clients get `BadAccess`, so even a client that hard-codes
+   the major opcode cannot invoke anything.
+
+Adding `Xnamespace-mgmt` to the blacklist in both hooks is the entire
+access-control implementation. Consequences:
+
+ * There is **no per-request privilege table**. Every request handler may
+   assume its caller is superPower. One choke point to audit, not twelve.
+ * `QueryVersion` is reachable only by superPower clients too. That is
+   fine: a client that cannot see the extension has nothing to negotiate,
+   and "not present" is the honest answer for it.
+ * No client can grant itself capabilities it lacks, because a
+   non-superPower client cannot reach any request, mutating or not.
+
+The built-in namespaces `root` and `anon` are **immutable** over the
+protocol: their name, capabilities, attributes and token set are fixed at
+boot. Any mutating request targeting them (delete, set-flags, add/remove
+token) returns `BadAccess`. They are configured only via the config file.
+
+
+3. Naming and identity
+-----------------------
+
+Namespaces are identified **by name** — the same unique key the code
+already uses (`XnsFindByName()`, `select_ns()`). Names are the only
+namespace identifier on the wire; there are no protocol-level numeric IDs.
+The server is free to keep an internal id or resource for its own
+bookkeeping, but that is an implementation detail and never appears in a
+request, reply or error. Given the low, synchronous traffic, string lookup
+costs nothing and a single identifier is simpler to reason about.
+
+Name rules (violations return `BadName`):
+
+ * Must be non-empty.
+ * Must be unique (duplicate on `CreateNamespace` → `BadName`).
+ * Must not contain the reserved nesting delimiter `'/'`. The delimiter is
+   reserved now so that a future hierarchy (`parent/child`) can be added
+   without a grammar break; using it today is rejected.
+ * Should be restricted to printable, non-whitespace characters so that any
+   protocol-created name remains expressible in `namespace.conf` (the
+   config parser splits on whitespace and treats `#` as a comment).
+   Implementations reject other characters with `BadName`.
+
+`BadName` (core error 15) is reused as the single name-related error:
+malformed, reserved-delimiter, duplicate-on-create, or no-such-namespace.
+
+Auth tokens, which have no natural human name, are referenced within a
+namespace by a small server-assigned opaque handle (`CARD32`) returned at
+creation. This is a per-namespace bookkeeping handle, not a global resource.
+
+
+4. Capabilities and attributes
+-------------------------------
+
+Two `CARD32` words describe a namespace.
+
+**Capabilities** — access permissions (the `allow*` / `superPower` fields):
+
+ | Bit     | Name                           |
+ | ------- | ------------------------------ |
+ | 1 << 0  | `XNS_CAPABILITY_MOUSE_MOTION`  |
+ | 1 << 1  | `XNS_CAPABILITY_SHAPE`         |
+ | 1 << 2  | `XNS_CAPABILITY_TRANSPARENCY`  |
+ | 1 << 3  | `XNS_CAPABILITY_INPUT`         |
+ | 1 << 4  | `XNS_CAPABILITY_KEYBOARD`      |
+ | 1 << 5  | `XNS_CAPABILITY_ADMIN`         |
+
+**Attributes** — lifecycle/status (new fields on `struct Xnamespace`):
+
+ | Bit     | Name                  | meaning                                 |
+ | ------- | --------------------- | --------------------------------------- |
+ | 1 << 0  | `XNS_ATTR_IMMUTABLE`  | read-only; set by server for root/anon  |
+ | 1 << 1  | `XNS_ATTR_TRANSIENT`  | destroy namespace when last client exits|
+
+Unused bits in either word are reserved, must be 0, and yield `BadValue`.
+New capabilities/attributes are added by allocating the next bit and
+bumping the minor version.
+
+
+5. Versioning
+-------------
+
+`QueryVersion` negotiates (major, minor). This document is major 1, minor 0.
+The client sends the highest version it supports; the server replies with
+the highest it supports that is not greater than the client's.
+
+
+6. Requests
+-----------
+
+Every request begins with the standard 4-byte extension header (major
+opcode, 1-byte minor opcode, 16-bit length in 4-byte units). All requests
+are 4-byte aligned. A namespace name is encoded as a single length-prefixed
+STRING8 (`CARD16` length + bytes + zero padding to a 4-byte boundary) — one
+uniform encoding, easy to parse.
+
+All mutating requests carry a reply so the manager round-trips and learns
+success or failure synchronously, instead of relying on asynchronous error
+delivery. Replies are deliberately minimal.
+
+Minor opcodes:
+
+ | Opcode | Request              | Reply |
+ | ------ | -------------------- | ----- |
+ |   0    | `QueryVersion`       | yes   |
+ |   1    | `ListNamespaces`     | yes   |
+ |   2    | `CreateNamespace`    | yes (ack) |
+ |   3    | `DeleteNamespace`    | yes (ack) |
+ |   4    | `QueryNamespace`     | yes   |
+ |   5    | `SetNamespaceFlags`  | yes (ack) |
+ |   6    | `AddAuthToken`       | yes   |
+ |   7    | `RemoveAuthToken`    | yes (ack) |
+ |   8    | `ListAuthTokens`     | yes   |
+ |   9    | `GetClientNamespace` | yes   |
+
+### 6.0 QueryVersion
+
+```
+  QueryVersion
+    client-major-version: CARD16
+    client-minor-version: CARD16
+  =>
+    major-version: CARD16
+    minor-version: CARD16
+```
+
+### 6.1 ListNamespaces
+
+```
+  ListNamespaces
+  =>
+    namespaces: LISTofNAMESPACEINFO
+```
+
+where each NAMESPACEINFO is a fixed header followed by the name:
+
+```
+    capabilities: CARD32       (section 4)
+    attributes:   CARD32       (section 4)
+    refcnt:       CARD32        (clients currently assigned)
+    num-tokens:   CARD32
+    name:         STRING8       (length-prefixed, padded)
+```
+
+### 6.2 CreateNamespace
+
+```
+  CreateNamespace
+    capabilities: CARD32       (initial caps)
+    attributes:   CARD32       (XnsAttrAutoRemove honored; XnsAttrBuiltin
+                                ignored/illegal)
+    name:         STRING8
+  =>
+    (empty ack)
+```
+
+Errors: `BadName` (empty / illegal char / reserved `'/'` / duplicate),
+`BadValue` (reserved capability or attribute bit set), `BadAlloc`.
+
+### 6.3 DeleteNamespace
+
+```
+  DeleteNamespace
+    onclients: CARD8           (0 = fail if any client present,
+                                1 = terminate all clients, then delete)
+    pad:       3 bytes
+    name:      STRING8
+  =>
+    (empty ack)
+```
+
+ * Deleting a built-in namespace → `BadAccess`.
+ * `onclients == 0` and the namespace still has clients → `BadAccess`
+   (busy). The manager must terminate them first or pass `onclients == 1`.
+ * `onclients == 1`: the server disconnects every client in the namespace
+   (as if each had closed its connection), then frees the namespace and
+   removes its auth tokens (calling `RemoveAuthorization()` for each).
+ * Any other `onclients` value → `BadValue`.
+
+### 6.4 QueryNamespace
+
+```
+  QueryNamespace
+    name: STRING8
+  =>
+    capabilities: CARD32
+    attributes:   CARD32
+    refcnt:       CARD32
+    num-tokens:   CARD32
+```
+
+`BadName` if no such namespace.
+
+### 6.5 SetNamespaceFlags
+
+Atomically updates the subset of capability bits selected by `value-mask`:
+
+```
+  SetNamespaceFlags
+    value-mask: CARD32         (which capability bits to apply)
+    values:     CARD32         (new values for the masked bits)
+    name:       STRING8
+  =>
+    capabilities: CARD32       (resulting capabilities)
+```
+
+`new_caps = (old_caps & ~value-mask) | (values & value-mask)`. Targeting a
+built-in namespace → `BadAccess`. A reserved bit in `value-mask` →
+`BadValue`. `BadName` if no such namespace. (Attributes are set only at
+creation in v0.1; there is no runtime attribute change.)
+
+### 6.6 AddAuthToken
+
+Runtime equivalent of an `auth` config line; internally calls
+`AddAuthorization()` exactly as `config.c` does and records the token.
+
+```
+  AddAuthToken
+    name:        STRING8        (namespace name)
+    auth-proto:  STRING8        (e.g. "MIT-MAGIC-COOKIE-1")
+    auth-data:   STRING8        (raw key bytes, length-prefixed — NOT hex)
+  =>
+    token-handle: CARD32        (per-namespace handle for removal)
+```
+
+The key is carried as raw bytes; the hex encoding in the config file
+(`hex2bin()` in `config.c`) is a text-file affordance with no place in a
+binary protocol. Targeting a built-in namespace → `BadAccess`. `BadName`
+if no such namespace; `BadValue` if `auth-proto` is empty; `BadAlloc` on
+failure.
+
+(Three length-prefixed STRING8s in a fixed order — the request stays
+trivially parseable despite three variable-length fields.)
+
+### 6.7 RemoveAuthToken
+
+```
+  RemoveAuthToken
+    token-handle: CARD32
+    name:         STRING8
+  =>
+    (empty ack)
+```
+
+Calls `RemoveAuthorization()` and unlinks the token. Removing a token does
+not disconnect clients already authenticated with it (standard X
+authorization semantics); it only prevents future connections from using
+it. `BadMatch` if the handle does not belong to the named namespace;
+`BadAccess` for a built-in namespace; `BadName` if no such namespace.
+
+### 6.8 ListAuthTokens
+
+```
+  ListAuthTokens
+    name: STRING8
+  =>
+    tokens: LISTofAUTHTOKENINFO
+```
+
+where AUTHTOKENINFO is:
+
+```
+    token-handle: CARD32
+    proto:        STRING8       (length-prefixed, padded)
+```
+
+Secret key material is **never** returned — only the protocol name and the
+handle. A compromised manager cannot exfiltrate cookies it did not create.
+
+### 6.9 GetClientNamespace
+
+Read-only introspection: which namespace a given client belongs to. Useful
+for auditing a namespace's members before a `DeleteNamespace onclients=1`.
+
+```
+  GetClientNamespace
+    client-resource: CARD32     (a resource base; 0 = the calling client)
+  =>
+    is-server: BOOL
+    pad:       3 bytes
+    name:      STRING8          (the client's namespace name)
+```
+
+This is the protocol view of `XnsClientPriv(client)->ns`.
+
+
+7. Errors
+---------
+
+The extension defines no new error codes; it reuses core errors:
+
+ * `BadAccess` — operation on an immutable built-in namespace; delete of a
+   busy namespace without `onclients=1`. (Also the result of a
+   non-superPower client reaching the extension, though the Xace hooks make
+   that unreachable in practice — defence in depth.)
+ * `BadName`   — namespace name empty, illegal, reserved-delimiter,
+   duplicate on create, or not found.
+ * `BadValue`  — reserved capability/attribute bit set; bad `onclients`
+   value; empty auth protocol.
+ * `BadMatch`  — token handle does not belong to the named namespace.
+ * `BadAlloc`  — out of memory.
+
+
+8. Mapping to the existing implementation
+-----------------------------------------
+
+Registered like any other extension (`AddExtension`, cf.
+`Xext/dpms/dpms.c:515`) from `NamespaceExtensionInit()` in
+`Xext/namespace/namespace.c`, after `XnsLoadConfig()` succeeds — no point
+exposing management when namespaces are disabled.
+
+ | Protocol concept       | Existing code                                   |
+ | ---------------------- | ----------------------------------------------- |
+ | namespace record       | `struct Xnamespace` (`namespace.h`)             |
+ | capability bits        | `allow*` / `superPower` bool fields             |
+ | find by name           | `XnsFindByName()`                               |
+ | create namespace       | `select_ns()` logic, factored out of `config.c` |
+ | add token              | `AddAuthorization()` + `xorg_list_append`       |
+ | remove token           | `RemoveAuthorization()` + `xorg_list_del`       |
+ | client → namespace     | `XnsClientPriv()->ns`                           |
+ | refcount               | `struct Xnamespace.refcnt`                      |
+
+Required changes:
+
+ 1. **Access gate.** Add `Xnamespace-mgmt` to the blacklist in both
+    `hook-ext-access.c` (invisible to non-superPower) and
+    `hook-ext-dispatch.c` (`BadAccess` on dispatch), alongside
+    `SECURITY`/`RECORD`/`XTEST`.
+ 2. **Shared setters.** Factor the per-field parsing in `parseLine()` into
+    helpers (`XnsCreateNamespace`, `XnsSetCaps`, `XnsAddToken`,
+    `XnsRemoveToken`) so the config loader and the protocol handlers share
+    one code path and cannot drift apart.
+ 3. **Removable tokens.** Add an opaque per-namespace `token-handle` to
+    `struct auth_token` and support unlinking + `RemoveAuthorization()`
+    (today tokens are only ever appended at boot).
+ 4. **New attribute fields.** Add `Bool builtin` is already present; add
+    `Bool autoRemove`. Set `builtin` for `root`/`anon`.
+ 5. **Auto-remove.** Centralise in `XnamespaceAssignClient()`: after the
+    `priv->ns->refcnt--` path, if the namespace is non-builtin, has
+    `autoRemove` set, and refcnt reached 0, destroy it (free tokens via
+    `RemoveAuthorization()`, unlink from `ns_list`, free). This is reached
+    naturally from `hookClientDestroy()`, which already calls
+    `XnamespaceAssignClient(subj, NULL)`. `root`/`anon` are safe because
+    they are builtin and start at `refcnt = 1`.
+ 6. **Client termination on delete.** For `DeleteNamespace onclients=1`,
+    walk clients whose `XnsClientPriv()->ns` matches and close them
+    (`CloseDownClient`), then free the namespace.
+ 7. **Dispatch.** A `ProcXnsDispatch` / `SProcXnsDispatch` pair with the
+    usual byte-swapped variants for each request.
+
+Serialization: everything runs in the single-threaded dispatch loop, so no
+locking is needed. Refcount and list mutations are safe as they happen only
+from request handlers and the existing callbacks.
+
+
+9. Remaining minor questions
+----------------------------
+
+ 1. **Reserved name charset.** `'/'` is reserved for nesting. Confirm the
+    full allowed charset (proposal: printable ASCII excluding whitespace,
+    `#`, and `/`) so protocol-created names round-trip through the config
+    grammar.
+ 2. **Auto-remove vs. explicit delete race.** If a transient namespace
+    auto-removes just before a manager issues `DeleteNamespace`, the delete
+    sees no such name and returns `BadName`. Is that acceptable (treat as
+    "already gone, success") or should auto-removed names linger briefly?
+    Proposal: `BadName` is fine; the namespace is gone either way.

--- a/doc/Xnamespace-protocol.md
+++ b/doc/Xnamespace-protocol.md
@@ -220,8 +220,8 @@ where each NAMESPACEINFO is a fixed header followed by the name:
 ```
   CreateNamespace
     capabilities: CARD32       (initial caps)
-    attributes:   CARD32       (XnsAttrAutoRemove honored; XnsAttrBuiltin
-                                ignored/illegal)
+    attributes:   CARD32       (XNS_ATTR_TRANSIENT honored; XNS_ATTR_IMMUTABLE
+                                rejected with BadValue if set)
     name:         STRING8
   =>
     (empty ack)
@@ -406,7 +406,7 @@ Required changes:
  3. **Removable tokens.** Add an opaque per-namespace `token-handle` to
     `struct auth_token` and support unlinking + `RemoveAuthorization()`
     (today tokens are only ever appended at boot).
- 4. **New attribute fields.** Add `Bool builtin` is already present; add
+ 4. **New attribute fields.** `Bool builtin` already exists; add
     `Bool autoRemove`. Set `builtin` for `root`/`anon`.
  5. **Auto-remove.** Centralise in `XnamespaceAssignClient()`: after the
     `priv->ns->refcnt--` path, if the namespace is non-builtin, has


### PR DESCRIPTION
This is a prototype for an X11 protocol extension to manange Xnamespace.

KISS approach, just enough for creating and destroying namespaces on the fly (eg. for containerized environments)