### PR TITLE
(master) os: split WriteToClient() into exported frontend + internal dixWriteToClient()

### DIFF
--- a/Xext/record/record.c
+++ b/Xext/record/record.c
@@ -47,6 +47,7 @@ and Jim Haggerty of Metheus.
 #include "dix/screenint_priv.h"
 #include "miext/extinit_priv.h"
 #include "os/client_priv.h"
+#include "os/io_priv.h"
 #include "os/mathx_priv.h"
 #include "os/osdep.h"
 #include "Xext/panoramiX/panoramiX.h"
@@ -243,13 +244,13 @@ RecordFlushReplyBuffer(RecordContextPtr pContext,
         return;
     ++pContext->inFlush;
     if (pContext->numBufBytes)
-        WriteToClient(pContext->pRecordingClient, pContext->numBufBytes,
+        dixWriteToClient(pContext->pRecordingClient, pContext->numBufBytes,
                       pContext->replyBuffer);
     pContext->numBufBytes = 0;
     if (len1)
-        WriteToClient(pContext->pRecordingClient, len1, data1);
+        dixWriteToClient(pContext->pRecordingClient, len1, data1);
     if (len2)
-        WriteToClient(pContext->pRecordingClient, len2, data2);
+        dixWriteToClient(pContext->pRecordingClient, len2, data2);
     --pContext->inFlush;
 }                               /* RecordFlushReplyBuffer */
 
@@ -2275,7 +2276,7 @@ ProcRecordGetContext(ClientPtr client)
         swapl(&reply.length);
         swapl(&reply.nClients);
     }
-    WriteToClient(client, sizeof(xRecordGetContextReply), &reply);
+    dixWriteToClient(client, sizeof(xRecordGetContextReply), &reply);
 
     /* write all the CLIENT_INFOs */
 
@@ -2292,8 +2293,8 @@ ProcRecordGetContext(ClientPtr client)
             rci.clientResource = pRCAP->pClientIDs[i];
             if (client->swapped)
                 swapl(&rci.clientResource);
-            WriteToClient(client, sizeof(xRecordClientInfo), &rci);
-            WriteToClient(client, sizeof(xRecordRange) * pri->nRanges,
+            dixWriteToClient(client, sizeof(xRecordClientInfo), &rci);
+            dixWriteToClient(client, sizeof(xRecordRange) * pri->nRanges,
                           pri->pRanges);
         }
     }

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -125,6 +125,7 @@ Equipment Corporation.
 #include "os/auth.h"
 #include "os/client_priv.h"
 #include "os/ddx_priv.h"
+#include "os/io_priv.h"
 #include "os/mathx_priv.h"
 #include "os/osdep.h"
 #include "os/probes_priv.h"
@@ -1382,7 +1383,7 @@ ProcQueryFont(ClientPtr client)
             SwapFont(reply, TRUE);
         }
 
-        WriteToClient(client, rlength, reply);
+        dixWriteToClient(client, rlength, reply);
         free(reply);
         return Success;
     }
@@ -3848,8 +3849,8 @@ SendConnSetup(ClientPtr client, const char *reason)
         if (client->swapped)
             WriteSConnSetupPrefix(client, &csp);
         else
-            WriteToClient(client, sz_xConnSetupPrefix, &csp);
-        WriteToClient(client, (int) csp.lengthReason, reason);
+            dixWriteToClient(client, sz_xConnSetupPrefix, &csp);
+        dixWriteToClient(client, (int) csp.lengthReason, reason);
         return client->noClientException = -1;
     }
 
