### PR TITLE
(master) hurd: build the xfree86 Xorg server by default in CI (kdrive non-fatal)

### DIFF
--- a/.github/scripts/hurd/run-xserver-build.sh
+++ b/.github/scripts/hurd/run-xserver-build.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 #
-# Runs INSIDE the Debian GNU/Hurd VM (over ssh) — see
-# .github/workflows/build-hurd.yml. EXPERIMENTAL: the X server is not (yet)
-# ported to GNU/Hurd, so this is expected to surface missing pieces rather than
-# go green. $REPO and $SHA are passed in by the workflow.
+# Runs INSIDE the Debian GNU/Hurd VM (over ssh) — see the xserver-build-hurd job
+# in .github/workflows/build-xserver.yml. Builds, as the job's FATAL pass/fail
+# gate, every X server proven to build on GNU/Hurd: Xvfb, Xnest, the physical
+# xfree86 Xorg server, Xephyr, and the GLX extension. The DRM-coupled bits
+# (dri*, glamor) and Xfbdev stay off — they need a DRM kernel interface / Linux
+# VTs that Hurd lacks (see the build section). $REPO and $SHA come from the
+# workflow.
 set -ex
 
 export DEBIAN_FRONTEND=noninteractive
@@ -33,7 +36,9 @@ for p in \
     libtirpc-dev nettle-dev libbsd-dev libgcrypt20-dev libepoxy-dev \
     libxcb-util-dev libxcb-icccm4-dev libxcb-shape0-dev libxcb-xkb-dev \
     libxcb-keysyms1-dev libxcb-image0-dev libxcb-render-util0-dev \
-    libxcb-randr0-dev libxcb-shm0-dev libxcb-render0-dev
+    libxcb-randr0-dev libxcb-shm0-dev libxcb-render0-dev \
+    libxcb-xv0-dev libxcb-glx0-dev \
+    libpciaccess-dev libdrm-dev
 do
     sudo apt-get install -y --no-install-recommends "$p" || echo "WARN: package $p not available on hurd"
 done
@@ -45,12 +50,28 @@ cd xserver
 git fetch --depth 1 origin "$SHA"
 git checkout FETCH_HEAD
 
-echo "==> meson setup (minimal Xvfb/Xnest, no glx/dri/xorg — bring-up)"
+# FATAL build: every server proven to build on GNU/Hurd, in one meson build so a
+# regression breaking any of them fails the lane:
+#   - Xvfb, Xnest    virtual DDXes
+#   - Xorg           the physical xfree86 server (libpciaccess has a Hurd backend,
+#                    so the PCI layer configures/links)
+#   - Xephyr         kdrive server that runs as an X client over XCB (no linux
+#                    fbdev/VT path), so unlike Xfbdev it builds fine on Hurd
+#   - glx            the GLX extension builds without libdrm (software/indirect)
+# udev + logind stay off (absent on Hurd → static config / input discovery).
+# The DRM-coupled subsystems stay off because Hurd has no DRM kernel interface:
+#   - dri1/dri2/dri3 — libdrm's <drm.h> pulls a nonexistent mach/x86_64/ioccom.h
+#   - glamor         — glamor_egl.c needs DRM_FORMAT_MOD_INVALID + GBM (no GBM
+#                      without DRM); confirmed non-buildable on Hurd
+# Xfbdev (kdrive fbdev) also stays off: it builds hw/kdrive/linux, which needs
+# Linux VTs (<linux/vt.h>) and would require a dedicated Hurd kdrive backend.
+echo "==> meson setup (Xvfb + Xnest + Xorg + Xephyr + glx — the servers that build on Hurd)"
 meson setup _build \
     -Dwerror=false \
-    -Dxvfb=true -Dxnest=true \
-    -Dxorg=false -Dxephyr=false -Dxfbdev=false \
-    -Dglx=false -Ddri2=false -Ddri3=false -Dudev=false -Dsystemd_logind=false
+    -Dxvfb=true -Dxnest=true -Dxorg=true -Dxephyr=true \
+    -Dglx=true \
+    -Dxfbdev=false -Dglamor=false -Ddri1=false -Ddri2=false -Ddri3=false \
+    -Dudev=false -Dsystemd_logind=false
 
-echo "==> meson compile"
+echo "==> meson compile (Xvfb + Xnest + Xorg + Xephyr + glx)"
 meson compile -C _build


### PR DESCRIPTION
Follow-up to the GNU/Hurd build lane: build **every X server that compiles on GNU/Hurd** by default, in the existing `xserver-build-hurd` job (parallel with the other platform lanes — no separate workflow).

### What builds on Hurd (all confirmed green in CI, one combined meson build ≈ 12 min)
| server | flag | status |
|---|---|---|
| Xvfb, Xnest | `-Dxvfb -Dxnest` | ✅ fatal |
| xfree86 **Xorg** | `-Dxorg` | ✅ fatal — `hw/xfree86/Xorg` |
| **Xephyr** | `-Dxephyr` | ✅ fatal — `hw/kdrive/ephyr/Xephyr` |
| **GLX** | `-Dglx` | ✅ fatal — builds without libdrm |

A regression breaking any of them fails CI.

### Kept off — fundamentally DRM/Linux-VT bound, not port bugs
| | reason |
|---|---|
| `dri1/dri2/dri3` | libdrm's `<drm.h>` pulls a nonexistent `mach/x86_64/ioccom.h` (Hurd has no DRM) |
| `glamor` | `glamor_egl.c` needs `DRM_FORMAT_MOD_INVALID` + GBM; GBM needs DRM → confirmed non-buildable on Hurd |
| `Xfbdev` (kdrive fbdev) | builds `hw/kdrive/linux` → needs Linux VTs `<linux/vt.h>` → would need a dedicated Hurd kdrive backend |

Thanks @stefan11111 for the review — glx and Xephyr are in the fatal build because of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
