### PR TITLE
(release/25.1) glamor: glamor_egl.c do not call xorgGlxCreateVendor()

### DIFF
--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -1059,7 +1059,6 @@ glamor_egl_screen_init(ScreenPtr screen, struct glamor_context *glamor_ctx)
 #ifdef GLXEXT
     if (!vendor_initialized) {
         GlxPushProvider(&glamor_provider);
-        xorgGlxCreateVendor();
         vendor_initialized = TRUE;
     }
 #endif


### PR DESCRIPTION
This calls installed default glx vendor at top of callback chain,
which causes problem with other glx vendors, because it always succeds
and set same vendor for screen.

Signed-off-by: Tautvis <gtautvis@gmail.com>
(cherry picked from commit ad1d4a28da71e58448707c62c167633630324186)