@@ -3902,8 +3903,8 @@ SendConnSetup(ClientPtr client, const char *reason)
                              lConnectionInfo);
     }
     else {
-        WriteToClient(client, sizeof(xConnSetupPrefix), lconnSetupPrefix);
-        WriteToClient(client, (int) (lconnSetupPrefix->length << 2),
+        dixWriteToClient(client, sizeof(xConnSetupPrefix), lconnSetupPrefix);
+        dixWriteToClient(client, (int) (lconnSetupPrefix->length << 2),
 		      lConnectionInfo);
     }
     client->clientState = ClientStateRunning;

--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -29,6 +29,7 @@
 #include "include/os.h"
 #include "include/resource.h"
 #include "include/window.h"
+#include "os/io_priv.h"       /* dixWriteToClient */
 
 /* pad scanline to a longword */
 #define BITMAP_SCANLINE_UNIT    32
@@ -753,7 +754,7 @@ static inline Atom dixGetAtomID(const char *name) {
  *
  * @param client      pointer to the client (ClientPtr)
  * @param event       pointer to the event
- * @return            return value of WriteToClient
+ * @return            return value of dixWriteToClient
  */
 static inline int xmitClientEvent(ClientPtr pClient, xEvent ev)
 {
@@ -762,7 +763,7 @@ static inline int xmitClientEvent(ClientPtr pClient, xEvent ev)
     if (pClient->swapped)
         swaps(&ev.u.u.sequenceNumber);
 
-    return WriteToClient(pClient, sizeof(xEvent), &ev);
+    return dixWriteToClient(pClient, sizeof(xEvent), &ev);
 }
 
 /*

--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -69,6 +69,7 @@ Equipment Corporation.
 #include "include/misc.h"
 #include "include/gcstruct.h"
 #include "os/auth.h"
+#include "os/io_priv.h"
 #include "os/log_priv.h"
 #include "Xext/xf86bigfont/xf86bigfontsrv.h"
 
@@ -1106,8 +1107,8 @@ doListFontsWithInfo(ClientPtr client, struct list_fonts_with_info_closure *c)
                     pby += 4;
                 }
             }
-            WriteToClient(client, length, reply);
-            WriteToClient(client, namelen, name);
+            dixWriteToClient(client, length, reply);
+            dixWriteToClient(client, namelen, name);
             if (pFontInfo == &fontInfo) {
                 free(fontInfo.props);
                 free(fontInfo.isStringProp);

--- a/dix/events.c
+++ b/dix/events.c
@@ -138,6 +138,7 @@ Equipment Corporation.
 #include "os/bug_priv.h"
 #include "os/client_priv.h"
 #include "os/fmt.h"
+#include "os/io_priv.h"
 #include "os/log_priv.h"
 #include "os/probes_priv.h"
 #include "Xext/panoramiX/panoramiX.h"
@@ -6146,14 +6147,14 @@ WriteEventsToClient(ClientPtr pClient, int count, xEvent *events)
             (*EventSwapVector[eventFrom->u.u.type & 0177])
                 (eventFrom, eventTo);
 
-            WriteToClient(pClient, eventlength, eventTo);
+            dixWriteToClient(pClient, eventlength, eventTo);
         }
     }
     else {
         /* only one GenericEvent, remember? that means either count is 1 and
          * eventlength is arbitrary or eventlength is 32 and count doesn't
          * matter. And we're all set. Woohoo. */
-        WriteToClient(pClient, count * eventlength, events);
+        dixWriteToClient(pClient, count * eventlength, events);
     }
 }
 

--- a/dix/request_priv.h
+++ b/dix/request_priv.h
@@ -11,20 +11,20 @@
 #include "include/dix.h"
 #include "include/dixstruct.h"
 #include "include/misc.h"    /* bytes_to_int32 */
