### PR TITLE
glx: migrate reply paths to the rpcbuf reply mechanism

### DIFF
--- a/Xext/glx/glxcmds.c
+++ b/Xext/glx/glxcmds.c
@@ -2365,9 +2365,8 @@ __glXDisp_QueryServerString(__GLXclientState * cl, GLbyte * pc)
 {
     ClientPtr client = cl->client;
     xGLXQueryServerStringReq *req = (xGLXQueryServerStringReq *) pc;
-    size_t n, length;
+    size_t n;
     const char *ptr;
-    char *buf;
     __GLXscreen *pGlxScreen;
     int err;
 
@@ -2395,36 +2394,17 @@ __glXDisp_QueryServerString(__GLXclientState * cl, GLbyte * pc)
     }
 
     n = strlen(ptr) + 1;
-    length = __GLX_PAD(n) >> 2;
+
+    /* string payload needs no byte-swapping (array of chars) */
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    x_rpcbuf_write_binary_pad(&rpcbuf, ptr, n);
 
     xGLXQueryServerStringReply reply = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = length,
-        .n = n
+        .n = n,
     };
+    X_REPLY_FIELD_CARD32(n);
 
-    buf = calloc(length, 4);
-    if (buf == NULL) {
-        return BadAlloc;
-    }
-    memcpy(buf, ptr, n);
-
-    if (client->swapped) {
-        swaps(&reply.sequenceNumber);
-        swapl(&reply.length);
-        swapl(&reply.n);
-        WriteToClient(client, sizeof(xGLXQueryServerStringReply), &reply);
-        /** no swap is needed for an array of chars **/
-        WriteToClient(client, length << 2, buf);
-    }
-    else {
-        WriteToClient(client, sizeof(xGLXQueryServerStringReply), &reply);
-        WriteToClient(client, (int) (length << 2), buf);
-    }
-
-    free(buf);
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int

--- a/Xext/glx/glxcmds.c
+++ b/Xext/glx/glxcmds.c
@@ -1001,22 +1001,7 @@ DoGetFBConfigs(__GLXclientState * cl, unsigned screen)
     if (!validGlxScreen(cl->client, screen, &pGlxScreen, &err))
         return err;
 
-    xGLXGetFBConfigsReply reply = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = __GLX_FBCONFIG_ATTRIBS_LENGTH * pGlxScreen->numFBConfigs,
-        .numFBConfigs = pGlxScreen->numFBConfigs,
-        .numAttribs = __GLX_TOTAL_FBCONFIG_ATTRIBS
-    };
-
-    if (client->swapped) {
-        swaps(&reply.sequenceNumber);
-        swapl(&reply.length);
-        swapl(&reply.numFBConfigs);
-        swapl(&reply.numAttribs);
-    }
-
-    WriteToClient(client, sizeof(xGLXGetFBConfigsReply), &reply);
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
     for (modes = pGlxScreen->fbconfigs; modes != NULL; modes = modes->next) {
         p = 0;
@@ -1089,13 +1074,18 @@ DoGetFBConfigs(__GLXclientState * cl, unsigned screen)
         }
         assert(p == __GLX_FBCONFIG_ATTRIBS_LENGTH);
 
-        if (client->swapped) {
-            SwapLongs((CARD32*)buf, __GLX_FBCONFIG_ATTRIBS_LENGTH);
-        }
-        WriteToClient(client, __GLX_SIZE_CARD32 * __GLX_FBCONFIG_ATTRIBS_LENGTH,
-                      (char *) buf);
+        /* attribs are CARD32; rpcbuf byte-swaps them when client->swapped */
+        x_rpcbuf_write_CARD32s(&rpcbuf, buf, __GLX_FBCONFIG_ATTRIBS_LENGTH);
     }
-    return Success;
+
+    xGLXGetFBConfigsReply reply = {
+        .numFBConfigs = pGlxScreen->numFBConfigs,
+        .numAttribs = __GLX_TOTAL_FBCONFIG_ATTRIBS
+    };
+    X_REPLY_FIELD_CARD32(numFBConfigs);
+    X_REPLY_FIELD_CARD32(numAttribs);
+
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int

