### PR TITLE
(backport 25.0) xfree86: pad the DGA QueryModes reply name to its announced length

### DIFF
--- a/hw/xfree86/common/xf86DGA.c
+++ b/hw/xfree86/common/xf86DGA.c
@@ -1367,6 +1367,21 @@ ProcXDGAQueryModes(ClientPtr client)
 
         WriteToClient(client, sz_xXDGAModeInfo, (char *) (&info));
         WriteToClient(client, size, mode[i].name);
+        /* rep.length and info.name_size both account for the name padded
+         * to a 4-byte boundary (see the size computation above), so the
+         * bytes actually written must match — otherwise the reply is
+         * short of its announced length and the client desyncs. Pad with
+         * zeroes; do not write info.name_size bytes straight from the name
+         * buffer, which would over-read past the terminating NUL. */
+        {
+            int namepad = pad_to_int32(size) - size;
+
+            if (namepad) {
+                static const char zeros[3] = { 0, 0, 0 };
+
+                WriteToClient(client, namepad, (char *) zeros);
+            }
+        }
     }
 
     free(mode);


### PR DESCRIPTION
Adapted backport of #3173 (master) to `release/25.0`.

**Bug confirmed on 25.0** (verified against the protocol framing): `ProcXDGAQueryModes` sets `rep.length = bytes_to_int32(size)` and `info.name_size = (strlen+1 + 3) & ~3` — both account for the mode name **padded** to 4 bytes — but writes only `strlen+1` bytes via `WriteToClient(client, size, mode[i].name)`. The reply is therefore **shorter than its announced `rep.length`**, desyncing the client.

25.0 still uses the old `WriteToClient` path (no `x_rpcbuf`), so the master one-liner (`x_rpcbuf_write_string_0t_pad`) does not apply; this **adapts** the fix by zero-padding the name to the 4-byte boundary. Padding is written as zeroes rather than over-reading the name buffer (which would leak adjacent memory). Compiles clean (xorg DDX).

Master PR: #3173
Master commit: 9fd97d52cf1af5d42359b9c17d2158eb3277d8ae

> 🤖 Backport prepared by Claude Code on behalf of @metux. **Do not auto-merge** — release-line merges are manual/maintainer-only.