-#include "include/os.h"      /* WriteToClient */
+#include "os/io_priv.h"      /* dixWriteToClient */
 
 /*
  * @brief write rpc buffer to client and then clear it
  *
  * @param pClient the client to write buffer to
  * @param rpcbuf  the buffer whose contents will be written
- * @return the result of WriteToClient() call
+ * @return the result of dixWriteToClient() call
  */
 static inline ssize_t WriteRpcbufToClient(ClientPtr pClient,
                                           x_rpcbuf_t *rpcbuf) {
     /* explicitly casting between (s)size_t and int - should be safe,
        since payloads are always small enough to easily fit into int. */
-    ssize_t ret = WriteToClient(pClient,
+    ssize_t ret = dixWriteToClient(pClient,
                                 (int)rpcbuf->wpos,
                                 rpcbuf->buffer);
     x_rpcbuf_clear(rpcbuf);
@@ -57,7 +57,7 @@ static inline int __write_reply_hdr_and_rpcbuf(
          swapl(&reply->length);
     }
 
-    WriteToClient(pClient, (int)hdrLen, hdrData);
+    dixWriteToClient(pClient, (int)hdrLen, hdrData);
     WriteRpcbufToClient(pClient, rpcbuf);
 
     return Success;
@@ -76,7 +76,7 @@ static inline int __write_reply_hdr_simple(
          swapl(&reply->length);
     }
 
-    WriteToClient(pClient, (int)hdrLen, hdrData);
+    dixWriteToClient(pClient, (int)hdrLen, hdrData);
     return Success;
 }
 

--- a/dix/swaprep.c
+++ b/dix/swaprep.c
@@ -52,6 +52,7 @@ SOFTWARE.
 
 #include "dix/dix_priv.h"
 #include "include/misc.h"
+#include "os/io_priv.h"
 
 #include "dixstruct.h"
 #include "scrnintstr.h"
@@ -590,7 +591,7 @@ WriteSConnectionInfo(ClientPtr pClient, unsigned long size, char *pInfo)
         return;
     }
     SwapConnSetupInfo(pInfo, pInfoTBase);
-    WriteToClient(pClient, (int) size, pInfoTBase);
+    dixWriteToClient(pClient, (int) size, pInfoTBase);
     free(pInfoTBase);
 }
 
@@ -610,7 +611,7 @@ WriteSConnSetupPrefix(ClientPtr pClient, xConnSetupPrefix * pcsp)
     xConnSetupPrefix cspT;
 
     SwapConnSetupPrefix(pcsp, &cspT);
