### PR TITLE
(master) dri3: remove unused wrap()/unwrap() macros from dri3_priv.h

### DIFF
--- a/Xext/dri3/dri3_priv.h
+++ b/Xext/dri3/dri3_priv.h
@@ -54,15 +54,6 @@ typedef struct dri3_screen_priv {
     const dri3_screen_info_rec *info;
 } dri3_screen_priv_rec, *dri3_screen_priv_ptr;
 
-#define wrap(priv,real,mem,func) {\
-    (priv)->mem = (real)->mem; \
-    (real)->mem = (func); \
-}
-
-#define unwrap(priv,real,mem) {\
-    (real)->mem = (priv)->mem; \
-}
-
 #define VERIFY_DRI3_SYNCOBJ(id, ptr, a)\
     do {\
         int rc = dixLookupResourceByType((void **)&(ptr), id,\


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