--- a/Xext/glx/indirect_program.c
+++ b/Xext/glx/indirect_program.c
@@ -66,7 +66,7 @@ DoGetProgramString(struct __GLXclientStateRec *cl, GLbyte * pc,
         GLenum pname;
         GLint compsize = 0;
         char *answer = NULL, answerBuffer[200];
-        xGLXSingleReply reply = { 0, };
+        xGLXGetTexImageReply reply = { 0 };
 
         if (do_swap) {
             target = (GLenum) bswap_32(*(int *) (pc + 0));
@@ -89,24 +89,14 @@ DoGetProgramString(struct __GLXclientStateRec *cl, GLbyte * pc,
             get_program_string(target, pname, (GLubyte *) answer);
         }
 
-        if (__glXErrorOccured()) {
-            __GLX_BEGIN_REPLY(0);
-            if (do_swap)
-                __GLX_SWAP_REPLY_HEADER();
-            __GLX_SEND_HEADER();
-        }
-        else {
-            __GLX_BEGIN_REPLY(compsize);
-            ((xGLXGetTexImageReply *) &reply)->width = compsize;
-            if (do_swap) {
-                __GLX_SWAP_REPLY_HEADER();
-                swapl(&((xGLXGetTexImageReply *) &reply)->width);
-            }
-            __GLX_SEND_HEADER();
-            __GLX_SEND_VOID_ARRAY(compsize);
+        x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+        if (!__glXErrorOccured()) {
+            reply.width = compsize;
+            X_REPLY_FIELD_CARD32(width);
+            x_rpcbuf_write_binary_pad(&rpcbuf, answer, compsize);
         }
 
-        error = Success;
+        error = X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     }
 
     return error;

--- a/Xext/glx/indirect_texture_compression.c
+++ b/Xext/glx/indirect_texture_compression.c
@@ -50,7 +50,7 @@ __glXDisp_GetCompressedTexImage(struct __GLXclientStateRec *cl, GLbyte * pc)
         const GLint level = *(GLint *) (pc + 4);
         GLint compsize = 0;
         char *answer = NULL, answerBuffer[200];
-        xGLXSingleReply reply = { 0, };
+        xGLXGetTexImageReply reply = { 0 };
 
         glGetTexLevelParameteriv(target, level, GL_TEXTURE_COMPRESSED_IMAGE_SIZE,
                                  &compsize);
@@ -63,18 +63,14 @@ __glXDisp_GetCompressedTexImage(struct __GLXclientStateRec *cl, GLbyte * pc)
             GetCompressedTexImageARB(target, level, answer);
         }
 
-        if (__glXErrorOccured()) {
-            __GLX_BEGIN_REPLY(0);
-            __GLX_SEND_HEADER();
-        }
-        else {
-            __GLX_BEGIN_REPLY(compsize);
-            ((xGLXGetTexImageReply *) &reply)->width = compsize;
-            __GLX_SEND_HEADER();
-            __GLX_SEND_VOID_ARRAY(compsize);
+        x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+        if (!__glXErrorOccured()) {
+            reply.width = compsize;
+            X_REPLY_FIELD_CARD32(width);
+            x_rpcbuf_write_binary_pad(&rpcbuf, answer, compsize);
         }
 
-        error = Success;
+        error = X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     }
 
     return error;
@@ -97,7 +93,7 @@ __glXDispSwap_GetCompressedTexImage(struct __GLXclientStateRec *cl, GLbyte * pc)
         const GLint level = (GLint) bswap_32(*(int *) (pc + 4));
         GLint compsize = 0;
         char *answer = NULL, answerBuffer[200];
-        xGLXSingleReply reply = { 0, };
+        xGLXGetTexImageReply reply = { 0 };
 
         glGetTexLevelParameteriv(target, level, GL_TEXTURE_COMPRESSED_IMAGE_SIZE,
                                  &compsize);
@@ -110,21 +106,14 @@ __glXDispSwap_GetCompressedTexImage(struct __GLXclientStateRec *cl, GLbyte * pc)
             GetCompressedTexImageARB(target, level, answer);
         }
 
-        if (__glXErrorOccured()) {
-            __GLX_BEGIN_REPLY(0);
-            __GLX_SWAP_REPLY_HEADER();
-            __GLX_SEND_HEADER();
-        }
-        else {
-            __GLX_BEGIN_REPLY(compsize);
-            ((xGLXGetTexImageReply *) &reply)->width = compsize;
-            __GLX_SWAP_REPLY_HEADER();
-            swapl(&((xGLXGetTexImageReply *) &reply)->width);
-            __GLX_SEND_HEADER();
-            __GLX_SEND_VOID_ARRAY(compsize);
+        x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+        if (!__glXErrorOccured()) {
+            reply.width = compsize;
+            X_REPLY_FIELD_CARD32(width);
+            x_rpcbuf_write_binary_pad(&rpcbuf, answer, compsize);
         }
 
-        error = Success;
+        error = X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
     }
 
     return error;

--- a/Xext/glx/indirect_util.c
+++ b/Xext/glx/indirect_util.c
@@ -167,23 +167,23 @@ __glXSendReplySwap(ClientPtr client, const void *data, size_t elements,
         reply_ints = bytes_to_int32(elements * element_size);
     }
 
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    /* data is already byte-swapped by the caller */
+    x_rpcbuf_write_CARD8s(&rpcbuf, data, reply_ints * 4);
+
     xGLXSingleReply reply = {
-        .length = bswap_32(reply_ints),
-        .type = X_Reply,
-        .sequenceNumber = bswap_16(client->sequence),
-        .size = bswap_32(elements),
-        .retval = bswap_32(retval),
+        .size = elements,
+        .retval = retval,
     };
+    X_REPLY_FIELD_CARD32(size);
+    X_REPLY_FIELD_CARD32(retval);
 
     /* Single element goes in reply padding; don't leak uninitialized data. */
     if (elements == 1) {
         (void) memcpy(&reply.pad3, data, element_size);
     }
