### PR TITLE
xfree86: x86emu: drop never-built x87 FPU emulation skeleton

### DIFF
--- a/hw/xfree86/x86emu/fpu.c
+++ b/hw/xfree86/x86emu/fpu.c
@@ -133,170 +133,8 @@ x86emuOp_esc_coprocess_d9(u8 X86EMU_UNUSED(op1))
         }
         break;
     }
-#ifdef X86EMU_FPU_PRESENT
-    /* execute */
-    switch (mod) {
-    case 3:
-        switch (rh) {
-        case 0:
-            x86emu_fpu_R_fld(X86EMU_FPU_STKTOP, stkelem);
-            break;
-        case 1:
-            x86emu_fpu_R_fxch(X86EMU_FPU_STKTOP, stkelem);
-            break;
-        case 2:
-            switch (rl) {
-            case 0:
-                x86emu_fpu_R_nop();
-                break;
-            default:
-                x86emu_fpu_illegal();
-                break;
-            }
-        case 3:
-            x86emu_fpu_R_fstp(X86EMU_FPU_STKTOP, stkelem);
-            break;
-        case 4:
-            switch (rl) {
-            case 0:
-                x86emu_fpu_R_fchs(X86EMU_FPU_STKTOP);
-                break;
-            case 1:
-                x86emu_fpu_R_fabs(X86EMU_FPU_STKTOP);
-                break;
-            case 4:
-                x86emu_fpu_R_ftst(X86EMU_FPU_STKTOP);
-                break;
-            case 5:
-                x86emu_fpu_R_fxam(X86EMU_FPU_STKTOP);
-                break;
-            default:
-                /* 2,3,6,7 */
-                x86emu_fpu_illegal();
-                break;
-            }
-            break;
-
-        case 5:
-            switch (rl) {
-            case 0:
-                x86emu_fpu_R_fld1(X86EMU_FPU_STKTOP);
-                break;
-            case 1:
-                x86emu_fpu_R_fldl2t(X86EMU_FPU_STKTOP);
-                break;
-            case 2:
-                x86emu_fpu_R_fldl2e(X86EMU_FPU_STKTOP);
-                break;
-            case 3:
-                x86emu_fpu_R_fldpi(X86EMU_FPU_STKTOP);
-                break;
-            case 4:
-                x86emu_fpu_R_fldlg2(X86EMU_FPU_STKTOP);
-                break;
-            case 5:
-                x86emu_fpu_R_fldln2(X86EMU_FPU_STKTOP);
-                break;
-            case 6:
-                x86emu_fpu_R_fldz(X86EMU_FPU_STKTOP);
-                break;
-            default:
-                /* 7 */
-                x86emu_fpu_illegal();
-                break;
-            }
-            break;
-
-        case 6:
-            switch (rl) {
-            case 0:
-                x86emu_fpu_R_f2xm1(X86EMU_FPU_STKTOP);
-                break;
-            case 1:
-                x86emu_fpu_R_fyl2x(X86EMU_FPU_STKTOP);
-                break;
-            case 2:
-                x86emu_fpu_R_fptan(X86EMU_FPU_STKTOP);
-                break;
-            case 3:
-                x86emu_fpu_R_fpatan(X86EMU_FPU_STKTOP);
-                break;
-            case 4:
-                x86emu_fpu_R_fxtract(X86EMU_FPU_STKTOP);
-                break;
-            case 5:
-                x86emu_fpu_illegal();
-                break;
-            case 6:
-                x86emu_fpu_R_decstp();
-                break;
-            case 7:
-                x86emu_fpu_R_incstp();
-                break;
-            }
-            break;
-
-        case 7:
-            switch (rl) {
-            case 0:
-                x86emu_fpu_R_fprem(X86EMU_FPU_STKTOP);
-                break;
-            case 1:
-                x86emu_fpu_R_fyl2xp1(X86EMU_FPU_STKTOP);
-                break;
-            case 2:
-                x86emu_fpu_R_fsqrt(X86EMU_FPU_STKTOP);
-                break;
-            case 3:
-                x86emu_fpu_illegal();
-                break;
-            case 4:
-                x86emu_fpu_R_frndint(X86EMU_FPU_STKTOP);
-                break;
-            case 5:
-                x86emu_fpu_R_fscale(X86EMU_FPU_STKTOP);
-                break;
-            case 6:
-            case 7:
-            default:
-                x86emu_fpu_illegal();
-                break;
-            }
-            break;
-
-        default:
-            switch (rh) {
-            case 0:
-                x86emu_fpu_M_fld(X86EMU_FPU_FLOAT, destoffset);
-                break;
-            case 1:
-                x86emu_fpu_illegal();
-                break;
-            case 2:
-                x86emu_fpu_M_fst(X86EMU_FPU_FLOAT, destoffset);
-                break;
-            case 3:
-                x86emu_fpu_M_fstp(X86EMU_FPU_FLOAT, destoffset);
-                break;
-            case 4:
-                x86emu_fpu_M_fldenv(X86EMU_FPU_WORD, destoffset);
-                break;
-            case 5:
-                x86emu_fpu_M_fldcw(X86EMU_FPU_WORD, destoffset);
-                break;
-            case 6:
-                x86emu_fpu_M_fstenv(X86EMU_FPU_WORD, destoffset);
-                break;
-            case 7:
-                x86emu_fpu_M_fstcw(X86EMU_FPU_WORD, destoffset);
-                break;
-            }
-        }
-    }
-#else
     (void) destoffset;
     (void) stkelem;
