### PR TITLE
(master) .github: add xserver SDK image (step 2 of driver-pipeline rework)

### DIFF
--- a/.github/docker/sdk/Dockerfile
+++ b/.github/docker/sdk/Dockerfile
@@ -1,0 +1,33 @@
+# Per-commit X-server + SDK image, built on top of the prebuilt deps base image.
+#
+# Step 2 of the driver-pipeline rework: builds the xserver with -Dxorg-sdk=true
+# and installs it (into the /opt/x11 prefix that the base image already uses for
+# its prereqs), so the driver builds can later consume a ready SDK from a
+# per-commit image (ghcr.io/.../xserver-sdk:<sha>) instead of the eviction-prone
+# actions/cache. Built + pushed by .github/workflows/sdk-image.yml.
+#
+# Multi-stage so the final image carries only the installed SDK (/opt/x11), not
+# the xserver source tree.
+
+# --- build stage: compile + install the SDK into /opt/x11 -------------------
+FROM ghcr.io/x11libre/xserver-ubuntu-build:latest AS build
+
+COPY . /src/xserver
+WORKDIR /src/xserver
+
+# The base image keeps its from-source prereqs (xorgproto, libxcvt, …) in
+# /opt/x11; point pkg-config there so the xserver build finds them, and install
+# the SDK into the same prefix. Args mirror the drivers-prepare-ubuntu job
+# (-Dxorg-sdk=true, Xorg DDX on, the X test servers off).
+RUN MACHINE="$(gcc -dumpmachine)" && \
+    export PKG_CONFIG_PATH="/opt/x11/lib/$MACHINE/pkgconfig:/opt/x11/lib/pkgconfig:/opt/x11/share/pkgconfig" && \
+    meson setup _build \
+        -Dprefix=/opt/x11 \
+        -Dxorg-sdk=true -Dxorg=true \
+        -Dxephyr=false -Dxvfb=false -Dxnest=false -Dxfbdev=false \
+        -Dwerror=false -Dxcsecurity=false && \
+    ninja -C _build install
+
+# --- final stage: base + the installed SDK, no source -----------------------
+FROM ghcr.io/x11libre/xserver-ubuntu-build:latest
+COPY --from=build /opt/x11 /opt/x11

--- a/.github/workflows/sdk-image.yml
+++ b/.github/workflows/sdk-image.yml
@@ -1,0 +1,45 @@
+name: Build xserver SDK image
+
+# Step 2 of the driver-pipeline rework: build the X-server + SDK from the
+# current commit on top of the deps base image and push it to GHCR as a
+# per-commit tag (xserver-sdk:<sha>, plus :latest). The driver builds will
+# later pull this image instead of restoring the xserver+SDK from the
+# eviction-prone actions/cache — see .github/docker/sdk/Dockerfile.
+#
+# For now this only produces the image (no existing job consumes it yet); a
+# later step makes the driver jobs run in `container: xserver-sdk:<sha>` and
+# drops the old drivers-prepare cache dance.
+
+on:
+    workflow_dispatch:
+    push:
+        paths:
+            - '.github/docker/sdk/**'
+            - '.github/workflows/sdk-image.yml'
+
+permissions:
+    contents: read
+    packages: write
+
+jobs:
+    build-sdk-image:
+        runs-on: ubuntu-latest
+        timeout-minutes: 60
+        steps:
+            - uses: actions/checkout@v6
+
+            - name: Log in to GHCR
+              run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+            - name: Build and push SDK image
+              run: |
+                  set -eux
+                  owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+                  img="ghcr.io/$owner/xserver-sdk"
+                  docker build \
+                      -t "$img:${GITHUB_SHA}" \
+                      -t "$img:latest" \
+                      -f .github/docker/sdk/Dockerfile \
+                      .
+                  docker push "$img:${GITHUB_SHA}"
+                  docker push "$img:latest"


### PR DESCRIPTION
Builds the X-server + SDK (-Dxorg-sdk=true) from the current commit on
top of the xserver-ubuntu-build base image and pushes it to GHCR as
xserver-sdk:<sha> (+ :latest). Multi-stage so the final image carries
only the installed SDK in /opt/x11, not the source.

This is the per-commit artifact the driver builds will consume in the
next step (container: xserver-sdk:<sha>) instead of restoring the
xserver+SDK from the actions/cache that can be evicted under load. No
existing job consumes it yet.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
