### PR TITLE
(master) os: busfault: drop retval from busfault_init()

### DIFF
--- a/os/busfault.c
+++ b/os/busfault.c
@@ -136,17 +136,17 @@ panic:
         FatalError("bus error\n");
 }
 
-Bool
-busfault_init(void)
+void busfault_init(void)
 {
     struct sigaction    act, old_act;
 
     act.sa_sigaction = busfault_sigaction;
     act.sa_flags = SA_SIGINFO;
     sigemptyset(&act.sa_mask);
-    if (sigaction(SIGBUS, &act, &old_act) < 0)
-        return FALSE;
+    if (sigaction(SIGBUS, &act, &old_act) < 0) {
+        ErrorF("busfault_init: sigaction() failed.\n");
+        return;
+    }
     previous_busfault_sigaction = old_act.sa_sigaction;
     xorg_list_init(&busfaults);
-    return TRUE;
 }

--- a/os/busfault.h
+++ b/os/busfault.h
@@ -25,10 +25,6 @@
 
 #include <dix-config.h>
 
-#include <X11/Xdefs.h>
-
-#include "include/misc.h"                         /* for TRUE/FALSE */
-
 typedef void (*busfault_notify_ptr) (void *context);
 
 #ifdef HAVE_SIGACTION
@@ -44,8 +40,7 @@ busfault_unregister(struct busfault *busfault);
 void
 busfault_check(void);
 
-Bool
-busfault_init(void);
+void busfault_init(void);
 
 #else
 
@@ -68,7 +63,7 @@ busfault_unregister(struct busfault *busfault)
 }
 
 static inline void busfault_check(void) {}
-static inline Bool busfault_init(void) { return FALSE; }
+static inline void busfault_init(void) {}
 
 #endif
 


### PR DESCRIPTION
Nobody's ever looking at the return value - and in case of error,
there's not much we can do, but emit an error message.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
