### PR TITLE
test/pyxtest: add test for ProcXIChangeCursor with window None

### DIFF
--- a/test/pyxtest/proto/xi.py
+++ b/test/pyxtest/proto/xi.py
@@ -11,6 +11,7 @@ XChangeDeviceProperty = 37
 XGetDeviceProperty = 39
 
 # XI2 minor opcodes
+XIChangeCursor = 42
 XIQueryVersion = 47
 XIPassiveGrabDevice = 54
 XIPassiveUngrabDevice = 55
@@ -72,6 +73,28 @@ class XIQueryVersionRequest:
             2,  # 8 bytes = 2 words
             self.major,
             self.minor,
+        )
+
+
+@dataclass
+class XIChangeCursorRequest:
+    """XIChangeCursor request."""
+
+    opcode: int
+    window: int
+    cursor: int
+    deviceid: int = XIAllMasterDevices
+
+    def to_bytes(self, byte_order: str = "<") -> bytes:
+        return struct.pack(
+            f"{byte_order}BBH II HH",
+            self.opcode,
+            XIChangeCursor,
+            4,
+            self.window,
+            self.cursor,
+            self.deviceid,
+            0,  # pad
         )
 
 

--- a/test/pyxtest/test_xi.py
+++ b/test/pyxtest/test_xi.py
@@ -7,7 +7,7 @@ import struct
 import pytest
 
 from proto import xi
-from xclient import BadLength, BadValue, Extension, X11Error, X11Reply
+from xclient import BadLength, BadWindow, BadValue, Extension, X11Error, X11Reply
 
 
 @pytest.fixture
@@ -389,3 +389,28 @@ class TestXIChangeDeviceControl:
                 "ChangeDeviceControl returned BadValue - "
                 "resolution values not byte-swapped"
             )
+
+
+class TestXIChangeCursor:
+    def test_change_cursor_null_window(self, xserver, xi_xclient):
+        """
+        XIChangeCursor dereferences pWin even if it's not set
+        """
+        opcode = xi_xclient.query_extension(Extension.XI).opcode
+        req = xi.XIChangeCursorRequest(
+            opcode=opcode,
+            window=0,
+            cursor=0,
+            deviceid=xi.VirtualCorePointer,
+        )
+        xi_xclient.send_request(req)
+        resp = xi_xclient.recv_response(timeout=5.0)
+
+        assert xserver.is_alive, "Server crashed"
+
+        # Without the fix: SegFault on a NULL WindowPtr
+        # With the fix: BadWindow
+        assert isinstance(resp, X11Error), f"Expected an error, got {resp}"
+        assert resp.error_code == BadWindow, (
+            "ChangeCursor didn't return BadWindow for Window 0"
+        )


### PR DESCRIPTION
Cherry-pick of upstream xorg/main `bb13ee0410` (Alan Coopersmith, MR [!2246](https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2246)) — adds a pyxtest regression test sending `XIChangeCursor` with `window == None (0)`.

**Note on context:** the upstream commit message says "Currently crashes the X server" — that refers to *unpatched* upstream. **Our tree already fixes this NULL-deref** (via `dixLookupWindow()` rejecting `None` with `BadWindow` in `ProcXIChangeCursor`, see `Xext/xinput/xichangecursor.c`). The test asserts exactly that fixed behaviour (`error_code == BadWindow` + server still alive), so here it serves as a **regression guard** and passes as-is. Verified the assertion matches our semantics; `xclient.BadWindow` is already used elsewhere in pyxtest and the suite is wired into `meson test`.

Test-only change (no server code touched). Picked up during the xorg-upstream relevance sweep; the sibling pyxtest commit (`035ff56180`, Solaris SO_PEERCRED) is already in our tree (`a5fb98da16`).
