### PR TITLE
(master) test/pyxtest: add Solaris equivalent for SO_PEERCRED

### DIFF
--- a/test/pyxtest/xserver.py
+++ b/test/pyxtest/xserver.py
@@ -11,6 +11,7 @@ from typing import Iterator
 import os
 import select
 import shutil
+import sys
 import subprocess
 import tempfile
 import time
@@ -521,10 +522,16 @@ class ExternalXServer:
         try:
             sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
             sock.connect(path)
-            cred = sock.getsockopt(
-                _socket.SOL_SOCKET, _socket.SO_PEERCRED, _struct.calcsize("iii")
-            )
-            pid, _, _ = _struct.unpack("iii", cred)
+            if sys.platform.startswith("sunos"):
+                import ucred as _ucred
+
+                ucred = _ucred.getpeer(sock.fileno())
+                pid = ucred.getpid()
+            else:
+                cred = sock.getsockopt(
+                    _socket.SOL_SOCKET, _socket.SO_PEERCRED, _struct.calcsize("iii")
+                )
+                pid, _, _ = _struct.unpack("iii", cred)
             sock.close()
             return pid
         except (OSError, _struct.error):


### PR DESCRIPTION
On Solaris, to get information about the process on the other side of
a socket, we use the getpeerucred() system call instead of the
SO_PEERCRED socket option.

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2241>
