### PR TITLE
(release/25.2) present: Fix missing byte swaps in sproc_present_pixmap()

### DIFF
--- a/Xext/present/present_request.c
+++ b/Xext/present/present_request.c
@@ -364,6 +364,7 @@ sproc_present_pixmap(ClientPtr client)
     swapll(&stuff->divisor);
     swapll(&stuff->remainder);
     swapl(&stuff->idle_fence);
+    SwapRestL(stuff);
     return proc_present_pixmap(client);
 }
 


### PR DESCRIPTION
### Backport dashboard

Master: #2659 ✅ merged

| Branch | PR | Status |
|---|---|---|
| release/25.2 | #3123 | ⬜ open ← this PR |

<sub>Auto-generated backport dashboard — links the source master PR and sibling backports with their merge status.</sub>

---

sproc_present_pixmap() was missing byte swaps the variable-length
xPresentNotify array after the fixed header was not
byte-swapped at all (each entry has window and serial CARD32 fields).

Fixes: a5ac3c871219 ("present: add missing byte swapping for various fields")

Assisted-by: Claude:claude-claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2202>
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit bd03a8d40807cbaacec888dea80e4b505aba2be8)


---

Backport of #2659 (master) to `release/25.2`.