-#endif                          /* X86EMU_FPU_PRESENT */
     DECODE_CLEAR_SEGOVR();
     END_OF_INSTR_NO_TRACE();
 }
@@ -354,43 +192,8 @@ x86emuOp_esc_coprocess_da(u8 X86EMU_UNUSED(op1))
         DECODE_PRINTF2("\tST(%d),ST\n", stkelem);
         break;
     }
-#ifdef X86EMU_FPU_PRESENT
-    switch (mod) {
-    case 3:
-        x86emu_fpu_illegal();
-        break;
-    default:
-        switch (rh) {
-        case 0:
-            x86emu_fpu_M_iadd(X86EMU_FPU_SHORT, destoffset);
-            break;
-        case 1:
-            x86emu_fpu_M_imul(X86EMU_FPU_SHORT, destoffset);
-            break;
-        case 2:
-            x86emu_fpu_M_icom(X86EMU_FPU_SHORT, destoffset);
-            break;
-        case 3:
-            x86emu_fpu_M_icomp(X86EMU_FPU_SHORT, destoffset);
-            break;
-        case 4:
-            x86emu_fpu_M_isub(X86EMU_FPU_SHORT, destoffset);
-            break;
-        case 5:
-            x86emu_fpu_M_isubr(X86EMU_FPU_SHORT, destoffset);
-            break;
-        case 6:
-            x86emu_fpu_M_idiv(X86EMU_FPU_SHORT, destoffset);
-            break;
-        case 7:
-            x86emu_fpu_M_idivr(X86EMU_FPU_SHORT, destoffset);
-            break;
-        }
-    }
-#else
     (void) destoffset;
     (void) stkelem;
-#endif
     DECODE_CLEAR_SEGOVR();
     END_OF_INSTR_NO_TRACE();
 }
@@ -456,66 +259,7 @@ x86emuOp_esc_coprocess_db(u8 X86EMU_UNUSED(op1))
     case 3:                    /* register to register */
         break;
     }
-#ifdef X86EMU_FPU_PRESENT
-    /* execute */
-    switch (mod) {
-    case 3:
-        switch (rh) {
-        case 4:
-            switch (rl) {
-            case 0:
-                x86emu_fpu_R_feni();
-                break;
-            case 1:
-                x86emu_fpu_R_fdisi();
-                break;
-            case 2:
-                x86emu_fpu_R_fclex();
-                break;
-            case 3:
-                x86emu_fpu_R_finit();
-                break;
-            default:
-                x86emu_fpu_illegal();
-                break;
-            }
-            break;
-        default:
-            x86emu_fpu_illegal();
-            break;
-        }
-        break;
-    default:
-        switch (rh) {
-        case 0:
-            x86emu_fpu_M_fild(X86EMU_FPU_SHORT, destoffset);
-            break;
-        case 1:
-            x86emu_fpu_illegal();
-            break;
-        case 2:
-            x86emu_fpu_M_fist(X86EMU_FPU_SHORT, destoffset);
-            break;
-        case 3:
-            x86emu_fpu_M_fistp(X86EMU_FPU_SHORT, destoffset);
-            break;
-        case 4:
-            x86emu_fpu_illegal();
-            break;
-        case 5:
-            x86emu_fpu_M_fld(X86EMU_FPU_LDBL, destoffset);
-            break;
-        case 6:
-            x86emu_fpu_illegal();
-            break;
-        case 7:
-            x86emu_fpu_M_fstp(X86EMU_FPU_LDBL, destoffset);
-            break;
-        }
-    }
-#else
     (void) destoffset;
