### PR TITLE
xfree86: Add missing string padding to the DGA QueryMode request handler

### DIFF
--- a/hw/xfree86/common/xf86DGA.c
+++ b/hw/xfree86/common/xf86DGA.c
@@ -1292,7 +1292,7 @@ ProcXDGAQueryModes(ClientPtr client)
         info.reserved2 = mode[i].reserved2;
 
         x_rpcbuf_write_CARD8s(&rpcbuf, (CARD8*)&info, sz_xXDGAModeInfo);
-        x_rpcbuf_write_CARD8s(&rpcbuf, (CARD8*)mode[i].name, size);
+        x_rpcbuf_write_string_0t_pad(&rpcbuf, mode[i].name);
     }
 
     free(mode);


### PR DESCRIPTION
Fixes: https://github.com/X11Libre/xserver/commit/4d66d6f9ac8db0ca78df6871fda97f42d9380701

---

## Backport dashboard

| Target branch | Backport PR | Status |
|---------------|-------------|--------|
| `release/25.2` | #3190 | 🔄 Open (clean cherry-pick) |
| `release/25.1` | #3191 | 🔄 Open (clean cherry-pick) |
| `release/25.0` | #3192 | 🔄 Open (**adapted** — old `WriteToClient` path) |

**Bug confirmed against the protocol framing, not assumed:** `ProcXDGAQueryModes` advertises each mode name's size *padded* to 4 bytes — via `info.name_size = (strlen+1 + 3) & ~3` on all lines, and additionally via `rep.length` on 25.0 — but the pre-fix code wrote only `strlen+1` (unpadded) bytes. So the server announced more than it sent. The sibling `ProcXDGASetMode` reply already used the padded helper, confirming padded names are the intended wire format. 25.2/25.1 carry the same `x_rpcbuf` code → clean cherry-pick; 25.0 still uses `WriteToClient` → the fix is adapted (zero-pad the name, never over-read the buffer). Release-line merges are manual/maintainer-only.
