### PR TITLE
.github: add RHEL build job

### DIFF
--- a/.github/scripts/rhel/install-pkg.sh
+++ b/.github/scripts/rhel/install-pkg.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+set -e
+
+echo "--> enable EPEL and CRB repositories"
+# Many X -devel packages live in CRB (CodeReady Builder) and EPEL rather
+# than BaseOS/AppStream.
+dnf -y install dnf-plugins-core epel-release
+dnf config-manager --set-enabled crb
+dnf -y makecache
+
+echo "--> install build dependencies"
+dnf -y install \
+	cairo-devel \
+	dbus-devel \
+	expat-devel \
+	gcc \
+	git \
+	libbsd-devel \
+	libdrm-devel \
+	libepoxy-devel \
+	libevdev-devel \
+	libffi-devel \
+	libgcrypt-devel \
+	libinput-devel \
+	libpciaccess-devel \
+	libtirpc-devel \
+	libunwind-devel \
+	libX11-devel \
+	libXau-devel \
+	libXaw-devel \
+	libxcb-devel \
+	libXdmcp-devel \
+	libXext-devel \
+	libXfixes-devel \
+	libXfont2-devel \
+	libXi-devel \
+	libXinerama-devel \
+	libxkbcommon-devel \
+	libxkbfile-devel \
+	libXmu-devel \
+	libXpm-devel \
+	libXrandr-devel \
+	libXrender-devel \
+	libXres-devel \
+	libxshmfence-devel \
+	libXt-devel \
+	libXtst-devel \
+	libXv-devel \
+	libxcvt-devel \
+	make \
+	mesa-libEGL-devel \
+	mesa-libGL-devel \
+	mesa-libGLES-devel \
+	mesa-libgbm-devel \
+	meson \
+	nettle-devel \
+	ninja-build \
+	pango-devel \
+	pixman-devel \
+	pkgconf-pkg-config \
+	python3-mako \
+	systemd-devel \
+	xcb-util-devel \
+	xcb-util-image-devel \
+	xcb-util-keysyms-devel \
+	xcb-util-renderutil-devel \
+	xcb-util-wm-devel \
+	xkbcomp \
+	xorg-x11-proto-devel \
+	xkeyboard-config

--- a/.github/scripts/rhel/run-xserver-build.sh
+++ b/.github/scripts/rhel/run-xserver-build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+./.github/scripts/rhel/install-pkg.sh
+
+echo "--> running xserver build ...."
+export MESON_BUILDDIR=_build
+
+rm -rf "$MESON_BUILDDIR"
+meson setup "$MESON_BUILDDIR" $MESON_ARGS
+meson configure "$MESON_BUILDDIR"
+meson compile -v -C "$MESON_BUILDDIR" $jobcount $ninja_args
+# tests not working yet
+# meson test -C "$MESON_BUILDDIR" --print-errorlogs $MESON_TEST_ARGS
+meson install --no-rebuild  -C "$MESON_BUILDDIR" $MESON_INSTALL_ARGS

--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -685,6 +685,29 @@ jobs:
             - name: build
               run: ./.github/scripts/gentoo/run-xserver-build.sh
 
+    xserver-build-rhel:
+        runs-on: ubuntu-latest
+        needs: ubuntu-fetch-pkg
+        strategy:
+            fail-fast: false
+            matrix:
+                rhelver: ['9', '10']
+        container:
+            # AlmaLinux is an ABI-identical RHEL rebuild; it stands in for
+            # RHEL here since the real UBI images can't enable CRB without
+            # an entitlement on public runners.
+            image: almalinux:${{ matrix.rhelver }}
+        env:
+            # werror off for now: RHEL 10's newer GCC trips -Werror=format-truncation
+            # in os/Xtranssock.c. Freshly-added platform; tighten once it's clean
+            # (same as the gentoo/solaris/openbsd jobs).
+            MESON_ARGS: -Dprefix=/usr -Dwerror=false -Dxcsecurity=true -Dxorg=true -Dxephyr=true -Dxvfb=true -Dxnest=true -Dxfbdev=false -Dsystemd_logind=false
+        steps:
+            - name: Check out repository code
+              uses: actions/checkout@v6
+            - name: build
+              run: ./.github/scripts/rhel/run-xserver-build.sh
+
     xserver-build-cygwin:
         # skip the redundant same-repo PR rebuild (see ubuntu-fetch-pkg)
         if: >-
@@ -800,6 +823,7 @@ jobs:
             - xserver-build-netbsd
             - xserver-build-arch
             - xserver-build-gentoo
+            - xserver-build-rhel
         steps:
             - name: Checkout
               uses: actions/checkout@v6


### PR DESCRIPTION
Adds a RHEL-family CI build job to `build-xserver.yml`.

- Matrix `rhelver: ['9', '10']` using `almalinux:9` / `almalinux:10` containers.
  AlmaLinux is an ABI-identical RHEL rebuild and stands in for RHEL here because
  the real UBI images can't enable CRB without an entitlement on public runners.
- `.github/scripts/rhel/install-pkg.sh` enables **EPEL + CRB** (CodeReady Builder,
  where most X `-devel` packages live) and installs the build dependencies via `dnf`.
- `.github/scripts/rhel/run-xserver-build.sh` runs meson setup/compile/install
  (`-Dwerror=true`). Tests are left disabled for now (not working yet).
- The job is wired into the aggregate `needs:` list.

Originally written 2026-06-12; it had been sitting on the incubator branch and was
never submitted. Cherry-picked cleanly onto current `master`.