-#endif
     DECODE_CLEAR_SEGOVR();
     END_OF_INSTR_NO_TRACE();
 }
@@ -571,69 +315,8 @@ x86emuOp_esc_coprocess_dc(u8 X86EMU_UNUSED(op1))
         DECODE_PRINTF2("\tST(%d),ST\n", stkelem);
         break;
     }
-#ifdef X86EMU_FPU_PRESENT
-    /* execute */
-    switch (mod) {
-    case 3:
-        switch (rh) {
-        case 0:
-            x86emu_fpu_R_fadd(stkelem, X86EMU_FPU_STKTOP);
-            break;
-        case 1:
-            x86emu_fpu_R_fmul(stkelem, X86EMU_FPU_STKTOP);
-            break;
-        case 2:
-            x86emu_fpu_R_fcom(stkelem, X86EMU_FPU_STKTOP);
-            break;
-        case 3:
-            x86emu_fpu_R_fcomp(stkelem, X86EMU_FPU_STKTOP);
-            break;
-        case 4:
-            x86emu_fpu_R_fsubr(stkelem, X86EMU_FPU_STKTOP);
-            break;
-        case 5:
-            x86emu_fpu_R_fsub(stkelem, X86EMU_FPU_STKTOP);
-            break;
-        case 6:
-            x86emu_fpu_R_fdivr(stkelem, X86EMU_FPU_STKTOP);
-            break;
-        case 7:
-            x86emu_fpu_R_fdiv(stkelem, X86EMU_FPU_STKTOP);
-            break;
-        }
-        break;
-    default:
-        switch (rh) {
-        case 0:
-            x86emu_fpu_M_fadd(X86EMU_FPU_DOUBLE, destoffset);
-            break;
-        case 1:
-            x86emu_fpu_M_fmul(X86EMU_FPU_DOUBLE, destoffset);
-            break;
-        case 2:
-            x86emu_fpu_M_fcom(X86EMU_FPU_DOUBLE, destoffset);
-            break;
-        case 3:
-            x86emu_fpu_M_fcomp(X86EMU_FPU_DOUBLE, destoffset);
-            break;
-        case 4:
-            x86emu_fpu_M_fsub(X86EMU_FPU_DOUBLE, destoffset);
-            break;
-        case 5:
-            x86emu_fpu_M_fsubr(X86EMU_FPU_DOUBLE, destoffset);
-            break;
-        case 6:
-            x86emu_fpu_M_fdiv(X86EMU_FPU_DOUBLE, destoffset);
-            break;
-        case 7:
-            x86emu_fpu_M_fdivr(X86EMU_FPU_DOUBLE, destoffset);
-            break;
-        }
-    }
-#else
     (void) destoffset;
     (void) stkelem;
-#endif
     DECODE_CLEAR_SEGOVR();
     END_OF_INSTR_NO_TRACE();
 }
@@ -685,59 +368,8 @@ x86emuOp_esc_coprocess_dd(u8 X86EMU_UNUSED(op1))
         DECODE_PRINTF2("\tST(%d),ST\n", stkelem);
         break;
     }
-#ifdef X86EMU_FPU_PRESENT
-    switch (mod) {
-    case 3:
-        switch (rh) {
-        case 0:
-            x86emu_fpu_R_ffree(stkelem);
-            break;
-        case 1:
-            x86emu_fpu_R_fxch(stkelem);
-            break;
-        case 2:
-            x86emu_fpu_R_fst(stkelem);  /* register version */
-            break;
-        case 3:
-            x86emu_fpu_R_fstp(stkelem); /* register version */
-            break;
-        default:
-            x86emu_fpu_illegal();
-            break;
-        }
-        break;
-    default:
-        switch (rh) {
-        case 0:
-            x86emu_fpu_M_fld(X86EMU_FPU_DOUBLE, destoffset);
-            break;
-        case 1:
-            x86emu_fpu_illegal();
-            break;
-        case 2:
-            x86emu_fpu_M_fst(X86EMU_FPU_DOUBLE, destoffset);
-            break;
-        case 3:
-            x86emu_fpu_M_fstp(X86EMU_FPU_DOUBLE, destoffset);
-            break;
-        case 4:
-            x86emu_fpu_M_frstor(X86EMU_FPU_WORD, destoffset);
-            break;
-        case 5:
-            x86emu_fpu_illegal();
-            break;
-        case 6:
-            x86emu_fpu_M_fsave(X86EMU_FPU_WORD, destoffset);
-            break;
-        case 7:
-            x86emu_fpu_M_fstsw(X86EMU_FPU_WORD, destoffset);
-            break;
-        }
-    }
-#else
     (void) destoffset;
     (void) stkelem;
