### PR TITLE
(release/25.2) glx: fix integer overflow in CreateContextAttribsARB length check

### DIFF
--- a/Xext/glx/createcontext.c
+++ b/Xext/glx/createcontext.c
@@ -114,7 +114,16 @@ __glXDisp_CreateContextAttribsARB(__GLXclientState * cl, GLbyte * pc)
 
     /* Verify that the size of the packet matches the size inferred from the
      * sizes specified for the various fields.
+     *
+     * Clamp numAttribs first: the size computation below multiplies it by 8
+     * in 32-bit arithmetic, so without this guard a value such as 0x20000000
+     * overflows to 0, lets a minimal request pass the length check, and then
+     * the attribute-parsing loop reads far out of bounds.  This mirrors the
+     * UINT32_MAX >> 3 clamp used by the other GLX context handlers.
      */
+    if (req->numAttribs > (UINT32_MAX >> 3))
+        return BadLength;
+
     const unsigned expected_size = (sizeof(xGLXCreateContextAttribsARBReq)
                                     + (req->numAttribs * 8)) / 4;
 


### PR DESCRIPTION
### Backport dashboard

Master: #2968 ✅ merged

| Branch | PR | Status |
|---|---|---|
| release/25.2 | #3104 | ⬜ open ← this PR |

<sub>Auto-generated backport dashboard — links the source master PR and sibling backports with their merge status.</sub>

---

**Backport of #2968** to `release/25.2`.

`release/25.2` has `__glXDisp_CreateContextAttribsARB()` (in `Xext/glx/createcontext.c`) with the `numAttribs * 8` size computation and **no** clamp — identical to master pre-fix → clean cherry-pick.

(25.1 and 25.0 already carry the `numAttribs > (UINT32_MAX >> 3)` clamp in that function, so neither needs this fix.)

---

__glXDisp_CreateContextAttribsARB() computed

    expected_size = (sizeof(req) + req->numAttribs * 8) / 4

in 32-bit unsigned arithmetic with no clamp on the attacker-controlled
numAttribs. A value such as 0x20000000 makes numAttribs * 8 wrap to 0, so a
minimal 28-byte request satisfies "req->length != expected_size", after which
the loop "for (i = 0; i < req->numAttribs; i++)" reads attribs[i*2] far past
the end of the request buffer (out-of-bounds read / crash).

Add the same "numAttribs > (UINT32_MAX >> 3)" clamp the other GLX context
handlers already use before the size computation.

Fixes: b840ba5f54de ("glx: Implement protocol for glXCreateContextAttribsARB")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit 0b52df40c2d1c22d7e95f4c282573d454880b278)
