### PR TITLE
xfree86: use modesetting driver by default on GeForce 8 and newer

### DIFF
--- a/hw/xfree86/common/xf86pciBus.c
+++ b/hw/xfree86/common/xf86pciBus.c
@@ -34,7 +34,9 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <pciaccess.h>
+#ifdef WITH_LIBDRM
 #include <xf86drm.h>
+#endif
 #include <X11/X.h>
 
 #include "os/log_priv.h"
@@ -1141,7 +1143,7 @@ xf86VideoPtrToDriverList(struct pci_device *dev, XF86MatchedDrivers *md)
     {
         int idx = 0;
 
-#if defined(__linux__) || defined(__NetBSD__)
+#if defined(WITH_LIBDRM) && (defined(__linux__) || defined(__NetBSD__))
         char busid[32];
         int fd;
 

--- a/hw/xfree86/common/xf86pciBus.c
+++ b/hw/xfree86/common/xf86pciBus.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <pciaccess.h>
+#include <xf86drm.h>
 #include <X11/X.h>
 
 #include "os/log_priv.h"
@@ -1141,6 +1142,25 @@ xf86VideoPtrToDriverList(struct pci_device *dev, XF86MatchedDrivers *md)
         int idx = 0;
 
 #if defined(__linux__) || defined(__NetBSD__)
+        char busid[32];
+        int fd;
+
+        snprintf(busid, sizeof(busid), "pci:%04x:%02x:%02x.%d",
+                 dev->domain, dev->bus, dev->dev, dev->func);
+
+       /* 'modesetting' is preferred for GeForce 8 and newer GPUs */
+        fd = drmOpenWithType("nouveau", busid, DRM_NODE_RENDER);
+        if (fd >= 0) {
+            uint64_t args[] = { 11 /* NOUVEAU_GETPARAM_CHIPSET_ID */, 0 };
+            int ret = drmCommandWriteRead(fd, 0 /* DRM_NOUVEAU_GETPARAM */,
+                                          &args, sizeof(args));
+            drmClose(fd);
+            if (ret == 0) {
+                if (args[1] == 0x050 || args[1] >= 0x80)
+                    break;
+            }
+        }
+
         driverList[idx++] = "nouveau";
 #endif
         driverList[idx++] = "modesetting";


### PR DESCRIPTION
This patch is currently carried by the Slackware XLibre package and was originally written by Ben Skeggs.

While investigating #3093, I found that my working Slackware build already included this downstream patch. After rebuilding the current upstream `master` without it, I was able to reproduce the original startup issue on my Intel/NVIDIA Optimus laptop.

This PR forwards the existing downstream patch for consideration upstream.

**Tested on:**

* Slackware-current
* Intel Iris Xe + NVIDIA GeForce MX450 (Optimus)

With this patch, the X server selects the `modesetting` DDX instead of `nouveau` for GeForce 8 and newer GPUs, matching the behavior of the Slackware package.
