### PR TITLE
(master) .github: only rebuild deps/SDK images on master, not every branch

### DIFF
--- a/.github/workflows/gentoo-image.yml
+++ b/.github/workflows/gentoo-image.yml
@@ -15,6 +15,7 @@ on:
         # weekly, Monday 04:00 UTC — keep the image fresh with the binhost
         - cron: '0 4 * * 1'
     push:
+        branches: [master]
         paths:
             - '.github/docker/gentoo/**'
             - '.github/workflows/gentoo-image.yml'

--- a/.github/workflows/sdk-image.yml
+++ b/.github/workflows/sdk-image.yml
@@ -13,6 +13,7 @@ name: Build xserver SDK image
 on:
     workflow_dispatch:
     push:
+        branches: [master]
         paths:
             - '.github/docker/sdk/**'
             - '.github/workflows/sdk-image.yml'

--- a/.github/workflows/ubuntu-deps-image.yml
+++ b/.github/workflows/ubuntu-deps-image.yml
@@ -11,6 +11,7 @@ on:
         # weekly, Monday 04:30 UTC — keep prereqs fresh with the distro
         - cron: '30 4 * * 1'
     push:
+        branches: [master]
         paths:
             - '.github/docker/ubuntu/**'
             - '.github/scripts/ubuntu/install-pkg.sh'


### PR DESCRIPTION
The gentoo / ubuntu-build / sdk image builders trigger on `push` with a
`paths:` filter but no branch restriction. On a feature-branch push the
paths filter matches (GitHub treats the new ref's files as added), so
every submit/* branch rebuilt the ~22min Gentoo deps image (and the
others) even though it never touched those files. Restrict the push
trigger to `branches: [master]`: the images rebuild only when their
definition actually changes on master (plus the weekly schedule and
workflow_dispatch); feature branches just consume the published :latest.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
