### PR TITLE
(master) glx: move GLYPHPADBYTES out of the SDK into its sole user

### DIFF
--- a/Xext/glx/xfont.c
+++ b/Xext/glx/xfont.c
@@ -42,6 +42,26 @@
 #include <dixfontstr.h>
 
 /*
+** Byte alignment of a scanline within an X server glyph bitmap.
+**
+** The X server stores each glyph's bitmap with its rows padded up to a fixed
+** boundary; GLYPHWIDTHBYTESPADDED() in <dixfontstr.h> rounds every row up to 4
+** bytes, so that boundary is 4.  This used to be the machine-dependent
+** GLYPHPADBYTES in <servermd.h>, tunable per platform for the old mfb/cfb glyph
+** blitters; those are long gone and the value is now fixed at 4 everywhere, so
+** the macro was dropped from the SDK.  This file -- the server-side
+** glXUseXFont() implementation -- is its sole remaining user, hence the local
+** definition.  It must stay in sync with GLYPHWIDTHBYTESPADDED()'s 4-byte pad.
+**
+** It is handed to GL_UNPACK_ALIGNMENT below so that, when glBitmap() reads the
+** raw X glyph rows out of client memory, OpenGL advances to the start of each
+** next row on the same boundary X padded them to (companion to the
+** GL_UNPACK_LSB_FIRST = BITMAP_BIT_ORDER setting, which conveys the bit order).
+** GL_UNPACK_ALIGNMENT only accepts 1/2/4/8, and 4 is valid.
+*/
+#define GLYPHPADBYTES 4
+
+/*
 ** Make a single GL bitmap from a single X glyph
 */
 static int

--- a/include/servermd.h
+++ b/include/servermd.h
@@ -59,8 +59,6 @@ SOFTWARE.
 #error "Too weird to live."
 #endif
 
-#define GLYPHPADBYTES           4
-
 #define BITMAP_SCANLINE_PAD  32
 #define LOG2_BITMAP_PAD		5
 #define LOG2_BYTES_PER_SCANLINE_PAD	2


### PR DESCRIPTION
GLYPHPADBYTES used to be a machine-dependent knob in <servermd.h>,
tunable per platform for the old mfb/cfb glyph blitters. Those are
long gone and the value has been fixed at 4 for over a decade; the
remaining "!= 4" code paths were just dropped (a09755b66), and
GLYPHWIDTHBYTESPADDED() now hardwires the 4-byte row pad directly.

That left the server-side glXUseXFont() implementation as the single
remaining user, where it is handed to GL_UNPACK_ALIGNMENT so OpenGL
steps to each next glyph row on the same boundary X padded them to.
Since it is no longer machine-dependent and nothing else references
it, there is no reason to keep it in the public SDK header: move the
definition next to its lone use in Xext/glx/xfont.c, with a comment
explaining what it is and why it must match GLYPHWIDTHBYTESPADDED().

No functional change.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
