### PR TITLE
xfree86: drop parentheses around DB() macro argument

### DIFF
--- a/hw/xfree86/x86emu/x86emu/debug.h
+++ b/hw/xfree86/x86emu/x86emu/debug.h
@@ -179,7 +179,7 @@
 #endif
 
 #ifdef DEBUG
-#define	DB(x)	(x)
+#define	DB(x)	x
 #else
 #define	DB(x)
 #endif


### PR DESCRIPTION
Commit a79d0cf1c95a ("xfree86: parentheses around macro argument symbols") wrapped the DB() macro argument in parentheses as part of a blanket policy. Unlike the other macros, DB() is used to guard whole statement blocks, e.g.

    DB(printk(...);
       if (...) ...)

so expanding to (x) produces (printk(...); if (...) ...), which is not valid C. This breaks the build of several files in the x86emu tree whenever DEBUG is enabled.

Revert the parentheses for DB() only, restoring a plain pass-through expansion.