### PR TITLE
xfree86: prefer boot_display over boot_vga for primary device

### DIFF
--- a/hw/xfree86/common/xf86pciBus.c
+++ b/hw/xfree86/common/xf86pciBus.c
@@ -109,8 +109,7 @@ xf86PciProbe(void)
             xf86PciVideoInfo[num - 1] = info;
 
             pci_device_probe(info);
-            if (primaryBus.type == BUS_NONE && (pci_device_is_boot_vga(info) ||
-                                                pci_device_is_boot_display(info))) {
+            if (primaryBus.type == BUS_NONE && pci_device_is_boot_display(info)) {
                 primaryBus.type = BUS_PCI;
                 primaryBus.id.pci = info;
             }
@@ -118,6 +117,18 @@ xf86PciProbe(void)
         }
     }
     free(iter);
+
+    /* If no boot display was found, fall back to the boot VGA device */
+    if (primaryBus.type == BUS_NONE) {
+        for (i = 0; i < num; i++) {
+            info = xf86PciVideoInfo[i];
+            if (pci_device_is_boot_vga(info)) {
+                primaryBus.type = BUS_PCI;
+                primaryBus.id.pci = info;
+                break;
+            }
+        }
+    }
 
     /* If we haven't found a primary device try a different heuristic */
     if (primaryBus.type == BUS_NONE && num) {

--- a/hw/xfree86/common/xf86platformBus.c
+++ b/hw/xfree86/common/xf86platformBus.c
@@ -388,7 +388,8 @@ xf86platformProbe(void)
         }
     }
 
-    /* Then check for pci_device_is_boot_vga()/pci_device_is_boot_display() */
+    /* After the OutputClass loop above, scan for the primary device via
+     * various methods, preferring boot display over boot VGA. */
     for (i = 0; i < xf86_num_platform_devices; i++) {
         struct xf86_platform_device *dev = &xf86_platform_devices[i];
 
@@ -396,13 +397,28 @@ xf86platformProbe(void)
             continue;
 
         pci_device_probe(dev->pdev);
-        if (pci_device_is_boot_display(dev->pdev) ||
-            pci_device_is_boot_vga(dev->pdev)) {
+        if (pci_device_is_boot_display(dev->pdev)) {
             primaryBus.type = BUS_PLATFORM;
             primaryBus.id.plat = dev;
+            return 0;
         }
     }
 
+    /* Fall back to boot VGA if no boot display was found. */
+    for (i = 0; i < xf86_num_platform_devices; i++) {
+        struct xf86_platform_device *dev = &xf86_platform_devices[i];
+
+        if (!dev->pdev)
+            continue;
+
+        if (pci_device_is_boot_vga(dev->pdev)) {
+            primaryBus.type = BUS_PLATFORM;
+            primaryBus.id.plat = dev;
+            return 0;
+        }
+    }
+
+    /* No primary device found. */
     return 0;
 }
 


### PR DESCRIPTION
Cherry-pick of upstream xorg/main `888b30c207` (MR [!2242](https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2242), Mario Limonciello).

The primary-device selection in both the PCI and platform bus probes tested `pci_device_is_boot_vga()` **and** `pci_device_is_boot_display()` together, so whichever device matched *either* condition first won — instead of actually preferring the boot **display**. This reworks both probes to scan for a boot display first and only fall back to the boot VGA device when none is found (preserving prior behaviour when `pci_device_is_boot_display()` is the stubbed `FALSE`).

Picked up during an xorg-upstream relevance sweep. Applies cleanly on our tree (we still carried the old joint check in `xf86pciBus.c` / `xf86platformBus.c`).

Verified locally: `hw/xfree86/Xorg` links clean with `-Dwerror=true` (gcc 14.2).
