### PR TITLE
Enable -Dwerror on the solaris/gentoo/openbsd build lanes

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -615,8 +615,6 @@ jobs:
     # mechanism as the BSD jobs above). Exercises the Solaris-specific os/ code
     # paths (procfs/psinfo, the sunos meson branch) that no other CI covers.
     # OpenIndiana packages the full X stack incl. Mesa, so GLX stays enabled.
-    # werror is off for now since this platform is freshly added; tighten once
-    # it is green.
     xserver-build-solaris:
         runs-on: ubuntu-latest
         needs: ubuntu-fetch-pkg
@@ -625,7 +623,7 @@ jobs:
             # libdrm-backed direct-rendering extensions can't work (and OI's
             # xf86drm.h pulls a drm.h that only exists for Linux). glx stays on
             # (Mesa is packaged) for indirect/software GLX.
-            MESON_ARGS: -Dwerror=false -Dxvfb=true -Dxnest=true -Dxorg=false -Dxephyr=false -Dxfbdev=false -Ddri2=false -Ddri3=false
+            MESON_ARGS: -Dwerror=true -Dxvfb=true -Dxnest=true -Dxorg=false -Dxephyr=false -Dxfbdev=false -Ddri2=false -Ddri3=false
         steps:
             - uses: actions/checkout@v6
             - uses: ./.github/actions/ubuntu-pkg-cache
@@ -642,13 +640,12 @@ jobs:
     # tooling is installed; X libs (incl. Mesa) come from /usr/X11R6. glx stays
     # enabled (indirect/software GLX against the base Mesa); dri2/dri3 stay off
     # (direct rendering needs a working DRM/KMS, n/a in the headless VM).
-    # werror off while the platform is freshly added.
     xserver-build-openbsd:
         runs-on: ubuntu-latest
         needs: ubuntu-fetch-pkg
         timeout-minutes: 90
         env:
-            MESON_ARGS: -Dwerror=false -Dxvfb=true -Dxnest=true -Dxorg=false -Dxephyr=false -Dxfbdev=false -Ddri2=false -Ddri3=false
+            MESON_ARGS: -Dwerror=true -Dxvfb=true -Dxnest=true -Dxorg=false -Dxephyr=false -Dxfbdev=false -Ddri2=false -Ddri3=false
         steps:
             - uses: actions/checkout@v6
             - uses: ./.github/actions/ubuntu-pkg-cache
@@ -718,6 +715,11 @@ jobs:
         container:
             image: alpine:latest
         env:
+            # werror stays off here: on musl, libbsd's <bsd/sys/cdefs.h> pulls the
+            # system <sys/cdefs.h>, which emits a #warning ("non-standard ...
+            # deprecated") that -Werror (-Werror=cpp) turns fatal in every TU using
+            # libbsd. That's a musl/libbsd toolchain quirk, not an xserver warning, so
+            # it can't be fixed in-tree (unlike solaris/gentoo/openbsd, now tightened).
             MESON_ARGS: -Dprefix=/usr -Dxcsecurity=true -Dxorg=true -Dxephyr=true -Dxvfb=true -Dxnest=true -Dxfbdev=false -Dsystemd_logind=false -Dwerror=false
         steps:
             # actions/checkout is a JS action; GitHub's bundled Node is
@@ -773,11 +775,7 @@ jobs:
         container:
             image: ghcr.io/x11libre/xserver-gentoo-deps:${{ needs.gentoo-deps-image.outputs.tag }}
         env:
-            # werror off: Gentoo's hardened toolchain (FORTIFY_SOURCE) trips
-            # -Werror=format-truncation in the bundled Xtrans (a bounded snprintf
-            # into sun_path) which other platforms don't hit. Matches the other
-            # freshly-added lanes (solaris/openbsd) while the platform is new.
-            MESON_ARGS: -Dprefix=/usr -Dwerror=false -Dxcsecurity=true -Dxorg=true -Dxephyr=true -Dxvfb=true -Dxnest=true -Dxfbdev=false -Dsystemd_logind=false
+            MESON_ARGS: -Dprefix=/usr -Dwerror=true -Dxcsecurity=true -Dxorg=true -Dxephyr=true -Dxvfb=true -Dxnest=true -Dxfbdev=false -Dsystemd_logind=false
         steps:
             - name: Check out repository code
               uses: actions/checkout@v6

--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -790,7 +790,7 @@ static int _XSERVTransSocketINETCreateListener (
 #ifdef IPv6
 	namelen = sizeof (struct sockaddr_in6);
 #ifdef SIN6_LEN
-	((struct sockaddr_in6 *)&sockname)->sin6_len = sizeof(sockname);
+	((struct sockaddr_in6 *)&sockname)->sin6_len = namelen;
 #endif
 	((struct sockaddr_in6 *)&sockname)->sin6_family = AF_INET6;
 	((struct sockaddr_in6 *)&sockname)->sin6_port = htons(sport);

--- a/os/client.c
+++ b/os/client.c
@@ -166,7 +166,7 @@ get_argmax_from_kern(void *arg)
 void
 DetermineClientCmd(pid_t pid, const char **cmdname, const char **cmdargs)
 {
-#if !defined(__APPLE__) && !defined(__DragonFly__) && !defined(__FreeBSD__)
+#if !defined(__APPLE__) && !defined(__DragonFly__) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
     char path[PATH_MAX + 1];
     int totsize = 0;
     int fd = 0;

--- a/test/bigreq/request-length.c
+++ b/test/bigreq/request-length.c
@@ -62,7 +62,8 @@ int main(int argc, char **argv)
     free(xcb_big_requests_enable_reply(c, xcb_big_requests_enable(c), NULL));
 
     /* Manually write out the bad request.  XCB can't help us here.*/
-    write(fd, &xise_req, sizeof(xise_req));
+    if (write(fd, &xise_req, sizeof(xise_req)) != sizeof(xise_req))
+        return 2;
 
     /* Block until the server has processed our mess and throws an
      * error. If we get disconnected, then the server has noticed what we're


### PR DESCRIPTION
Enables `-Dwerror=true` on three more build lanes (**solaris**, **gentoo**, **openbsd**), fixing the two real warnings that blocked them. Follows the RHEL tightening (#3176).

**Source fixes (preceding commits):**
- `test/bigreq/request-length.c` ignored `write()`'s return → `-Werror=unused-result` on gentoo. Now checked (short write → `return 2`).
- `os/client.c` declared the `/proc/pid/cmdline` vars `path`/`totsize`/`fd` on OpenBSD even though OpenBSD uses the `kvm_getprocs` branch → `-Werror=unused-variable` (clang). Excluded `__OpenBSD__` from the declaration guard.

**Lane flips:**
- **solaris** — probe showed it already builds clean under werror.
- **gentoo** — its old `-Werror=format-truncation` blocker is already fixed (in `set_sun_path`, #3176); only the bigreq write remained.
- **openbsd** — only the unused `/proc` vars remained.
- **alpine stays `-Dwerror=false`** (documented inline): on musl, libbsd's `<bsd/sys/cdefs.h>` → system `<sys/cdefs.h>` emits a `#warning` that `-Werror=cpp` turns fatal in *every* libbsd-using TU — a musl/libbsd toolchain quirk, not an xserver warning, so it can't be fixed in-tree.

Verified locally: the bigreq test object compiles clean under `-Dwerror=true` (gcc 14.2). The solaris/openbsd lanes are validated by this PR's CI (can't build those locally).
