### PR TITLE
.github: add OpenBSD build

### DIFF
--- a/.github/scripts/openbsd/install-pkg.sh
+++ b/.github/scripts/openbsd/install-pkg.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+set -e
+
+# OpenBSD ships X.Org (xenocara) in the base system under /usr/X11R6, so the X
+# libraries, the protocol headers and their pkg-config files are already
+# present — only the build tooling (and a few libs not in base) come from
+# packages via pkg_add. The vmactions OpenBSD image pre-configures the package
+# mirror (installurl / PKG_PATH), so a plain pkg_add resolves.
+
+# Retry a command a few times with linear backoff; package mirrors flake
+# transiently and a single network hiccup must not abort the whole CI run.
+retry() {
+    n=0
+    max=3
+    while true; do
+        n=$((n + 1))
+        if "$@"; then
+            return 0
+        fi
+        if [ "$n" -ge "$max" ]; then
+            echo "--> '$*' failed after $max attempts" >&2
+            return 1
+        fi
+        echo "--> '$*' failed (attempt $n/$max), retrying in $((n * 10))s ..." >&2
+        sleep $((n * 10))
+    done
+}
+
+echo "--> install build tooling + deps not in base"
+# -I: non-interactive (don't prompt on ambiguous matches). meson pulls python3.
+# epoll-shim: the server hard-requires it on the BSDs (meson.build) to emulate
+# the Linux epoll API; it is not part of the base system.
+retry pkg_add -I meson ninja pkgconf git epoll-shim

--- a/.github/scripts/openbsd/run-xserver-build.sh
+++ b/.github/scripts/openbsd/run-xserver-build.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -e
+
+./.github/scripts/openbsd/install-pkg.sh
+
+echo "--> running xserver build ...."
+export MESON_BUILDDIR=_build
+
+# OpenBSD's base X.Org lives under /usr/X11R6 (libs, headers, .pc files); pkg_add
+# packages (meson deps, epoll-shim, ...) install under /usr/local. Point
+# meson/pkg-config and the compiler/linker at both trees.
+PKG_CONFIG_PATH="/usr/X11R6/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:/usr/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+CPPFLAGS="-I/usr/X11R6/include -I/usr/local/include ${CPPFLAGS:-}"
+LDFLAGS="-L/usr/X11R6/lib -L/usr/local/lib ${LDFLAGS:-}"
+export PKG_CONFIG_PATH CPPFLAGS LDFLAGS
+
+rm -rf "$MESON_BUILDDIR"
+meson setup "$MESON_BUILDDIR" $MESON_ARGS
+meson configure "$MESON_BUILDDIR"
+meson compile -v -C "$MESON_BUILDDIR" $jobcount $ninja_args
+# tests not wired up for this platform yet
+# meson test -C "$MESON_BUILDDIR" --print-errorlogs $MESON_TEST_ARGS

--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -596,6 +596,65 @@ jobs:
                   usesh: true
                   run:     ./.github/scripts/solaris/run-xserver-build.sh
 
+    # OpenBSD build, run in an OpenBSD VM (vmactions, same mechanism as the
+    # other BSD jobs). OpenBSD ships X.Org (xenocara) in base, so only build
+    # tooling is installed; X libs (incl. Mesa) come from /usr/X11R6. glx stays
+    # enabled (indirect/software GLX against the base Mesa); dri2/dri3 stay off
+    # (direct rendering needs a working DRM/KMS, n/a in the headless VM).
+    # werror off while the platform is freshly added.
+    xserver-build-openbsd:
+        runs-on: ubuntu-latest
+        needs: ubuntu-fetch-pkg
+        timeout-minutes: 90
+        env:
+            MESON_ARGS: -Dwerror=false -Dxvfb=true -Dxnest=true -Dxorg=false -Dxephyr=false -Dxfbdev=false -Ddri2=false -Ddri3=false
+        steps:
+            - uses: actions/checkout@v6
+            - uses: ./.github/actions/ubuntu-pkg-cache
+
+            # VM boot / image provisioning flakes transiently; retry the whole
+            # VM step up to 3x, tearing down the leftover domain between tries
+            # (see .github/actions/libvirt-cleanup). Only the last attempt is
+            # allowed to fail the job; a success short-circuits the rest.
+            - name: run in OpenBSD VM (attempt 1)
+              id: openbsd-1
+              continue-on-error: true
+              uses: vmactions/openbsd-vm@v1
+              with:
+                  envs: 'MESON_ARGS'
+                  usesh: true
+                  run:     ./.github/scripts/openbsd/run-xserver-build.sh
+
+            - name: cleanup stale VM before retry
+              if: steps.openbsd-1.outcome == 'failure'
+              uses: ./.github/actions/libvirt-cleanup
+              with:
+                  guest: openbsd
+
+            - name: run in OpenBSD VM (attempt 2)
+              id: openbsd-2
+              if: steps.openbsd-1.outcome == 'failure'
+              continue-on-error: true
+              uses: vmactions/openbsd-vm@v1
+              with:
+                  envs: 'MESON_ARGS'
+                  usesh: true
+                  run:     ./.github/scripts/openbsd/run-xserver-build.sh
+
+            - name: cleanup stale VM before final retry
+              if: steps.openbsd-1.outcome == 'failure' && steps.openbsd-2.outcome == 'failure'
+              uses: ./.github/actions/libvirt-cleanup
+              with:
+                  guest: openbsd
+
+            - name: run in OpenBSD VM (attempt 3)
+              if: steps.openbsd-1.outcome == 'failure' && steps.openbsd-2.outcome == 'failure'
+              uses: vmactions/openbsd-vm@v1
+              with:
+                  envs: 'MESON_ARGS'
+                  usesh: true
+                  run:     ./.github/scripts/openbsd/run-xserver-build.sh
+
     xserver-build-alpine:
         runs-on: ubuntu-latest
         needs: ubuntu-fetch-pkg


### PR DESCRIPTION
Adds an OpenBSD CI lane (vmactions/openbsd-vm), mirroring the other BSD jobs.

- OpenBSD ships X.Org (xenocara) in base under /usr/X11R6, so only build tooling (meson/ninja/pkgconf/git) + epoll-shim are installed via pkg_add; the X libraries (incl. Mesa) come from base.
- 3x VM-boot retry with libvirt-cleanup, like the freebsd job.
- Config: Xvfb+Xnest, GLX on (indirect/software against base Mesa), dri2/dri3 off (direct rendering needs DRM/KMS, n/a in the headless VM).

Full build verified green on the wip/openbsd branch (382/382, all jobs success).

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>