### PR TITLE
(master) xfree86: x86emu: drop ifdef on SCITECH symbol

### DIFF
--- a/hw/xfree86/x86emu/x86emu.h
+++ b/hw/xfree86/x86emu/x86emu.h
@@ -41,16 +41,9 @@
 #ifndef __X86EMU_X86EMU_H
 #define __X86EMU_X86EMU_H
 
-#ifdef SCITECH
-#include "scitech.h"
-#define	X86API	_ASMAPI
-#define	X86APIP	_ASMAPIP
-typedef int X86EMU_pioAddr;
-#else
 #include "x86emu/types.h"
 #define	X86API
 #define	X86APIP	*
-#endif
 #include "x86emu/regs.h"
 
 /*---------------------- Macros and type definitions ----------------------*/


### PR DESCRIPTION
Nobody's ever setting this symbol, so those code pathes aren't needed.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