-    WriteToClient(client, sizeof(xGLXSingleReply), &reply);
 
-    if (reply_ints != 0) {
-        WriteToClient(client, reply_ints * 4, data);
-    }
+    X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static int

--- a/Xext/glx/single2.c
+++ b/Xext/glx/single2.c
@@ -385,20 +385,17 @@ DoGetString(__GLXclientState * cl, GLbyte * pc, GLboolean need_swap)
         length = strlen((const char *) string) + 1;
     }
 
-    xGLXSingleReply reply = { 0 };
-    __GLX_BEGIN_REPLY(length);
-    __GLX_PUT_SIZE(length);
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    /* string is an array of chars; no byte-swapping needed */
+    x_rpcbuf_write_binary_pad(&rpcbuf, string, length);
 
-    if (need_swap) {
-        __GLX_SWAP_REPLY_SIZE();
-        __GLX_SWAP_REPLY_HEADER();
-    }
+    xGLXSingleReply reply = {
+        .size = length,
+    };
+    X_REPLY_FIELD_CARD32(size);
 
-    __GLX_SEND_HEADER();
-    WriteToClient(client, length, string);
     free(buf);
-
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int

--- a/Xext/glx/single2.c
+++ b/Xext/glx/single2.c
@@ -247,12 +247,8 @@ __glXDisp_Finish(__GLXclientState * cl, GLbyte * pc)
     glFinish();
 
     /* Send empty reply packet to indicate finish is finished */
-    client = cl->client;
-
     xGLXSingleReply reply = { 0 };
-    __GLX_BEGIN_REPLY(0);
-    __GLX_SEND_HEADER();
-    return Success;
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 #define SEPARATOR " "

--- a/Xext/glx/single2swap.c
+++ b/Xext/glx/single2swap.c
@@ -256,12 +256,7 @@ __glXDispSwap_Finish(__GLXclientState * cl, GLbyte * pc)
 
     /* Send empty reply packet to indicate finish is finished */
     xGLXSingleReply reply = { 0 };
-    __GLX_BEGIN_REPLY(0);
-    __GLX_PUT_RETVAL(0);
-    __GLX_SWAP_REPLY_HEADER();
-    __GLX_SEND_HEADER();
-
-    return Success;
+    return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
 int

--- a/Xext/glx/single2swap.c
+++ b/Xext/glx/single2swap.c
@@ -119,12 +119,8 @@ __glXDispSwap_RenderMode(__GLXclientState * cl, GLbyte * pc)
 {
     ClientPtr client = cl->client;
     __GLXcontext *cx;
-    GLint nitems = 0, retBytes = 0, retval, newModeCheck;
-    GLubyte *retBuffer = NULL;
+    GLint nitems = 0, retval, newModeCheck;
     GLenum newMode;
-
-    __GLX_DECLARE_SWAP_VARIABLES;
-    __GLX_DECLARE_SWAP_ARRAY_VARIABLES;
     int error;
 
     REQUEST_FIXED_SIZE(xGLXSingleReq, 4);
@@ -139,6 +135,10 @@ __glXDispSwap_RenderMode(__GLXclientState * cl, GLbyte * pc)
     swapl((CARD32*)pc);
     newMode = *(GLenum *) pc;
     retval = glRenderMode(newMode);
+
+    /* feedback/select payload is CARD32-sized; rpcbuf byte-swaps it when
+       client->swapped */
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
     /* Check that render mode worked */
     glGetIntegerv(GL_RENDER_MODE, &newModeCheck);
@@ -166,9 +166,7 @@ __glXDispSwap_RenderMode(__GLXclientState * cl, GLbyte * pc)
         else {
             nitems = retval;
         }
-        retBytes = nitems * __GLX_SIZE_FLOAT32;
-        retBuffer = (GLubyte *) cx->feedbackBuf;
-        __GLX_SWAP_FLOAT_ARRAY((GLbyte *) retBuffer, nitems);
+        x_rpcbuf_write_CARD32s(&rpcbuf, (CARD32*)cx->feedbackBuf, nitems);
         cx->renderMode = newMode;
         break;
     case GL_SELECT:
@@ -197,9 +195,7 @@ __glXDispSwap_RenderMode(__GLXclientState * cl, GLbyte * pc)
             }
             nitems = bp - cx->selectBuf;
         }
-        retBytes = nitems * __GLX_SIZE_CARD32;
-        retBuffer = (GLubyte *) cx->selectBuf;
-        SwapLongs((CARD32*)retBuffer, nitems);
+        x_rpcbuf_write_CARD32s(&rpcbuf, (CARD32*)cx->selectBuf, nitems);
         cx->renderMode = newMode;
         break;
     }
@@ -210,23 +206,15 @@ __glXDispSwap_RenderMode(__GLXclientState * cl, GLbyte * pc)
      */
  noChangeAllowed:;
     xGLXRenderModeReply reply = {
-        .type = X_Reply,
-        .sequenceNumber = client->sequence,
-        .length = nitems,
         .retval = retval,
         .size = nitems,
         .newMode = newMode
     };
