### PR TITLE
(backport 25.2) glx: fix missing reply header / byte-swap in swapped pixel queries

### DIFF
--- a/Xext/glx/indirect_program.c
+++ b/Xext/glx/indirect_program.c
@@ -88,11 +88,17 @@ DoGetProgramString(struct __GLXclientStateRec *cl, GLbyte * pc,
 
         if (__glXErrorOccured()) {
             __GLX_BEGIN_REPLY(0);
+            if (do_swap)
+                __GLX_SWAP_REPLY_HEADER();
             __GLX_SEND_HEADER();
         }
         else {
             __GLX_BEGIN_REPLY(compsize);
             ((xGLXGetTexImageReply *) &reply)->width = compsize;
+            if (do_swap) {
+                __GLX_SWAP_REPLY_HEADER();
+                swapl(&((xGLXGetTexImageReply *) &reply)->width);
+            }
             __GLX_SEND_HEADER();
             __GLX_SEND_VOID_ARRAY(compsize);
         }

--- a/Xext/glx/indirect_program.c
+++ b/Xext/glx/indirect_program.c
@@ -52,7 +52,10 @@ DoGetProgramString(struct __GLXclientStateRec *cl, GLbyte * pc,
     xGLXVendorPrivateWithReplyReq *const req =
         (xGLXVendorPrivateWithReplyReq *) pc;
     int error;
-    __GLXcontext *const cx = __glXForceCurrent(cl, req->contextTag, &error);
+    __GLXcontext *const cx =
+        __glXForceCurrent(cl,
+                          do_swap ? bswap_32(req->contextTag) : req->contextTag,
+                          &error);
     ClientPtr client = cl->client;
 
     REQUEST_FIXED_SIZE(xGLXVendorPrivateWithReplyReq, 8);

--- a/Xext/glx/indirect_texture_compression.c
+++ b/Xext/glx/indirect_texture_compression.c
@@ -112,11 +112,14 @@ __glXDispSwap_GetCompressedTexImage(struct __GLXclientStateRec *cl, GLbyte * pc)
 
         if (__glXErrorOccured()) {
             __GLX_BEGIN_REPLY(0);
+            __GLX_SWAP_REPLY_HEADER();
             __GLX_SEND_HEADER();
         }
         else {
             __GLX_BEGIN_REPLY(compsize);
             ((xGLXGetTexImageReply *) &reply)->width = compsize;
+            __GLX_SWAP_REPLY_HEADER();
+            swapl(&((xGLXGetTexImageReply *) &reply)->width);
             __GLX_SEND_HEADER();
             __GLX_SEND_VOID_ARRAY(compsize);
         }

--- a/Xext/glx/singlepixswap.c
+++ b/Xext/glx/singlepixswap.c
@@ -267,6 +267,7 @@ GetSeparableFilter(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     if (__glXErrorOccured()) {
         __GLX_BEGIN_REPLY(0);
         __GLX_SWAP_REPLY_HEADER();
+        __GLX_SEND_HEADER();
     }
     else {
         __GLX_BEGIN_REPLY(compsize + compsize2);
@@ -275,6 +276,7 @@ GetSeparableFilter(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
         swapl(&height);
         ((xGLXGetSeparableFilterReply *) &reply)->width = width;
         ((xGLXGetSeparableFilterReply *) &reply)->height = height;
+        __GLX_SEND_HEADER();
         __GLX_SEND_VOID_ARRAY(compsize + compsize2);
     }
 
@@ -353,6 +355,7 @@ GetConvolutionFilter(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     if (__glXErrorOccured()) {
         __GLX_BEGIN_REPLY(0);
         __GLX_SWAP_REPLY_HEADER();
+        __GLX_SEND_HEADER();
     }
     else {
         __GLX_BEGIN_REPLY(compsize);
@@ -361,6 +364,7 @@ GetConvolutionFilter(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
         swapl(&height);
         ((xGLXGetConvolutionFilterReply *) &reply)->width = width;
         ((xGLXGetConvolutionFilterReply *) &reply)->height = height;
+        __GLX_SEND_HEADER();
         __GLX_SEND_VOID_ARRAY(compsize);
     }
 
@@ -433,12 +437,14 @@ GetHistogram(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     if (__glXErrorOccured()) {
         __GLX_BEGIN_REPLY(0);
         __GLX_SWAP_REPLY_HEADER();
+        __GLX_SEND_HEADER();
     }
     else {
         __GLX_BEGIN_REPLY(compsize);
         __GLX_SWAP_REPLY_HEADER();
         swapl(&width);
         ((xGLXGetHistogramReply *) &reply)->width = width;
+        __GLX_SEND_HEADER();
         __GLX_SEND_VOID_ARRAY(compsize);
     }
 
@@ -505,10 +511,12 @@ GetMinmax(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     if (__glXErrorOccured()) {
         __GLX_BEGIN_REPLY(0);
         __GLX_SWAP_REPLY_HEADER();
+        __GLX_SEND_HEADER();
     }
     else {
         __GLX_BEGIN_REPLY(compsize);
         __GLX_SWAP_REPLY_HEADER();
+        __GLX_SEND_HEADER();
         __GLX_SEND_VOID_ARRAY(compsize);
     }
 
@@ -581,12 +589,14 @@ GetColorTable(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     if (__glXErrorOccured()) {
         __GLX_BEGIN_REPLY(0);
         __GLX_SWAP_REPLY_HEADER();
+        __GLX_SEND_HEADER();
     }
     else {
         __GLX_BEGIN_REPLY(compsize);
         __GLX_SWAP_REPLY_HEADER();
         swapl(&width);
         ((xGLXGetColorTableReply *) &reply)->width = width;
+        __GLX_SEND_HEADER();
         __GLX_SEND_VOID_ARRAY(compsize);
     }
 


### PR DESCRIPTION
Backport of [#3155](https://github.com/X11Libre/xserver/pull/3155) (master)

Master: #3155 ✅ merged

| Branch | PR | Status |
|---|---|---|
| release/25.2 | #3159 | ⬜ open ← this PR |

<sub>Auto-generated backport dashboard — links the source master PR and sibling backports with their merge status.</sub>

---

Backport of the swapped-GLX-reply correctness fixes from master (#3155) to
`release/25.2`. Clean cherry-pick (3 commits); `release/25.2` carries the same
GLX code as master for these handlers.

All three issues affect only byte-swapped clients (opposite byte order from the
server), which is why they went unnoticed:

1. **Missing reply header in swapped pixel queries** (`singlepixswap.c`) — the
   swapped `GetSeparableFilter` / `GetConvolutionFilter` / `GetHistogram` /
   `GetMinmax` / `GetColorTable` handlers built and swapped the reply header but
   never sent it (`__GLX_SEND_HEADER()` missing in both branches), so the client
   received the payload with no reply header and desynchronised.

2. **Reply not byte-swapped in swapped GetCompressedTexImage / GetProgramString**
   (`indirect_texture_compression.c`, `indirect_program.c`) — neither the reply
   header nor the `width` field was byte-swapped on the swapped path.

3. **contextTag not byte-swapped in swapped GetProgramString**
   (`indirect_program.c`) — `DoGetProgramString()` read `req->contextTag` raw on
   the swapped path, so `__glXForceCurrent()` failed to find the context and the
   request errored out before any reply.

Built locally; the GLX protocol unit tests pass. (The pre-existing
`pyxtest/test_render.py` and `pyxtest/test_present.py` failures in my local
ASAN/Xvfb sandbox are unrelated — they fail the same way on the clean
`release/25.2` base.)

Note: `release/25.0` and `release/25.1` do **not** contain
`singlepixswap.c` / `indirect_program.c` / `indirect_texture_compression.c`
(different GLX dispatch layout), so this fix does not cherry-pick there as-is;
an adapted backport would be a separate effort if those releases need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
