### PR TITLE
(master) dix: colormap: declare variables where needed in IsMapInstalled()

### DIFF
--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -2471,14 +2471,12 @@ StoreColors(ColormapPtr pmap, int count, xColorItem * defs, ClientPtr client)
 
 bool IsMapInstalled(Colormap map, WindowPtr pWin)
 {
-    Colormap *pmaps;
-    int nummaps;
-
-    pmaps = calloc(pWin->drawable.pScreen->maxInstalledCmaps,
+    Colormap *pmaps = calloc(pWin->drawable.pScreen->maxInstalledCmaps,
                    sizeof(Colormap));
     if (!pmaps)
         return FALSE;
-    nummaps = (*pWin->drawable.pScreen->ListInstalledColormaps)
+
+    int nummaps = (*pWin->drawable.pScreen->ListInstalledColormaps)
         (pWin->drawable.pScreen, pmaps);
 
     bool found = FALSE;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