-    swaps(&reply.sequenceNumber);
-    swapl(&reply.length);
-    swapl(&reply.retval);
-    swapl(&reply.size);
-    swapl(&reply.newMode);
-    WriteToClient(client, sizeof(xGLXRenderModeReply), &reply);
-    if (retBytes) {
-        WriteToClient(client, retBytes, retBuffer);
-    }
-    return Success;
+    X_REPLY_FIELD_CARD32(retval);
+    X_REPLY_FIELD_CARD32(size);
+    X_REPLY_FIELD_CARD32(newMode);
+
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int

--- a/Xext/glx/singlepix.c
+++ b/Xext/glx/singlepix.c
@@ -78,16 +78,11 @@ __glXDisp_ReadPixels(__GLXclientState * cl, GLbyte * pc)
                  *(GLsizei *) (pc + 8), *(GLsizei *) (pc + 12),
                  *(GLenum *) (pc + 16), *(GLenum *) (pc + 20), answer);
 
-    if (__glXErrorOccured()) {
-        __GLX_BEGIN_REPLY(0);
-        __GLX_SEND_HEADER();
-    }
-    else {
-        __GLX_BEGIN_REPLY(compsize);
-        __GLX_SEND_HEADER();
-        __GLX_SEND_VOID_ARRAY(compsize);
-    }
-    return Success;
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    if (!__glXErrorOccured())
+        x_rpcbuf_write_binary_pad(&rpcbuf, answer, compsize);
+
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -101,7 +96,7 @@ __glXDisp_GetTexImage(__GLXclientState * cl, GLbyte * pc)
     int error;
     char *answer, answerBuffer[200];
     GLint width = 0, height = 0, depth = 1;
-    xGLXSingleReply reply = { 0, };
+    xGLXGetTexImageReply reply = { 0 };
 
     REQUEST_FIXED_SIZE(xGLXSingleReq, 20);
 
@@ -137,19 +132,18 @@ __glXDisp_GetTexImage(__GLXclientState * cl, GLbyte * pc)
     glGetTexImage(*(GLenum *) (pc + 0), *(GLint *) (pc + 4),
                   *(GLenum *) (pc + 8), *(GLenum *) (pc + 12), answer);
 
