### PR TITLE
(master) xfree86: vbe: fix memory leak on VideoModePtr allocation failure

### DIFF
--- a/hw/xfree86/int10/vbe.c
+++ b/hw/xfree86/int10/vbe.c
@@ -397,8 +397,10 @@ VBEGetVBEInfo(vbeInfoPtr pVbe)
     i = 0;
     while (modes[i] != 0xffff)
         i++;
-    if (!(block->VideoModePtr = calloc(i + 1, sizeof(CARD16))))
+    if (!(block->VideoModePtr = calloc(i + 1, sizeof(CARD16)))) {
+        VBEFreeVBEInfo(block);
         return NULL;
+    }
     memcpy(block->VideoModePtr, modes, sizeof(CARD16) * i);
     block->VideoModePtr[i] = 0xffff;
 


### PR DESCRIPTION
In VBEGetVBEInfo(), when the calloc() for block->VideoModePtr fails, the
already-allocated VbeInfoBlock was leaked on the error path. By that point
block->OEMStringPtr has also been strdup()'d, so a bare free(block) would
still leak that string. Use VBEFreeVBEInfo() to release the partially-built
block together with all strings it already owns (the fields not yet set are
NULL from the initial calloc(), so freeing them is safe).

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
