### PR TITLE
dix: Silence a compiler warning in doListFontsWithInfo()

### DIFF
--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -902,7 +902,7 @@ doListFontsWithInfo(ClientPtr client, struct list_fonts_with_info_closure *c)
 {
     FontPathElementPtr fpe;
     int err = Successful;
-    char *name;
+    char *name = NULL;
     int namelen = 0;
     int numFonts;
     FontInfoRec fontInfo, *pFontInfo;
@@ -962,6 +962,10 @@ doListFontsWithInfo(ClientPtr client, struct list_fonts_with_info_closure *c)
              * is BadFontName, indicating the alias resolution
              * is complete.
              */
+            if (!name) {
+                err = BadFontName;
+                goto ContBadFontName;
+            }
             if (c->haveSaved) {
                 char *tmpname;
                 int tmpnamelen;


### PR DESCRIPTION
dix: Silence a compiler warning in doListFontsWithInfo()

Static analyzer reports:

| dix/dixfonts.c:936:17: uninit_use_in_call: Using uninitialized value "name" when calling "memcpy".
|   934|                   free(c->savedName);
|   935|                   c->savedName = XNFalloc(namelen + 1);
|   936|->                 memcpy(c->savedName, name, namelen + 1);
|   937|                   aliascount = 20;
|   938|               }

To silence the warning, we cannot just set "name" to NULL, as this could
potentially cause a NULL pointer in memcpy(), we also need to check if
the value was set. If not, just bail out with a BadFontNAme error.

Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2238>
(cherry picked from commit 5d011bf3da81595bef25ca89458249c1037a4f51)