### PR TITLE
(release/25.2) randr: zero provider info reply buffer in ProcRRGetProviderInfo

### DIFF
--- a/Xext/randr/rrprovider.c
+++ b/Xext/randr/rrprovider.c
@@ -161,7 +161,10 @@ ProcRRGetProviderInfo (ClientPtr client)
 
     extraLen = reply.length << 2;
     if (extraLen) {
-        extra = x_rpcbuf_reserve(&rpcbuf, extraLen);
+        /* Use the zeroing variant: the provider name is copied with its exact
+         * length, leaving the trailing alignment padding uninitialized, which
+         * would otherwise leak heap memory to the client. */
+        extra = x_rpcbuf_reserve0(&rpcbuf, extraLen);
         if (!extra)
             return BadAlloc;
     }


### PR DESCRIPTION
### Backport dashboard

Master: #2981 ✅ merged

| Branch | PR | Status |
|---|---|---|
| release/25.2 | #3106 | ⬜ open ← this PR |

<sub>Auto-generated backport dashboard — links the source master PR and sibling backports with their merge status.</sub>

---

**Backport of #2981** to `release/25.2`.

Clean cherry-pick — `release/25.2` carried the identical pre-fix code at the same path. (`release/25.1` already contains the fix; `release/25.0` already contains it or predates the affected code — see the backport dashboard on #2981.)

---

The reply "extra" buffer was allocated with the non-zeroing
x_rpcbuf_reserve(), and the provider name is copied with
memcpy(name, provider->name, reply.nameLength). Because the reserved length
rounds nameLength up to a 4-byte multiple, the up-to-3 trailing padding bytes
after the name were left uninitialized and sent to the client (e.g. for
"modesetting", nameLength 11), disclosing heap memory.

Use x_rpcbuf_reserve0() to zero the buffer.

Fixes: 36ef6a448b45 ("randr: ProcRRGetProviderInfo(): use x_rpcbuf_t")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit 16547f561d45a91eaa66d6e255b6b718b1c03a4e)

