### PR TITLE
(master) test: raise XTS suite timeout to 3600s to avoid CI flake

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -90,7 +90,7 @@ if get_option('xvfb')
     test('XTS',
         find_program('scripts/xvfb-piglit.sh'),
         env: piglit_env,
-        timeout: 1200,
+        timeout: 3600,
         suite: 'xvfb'
     )
 
@@ -131,7 +131,7 @@ if get_option('xvfb')
             test('XTS',
                 find_program('scripts/xephyr-glamor' + testsuite + '-piglit.sh'),
                 env: piglit_env,
-                timeout: 1200,
+                timeout: 3600,
                 suite: 'xephyr-glamor' + testsuite,
             )
 


### PR DESCRIPTION
The xvfb and xephyr-glamor XTS suites carry a meson timeout of 1200s.
XTS on llvmpipe is slow (the -debug build slower still), so the suite
occasionally exceeds 1200s and is killed by SIGTERM — reported as a
TIMEOUT with "Ok: 15, Fail: 0", i.e. a pure wall-clock overrun, not a
hung server or a real test failure. Raise the timeout to 3600s for
headroom; behaviour is otherwise unchanged.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
