### PR TITLE
(master) .github: add GNU/Hurd VM build lane (Xvfb + Xnest)

### DIFF
--- a/.github/scripts/hurd/run-vm-build.sh
+++ b/.github/scripts/hurd/run-vm-build.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+#
+# Host-side orchestration for the GNU/Hurd build (runs on the ubuntu runner).
+# There is no vmactions/hurd-vm, so this hand-rolls the VM: fetch Debian's
+# pre-installed GNU/Hurd amd64 image, inject an ssh key + serial console, boot
+# it in QEMU (rumpdisk → needs q35 + an AHCI disk; gnumach hangs on -smp>1),
+# retry the boot up to 3x (VM boot can flake transiently), then build the
+# xserver inside via run-xserver-build.sh. $REPO and $SHA come from the env.
+set -euo pipefail
+
+IMG_URL="${IMG_URL:-https://cdimage.debian.org/cdimage/ports/latest/hurd-amd64/debian-hurd.img.tar.gz}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+echo "==> fetch + extract image"
+wget -q -O hurd.img.tar.gz "$IMG_URL"
+tar -xzf hurd.img.tar.gz
+img=$(echo debian-hurd-*.img)
+ls -la "$img"
+
+echo "==> inject ssh key + route guest console to serial"
+ssh-keygen -t ed25519 -N '' -f hurd_key
+loop=$(sudo losetup -fP --show "$img")
+mkdir -p mnt
+mounted=""
+for part in "${loop}"p*; do
+    if sudo mount -t ext2 "$part" mnt 2>/dev/null; then
+        if [ -f mnt/etc/passwd ]; then mounted="$part"; break; fi
+        sudo umount mnt
+    fi
+done
+test -n "$mounted"
+sudo mkdir -p mnt/root/.ssh
+sudo cp hurd_key.pub mnt/root/.ssh/authorized_keys
+sudo chmod 700 mnt/root/.ssh
+sudo chmod 600 mnt/root/.ssh/authorized_keys
+sudo chown -R 0:0 mnt/root/.ssh
+if [ -f mnt/etc/ssh/sshd_config ]; then
+    sudo sed -i 's/^#*PermitRootLogin.*/PermitRootLogin prohibit-password/' mnt/etc/ssh/sshd_config
+    sudo sed -i 's/^#*PubkeyAuthentication.*/PubkeyAuthentication yes/' mnt/etc/ssh/sshd_config
+fi
+# GRUB + gnumach log to VGA; route to serial so the boot is visible on -nographic.
+if [ -f mnt/boot/grub/grub.cfg ]; then
+    sudo sed -i '1i serial --unit=0 --speed=115200\nterminal_input console serial\nterminal_output console serial' mnt/boot/grub/grub.cfg
+    sudo sed -i '/^[[:space:]]*multiboot/ s/$/ console=com0/' mnt/boot/grub/grub.cfg
+fi
+sudo umount mnt
+sudo losetup -d "$loop"
+
+# /dev/kvm exists on GH runners but the runner user can't access it by default.
+accel="-accel tcg"
+if [ -e /dev/kvm ] && sudo chmod 666 /dev/kvm 2>/dev/null; then accel="-enable-kvm"; fi
+echo "==> qemu accel: $accel"
+
+SSH="ssh -i hurd_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=8 -p 2222 root@127.0.0.1"
+
+qpid=""
+cleanup() { [ -n "$qpid" ] && kill "$qpid" 2>/dev/null || true; }
+trap cleanup EXIT
+
+boot_to_ssh() {
+    qemu-system-x86_64 $accel -M q35 -m 4G \
+        -drive id=disk,file="$img",cache=writeback,format=raw,if=none \
+        -device ich9-ahci,id=ahci \
+        -device ide-hd,bus=ahci.0,drive=disk \
+        -net user,hostfwd=tcp:127.0.0.1:2222-:22 \
+        -net nic,model=e1000 \
+        -nographic > qemu.log 2>&1 &
+    qpid=$!
+    sleep 8
+    kill -0 "$qpid" 2>/dev/null || { echo "qemu exited immediately:"; cat qemu.log; return 1; }
+    for i in $(seq 1 40); do
+        kill -0 "$qpid" 2>/dev/null || { echo "qemu died during boot:"; tail -80 qemu.log; return 1; }
+        if $SSH true 2>/dev/null; then return 0; fi
+        [ $((i % 6)) -eq 0 ] && { echo "--- boot console after $i tries ---"; tail -20 qemu.log || true; }
+        sleep 10
+    done
+    echo "ssh never came up:"; tail -80 qemu.log
+    return 1
+}
+
+up=""
+for attempt in 1 2 3; do
+    echo "==> VM boot attempt $attempt/3"
+    if boot_to_ssh; then up=1; break; fi
+    echo "==> boot attempt $attempt failed; killing qemu and retrying"
+    [ -n "$qpid" ] && kill "$qpid" 2>/dev/null || true
+    qpid=""
+    sleep 5
+done
+[ -n "$up" ] || { echo "::error::Hurd VM never booted to ssh after 3 attempts"; exit 1; }
+
+echo "==> running build inside the VM"
+$SSH "REPO='$REPO' SHA='$SHA' sh -s" < "$HERE/run-xserver-build.sh"

