### PR TITLE
(backport 25.2) glamor: glamor_egl.c do not call xorgGlxCreateVendor()

### DIFF
--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -1735,7 +1735,6 @@ glamor_egl_screen_init(ScreenPtr screen, struct glamor_context *glamor_ctx)
 #ifdef GLXEXT
     if (!vendor_initialized) {
         GlxPushProvider(&glamor_provider);
-        xorgGlxCreateVendor();
         vendor_initialized = TRUE;
     }
 #endif


### PR DESCRIPTION
Backport of #3174 (master) to `release/25.2`.

glamor_egl.c called `xorgGlxCreateVendor()` at the top of the GLX provider callback chain, which always succeeds and thus breaks other GLX vendors. The call is removed; `GlxPushProvider(&glamor_provider)` remains. Applies cleanly (the call is present on 25.2).

Master PR: #3174
Master commit: ad1d4a28da71e58448707c62c167633630324186

> 🤖 Backport prepared by Claude Code on behalf of @metux. **Do not auto-merge** — release-line merges are manual/maintainer-only.