### PR TITLE
(master) dix: move screen destruction loop into dixFreeAllScreens()

### DIFF
--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -304,7 +304,7 @@ extern Bool enableBackingStore;
 /* in generated BuiltInAtoms.c */
 void MakePredeclaredAtoms(void);
 
-void dixFreeScreen(ScreenPtr pScreen);
+void dixFreeAllScreens(void);
 
 /*
  * @brief call the screen's UnrealizeWindow proc

--- a/dix/main.c
+++ b/dix/main.c
@@ -317,26 +317,8 @@ dix_main(int argc, char *argv[], char *envp[])
         DIX_FOR_EACH_SCREEN({ walkScreen->root = NullWindow; });
 
         CloseDownDevices();
-
         CloseDownEvents();
-
-        if (screenInfo.numGPUScreens > 0) {
-            for (int walkScreenIdx = screenInfo.numGPUScreens - 1; walkScreenIdx >= 0; walkScreenIdx--) {
-                ScreenPtr walkScreen = screenInfo.gpuscreens[walkScreenIdx];
-                dixFreeScreen(walkScreen);
-                screenInfo.numGPUScreens = walkScreenIdx;
-            }
-        }
-        memset(&screenInfo.gpuscreens, 0, sizeof(screenInfo.gpuscreens));
-
-        if (screenInfo.numScreens > 0) {
-            for (int walkScreenIdx = screenInfo.numScreens - 1; walkScreenIdx >= 0; walkScreenIdx--) {
-                ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
-                dixFreeScreen(walkScreen);
-                screenInfo.numScreens = walkScreenIdx;
-            }
-        }
-        memset(&screenInfo.screens, 0, sizeof(screenInfo.screens));
+        dixFreeAllScreens();
 
         ReleaseClientIds(serverClient);
         dixFreePrivates(serverClient->devPrivates, PRIVATE_CLIENT);

--- a/dix/screen.c
+++ b/dix/screen.c
@@ -14,7 +14,7 @@
 CallbackListPtr ScreenSaverAccessCallback = NULL;
 CallbackListPtr ScreenAccessCallback = NULL;
 
-void dixFreeScreen(ScreenPtr pScreen)
+static void dixFreeScreen(ScreenPtr pScreen)
 {
     if (!pScreen)
         return;
@@ -31,4 +31,25 @@ void dixFreeScreen(ScreenPtr pScreen)
     DeleteCallbackList(&pScreen->hookPixmapDestroy);
     DeleteCallbackList(&pScreen->hookPostCreateResources);
     free(pScreen);
+}
+
+void dixFreeAllScreens(void)
+{
+    if (screenInfo.numGPUScreens > 0) {
+        for (int walkScreenIdx = screenInfo.numGPUScreens - 1; walkScreenIdx >= 0; walkScreenIdx--) {
+            ScreenPtr walkScreen = screenInfo.gpuscreens[walkScreenIdx];
+            dixFreeScreen(walkScreen);
+            screenInfo.numGPUScreens = walkScreenIdx;
+        }
+    }
+    memset(&screenInfo.gpuscreens, 0, sizeof(screenInfo.gpuscreens));
+
+    if (screenInfo.numScreens > 0) {
+        for (int walkScreenIdx = screenInfo.numScreens - 1; walkScreenIdx >= 0; walkScreenIdx--) {
+            ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];
+            dixFreeScreen(walkScreen);
+            screenInfo.numScreens = walkScreenIdx;
+        }
+    }
+    memset(&screenInfo.screens, 0, sizeof(screenInfo.screens));
 }


### PR DESCRIPTION
Consolidate the screen destruction code in its own function and
so move it out of the big main loop.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit 968478e5aa4363018cc6c8f7bac9174590a7e346)