-    WriteToClient(pClient, sizeof(cspT), &cspT);
+    dixWriteToClient(pClient, sizeof(cspT), &cspT);
 }
 
 /*

--- a/include/meson.build
+++ b/include/meson.build
@@ -277,6 +277,12 @@ conf_data.set('X_REGISTRY_REQUEST', build_registry_request ? '1' : false)
 conf_data.set('HAVE_SHA1_IN_' + sha1.to_upper(), '1', description: 'Use @0@ SHA1 functions'.format(sha1))
 conf_data.set('HAVE_LIBUNWIND', get_option('libunwind'))
 
+debug_writetoclient = get_option('debug_writetoclient')
+conf_data.set('CONFIG_DEBUG_WRITETOCLIENT',
+              debug_writetoclient != 'none' ? '1' : false)
+conf_data.set('CONFIG_DEBUG_WRITETOCLIENT_BACKTRACE',
+              debug_writetoclient == 'backtrace' ? '1' : false)
+
 conf_data.set('HAVE_APM', (build_apm or build_acpi) ? '1' : false)
 conf_data.set('HAVE_ACPI', build_acpi ? '1' : false)
 

--- a/include/os.h
+++ b/include/os.h
@@ -104,6 +104,19 @@ typedef struct _NewClientRec *NewClientPtr;
 
 extern _X_EXPORT int ReadFdFromClient(ClientPtr client);
 
+/**
+ * @brief write @p count bytes from @p buf into the client's output buffer
+ *
+ * @deprecated Legacy entry point, kept for ABI compatibility. Drivers and
+ *             external modules should not write to clients directly; this
+ *             remains exported only for existing out-of-tree users. In-tree
+ *             code uses the internal dixWriteToClient() worker instead.
+ *
+ * @param who    the client to write to
+ * @param count  number of bytes to write
+ * @param buf    data to write
+ * @return       number of bytes buffered, 0 on no-op, -1 on error
+ */
 extern _X_EXPORT int WriteToClient(ClientPtr /*who */ , int /*count */ ,
                                    const void * /*buf */ );
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -153,6 +153,12 @@ option('xpbproxy', type: 'boolean', value: false,
 option('libunwind', type: 'boolean', value: false,
         description: 'Use libunwind for backtrace reporting')
 
+option('debug_writetoclient', type: 'combo',
+        choices: ['none', 'caller', 'backtrace'], value: 'none',
+        description: 'Debug logging of calls to the exported WriteToClient() ' +
+                     'frontend (caller = lightweight return address, ' +
+                     'backtrace = full stack)')
+
 option('docs', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
         description: 'Build documentation')
 option('devel-docs', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',

--- a/os/io.c
+++ b/os/io.c
@@ -761,7 +761,7 @@ OutputBufferMakeRoomAndFlush(ClientPtr who, OsCommPtr oc, const void* extra_buf,
 }
 
 /*****************
- * WriteToClient
+ * dixWriteToClient
  *    Copies buf into ClientPtr.buf if it fits (with padding), else
  *    flushes ClientPtr.buf and buf to client.  As of this writing,
  *    every use of WriteToClient is cast to void, and the result
@@ -769,10 +769,13 @@ OutputBufferMakeRoomAndFlush(ClientPtr who, OsCommPtr oc, const void* extra_buf,
  *    that are sending several chunks of data and want to break
  *    out of a loop on error.  Thus, we will leave the type of
  *    this routine as int.
+ *
+ *    This is the internal worker; WriteToClient() is the exported
+ *    frontend (see below).
  *****************/
 
 int
-WriteToClient(ClientPtr who, int count, const void *__buf)
+dixWriteToClient(ClientPtr who, int count, const void *__buf)
 {
     OsCommPtr oc;
     int padBytes;
@@ -894,6 +897,19 @@ WriteToClient(ClientPtr who, int count, const void *__buf)
         oco->count += padBytes;
     }
     return count;
+}
+
+/*****************
+ * WriteToClient
+ *    Exported (legacy) frontend for dixWriteToClient(). Kept for ABI
+ *    compatibility with external drivers / modules. In-tree callers use
+ *    dixWriteToClient() directly.
+ *****************/
+
+int
+WriteToClient(ClientPtr who, int count, const void *buf)
+{
+    return dixWriteToClient(who, count, buf);
 }
 
  /********************

--- a/os/io.c
+++ b/os/io.c
@@ -53,6 +53,17 @@ SOFTWARE.
 
 #include <dix-config.h>
 
+/* optional debug logging of the exported WriteToClient() frontend.
+ * the lightweight 'caller' variant resolves the return address via dladdr(),
+ * so pull in <dlfcn.h> (needs _GNU_SOURCE) before any other system header. */
+#if defined(CONFIG_DEBUG_WRITETOCLIENT) && \
+    !defined(CONFIG_DEBUG_WRITETOCLIENT_BACKTRACE) && defined(HAVE_DLFCN_H)
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <dlfcn.h>
+#endif
+
 #include <assert.h>
 #undef DEBUG_COMMUNICATION
 
@@ -909,6 +920,24 @@ dixWriteToClient(ClientPtr who, int count, const void *__buf)
 int
 WriteToClient(ClientPtr who, int count, const void *buf)
 {
+#ifdef CONFIG_DEBUG_WRITETOCLIENT
+#ifdef CONFIG_DEBUG_WRITETOCLIENT_BACKTRACE
+    ErrorF("WriteToClient: client=%d count=%d\n", who ? who->index : -1, count);
+    xorg_backtrace();
+#else
+    void *ra = __builtin_return_address(0);
+#ifdef HAVE_DLFCN_H
+    Dl_info info;
+    if (dladdr(ra, &info) && info.dli_sname) {
+        ErrorF("WriteToClient: client=%d count=%d caller=%s+%p\n",
+               who ? who->index : -1, count, info.dli_sname, ra);
+    }
+    else
+#endif
+        ErrorF("WriteToClient: client=%d count=%d caller=%p\n",
+               who ? who->index : -1, count, ra);
+#endif
+#endif
     return dixWriteToClient(who, count, buf);
 }
 

--- a/os/io_priv.h
+++ b/os/io_priv.h
@@ -24,6 +24,26 @@ typedef struct {
     int flags;
 } OsCommRec, *OsCommPtr;
 
+/**
+ * @brief write @p count bytes from @p buf into the client's output buffer
+ *
+ * This is the internal worker behind the exported WriteToClient() frontend
+ * and does the actual buffering / flushing. All in-tree callers should use
+ * this directly instead of the exported WriteToClient().
+ *
+ * @note Even though this is an internal API, the symbol is exported
+ *       (_X_EXPORT) because in-tree modules that may be built as separate
+ *       shared objects (e.g. GLX) need to link against it. It is NOT meant
+ *       to be used by external drivers / modules — those keep using the
+ *       legacy WriteToClient() entry point.
+ *
+ * @param who    the client to write to
+ * @param count  number of bytes to write
+ * @param buf    data to write
+ * @return       number of bytes buffered, 0 on no-op, -1 on error
+ */
+_X_EXPORT int dixWriteToClient(ClientPtr who, int count, const void *buf);
+
 int FlushClient(ClientPtr who, OsCommPtr oc);
 void FreeOsBuffers(OsCommPtr oc);
 void CloseDownFileDescriptor(OsCommPtr oc);

--- a/test/meson.build
+++ b/test/meson.build
@@ -236,7 +236,7 @@ if build_xorg
        ldwraps = [
         '-Wl,-wrap,dixLookupWindow',
         '-Wl,-wrap,dixLookupResourceOwner',
-        '-Wl,-wrap,WriteToClient',
+        '-Wl,-wrap,dixWriteToClient',
         '-Wl,-wrap,dixLookupWindow',
         '-Wl,-wrap,XISetEventMask',
         '-Wl,-wrap,AddResource',

--- a/test/xi1/protocol-xchangedevicecontrol.c
+++ b/test/xi1/protocol-xchangedevicecontrol.c
@@ -42,7 +42,7 @@
 
 #include "protocol-common.h"
 
-DECLARE_WRAP_FUNCTION(WriteToClient, void, ClientPtr client, int len, void *data);
+DECLARE_WRAP_FUNCTION(dixWriteToClient, void, ClientPtr client, int len, void *data);
 
 extern ClientRec client_window;
 static ClientRec client_request;
@@ -96,7 +96,7 @@ test_ChangeDeviceControl(void)
 
     request_init(request, ChangeDeviceControl);
 
-    wrapped_WriteToClient  = reply_ChangeDeviceControl;
+    wrapped_dixWriteToClient  = reply_ChangeDeviceControl;
 
     client_request = init_client(request->length, request);
 

--- a/test/xi2/protocol-common.c
+++ b/test/xi2/protocol-common.c
@@ -285,9 +285,9 @@ init_simple(void)
     devices = init_devices();
 }
 
-WRAP_FUNCTION(WriteToClient, void, ClientPtr client, int len, void *data)
+WRAP_FUNCTION(dixWriteToClient, void, ClientPtr client, int len, void *data)
 {
-    IMPLEMENT_WRAP_FUNCTION(WriteToClient, client, len, data);
+    IMPLEMENT_WRAP_FUNCTION(dixWriteToClient, client, len, data);
 }
 
 WRAP_FUNCTION(XISetEventMask, int,

--- a/test/xi2/protocol-xigetclientpointer.c
+++ b/test/xi2/protocol-xigetclientpointer.c
@@ -45,7 +45,7 @@
 
 #include "protocol-common.h"
 
-DECLARE_WRAP_FUNCTION(WriteToClient, void, ClientPtr client, int len, void *data);
+DECLARE_WRAP_FUNCTION(dixWriteToClient, void, ClientPtr client, int len, void *data);
 
 static struct {
     int cp_is_set;
@@ -114,7 +114,7 @@ test_XIGetClientPointer(void)
 
     request.win = CLIENT_WINDOW_ID;
 
-    wrapped_WriteToClient = reply_XIGetClientPointer;
+    wrapped_dixWriteToClient = reply_XIGetClientPointer;
 
     client_request = init_client(request.length, &request);
 

--- a/test/xi2/protocol-xigetselectedevents.c
+++ b/test/xi2/protocol-xigetselectedevents.c
@@ -55,7 +55,7 @@
 
 #include "protocol-common.h"
 
-DECLARE_WRAP_FUNCTION(WriteToClient, void, ClientPtr client, int len, void *data);
+DECLARE_WRAP_FUNCTION(dixWriteToClient, void, ClientPtr client, int len, void *data);
 DECLARE_WRAP_FUNCTION(AddResource, Bool, XID id, RESTYPE type, void *value);
 
 static void reply_XIGetSelectedEvents(ClientPtr client, int len, void *data);
@@ -94,7 +94,7 @@ reply_XIGetSelectedEvents(ClientPtr client, int len, void *data)
 
     assert(reply.num_masks == test_data.num_masks_expected);
 
-    wrapped_WriteToClient = reply_XIGetSelectedEvents_data;
+    wrapped_dixWriteToClient = reply_XIGetSelectedEvents_data;
 }
 
 static void
@@ -135,12 +135,12 @@ request_XIGetSelectedEvents(xXIGetSelectedEventsReq * req, int error)
 
     client = init_client(req->length, req);
 
-    wrapped_WriteToClient = reply_XIGetSelectedEvents;
+    wrapped_dixWriteToClient = reply_XIGetSelectedEvents;
 
     rc = ProcXIGetSelectedEvents(&client);
     assert(rc == error);
 
-    wrapped_WriteToClient = reply_XIGetSelectedEvents;
+    wrapped_dixWriteToClient = reply_XIGetSelectedEvents;
     client.swapped = TRUE;
 
     /* MUST NOT swap req->length here !

--- a/test/xi2/protocol-xipassivegrabdevice.c
+++ b/test/xi2/protocol-xipassivegrabdevice.c
@@ -46,7 +46,7 @@
 
 #include "protocol-common.h"
 
-DECLARE_WRAP_FUNCTION(WriteToClient, void, ClientPtr client, int len, void *data);
+DECLARE_WRAP_FUNCTION(dixWriteToClient, void, ClientPtr client, int len, void *data);
 DECLARE_WRAP_FUNCTION(GrabButton, int,
                       ClientPtr client, DeviceIntPtr dev,
                       DeviceIntPtr modifier_device, int button,
@@ -101,7 +101,7 @@ reply_XIPassiveGrabDevice(ClientPtr client, int len, void *data)
     /* ProcXIPassiveGrabDevice sends the data in two batches, let the second
      * handler handle the modifier data */
     if (reply.num_modifiers > 0)
-        wrapped_WriteToClient = reply_XIPassiveGrabDevice_data;
+        wrapped_dixWriteToClient = reply_XIPassiveGrabDevice_data;
 }
 
 static void
@@ -127,7 +127,7 @@ reply_XIPassiveGrabDevice_data(ClientPtr client, int len, void *data)
         assert(mods->pad1 == 0);
     }
 
