### PR TITLE
dix: Silence a compiler warning in doListFontsAndAliases()

### DIFF
--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -627,7 +627,7 @@ doListFontsAndAliases(ClientPtr client, struct list_fonts_closure *c)
     int err = Successful;
     FontNamesPtr names = NULL;
     char *name, *resolved = NULL;
-    int namelen, resolvedlen;
+    int namelen, resolvedlen = 0;
     int aliascount = 0;
 
     if (client->clientGone) {


### PR DESCRIPTION
dix: Silence a compiler warning in doListFontsAndAliases()

Compiler complains that "resolvedlen" might be uninitialized:

| dix/dixfonts.c:559:5: var_decl: Declaring variable "resolvedlen" without initializer.
| dix/dixfonts.c:674:17: uninit_use: Using uninitialized value "resolvedlen".
|    672|                    * is complete.
|    673|                    */
|    674|->                 if (resolvedlen > XLFDMAXFONTNAMELEN) {
|    675|                       err = BadFontName;
|    676|                       goto ContBadFontName;

Most likely a false positive, while immediately after the (newly added)
test, there was a memcpy() using "resolvedlen" and the compiler did not
choke on that before.

Either way, initializing "resolvedlen" to 0 is a small price to pay to
silence the compiler warning and keep us on the safe side.

Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2237>