--- a/.github/scripts/hurd/run-xserver-build.sh
+++ b/.github/scripts/hurd/run-xserver-build.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+#
+# Runs INSIDE the Debian GNU/Hurd VM (over ssh) — see
+# .github/workflows/build-hurd.yml. EXPERIMENTAL: the X server is not (yet)
+# ported to GNU/Hurd, so this is expected to surface missing pieces rather than
+# go green. $REPO and $SHA are passed in by the workflow.
+set -ex
+
+export DEBIAN_FRONTEND=noninteractive
+
+echo "==> uname / arch"
+uname -a || true
+
+echo "==> apt update"
+sudo apt-get update
+
+# Toolchain MUST succeed (apt is transactional: one unlocatable package aborts
+# the whole install, so keep the essentials separate from the maybe-renamed X
+# libs — otherwise a missing lib takes git/meson down with it, as it did).
+echo "==> install toolchain (required)"
+sudo apt-get install -y --no-install-recommends \
+    git build-essential meson ninja-build pkg-config ca-certificates
+
+# X libraries + helpers: best-effort, one at a time, so a package the Hurd port
+# lacks or renames only skips itself (named in the log); meson then reports what
+# is genuinely required and absent.
+echo "==> install X libs (best-effort)"
+for p in \
+    libpixman-1-dev libxfont2-dev libxfont-dev libxkbfile-dev xtrans-dev \
+    x11proto-dev xorg-sgml-doctools libxcvt-dev libxau-dev libxdmcp-dev \
+    libxcb1-dev libx11-dev libxext-dev libxfixes-dev libxrender-dev \
+    libxi-dev libxtst-dev libxres-dev libxshmfence-dev libfontenc-dev \
+    libtirpc-dev nettle-dev libbsd-dev libgcrypt20-dev libepoxy-dev \
+    libxcb-util-dev libxcb-icccm4-dev libxcb-shape0-dev libxcb-xkb-dev \
+    libxcb-keysyms1-dev libxcb-image0-dev libxcb-render-util0-dev \
+    libxcb-randr0-dev libxcb-shm0-dev libxcb-render0-dev
+do
+    sudo apt-get install -y --no-install-recommends "$p" || echo "WARN: package $p not available on hurd"
+done
+
+echo "==> clone xserver @ $SHA"
+rm -rf xserver
+git clone --depth 1 "https://github.com/$REPO" xserver
+cd xserver
+git fetch --depth 1 origin "$SHA"
+git checkout FETCH_HEAD
+
+echo "==> meson setup (minimal Xvfb/Xnest, no glx/dri/xorg — bring-up)"
+meson setup _build \
+    -Dwerror=false \
+    -Dxvfb=true -Dxnest=true \
+    -Dxorg=false -Dxephyr=false -Dxfbdev=false \
+    -Dglx=false -Ddri2=false -Ddri3=false -Dudev=false -Dsystemd_logind=false
+
+echo "==> meson compile"
+meson compile -C _build

--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -647,6 +647,22 @@ jobs:
                   usesh: true
                   run:     ./.github/scripts/openbsd/run-xserver-build.sh
 
+    xserver-build-hurd:
+        runs-on: ubuntu-latest
+        needs: ubuntu-fetch-pkg
+        timeout-minutes: 120
+        env:
+            REPO: ${{ github.repository }}
+            SHA: ${{ github.sha }}
+        steps:
+            - uses: actions/checkout@v6
+            - name: Install QEMU
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y qemu-system-x86 qemu-utils openssh-client
+            - name: Boot GNU/Hurd VM and build (Xvfb + Xnest)
+              run: ./.github/scripts/hurd/run-vm-build.sh
+
     xserver-build-alpine:
         runs-on: ubuntu-latest
         needs: ubuntu-fetch-pkg


### PR DESCRIPTION
There is no vmactions GNU/Hurd VM, so this hand-rolls one on the ubuntu
runner: it fetches Debian's pre-installed Hurd amd64 image, injects an
ssh key and routes the guest console to serial, then boots it in QEMU
and builds the X server inside via ssh.

Key gotchas baked into the scripts:

  - The amd64 Hurd image uses rumpdisk for SATA, so the disk must be
    attached via q35 + an ich9-ahci AHCI controller (the default i440fx
    IDE disk yields an ext2fs I/O error and never boots).
  - gnumach only boots single-CPU (no -smp).
  - GRUB and gnumach log to VGA only; the grub.cfg is patched to add a
    serial console so the boot is visible under -nographic.
  - /dev/kvm exists on GH runners but isn't accessible to the runner
    user; chmod 666 it (falls back to TCG if unavailable).
  - VM boot can flake transiently, so boot is retried up to 3x.

Inside the VM the toolchain (git, meson, ninja, pkg-config) install is
fatal; the X protocol libs are best-effort, and the server is configured
for the parts that build on Hurd today: -Dxvfb=true -Dxnest=true with
xorg/xephyr/glx/dri/udev/logind disabled.

Runs in ~10.5 min and is wired into the primary "Build X servers"
workflow alongside the other platform lanes.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
