### PR TITLE
os/strlcpy: modernize pointer qualifiers and remove register keyword

### DIFF
--- a/include/os.h
+++ b/include/os.h
@@ -225,9 +225,9 @@ xstrcasestr(const char *s, const char *find);
 
 #ifndef HAVE_STRLCPY
 extern _X_EXPORT size_t
-strlcpy(char *dst, const char *src, size_t siz);
+strlcpy(char * _X_RESTRICT_KYWD dst, const char * _X_RESTRICT_KYWD src, size_t siz);
 extern _X_EXPORT size_t
-strlcat(char *dst, const char *src, size_t siz);
+strlcat(char * _X_RESTRICT_KYWD dst, const char * _X_RESTRICT_KYWD src, size_t siz);
 #endif
 
 #ifndef HAVE_STRNDUP

--- a/os/strlcat.c
+++ b/os/strlcat.c
@@ -30,9 +30,9 @@
 size_t
 strlcat(char *dst, const char *src, size_t siz)
 {
-    register char *d = dst;
-    register const char *s = src;
-    register size_t n = siz;
+    char *d = dst;
+    const char *s = src;
+    size_t n = siz;
     size_t dlen;
 
     /* Find the end of dst and adjust bytes left but don't go past end */

--- a/os/strlcat.c
+++ b/os/strlcat.c
@@ -28,7 +28,7 @@
  * If retval >= siz, truncation occurred.
  */
 size_t
-strlcat(char *dst, const char *src, size_t siz)
+strlcat(char * _X_RESTRICT_KYWD dst, const char * _X_RESTRICT_KYWD src, size_t siz)
 {
     char *d = dst;
     const char *s = src;

--- a/os/strlcpy.c
+++ b/os/strlcpy.c
@@ -29,9 +29,9 @@
 size_t
 strlcpy(char *dst, const char *src, size_t siz)
 {
-    register char *d = dst;
-    register const char *s = src;
-    register size_t n = siz;
+    char *d = dst;
+    const char *s = src;
+    size_t n = siz;
 
     /* Copy as many bytes as will fit */
     if (n != 0 && --n != 0) {

--- a/os/strlcpy.c
+++ b/os/strlcpy.c
@@ -27,7 +27,7 @@
  * Returns strlen(src); if retval >= siz, truncation occurred.
  */
 size_t
-strlcpy(char *dst, const char *src, size_t siz)
+strlcpy(char * _X_RESTRICT_KYWD dst, const char * _X_RESTRICT_KYWD src, size_t siz)
 {
     char *d = dst;
     const char *s = src;


### PR DESCRIPTION
Three small cleanups related to strlcpy/strlcat:

- Remove the register keyword from local variables in os/strlcpy.c.
  It has been a no-op in modern C compilers for decades and only adds
  noise.

- Add restrict qualifiers to the dst and src pointer parameters in the
  strlcpy() and strlcat() implementations. These functions require
  non-overlapping source and destination buffers by contract, and
  making that explicit can enable additional compiler optimizations.

- Update the corresponding declarations in include/os.h to match the
  implementation signatures.

Signed-off-by: Victor Lev <levvictor123@gmail.com>