### PR TITLE
(release/25.2) Xi: fix NULL pointer dereference in ProcXQueryDeviceState

### DIFF
--- a/Xext/xinput/queryst.c
+++ b/Xext/xinput/queryst.c
@@ -76,6 +76,13 @@ ProcXQueryDeviceState(ClientPtr client)
     if (rc != Success && rc != BadAccess)
         return rc;
 
+    /* dixLookupDevice() leaves dev NULL on anything other than Success,
+     * including BadAccess. The code below intentionally continues on
+     * BadAccess to blank out the state, but it cannot do so without a valid
+     * device, so bail out rather than dereferencing NULL. */
+    if (!dev)
+        return rc;
+
     v = dev->valuator;
     if (v != NULL && v->motionHintWindow != NULL)
         MaybeStopDeviceHint(dev, client);


### PR DESCRIPTION
### Backport dashboard

Master: #2974 ✅ merged

| Branch | PR | Status |
|---|---|---|
| release/25.2 | #3110 | ⬜ open ← this PR |

<sub>Auto-generated backport dashboard — links the source master PR and sibling backports with their merge status.</sub>

---

**Backport of #2974** to `release/25.2`.

Clean cherry-pick — `release/25.2` carried the identical pre-fix code at the same path. (`release/25.1` already contains the fix; `release/25.0` already contains it or predates the affected code — see the backport dashboard on #2974.)

---

The handler deliberately continues when dixLookupDevice() returns BadAccess
(to emit class headers with the device state blanked out). However
dixLookupDevice() leaves *pDev == NULL on any non-Success return, so the
subsequent "v = dev->valuator" dereferenced NULL and crashed the server.

This is reachable when an XACE/SELinux hook denies the client's DixReadAccess
to the device. Bail out when dev is NULL instead of dereferencing it.

Fixes: 8502c06e19a4 ("xace: Fake return values on denials in input polling requests.")
Fixes: 5c03d131815c ("xace: add new hooks + access controls: XInput extension.")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit a12b92d4b68d598ddd3e4ad11eeb125d3f673287)