-    wrapped_WriteToClient = reply_XIPassiveGrabDevice;
+    wrapped_dixWriteToClient = reply_XIPassiveGrabDevice;
 }
 
 static void
@@ -197,7 +197,7 @@ test_XIPassiveGrabDevice(void)
 
     request->grab_window = CLIENT_WINDOW_ID;
 
-    wrapped_WriteToClient = reply_XIPassiveGrabDevice;
+    wrapped_dixWriteToClient = reply_XIPassiveGrabDevice;
     client_request = init_client(request->length, request);
 
     dbg("Testing invalid device\n");

--- a/test/xi2/protocol-xiquerydevice.c
+++ b/test/xi2/protocol-xiquerydevice.c
@@ -45,12 +45,12 @@
 
 #include "protocol-common.h"
 
-DECLARE_WRAP_FUNCTION(WriteToClient, void, ClientPtr client, int len, void *data);
+DECLARE_WRAP_FUNCTION(dixWriteToClient, void, ClientPtr client, int len, void *data);
 /*
  * Protocol testing for XIQueryDevice request and reply.
  *
  * Test approach:
- * Wrap WriteToClient to intercept server's reply. ProcXIQueryDevice returns
+ * Wrap dixWriteToClient to intercept server's reply. ProcXIQueryDevice returns
  * data in two batches, once for the request, once for the trailing data
  * with the device information.
  * Repeatedly test with varying deviceids and check against data in reply.
@@ -91,7 +91,7 @@ reply_XIQueryDevice(ClientPtr client, int len, void *data)
 
     test_data.num_devices_in_reply = reply.num_devices;
 
-    wrapped_WriteToClient = reply_XIQueryDevice_data;
+    wrapped_dixWriteToClient = reply_XIQueryDevice_data;
 }
 
 /* reply handling for the trailing bytes that constitute the device info */
