### PR TITLE
Xext: xv: actually set the resources_initialized guard

### DIFF
--- a/Xext/xv/xvmain.c
+++ b/Xext/xv/xvmain.c
@@ -251,6 +251,8 @@ CreateResourceTypes(void)
         return FALSE;
     }
 
+    resources_initialized = true;
+
     return TRUE;
 }
 


### PR DESCRIPTION
Completes commit 75b627ed7e: the `resources_initialized` flag in `CreateResourceTypes()` is checked (early-return) but was never set to `true`, so the guard never trips.

Today it's harmless — the per-`serverGeneration` guards in `XvExtensionInit()`/`XvScreenInit()` still ensure `CreateResourceTypes()` is reached only once. But the flag is meant to be the real idempotency guard ("can be called from different angles"); without the write, any extra call re-runs all six `CreateNewResourceType()` calls, allocating fresh RESTYPE ids (leaking the finite id space) and reassigning the `XvRT*` globals.

Sets the flag once the resource types have been created.

Build-verified (`Xvfb` links clean).

---
Split out of #1455 (which drops those very `serverGeneration` guards and thus makes this flag load-bearing). **This PR should land first** — otherwise #1455 would reintroduce the double-creation it relies on this flag to prevent.