### PR TITLE
(release/25.2) xfree86: Add missing string padding to the DGA QueryMode request handler

### DIFF
--- a/hw/xfree86/common/xf86DGA.c
+++ b/hw/xfree86/common/xf86DGA.c
@@ -1292,7 +1292,7 @@ ProcXDGAQueryModes(ClientPtr client)
         info.reserved2 = mode[i].reserved2;
 
         x_rpcbuf_write_CARD8s(&rpcbuf, (CARD8*)&info, sz_xXDGAModeInfo);
-        x_rpcbuf_write_CARD8s(&rpcbuf, (CARD8*)mode[i].name, size);
+        x_rpcbuf_write_string_0t_pad(&rpcbuf, mode[i].name);
     }
 
     free(mode);


### PR DESCRIPTION
Fixes: https://github.com/X11Libre/xserver/commit/4d66d6f9ac8db0ca78df6871fda97f42d9380701

Signed-off-by: stefan11111 <stefan11111github@gmail.com>
(cherry picked from commit 9fd97d52cf1af5d42359b9c17d2158eb3277d8ae)
