### PR TITLE
(master) ci: de-duplicate pipeline runs for pull requests

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -12,8 +12,25 @@ on:
     push:
     pull_request:
 
+# If a ref is pushed again (or a PR gets a new commit) while its previous run is
+# still in flight, cancel the stale run — only the newest commit needs building.
+# Keyed by ref, so each branch/PR is independent.
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     ubuntu-fetch-pkg:
+        # De-duplicate PR runs without a branch-name convention: on a same-repo
+        # pull_request the branch's own push event already builds it, so skip the
+        # redundant build here. Fork PRs raise no push event in this repo, so
+        # they still build. Every build job chains off this root (and the three
+        # other no-needs roots below), so skipping it skips them too. Normal
+        # branch pushes are unaffected — they build exactly as before, and the
+        # push run's checks still populate the PR's status indicator.
+        if: >-
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name != github.repository
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
@@ -255,6 +272,10 @@ jobs:
               run: .github/scripts/meson-build.sh --run-install
 
     xserver-build-macos:
+        # skip the redundant same-repo PR rebuild (see ubuntu-fetch-pkg)
+        if: >-
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name != github.repository
         env:
             MESON_ARGS: -Dprefix=/tmp -Dglx=false -Dxnest=false -Dxfbdev=false
             X11_PREFIX: /Users/runner/x11
@@ -381,6 +402,10 @@ jobs:
               run: ./.github/scripts/alpine/run-xserver-build.sh
 
     xserver-build-cygwin:
+        # skip the redundant same-repo PR rebuild (see ubuntu-fetch-pkg)
+        if: >-
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name != github.repository
         runs-on: windows-latest
         steps:
             - name: Cygwin packages cache
@@ -438,6 +463,10 @@ jobs:
                   bash ./.github/scripts/Cygwin/build.sh
 
     xserver-build-arch:
+        # skip the redundant same-repo PR rebuild (see ubuntu-fetch-pkg)
+        if: >-
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name != github.repository
         runs-on: ubuntu-latest
         steps:
           - uses: actions/checkout@v6


### PR DESCRIPTION
A push to a branch that also has an open pull request triggered two identical
workflow runs: one for the `push` event and one for the `pull_request`
(synchronize) event. That doubles the runner cost and clutters the checks list,
most painfully when a PR branch is re-pushed repeatedly.

Drop the redundant run without changing normal-branch behaviour and without
relying on any branch-name convention:

  - A top-level `concurrency` group keyed by `github.ref`, with
    `cancel-in-progress: true`, cancels a still-running run when the same ref is
    pushed again. Only the newest commit gets built; stale in-flight runs are
    aborted.

  - A guard on the four build jobs that have no `needs:` (ubuntu-fetch-pkg,
    xserver-build-macos, xserver-build-cygwin, xserver-build-arch):

        if: >-
            github.event_name != 'pull_request' ||
            github.event.pull_request.head.repo.full_name != github.repository

    On the `pull_request` event for a branch in this same repository the second
    operand is false, so the job is skipped: the branch's own `push` event has
    already built it. Every other build job chains off one of these four roots,
    and a skipped `needs:` job skips its dependents, so the condition does not
    have to be repeated on each job.

Fork PRs raise no `push` event in this repository, so the second operand is
true and they keep building via the `pull_request` event exactly as before.
Pushes to ordinary branches still run on `push`, unchanged. The PR-only
`check-sign-off` job and the tag-only `release` job are deliberately left
untouched.

The PR checks indicator is unaffected: for GitHub Actions the required
status-check context is the job name (independent of the triggering event), and
for a same-repo PR the push run reports those jobs against the very commit the
PR points at.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
