### PR TITLE
(release/25.2) Xext: xtest: fix stack out-of-bounds write in ProcXTestFakeInput

### DIFF
--- a/Xext/xtest/xtest.c
+++ b/Xext/xtest/xtest.c
@@ -260,7 +260,7 @@ ProcXTestFakeInput(ClientPtr client)
 
         if (type == XI_DeviceMotionNotify) {
             firstValuator = ((deviceValuator *) (ev + 1))->first_valuator;
-            if (firstValuator > dev->valuator->numAxes) {
+            if (firstValuator >= dev->valuator->numAxes) {
                 client->errorValue = ev->u.u.type;
                 return BadValue;
             }
@@ -290,6 +290,21 @@ ProcXTestFakeInput(ClientPtr client)
                 client->errorValue = dv->first_valuator;
                 return BadValue;
             }
+            if (dv->num_valuators < 1 || dv->num_valuators > 6) {
+                client->errorValue = dv->num_valuators;
+                return BadValue;
+            }
+
+            /* Validate that the valuators stay within the device's axis
+             * count *before* writing them, otherwise an attacker-controlled
+             * first_valuator/num_valuators combination writes past the end of
+             * the fixed-size valuators[MAX_VALUATORS] stack array. */
+            numValuators += dv->num_valuators;
+            if (firstValuator + numValuators > dev->valuator->numAxes) {
+                client->errorValue = dv->num_valuators;
+                return BadValue;
+            }
+
             switch (dv->num_valuators) {
             case 6:
                 valuators[base + 5] = dv->valuator5;
@@ -304,18 +319,9 @@ ProcXTestFakeInput(ClientPtr client)
             case 1:
                 valuators[base] = dv->valuator0;
                 break;
-            default:
-                client->errorValue = dv->num_valuators;
-                return BadValue;
             }
 
             base += dv->num_valuators;
-            numValuators += dv->num_valuators;
-
-            if (firstValuator + numValuators > dev->valuator->numAxes) {
-                client->errorValue = dv->num_valuators;
-                return BadValue;
-            }
         }
         type = type - XI_DeviceKeyPress + KeyPress;
 


### PR DESCRIPTION
### Backport dashboard

Master: #2964 ✅ merged

| Branch | PR | Status |
|---|---|---|
| release/25.2 | #3115 | ⬜ open ← this PR |

<sub>Auto-generated backport dashboard — links the source master PR and sibling backports with their merge status.</sub>

---

ProcXTestFakeInput() copies attacker-controlled valuator values into the
fixed-size on-stack array int valuators[MAX_VALUATORS] (MAX_VALUATORS == 36)
when faking an XI DeviceMotionNotify event.

Two flaws allowed a write past the end of that array:

  * The initial check used "firstValuator > dev->valuator->numAxes", so
    firstValuator == numAxes (legitimately up to 36) was accepted, leaving
    base == 36 at the start of the first iteration.

  * The per-valuator range check
    "firstValuator + numValuators > dev->valuator->numAxes" was performed
    *after* the switch that already wrote valuators[base .. base + 5], so the
    out-of-bounds write happened before the request was rejected with
    BadValue.

A client controlling an XI device with numAxes == 36 could therefore send a
DeviceValuator with first_valuator == 36 and num_valuators in 1..6 and write
up to six attacker-controlled INT32s past the end of the stack buffer.

Tighten the initial check to ">=" and validate num_valuators and the axis
range *before* writing the valuators.

Fixes: 105d28652d1f ("Xext: use GPE/GKE from XTestFakeInput #16145")
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit 335fffed92d1e3ac5e12ff71ad57f1c7906c7a07)


---

Backport of #2964 (master) to `release/25.2`.