-#endif
     DECODE_CLEAR_SEGOVR();
     END_OF_INSTR_NO_TRACE();
 }
@@ -795,71 +427,8 @@ x86emuOp_esc_coprocess_de(u8 X86EMU_UNUSED(op1))
         DECODE_PRINTF2("\tST(%d),ST\n", stkelem);
         break;
     }
-#ifdef X86EMU_FPU_PRESENT
-    switch (mod) {
-    case 3:
-        switch (rh) {
-        case 0:
-            x86emu_fpu_R_faddp(stkelem, X86EMU_FPU_STKTOP);
-            break;
-        case 1:
-            x86emu_fpu_R_fmulp(stkelem, X86EMU_FPU_STKTOP);
-            break;
-        case 2:
-            x86emu_fpu_R_fcomp(stkelem, X86EMU_FPU_STKTOP);
-            break;
-        case 3:
-            if (stkelem == 1)
-                x86emu_fpu_R_fcompp(stkelem, X86EMU_FPU_STKTOP);
-            else
-                x86emu_fpu_illegal();
-            break;
-        case 4:
-            x86emu_fpu_R_fsubrp(stkelem, X86EMU_FPU_STKTOP);
-            break;
-        case 5:
-            x86emu_fpu_R_fsubp(stkelem, X86EMU_FPU_STKTOP);
-            break;
-        case 6:
-            x86emu_fpu_R_fdivrp(stkelem, X86EMU_FPU_STKTOP);
-            break;
-        case 7:
-            x86emu_fpu_R_fdivp(stkelem, X86EMU_FPU_STKTOP);
-            break;
-        }
-        break;
-    default:
-        switch (rh) {
-        case 0:
-            x86emu_fpu_M_fiadd(X86EMU_FPU_WORD, destoffset);
-            break;
-        case 1:
-            x86emu_fpu_M_fimul(X86EMU_FPU_WORD, destoffset);
-            break;
-        case 2:
-            x86emu_fpu_M_ficom(X86EMU_FPU_WORD, destoffset);
-            break;
-        case 3:
-            x86emu_fpu_M_ficomp(X86EMU_FPU_WORD, destoffset);
-            break;
-        case 4:
-            x86emu_fpu_M_fisub(X86EMU_FPU_WORD, destoffset);
-            break;
-        case 5:
-            x86emu_fpu_M_fisubr(X86EMU_FPU_WORD, destoffset);
-            break;
-        case 6:
-            x86emu_fpu_M_fidiv(X86EMU_FPU_WORD, destoffset);
-            break;
-        case 7:
-            x86emu_fpu_M_fidivr(X86EMU_FPU_WORD, destoffset);
-            break;
-        }
-    }
-#else
     (void) destoffset;
     (void) stkelem;
-#endif
     DECODE_CLEAR_SEGOVR();
     END_OF_INSTR_NO_TRACE();
 }
@@ -918,59 +487,8 @@ x86emuOp_esc_coprocess_df(u8 X86EMU_UNUSED(op1))
         DECODE_PRINTF2("\tST(%d)\n", stkelem);
         break;
     }
