### PR TITLE
ci: bump go-x11proto test dependency to v0.0.4

### DIFF
--- a/.github/scripts/conf.sh
+++ b/.github/scripts/conf.sh
@@ -13,7 +13,7 @@ export PKG_CONFIG_PATH="$X11_PREFIX/lib/x86_64-linux-gnu/pkgconfig:$X11_PREFIX/l
 
 export PKG_PIGLIT_REF=59111996534f875ca88bce51f21fa2e6564895da
 export PKG_XTS_REF=6cf94400a09abecd6b86e4eb6441741acecd51f6
-export PKG_GOXPROTO_REF="${GOXPROTO_REF:-v0.0.3}"
+export PKG_GOXPROTO_REF="${GOXPROTO_REF:-v0.0.4}"
 export PKG_RENDERCHECK_REF=rendercheck-1.6
 export PKG_LIBDRM_REF=libdrm-2.4.121
 export PKG_LIBXCVT_REF=libxcvt-0.1.0

--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -7,7 +7,7 @@ env:
     MESON_BUILDDIR:  "__BUILD"
     X11_PREFIX:      /home/runner/x11
     X11_BUILD_DIR:   /home/runner/work/xserver/xserver/WORK/sources/3rdparty
-    GOXPROTO_REF:    v0.0.3
+    GOXPROTO_REF:    v0.0.4
 
 on:
     push:


### PR DESCRIPTION
Bumps the pinned go-x11proto (goxproto) CI test dependency from `v0.0.3` to `v0.0.4` (= X11Libre/go-x11proto@dbf9839).

v0.0.4 fixes a `panic: send on closed channel` race in the go-x11proto client's event read loop — `eventCh`/`errorCh` were closed by `Close()` while `readLoop` was still delivering an event. This surfaced as intermittent `go-xts` CI failures (e.g. `TestXSettingsWatch`).

Two pins bumped:
- `.github/scripts/conf.sh`: `PKG_GOXPROTO_REF` default
- `.github/workflows/build-xserver.yml`: `GOXPROTO_REF` env

(`install-prereq.sh` consumes `$PKG_GOXPROTO_REF`, so it tracks the bump automatically.)