### PR TITLE
(release/25.2) Xext: xvmc: guard against NULL screen private in ProcXvMCGetDRInfo

### DIFF
--- a/Xext/xv/xvmc.c
+++ b/Xext/xv/xvmc.c
@@ -607,6 +607,12 @@ ProcXvMCGetDRInfo(ClientPtr client)
     pScreen = pPort->pAdaptor->pScreen;
     pScreenPriv = XVMC_GET_PRIVATE(pScreen);
 
+    /* The port may live on a screen that never initialized XvMC, in which case
+     * the per-screen private is NULL. Match the other port-taking handlers and
+     * reject it instead of dereferencing NULL. */
+    if (!pScreenPriv)
+        return BadMatch;
+
     int nameLen = strlen(pScreenPriv->clientDriverName) + 1;
     int busIDLen = strlen(pScreenPriv->busID) + 1;
 


### PR DESCRIPTION
### Backport dashboard

Master: #2970 ✅ merged

| Branch | PR | Status |
|---|---|---|
| release/25.2 | #3111 | ⬜ open ← this PR |

<sub>Auto-generated backport dashboard — links the source master PR and sibling backports with their merge status.</sub>

---

**Backport of #2970** to `release/25.2`.

Clean cherry-pick — `release/25.2` carried the identical pre-fix code at the same path. (`release/25.1` already contains the fix; `release/25.0` already contains it or predates the affected code — see the backport dashboard on #2970.)

---

ProcXvMCGetDRInfo() fetched the per-screen XvMC private with
XVMC_GET_PRIVATE() and immediately dereferenced it
(strlen(pScreenPriv->clientDriverName)). The private is NULL for any screen on
which XvMCScreenInit() was never called, while the extension and its private
key become available globally as soon as any screen enables XvMC.

A local client owning a valid Xv port on a non-XvMC screen (e.g. a multi-GPU
setup where only one screen has XvMC) could thus crash the server. The three
other port-taking XvMC handlers already check for NULL; do the same here and
return BadMatch.

Fixes: 3b0dce3620e4 ("lib/XvMC/Imake Added support for automatic loading of the correct hardware XvMC driver.")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit 6db14d020d745946c13228776d135fef50d704fe)

