### PR TITLE
(release/25.2) glx: reject duplicate GLX drawable for a window (fix UAF in DrawableGone)

### DIFF
--- a/Xext/glx/glxcmds.c
+++ b/Xext/glx/glxcmds.c
@@ -1145,6 +1145,33 @@ DoCreateGLXDrawable(ClientPtr client, __GLXscreen * pGlxScreen,
     if (pGlxScreen->pScreen != pDraw->pScreen)
         return BadMatch;
 
+    if (type == GLX_DRAWABLE_WINDOW) {
+        /* The GLX window id is a fresh, client-allocated resource id, so
+         * validate it like any other new resource (in the client's id range
+         * and not already in use). */
+        LEGAL_NEW_RESOURCE(glxDrawableId, client);
+
+        /* A window may have only a single GLX drawable associated with it. We
+         * register the __GLXdrawable under both the GLX window id and the X
+         * window id (see below) so DrawableGone() runs regardless of teardown
+         * order. If the client calls glXCreateWindow() again for the same X
+         * window, the second AddResource() below would register a duplicate
+         * (pDraw->id, __glXDrawableRes) resource aliasing a *different*
+         * __GLXdrawable. Tearing the window down then frees one __GLXdrawable
+         * via FreeResourceByType() while leaving the other resource entry
+         * pointing at it, causing a use-after-free / double free in
+         * DrawableGone() (issue #1491). The GLX spec disallows associating two
+         * GLX windows with one X window, so reject it up front with BadAlloc. */
+        if (drawableId != glxDrawableId) {
+            __GLXdrawable *existing;
+
+            if (dixLookupResourceByType((void **) &existing, pDraw->id,
+                                        __glXDrawableRes, client,
+                                        DixGetAttrAccess) == Success)
+                return BadAlloc;
+        }
+    }
+
     pGlxDraw = pGlxScreen->createDrawable(client, pGlxScreen, pDraw,
                                           drawableId, type,
                                           glxDrawableId, config);


### PR DESCRIPTION
### Backport dashboard

Master: #3145 ✅ merged

| Branch | PR | Status |
|---|---|---|
| release/25.0 | #3148 | ⬜ open |
| release/25.1 | #3147 | ⬜ open |
| release/25.2 | #3146 | ⬜ open ← this PR |

<sub>Auto-generated backport dashboard — links the source master PR and sibling backports with their merge status.</sub>

---

**Backport of #3145** (master → `release/25.2`). Original fix for #1491.

---

DoCreateGLXDrawable() registers a window's __GLXdrawable under two
resource ids: the GLX window id and the underlying X window id, so that
DrawableGone() runs regardless of teardown order. The single-drawable
case stays consistent because DrawableGone() frees the partner entry
with FreeResourceByType(..., skipFree=TRUE), i.e. without recursing.

Nothing, however, stopped a client from calling glXCreateWindow() more
than once for the same X window. Each extra call registered another
(pDraw->id, __glXDrawableRes) resource aliasing a *different*
__GLXdrawable. On teardown FreeResourceByType() frees an arbitrary one
of those duplicate entries while the remaining one keeps pointing at the
already-destroyed __GLXdrawable; the next doFreeResource() then calls
DrawableGone() on freed memory and jumps through glxPriv->destroy() -
use-after-free / double free and a server crash. Any GLX client can
trigger this (issue #1491).

Fix it in DoCreateGLXDrawable(): a window may have at most one GLX
drawable, so bail out with BadAlloc if pDraw->id already has a
__glXDrawableRes resource (the GLX spec disallows associating two GLX
windows with one X window anyway). Also validate the client-supplied GLX
window id with LEGAL_NEW_RESOURCE(), like every other new resource, so a
bogus or already-used id cannot create the same aliasing on the
GLX-window-id side. Pixmap and pbuffer drawables are unaffected: the
check is gated on GLX_DRAWABLE_WINDOW, and pbuffers legitimately reuse
the id as their backing pixmap.

Reproduced with the issue's minimal client on Xephyr (swrast): the
unpatched server segfaults in DrawableGone() (glxext.c:131,
glxPriv->destroy on a freed drawable) during FreeClientResources(); the
patched server survives repeated runs while normal single-window GLX
(glXMakeCurrent + render) keeps working.

The Xshape flavour of this resource-table aliasing was addressed by
moving it to devPrivates (#1810); this is the GLX side. Diagnosis in
#1507 by @branc116, with the swrast-path use-after-free further
confirmed by @squishypinkelephant.

Fixes: #1491
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
(cherry picked from commit 5d96fc048e02120357530bea5cf28c13774566c7)

