### PR TITLE
(master) glamor: glamor_egl.c do not call xorgGlxCreateVendor()

### DIFF
--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -1735,7 +1735,6 @@ glamor_egl_screen_init(ScreenPtr screen, struct glamor_context *glamor_ctx)
 #ifdef GLXEXT
     if (!vendor_initialized) {
         GlxPushProvider(&glamor_provider);
-        xorgGlxCreateVendor();
         vendor_initialized = TRUE;
     }
 #endif

--- a/include/glx_extinit.h
+++ b/include/glx_extinit.h
@@ -42,6 +42,11 @@ struct __GLXprovider {
 extern __GLXprovider __glXDRISWRastProvider;
 
 void GlxPushProvider(__GLXprovider * provider);
+
+/**
+ * @brief xorgGlxCreateVendor adds default glx vendor callback
+ * @warning this function need to be called once, because it installs `catch-all` style which always succeed
+ */
 void xorgGlxCreateVendor(void);
 
 #else /* GLXEXT */


### PR DESCRIPTION
Not 100% sure if it impacts kdrive

---

## Backport dashboard

| Target branch | Backport PR | Status |
|---------------|-------------|--------|
| `release/25.2` | #3187 | 🔄 Open |
| `release/25.1` | #3188 | 🔄 Open |
| `release/25.0` | #3189 | 🔄 Open |

The `xorgGlxCreateVendor()` call is present in `glamor_egl.c` on all three release lines, so the one-line removal applies cleanly to each. Release-line merges are manual/maintainer-only.
