### PR TITLE
os: fix -Wformat-truncation in set_sun_path(), re-enable werror on RHEL

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -698,10 +698,7 @@ jobs:
             # an entitlement on public runners.
             image: almalinux:${{ matrix.rhelver }}
         env:
-            # werror off for now: RHEL 10's newer GCC trips -Werror=format-truncation
-            # in os/Xtranssock.c. Freshly-added platform; tighten once it's clean
-            # (same as the gentoo/solaris/openbsd jobs).
-            MESON_ARGS: -Dprefix=/usr -Dwerror=false -Dxcsecurity=true -Dxorg=true -Dxephyr=true -Dxvfb=true -Dxnest=true -Dxfbdev=false -Dsystemd_logind=false
+            MESON_ARGS: -Dprefix=/usr -Dwerror=true -Dxcsecurity=true -Dxorg=true -Dxephyr=true -Dxvfb=true -Dxnest=true -Dxfbdev=false -Dsystemd_logind=false
         steps:
             - name: Check out repository code
               uses: actions/checkout@v6

--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -610,8 +610,8 @@ static int
 set_sun_path(const char *port, const char *upath, char *path, int abstract)
 {
     struct sockaddr_un s;
-    ssize_t maxlen = sizeof(s.sun_path) - 1;
     const char *at = "";
+    int n;
 
     if (!port || !*port || !path)
 	return -1;
@@ -626,9 +626,9 @@ set_sun_path(const char *port, const char *upath, char *path, int abstract)
     if (*port == '/') /* a full pathname */
 	upath = "";
 
-    if ((ssize_t)(strlen(at) + strlen(upath) + strlen(port)) > maxlen)
+    n = snprintf(path, sizeof(s.sun_path), "%s%s%s", at, upath, port);
+    if (n < 0 || (size_t) n >= sizeof(s.sun_path))
 	return -1;
-    snprintf(path, sizeof(s.sun_path), "%s%s%s", at, upath, port);
     return 0;
 }
 #endif


### PR DESCRIPTION
Fixes the `-Wformat-truncation` warning in `os/Xtranssock.c` `set_sun_path()` and re-tightens the RHEL CI job to `-Dwerror=true`.

**The warning** (`os/Xtranssock.c:631: '%s' directive output may be truncated …`, `[-Werror=format-truncation=]`) is a GCC false positive on newer GCC (AlmaLinux/RHEL 10, gcc 14): the manual `strlen(...) > maxlen` pre-check already guarantees the `snprintf` can't truncate, but GCC can't connect the two and warns anyway. It was the reason the freshly-added RHEL job had to run with `-Dwerror=false` (#3172).

**The fix** checks the `snprintf` return value instead of pre-computing the length — same behaviour (a path that doesn't fit returns `-1`), but the truncation handling is now explicit, so GCC is satisfied. The redundant `maxlen` guard is removed.

Second commit flips the RHEL job back to `-Dwerror=true`, so the `xserver-build-rhel (10)` leg in this PR validates the fix directly.

Verified locally: `os/.../transport.c.o` builds clean with `-Dwerror=true` (gcc 14.2).
