### PR TITLE
list: make xorg_list cope with zero-initialized list heads

### DIFF
--- a/include/list.h
+++ b/include/list.h
@@ -215,6 +215,7 @@ __xorg_list_del(struct xorg_list *prev, struct xorg_list *next)
 static inline void
 xorg_list_del(struct xorg_list *entry)
 {
+    __xorg_list_autoinit(entry);
     __xorg_list_del(entry->prev, entry->next);
     xorg_list_init(entry);
 }
@@ -379,7 +380,7 @@ xorg_list_append_ndup(struct xorg_list *entry, struct xorg_list *head)
 #define xorg_list_for_each_entry_safe(pos, tmp, head, member)		\
     for ((pos) = NULL,                                                    \
          (pos) = __container_of((head)->next, (pos), member),		\
-	 (tmp) = __container_of((pos)->member.next, (pos), member);		\
+	 (tmp) = __container_of((head)->next ? (pos)->member.next : NULL, (pos), member); \
 	 (((head)->next != NULL) && (&(pos)->member != (head)));		\
 	 (pos) = (tmp), (tmp) = __container_of((pos)->member.next, (tmp), member))
 


### PR DESCRIPTION
Most `xorg_list` operations already tolerate a list head that was merely **zero-initialized** (`next == prev == NULL`) instead of run through `xorg_list_init()`:

- `xorg_list_add()` / `xorg_list_append()` auto-init via `__xorg_list_autoinit()`
- `xorg_list_for_each_entry()`, `xorg_list_is_empty()`, `xorg_list_present()` guard against a `NULL` `head->next`

Two paths were still missed, so a list head embedded in a `calloc()`'d struct could crash *before anything was ever added to it*:

1. **`xorg_list_for_each_entry_safe()`** guarded its loop *condition* with `(head)->next != NULL`, but its init clause unconditionally computed `tmp = container_of((pos)->member.next, ...)`. On a zeroed head, `pos` resolves to `container_of(NULL)` and reading `(pos)->member.next` dereferences address `0` — crashing *before* the guard is ever evaluated. Now `tmp` is seeded from `(head)->next ? (pos)->member.next : NULL`, so an empty/zeroed list iterates zero times without dereferencing anything.

2. **`xorg_list_del()`** dereferenced `entry->prev` / `entry->next` directly, so resetting a zeroed head (the documented *"reset to empty list"* use) would NULL-deref. It now auto-inits first, consistent with `xorg_list_add()` / `xorg_list_append()`.

With these, a zero-initialized `xorg_list` head behaves as a valid empty list across the whole API — an embedded list head no longer strictly requires an explicit `xorg_list_init()` to be safe.

### Why

This was found while repairing #1639 (`dix: use xorg_list saveSet list`): its CI failed because the `xvfb`/`xephyr-glamor` XTS jobs crashed the server (`Caught signal 11 … at address 0x0`). Root cause was a `client->saveSets` head that was never `xorg_list_init()`'d; `DeleteWindowFromAnySaveSet()` iterates **every** client's `saveSets` with `xorg_list_for_each_entry_safe()`, hitting the gap above on any client that never added a save-set entry. #1639 carries the targeted explicit-init fix; this PR closes the underlying macro gap so the same class of bug can't recur for other zero-allocated heads.

### Testing

Reproduced the exact `Segmentation fault at address 0x0` with a minimal client (window owned by client A, added to client B's save-set, B disconnects → `HandleSaveSet` + window teardown → `DeleteWindowFromAnySaveSet`) against an `Xvfb` built **without** the explicit init; with this macro change alone the server stays alive. `meson test … unit` (which exercises `test/list.c`) passes; servers link and run.