@@ -292,7 +292,7 @@ request_XIQueryDevice(struct test_data *querydata, int deviceid, int error)
 
     request_init(&request, XIQueryDevice);
     client = init_client(request.length, &request);
-    wrapped_WriteToClient = reply_XIQueryDevice;
+    wrapped_dixWriteToClient = reply_XIQueryDevice;
 
     querydata->which_device = deviceid;
 
@@ -303,7 +303,7 @@ request_XIQueryDevice(struct test_data *querydata, int deviceid, int error)
     if (rc != Success)
         assert(client.errorValue == deviceid);
 
-    wrapped_WriteToClient = reply_XIQueryDevice;
+    wrapped_dixWriteToClient = reply_XIQueryDevice;
 
     client.swapped = TRUE;
     swaps(&request.length);
@@ -323,7 +323,7 @@ test_XIQueryDevice(void)
 
     init_simple();
 
-    wrapped_WriteToClient = reply_XIQueryDevice;
+    wrapped_dixWriteToClient = reply_XIQueryDevice;
     request_init(&request, XIQueryDevice);
 
     dbg("Testing XIAllDevices.\n");

--- a/test/xi2/protocol-xiquerypointer.c
+++ b/test/xi2/protocol-xiquerypointer.c
@@ -45,7 +45,7 @@
 
 #include "protocol-common.h"
 