-    if (__glXErrorOccured()) {
-        __GLX_BEGIN_REPLY(0);
-        __GLX_SEND_HEADER();
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    if (!__glXErrorOccured()) {
+        reply.width = width;
+        reply.height = height;
+        reply.depth = depth;
+        X_REPLY_FIELD_CARD32(width);
+        X_REPLY_FIELD_CARD32(height);
+        X_REPLY_FIELD_CARD32(depth);
+        x_rpcbuf_write_binary_pad(&rpcbuf, answer, compsize);
     }
-    else {
-        __GLX_BEGIN_REPLY(compsize);
-        ((xGLXGetTexImageReply *) &reply)->width = width;
-        ((xGLXGetTexImageReply *) &reply)->height = height;
-        ((xGLXGetTexImageReply *) &reply)->depth = depth;
-        __GLX_SEND_HEADER();
-        __GLX_SEND_VOID_ARRAY(compsize);
-    }
-    return Success;
+
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -179,16 +173,11 @@ __glXDisp_GetPolygonStipple(__GLXclientState * cl, GLbyte * pc)
     __glXClearErrorOccured();
     glGetPolygonStipple((GLubyte *) answer);
 
-    if (__glXErrorOccured()) {
-        __GLX_BEGIN_REPLY(0);
-        __GLX_SEND_HEADER();
-    }
-    else {
-        __GLX_BEGIN_REPLY(128);
-        __GLX_SEND_HEADER();
-        __GLX_SEND_BYTE_ARRAY(128);
-    }
-    return Success;
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    if (!__glXErrorOccured())
+        x_rpcbuf_write_binary_pad(&rpcbuf, answer, 128);
+
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static int
@@ -202,7 +191,7 @@ GetSeparableFilter(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     int error;
     char *answer, answerBuffer[200];
     GLint width = 0, height = 0;
-    xGLXSingleReply reply = { 0, };
+    xGLXGetSeparableFilterReply reply = { 0 };
 
     cx = __glXForceCurrent(cl, tag, &error);
     if (!cx) {
@@ -237,19 +226,16 @@ GetSeparableFilter(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     glGetSeparableFilter(*(GLenum *) (pc + 0), *(GLenum *) (pc + 4),
                          *(GLenum *) (pc + 8), answer, answer + compsize, NULL);
 
-    if (__glXErrorOccured()) {
-        __GLX_BEGIN_REPLY(0);
-        __GLX_SEND_HEADER();
-    }
-    else {
-        __GLX_BEGIN_REPLY(compsize + compsize2);
-        ((xGLXGetSeparableFilterReply *) &reply)->width = width;
-        ((xGLXGetSeparableFilterReply *) &reply)->height = height;
-        __GLX_SEND_HEADER();
-        __GLX_SEND_VOID_ARRAY(compsize + compsize2);
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    if (!__glXErrorOccured()) {
+        reply.width = width;
+        reply.height = height;
+        X_REPLY_FIELD_CARD32(width);
+        X_REPLY_FIELD_CARD32(height);
+        x_rpcbuf_write_binary_pad(&rpcbuf, answer, compsize + compsize2);
     }
 
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -281,7 +267,7 @@ GetConvolutionFilter(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     int error;
     char *answer, answerBuffer[200];
     GLint width = 0, height = 0;
-    xGLXSingleReply reply = { 0, };
+    xGLXGetConvolutionFilterReply reply = { 0 };
 
     cx = __glXForceCurrent(cl, tag, &error);
     if (!cx) {
@@ -314,19 +300,16 @@ GetConvolutionFilter(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     glGetConvolutionFilter(*(GLenum *) (pc + 0), *(GLenum *) (pc + 4),
                            *(GLenum *) (pc + 8), answer);
 
-    if (__glXErrorOccured()) {
-        __GLX_BEGIN_REPLY(0);
-        __GLX_SEND_HEADER();
-    }
-    else {
-        __GLX_BEGIN_REPLY(compsize);
-        ((xGLXGetConvolutionFilterReply *) &reply)->width = width;
-        ((xGLXGetConvolutionFilterReply *) &reply)->height = height;
-        __GLX_SEND_HEADER();
-        __GLX_SEND_VOID_ARRAY(compsize);
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    if (!__glXErrorOccured()) {
+        reply.width = width;
+        reply.height = height;
+        X_REPLY_FIELD_CARD32(width);
+        X_REPLY_FIELD_CARD32(height);
+        x_rpcbuf_write_binary_pad(&rpcbuf, answer, compsize);
     }
 
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -358,7 +341,7 @@ GetHistogram(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     int error;
     char *answer, answerBuffer[200];
     GLint width = 0;
-    xGLXSingleReply reply = { 0, };
+    xGLXGetHistogramReply reply = { 0 };
 
     cx = __glXForceCurrent(cl, tag, &error);
     if (!cx) {
@@ -385,18 +368,14 @@ GetHistogram(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     __glXClearErrorOccured();
     glGetHistogram(target, reset, format, type, answer);
 
-    if (__glXErrorOccured()) {
-        __GLX_BEGIN_REPLY(0);
-        __GLX_SEND_HEADER();
-    }
-    else {
-        __GLX_BEGIN_REPLY(compsize);
-        ((xGLXGetHistogramReply *) &reply)->width = width;
-        __GLX_SEND_HEADER();
-        __GLX_SEND_VOID_ARRAY(compsize);
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    if (!__glXErrorOccured()) {
+        reply.width = width;
+        X_REPLY_FIELD_CARD32(width);
+        x_rpcbuf_write_binary_pad(&rpcbuf, answer, compsize);
     }
 
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -449,17 +428,11 @@ GetMinmax(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     __glXClearErrorOccured();
     glGetMinmax(target, reset, format, type, answer);
 
-    if (__glXErrorOccured()) {
-        __GLX_BEGIN_REPLY(0);
-        __GLX_SEND_HEADER();
-    }
-    else {
-        __GLX_BEGIN_REPLY(compsize);
-        __GLX_SEND_HEADER();
-        __GLX_SEND_VOID_ARRAY(compsize);
-    }
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    if (!__glXErrorOccured())
+        x_rpcbuf_write_binary_pad(&rpcbuf, answer, compsize);
 
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -491,7 +464,7 @@ GetColorTable(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     int error;
     char *answer, answerBuffer[200];
     GLint width = 0;
-    xGLXSingleReply reply = { 0, };
+    xGLXGetColorTableReply reply = { 0 };
 
     cx = __glXForceCurrent(cl, tag, &error);
     if (!cx) {
@@ -518,18 +491,14 @@ GetColorTable(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     glGetColorTable(*(GLenum *) (pc + 0), *(GLenum *) (pc + 4),
                     *(GLenum *) (pc + 8), answer);
 
-    if (__glXErrorOccured()) {
-        __GLX_BEGIN_REPLY(0);
-        __GLX_SEND_HEADER();
-    }
-    else {
-        __GLX_BEGIN_REPLY(compsize);
-        ((xGLXGetColorTableReply *) &reply)->width = width;
-        __GLX_SEND_HEADER();
-        __GLX_SEND_VOID_ARRAY(compsize);
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    if (!__glXErrorOccured()) {
+        reply.width = width;
+        X_REPLY_FIELD_CARD32(width);
+        x_rpcbuf_write_binary_pad(&rpcbuf, answer, compsize);
     }
 
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int

--- a/Xext/glx/singlepixswap.c
+++ b/Xext/glx/singlepixswap.c
@@ -85,18 +85,11 @@ __glXDispSwap_ReadPixels(__GLXclientState * cl, GLbyte * pc)
                  *(GLsizei *) (pc + 8), *(GLsizei *) (pc + 12),
                  *(GLenum *) (pc + 16), *(GLenum *) (pc + 20), answer);
 
-    if (__glXErrorOccured()) {
-        __GLX_BEGIN_REPLY(0);
-        __GLX_SWAP_REPLY_HEADER();
-        __GLX_SEND_HEADER();
-    }
-    else {
-        __GLX_BEGIN_REPLY(compsize);
-        __GLX_SWAP_REPLY_HEADER();
-        __GLX_SEND_HEADER();
-        __GLX_SEND_VOID_ARRAY(compsize);
-    }
-    return Success;
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    if (!__glXErrorOccured())
+        x_rpcbuf_write_binary_pad(&rpcbuf, answer, compsize);
+
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -111,7 +104,7 @@ __glXDispSwap_GetTexImage(__GLXclientState * cl, GLbyte * pc)
     int error;
     char *answer, answerBuffer[200];
     GLint width = 0, height = 0, depth = 1;
-    xGLXSingleReply reply = { 0, };
+    xGLXGetTexImageReply reply = { 0 };
 
     REQUEST_FIXED_SIZE(xGLXSingleReq, 20);
 
@@ -153,24 +146,18 @@ __glXDispSwap_GetTexImage(__GLXclientState * cl, GLbyte * pc)
     glGetTexImage(*(GLenum *) (pc + 0), *(GLint *) (pc + 4),
                   *(GLenum *) (pc + 8), *(GLenum *) (pc + 12), answer);
 
-    if (__glXErrorOccured()) {
-        __GLX_BEGIN_REPLY(0);
-        __GLX_SWAP_REPLY_HEADER();
-        __GLX_SEND_HEADER();
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    if (!__glXErrorOccured()) {
+        reply.width = width;
+        reply.height = height;
+        reply.depth = depth;
+        X_REPLY_FIELD_CARD32(width);
+        X_REPLY_FIELD_CARD32(height);
+        X_REPLY_FIELD_CARD32(depth);
+        x_rpcbuf_write_binary_pad(&rpcbuf, answer, compsize);
     }
-    else {
-        __GLX_BEGIN_REPLY(compsize);
-        __GLX_SWAP_REPLY_HEADER();
-        swapl(&width);
-        swapl(&height);
-        swapl(&depth);
-        ((xGLXGetTexImageReply *) &reply)->width = width;
-        ((xGLXGetTexImageReply *) &reply)->height = height;
-        ((xGLXGetTexImageReply *) &reply)->depth = depth;
-        __GLX_SEND_HEADER();
-        __GLX_SEND_VOID_ARRAY(compsize);
-    }
-    return Success;
+
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -199,18 +186,11 @@ __glXDispSwap_GetPolygonStipple(__GLXclientState * cl, GLbyte * pc)
 
     __glXClearErrorOccured();
     glGetPolygonStipple((GLubyte *) answer);
-    if (__glXErrorOccured()) {
-        __GLX_BEGIN_REPLY(0);
-        __GLX_SWAP_REPLY_HEADER();
-        __GLX_SEND_HEADER();
-    }
-    else {
-        __GLX_BEGIN_REPLY(128);
-        __GLX_SWAP_REPLY_HEADER();
-        __GLX_SEND_HEADER();
-        __GLX_SEND_BYTE_ARRAY(128);
-    }
-    return Success;
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    if (!__glXErrorOccured())
+        x_rpcbuf_write_binary_pad(&rpcbuf, answer, 128);
+
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 static int
@@ -225,7 +205,7 @@ GetSeparableFilter(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
 
     char *answer, answerBuffer[200];
     GLint width = 0, height = 0;
-    xGLXSingleReply reply = { 0, };
+    xGLXGetSeparableFilterReply reply = { 0 };
 
     cx = __glXForceCurrent(cl, tag, &error);
     if (!cx) {
@@ -264,23 +244,16 @@ GetSeparableFilter(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     glGetSeparableFilter(*(GLenum *) (pc + 0), *(GLenum *) (pc + 4),
                          *(GLenum *) (pc + 8), answer, answer + compsize, NULL);
 
-    if (__glXErrorOccured()) {
-        __GLX_BEGIN_REPLY(0);
-        __GLX_SWAP_REPLY_HEADER();
-        __GLX_SEND_HEADER();
-    }
-    else {
-        __GLX_BEGIN_REPLY(compsize + compsize2);
-        __GLX_SWAP_REPLY_HEADER();
-        swapl(&width);
-        swapl(&height);
-        ((xGLXGetSeparableFilterReply *) &reply)->width = width;
-        ((xGLXGetSeparableFilterReply *) &reply)->height = height;
-        __GLX_SEND_HEADER();
-        __GLX_SEND_VOID_ARRAY(compsize + compsize2);
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    if (!__glXErrorOccured()) {
+        reply.width = width;
+        reply.height = height;
+        X_REPLY_FIELD_CARD32(width);
+        X_REPLY_FIELD_CARD32(height);
+        x_rpcbuf_write_binary_pad(&rpcbuf, answer, compsize + compsize2);
     }
 
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -315,7 +288,7 @@ GetConvolutionFilter(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
 
     char *answer, answerBuffer[200];
     GLint width = 0, height = 0;
-    xGLXSingleReply reply = { 0, };
+    xGLXGetConvolutionFilterReply reply = { 0 };
 
     cx = __glXForceCurrent(cl, tag, &error);
     if (!cx) {
@@ -352,23 +325,16 @@ GetConvolutionFilter(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     glGetConvolutionFilter(*(GLenum *) (pc + 0), *(GLenum *) (pc + 4),
                            *(GLenum *) (pc + 8), answer);
 
-    if (__glXErrorOccured()) {
-        __GLX_BEGIN_REPLY(0);
-        __GLX_SWAP_REPLY_HEADER();
-        __GLX_SEND_HEADER();
-    }
-    else {
-        __GLX_BEGIN_REPLY(compsize);
-        __GLX_SWAP_REPLY_HEADER();
-        swapl(&width);
-        swapl(&height);
-        ((xGLXGetConvolutionFilterReply *) &reply)->width = width;
-        ((xGLXGetConvolutionFilterReply *) &reply)->height = height;
-        __GLX_SEND_HEADER();
-        __GLX_SEND_VOID_ARRAY(compsize);
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    if (!__glXErrorOccured()) {
+        reply.width = width;
+        reply.height = height;
+        X_REPLY_FIELD_CARD32(width);
+        X_REPLY_FIELD_CARD32(height);
+        x_rpcbuf_write_binary_pad(&rpcbuf, answer, compsize);
     }
 
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -403,7 +369,7 @@ GetHistogram(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
 
     char *answer, answerBuffer[200];
     GLint width = 0;
-    xGLXSingleReply reply = { 0, };
+    xGLXGetHistogramReply reply = { 0 };
 
     cx = __glXForceCurrent(cl, tag, &error);
     if (!cx) {
@@ -434,21 +400,14 @@ GetHistogram(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     __glXClearErrorOccured();
     glGetHistogram(target, reset, format, type, answer);
 
-    if (__glXErrorOccured()) {
-        __GLX_BEGIN_REPLY(0);
-        __GLX_SWAP_REPLY_HEADER();
-        __GLX_SEND_HEADER();
-    }
-    else {
-        __GLX_BEGIN_REPLY(compsize);
-        __GLX_SWAP_REPLY_HEADER();
-        swapl(&width);
-        ((xGLXGetHistogramReply *) &reply)->width = width;
-        __GLX_SEND_HEADER();
-        __GLX_SEND_VOID_ARRAY(compsize);
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    if (!__glXErrorOccured()) {
+        reply.width = width;
+        X_REPLY_FIELD_CARD32(width);
+        x_rpcbuf_write_binary_pad(&rpcbuf, answer, compsize);
     }
 
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -508,19 +467,11 @@ GetMinmax(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     __glXClearErrorOccured();
     glGetMinmax(target, reset, format, type, answer);
 
-    if (__glXErrorOccured()) {
-        __GLX_BEGIN_REPLY(0);
-        __GLX_SWAP_REPLY_HEADER();
-        __GLX_SEND_HEADER();
-    }
-    else {
-        __GLX_BEGIN_REPLY(compsize);
-        __GLX_SWAP_REPLY_HEADER();
-        __GLX_SEND_HEADER();
-        __GLX_SEND_VOID_ARRAY(compsize);
-    }
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    if (!__glXErrorOccured())
+        x_rpcbuf_write_binary_pad(&rpcbuf, answer, compsize);
 
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int
@@ -555,7 +506,7 @@ GetColorTable(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
 
     char *answer, answerBuffer[200];
     GLint width = 0;
-    xGLXSingleReply reply = { 0, };
+    xGLXGetColorTableReply reply = { 0 };
 
     cx = __glXForceCurrent(cl, tag, &error);
     if (!cx) {
@@ -586,21 +537,14 @@ GetColorTable(__GLXclientState * cl, GLbyte * pc, GLXContextTag tag)
     glGetColorTable(*(GLenum *) (pc + 0), *(GLenum *) (pc + 4),
                     *(GLenum *) (pc + 8), answer);
 
-    if (__glXErrorOccured()) {
-        __GLX_BEGIN_REPLY(0);
-        __GLX_SWAP_REPLY_HEADER();
-        __GLX_SEND_HEADER();
-    }
-    else {
-        __GLX_BEGIN_REPLY(compsize);
-        __GLX_SWAP_REPLY_HEADER();
-        swapl(&width);
-        ((xGLXGetColorTableReply *) &reply)->width = width;
-        __GLX_SEND_HEADER();
-        __GLX_SEND_VOID_ARRAY(compsize);
+    x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
+    if (!__glXErrorOccured()) {
+        reply.width = width;
+        X_REPLY_FIELD_CARD32(width);
+        x_rpcbuf_write_binary_pad(&rpcbuf, answer, compsize);
     }
 
-    return Success;
+    return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
 }
 
 int

--- a/Xext/glx/unpack.h
+++ b/Xext/glx/unpack.h
@@ -51,20 +51,6 @@
 #define __GLX_GET_DOUBLE(dst,src)	(dst) = *((GLdouble*)(src))
 #endif
 
-#define __GLX_BEGIN_REPLY(size) \
-	reply.length = __GLX_PAD((size)) >> 2;	\
-	reply.type = X_Reply; 			\
-	reply.sequenceNumber = client->sequence;
-
-#define __GLX_SEND_HEADER() \
-	WriteToClient (client, sizeof(xGLXSingleReply), &reply);
-
-#define __GLX_PUT_RETVAL(a) \
-	reply.retval = (a);
-
-#define __GLX_PUT_SIZE(a) \
-	reply.size = (a);
-
 /*
 ** Get a buffer to hold returned data, with the given alignment.  If we have
 ** to realloc, allocate size+align, in case the pointer has to be bumped for
@@ -91,26 +77,6 @@
     } else {								 \
 	(res) = (char *)answerBuffer;					 \
     }
-
-#define __GLX_SEND_BYTE_ARRAY(len) \
-	WriteToClient(client, __GLX_PAD((len)*__GLX_SIZE_INT8), answer)
-
-#define __GLX_SEND_SHORT_ARRAY(len) \
-	WriteToClient(client, __GLX_PAD((len)*__GLX_SIZE_INT16), answer)
-
-#define __GLX_SEND_INT_ARRAY(len) \
-	WriteToClient(client, (len)*__GLX_SIZE_INT32, answer)
-
-#define __GLX_SEND_FLOAT_ARRAY(len) \
-	WriteToClient(client, (len)*__GLX_SIZE_FLOAT32, answer)
-
-#define __GLX_SEND_DOUBLE_ARRAY(len) \
-	WriteToClient(client, (len)*__GLX_SIZE_FLOAT64, answer)
-
-#define __GLX_SEND_VOID_ARRAY(len)  __GLX_SEND_BYTE_ARRAY((len))
-#define __GLX_SEND_UBYTE_ARRAY(len)  __GLX_SEND_BYTE_ARRAY((len))
-#define __GLX_SEND_USHORT_ARRAY(len) __GLX_SEND_SHORT_ARRAY((len))
-#define __GLX_SEND_UINT_ARRAY(len)  __GLX_SEND_INT_ARRAY((len))
 
 /*
 ** PERFORMANCE NOTE:
@@ -161,15 +127,5 @@
 	    __GLX_SWAP_FLOAT(swapPC);		\
 	    swapPC += __GLX_SIZE_FLOAT32;	\
 	}
-
-#define __GLX_SWAP_REPLY_HEADER() \
-	swaps(&reply.sequenceNumber); \
-	swapl(&reply.length);
-
-#define __GLX_SWAP_REPLY_RETVAL() \
-	swpal(&reply.retval)
-
-#define __GLX_SWAP_REPLY_SIZE() \
-	swapl(&reply.size)
 
 #endif                          /* !__GLX_unpack_h__ */


### PR DESCRIPTION
Migrate the GLX reply paths off direct `WriteToClient()` / the old
`__GLX_BEGIN_REPLY` / `__GLX_SEND_HEADER` / `__GLX_SEND_*_ARRAY` reply macros
onto the modern rpcbuf reply path (`x_rpcbuf_t` + `X_SEND_REPLY_WITH_RPCBUF` /
`X_SEND_REPLY_SIMPLE`), which already underpins the DIX reply helpers.

After this series, `Xext/glx/` no longer calls `WriteToClient()` directly.

## Unified reply pattern

Every reply handler now follows the same shape, keyed on `client->swapped`:

```c
x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
/* payload: typed writes (auto byte-swap) or raw bytes/strings */
x_rpcbuf_write_CARD32s(&rpcbuf, data, n);     /* element-swapped */
x_rpcbuf_write_binary_pad(&rpcbuf, bytes, n); /* raw image/string */

xGLX...Reply reply = { .field = ... };        /* host order */
X_REPLY_FIELD_CARD32(field);                   /* swap iff client->swapped */
return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf); /* length + header automatic */
```

- The reply length is derived from the payload by `X_SEND_REPLY_WITH_RPCBUF()`;
  the header (`type`/`length`/`sequenceNumber`) is set and byte-swapped there.
- Reply-specific fields are swapped via `X_REPLY_FIELD_CARD*()` (no-op for
  unswapped clients), so the swapped and non-swapped handlers become essentially
  identical and the hand-rolled `swapl()` / `__GLX_SWAP_*` drop out.
- Image/string payloads are raw byte streams (`x_rpcbuf_write_binary_pad`);
  element arrays use the typed `x_rpcbuf_write_CARD32s` etc. so the buffer's
  `swapped` flag does the per-element swap.

## Scope / notes

- Touches only `Xext/glx/*` (9 files), net **−206 lines**. No protocol/ABI
  change.
- Builds on the already-merged export of `x_rpcbuf_write_binary_pad()`
  (commit a1da0dafd1); requires no further symbol exports.
- The swapped-reply **correctness bugs** found while doing this work were sent
  separately and are already on master (#3155) and backported to 25.2 (#3159);
  this series is pure refactor on top of them.
- Built locally, GLX protocol unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