-#ifdef X86EMU_FPU_PRESENT
-    switch (mod) {
-    case 3:
-        switch (rh) {
-        case 0:
-            x86emu_fpu_R_ffree(stkelem);
-            break;
-        case 1:
-            x86emu_fpu_R_fxch(stkelem);
-            break;
-        case 2:
-            x86emu_fpu_R_fst(stkelem);  /* register version */
-            break;
-        case 3:
-            x86emu_fpu_R_fstp(stkelem); /* register version */
-            break;
-        default:
-            x86emu_fpu_illegal();
-            break;
-        }
-        break;
-    default:
-        switch (rh) {
-        case 0:
-            x86emu_fpu_M_fild(X86EMU_FPU_WORD, destoffset);
-            break;
-        case 1:
-            x86emu_fpu_illegal();
-            break;
-        case 2:
-            x86emu_fpu_M_fist(X86EMU_FPU_WORD, destoffset);
-            break;
-        case 3:
-            x86emu_fpu_M_fistp(X86EMU_FPU_WORD, destoffset);
-            break;
-        case 4:
-            x86emu_fpu_M_fbld(X86EMU_FPU_BSD, destoffset);
-            break;
-        case 5:
-            x86emu_fpu_M_fild(X86EMU_FPU_LONG, destoffset);
-            break;
-        case 6:
-            x86emu_fpu_M_fbstp(X86EMU_FPU_BSD, destoffset);
-            break;
-        case 7:
-            x86emu_fpu_M_fistp(X86EMU_FPU_LONG, destoffset);
-            break;
-        }
-    }
-#else
     (void) destoffset;
     (void) stkelem;
-#endif
     DECODE_CLEAR_SEGOVR();
     END_OF_INSTR_NO_TRACE();
 }

--- a/hw/xfree86/x86emu/x86emu/fpu_regs.h
+++ b/hw/xfree86/x86emu/x86emu/fpu_regs.h
@@ -39,65 +39,6 @@
 #ifndef __X86EMU_FPU_REGS_H
 #define __X86EMU_FPU_REGS_H
 
-#ifdef X86_FPU_SUPPORT
-
-/* Basic 8087 register can hold any of the following values: */
-
-union x86_fpu_reg_u {
-    s8 tenbytes[10];
-    double dval;
-    float fval;
-    s16 sval;
-    s32 lval;
-};
-
-struct x86_fpu_reg {
-    union x86_fpu_reg_u reg;
-    char tag;
-};
-
-/*
- * Since we are not going to worry about the problems of aliasing
- * registers, every time a register is modified, its result type is
- * set in the tag fields for that register.  If some operation
- * attempts to access the type in a way inconsistent with its current
- * storage format, then we flag the operation.  If common, we'll
- * attempt the conversion.
- */
-
-#define  X86_FPU_VALID          0x80
-#define  X86_FPU_REGTYP(r)      ((r) & 0x7F)
-
-#define  X86_FPU_WORD           0x0
-#define  X86_FPU_SHORT          0x1
-#define  X86_FPU_LONG           0x2
-#define  X86_FPU_FLOAT          0x3
-#define  X86_FPU_DOUBLE         0x4
-#define  X86_FPU_LDBL           0x5
-#define  X86_FPU_BSD            0x6
-
-#define  X86_FPU_STKTOP  0
-
-struct x86_fpu_registers {
-    struct x86_fpu_reg x86_fpu_stack[8];
-    int x86_fpu_flags;
-    int x86_fpu_config;         /* rounding modes, etc. */
-    short x86_fpu_tos, x86_fpu_bos;
-};
-
-/*
- * There are two versions of the following macro.
- *
- * One version is for opcode D9, for which there are more than 32
- * instructions encoded in the second byte of the opcode.
- *
- * The other version, deals with all the other 7 i87 opcodes, for
- * which there are only 32 strings needed to describe the
- * instructions.
- */
-
-#endif                          /* X86_FPU_SUPPORT */
-
 #ifdef DEBUG
 #define DECODE_PRINTINSTR32(t,mod,rh,rl)     	\
 	DECODE_PRINTF((t)[((mod)<<3)+(rh)]);


### PR DESCRIPTION
The x86emuOp_esc_coprocess_d8..df handlers (x87 opcodes 0xD8-0xDF) each
carried an `#ifdef X86EMU_FPU_PRESENT` branch with the "real" x87
emulation and an `#else` stub that merely decodes and skips the
instruction.

X86EMU_FPU_PRESENT is never defined -- there is no build option for it --
so the stubs are what has always run. Worse, the real-FPU branches call
~96 distinct x86emu_fpu_*() routines that are defined nowhere in the tree,
so the code could not even link if the macro were defined: it is an
abandoned skeleton, not a switchable feature.

Drop the dead branches (keeping the decode + stub that actually runs, so
behavior is unchanged: x87 ops are still decoded and skipped) and the
matching dead `#ifdef X86_FPU_SUPPORT` register-file block in fpu_regs.h
(the DECODE_PRINTINSTR* debug macros there are kept). 541 lines of dead
code removed; libx86emu and int10 build unchanged.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