-DECLARE_WRAP_FUNCTION(WriteToClient, void, ClientPtr client, int len, void *data);
+DECLARE_WRAP_FUNCTION(dixWriteToClient, void, ClientPtr client, int len, void *data);
 
 extern ClientRec client_window;
 static ClientRec client_request;
@@ -107,13 +107,13 @@ reply_XIQueryPointer(ClientPtr client, int len, void *data)
 
     assert(reply.same_screen == xTrue);
 
-    wrapped_WriteToClient = reply_XIQueryPointer_data;
+    wrapped_dixWriteToClient = reply_XIQueryPointer_data;
 }
 
 static void
 reply_XIQueryPointer_data(ClientPtr client, int len, void *data)
 {
-    wrapped_WriteToClient = reply_XIQueryPointer;
+    wrapped_dixWriteToClient = reply_XIQueryPointer;
 
     assert(len < 0xffff); /* suspicious size, swapping bug */
 }
@@ -153,7 +153,7 @@ test_XIQueryPointer(void)
 
     request_init(&request, XIQueryPointer);
 
-    wrapped_WriteToClient = reply_XIQueryPointer;
+    wrapped_dixWriteToClient = reply_XIQueryPointer;
 
     client_request = init_client(request.length, &request);
 

--- a/test/xi2/protocol-xiqueryversion.c
+++ b/test/xi2/protocol-xiqueryversion.c
@@ -30,7 +30,7 @@
  * Protocol testing for XIQueryVersion request and reply.
  *
  * Test approach:
- * Wrap WriteToClient to intercept the server's reply.
+ * Wrap dixWriteToClient to intercept the server's reply.
  * Repeatedly test a client/server version combination, compare version in
  * reply with versions given. Version must be equal to either
  * server version or client version, whichever is smaller.
@@ -52,7 +52,7 @@
 #include "protocol-common.h"
 #include "Xext/xinput/exglobals.h"
 
-DECLARE_WRAP_FUNCTION(WriteToClient, void, ClientPtr client, int len, void *data);
+DECLARE_WRAP_FUNCTION(dixWriteToClient, void, ClientPtr client, int len, void *data);
 
 extern XExtensionVersion XIVersion;
 
@@ -159,7 +159,7 @@ test_XIQueryVersion(void)
 {
     init_simple();
 
-    wrapped_WriteToClient = reply_XIQueryVersion;
+    wrapped_dixWriteToClient = reply_XIQueryVersion;
 
     dbg("Server version 2.0 - client versions [1..3].0\n");
     /* some simple tests to catch common errors quickly */
@@ -216,7 +216,7 @@ test_XIQueryVersion_multiple(void)
     XIVersion.major_version = 2;
     XIVersion.minor_version = 2;
 
-    wrapped_WriteToClient = reply_XIQueryVersion_multiple;
+    wrapped_dixWriteToClient = reply_XIQueryVersion_multiple;
 
     /* run 1 */
 


### PR DESCRIPTION
Split the exported `WriteToClient()` into a thin exported frontend plus an
internal worker `dixWriteToClient()`, move all in-tree callers onto the worker,
and add optional buildtime debug logging of the frontend.

## Commits

1. **os: split WriteToClient() into exported frontend and internal dixWriteToClient()**
   The actual buffering/flushing body moves into `dixWriteToClient()` (declared
   in the private `os/io_priv.h`, still `_X_EXPORT` because in-tree modules built
   as separate shared objects — e.g. GLX — link against it). `WriteToClient()`
   stays as the exported, legacy frontend (documented as such in `os.h`) and just
   delegates. The xi1/xi2 protocol unit-test linker wrap is retargeted to
   `dixWriteToClient` so reply capture keeps working.

2. **dix: use internal dixWriteToClient()** — the modern `X_SEND_REPLY_*` reply
   helpers (`request_priv.h`), `xmitClientEvent()` (`dix_priv.h`) and the direct
   callers in `dispatch.c` / `events.c` / `swaprep.c` / `dixfonts.c`.

3. **Xext: record: use internal dixWriteToClient()**.

4. **os: add optional debug logging of WriteToClient() frontend calls** — meson
   combo option `debug_writetoclient` (`none` / `caller` / `backtrace`) mapping to
   `CONFIG_DEBUG_WRITETOCLIENT[_BACKTRACE]`. Default `none` keeps the frontend a
   plain tail-call. `caller` logs client/count plus the return address (resolved
   via `dladdr()` when available); `backtrace` adds a full `xorg_backtrace()`.
   Lets one find out-of-tree / not-yet-converted callers still using the public
   entry point.

## Notes

- Each commit builds on its own; `meson test` (incl. the xi protocol tests) green.
- GLX no longer calls `WriteToClient()` directly after the rpcbuf migration, so it
  reaches `dixWriteToClient()` transitively via the `request_priv.h` reply helpers —
  no GLX changes are needed here.
