### PR TITLE
(master) .github: add ubuntu deps base image (step 1 of driver-pipeline rework)

### DIFF
--- a/.github/docker/ubuntu/Dockerfile
+++ b/.github/docker/ubuntu/Dockerfile
@@ -1,0 +1,36 @@
+# Base image for the ubuntu xserver / SDK / driver builds.
+#
+# Bakes in everything those jobs install before building the xserver itself:
+#   - the apt build dependencies (.github/scripts/ubuntu/install-pkg.sh)
+#   - the from-source prereqs that are otherwise rebuilt/actions-cached each run
+#     (.github/scripts/ubuntu/install-prereq.sh: rendercheck, libdrm, libxcvt,
+#      xorgproto, xts, piglit, goxproto)
+#
+# So CI jobs based on this image skip apt + the prereq build/restore entirely
+# and go straight to building the xserver. This is step 1 of the driver-pipeline
+# rework; later steps build the xserver+SDK on top of it and feed the driver
+# builds from a per-commit image instead of the eviction-prone actions/cache.
+#
+# Built + pushed to GHCR by .github/workflows/ubuntu-deps-image.yml. The prereq
+# versions come from .github/scripts/conf.sh (PKG_*_REF), so a change there (or
+# to the install scripts) rebuilds the image via that workflow's path filter.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+# Stable, documented locations for the baked prereqs; consuming jobs point
+# X11_PREFIX / X11_BUILD_DIR (and PKG_CONFIG_PATH) here.
+ENV X11_PREFIX=/opt/x11
+ENV X11_BUILD_DIR=/opt/x11-build
+
+COPY .github /src/.github
+WORKDIR /src
+
+# apt build dependencies (same list the ubuntu-install-pkg action uses)
+RUN apt-get update && \
+    ./.github/scripts/ubuntu/install-pkg.sh && \
+    rm -rf /var/lib/apt/lists/*
+
+# from-source prereqs (rendercheck, libdrm, libxcvt, xorgproto, xts, piglit,
+# goxproto) — installed into $X11_PREFIX, sources/test trees kept in
+# $X11_BUILD_DIR (piglit/goxproto/xts are used directly from there at test time)
+RUN ./.github/scripts/ubuntu/install-prereq.sh

--- a/.github/workflows/ubuntu-deps-image.yml
+++ b/.github/workflows/ubuntu-deps-image.yml
@@ -1,0 +1,47 @@
+name: Build ubuntu deps image
+
+# Builds the base image (.github/docker/ubuntu/Dockerfile) with the apt build
+# dependencies and the from-source prereqs baked in, and pushes it to GHCR. The
+# xserver/SDK/driver builds use it so they skip apt + the prereq build on every
+# run. Off the PR critical path: on demand, weekly, or when the inputs change.
+
+on:
+    workflow_dispatch:
+    schedule:
+        # weekly, Monday 04:30 UTC — keep prereqs fresh with the distro
+        - cron: '30 4 * * 1'
+    push:
+        paths:
+            - '.github/docker/ubuntu/**'
+            - '.github/scripts/ubuntu/install-pkg.sh'
+            - '.github/scripts/ubuntu/install-prereq.sh'
+            - '.github/scripts/conf.sh'
+            - '.github/scripts/util.sh'
+            - '.github/workflows/ubuntu-deps-image.yml'
+
+permissions:
+    contents: read
+    packages: write
+
+jobs:
+    build-ubuntu-deps-image:
+        runs-on: ubuntu-latest
+        timeout-minutes: 120
+        steps:
+            - uses: actions/checkout@v6
+
+            - name: Log in to GHCR
+              run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+            - name: Build and push image
+              run: |
+                  set -eux
+                  owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+                  img="ghcr.io/$owner/xserver-ubuntu-build"
+                  docker build \
+                      -t "$img:latest" \
+                      -t "$img:${GITHUB_SHA::12}" \
+                      -f .github/docker/ubuntu/Dockerfile \
+                      .
+                  docker push "$img:latest"
+                  docker push "$img:${GITHUB_SHA::12}"


### PR DESCRIPTION
Adds a prebuilt base image with the apt build dependencies and the
from-source prereqs (rendercheck, libdrm, libxcvt, xorgproto, xts,
piglit, goxproto) baked in, plus a builder workflow that pushes it to
GHCR (on demand / weekly / on input change).

This is step 1 of reworking the driver pipeline: later steps build the
xserver+SDK on top of this image and hand it to the driver builds via a
per-commit image instead of the eviction-prone actions/cache (under high
load the SDK cache can be evicted before the queued driver jobs restore
it, forcing a full manual rerun).

No existing job is changed yet — this only adds the image + builder.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
