### PR TITLE
(master) os: drop Linux abstract-socket support for the local transport

### DIFF
--- a/os/Xtransint.h
+++ b/os/Xtransint.h
@@ -217,14 +217,12 @@ typedef struct _Xtransport_table {
 #define TRANS_DISABLED	(1<<2)	/* Don't open this one */
 #define TRANS_NOLISTEN  (1<<3)  /* Don't listen on this one */
 #define TRANS_NOUNLINK	(1<<4)	/* Don't unlink transport endpoints */
-#define TRANS_ABSTRACT	(1<<5)	/* This previously meant that abstract sockets should be used available.  For security
-                                 * reasons, this is now a no-op on the client side, but it is still supported for servers.
-                                 */
+/* (1<<5) was TRANS_ABSTRACT (Linux abstract sockets) - removed */
 #define TRANS_NOXAUTH	(1<<6)	/* Don't verify authentication (because it's secure some other way at the OS layer) */
 #define TRANS_RECEIVED	(1<<7)  /* The fd for this has already been opened by someone else. */
 
 /* Flags to preserve when setting others */
-#define TRANS_KEEPFLAGS	(TRANS_NOUNLINK|TRANS_ABSTRACT)
+#define TRANS_KEEPFLAGS	(TRANS_NOUNLINK)
 
 #ifdef XTRANS_TRANSPORT_C /* only provide static function prototypes when
 			     building the transport.c file that has them in */

--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -136,10 +136,6 @@ from the copyright holders.
 /* others don't need this */
 #define SocketInitOnce() /**/
 
-#ifdef __linux__
-#define HAVE_ABSTRACT_SOCKETS
-#endif
-
 #define MIN_BACKLOG 128
 #ifdef SOMAXCONN
 #if SOMAXCONN > MIN_BACKLOG
@@ -607,29 +603,55 @@ static int _XSERVTransSocketSetOption (XtransConnInfo ciptr, int option, int arg
 
 #ifdef UNIXCONN
 static int
-set_sun_path(const char *port, const char *upath, char *path, int abstract)
+set_sun_path(const char *port, const char *upath, char *path)
 {
     struct sockaddr_un s;
-    const char *at = "";
     int n;
 
     if (!port || !*port || !path)
 	return -1;
 
-#ifdef HAVE_ABSTRACT_SOCKETS
-    if (port[0] == '@')
-	upath = "";
-    else if (abstract)
-	at = "@";
-#endif
-
     if (*port == '/') /* a full pathname */
 	upath = "";
 
-    n = snprintf(path, sizeof(s.sun_path), "%s%s%s", at, upath, port);
+    n = snprintf(path, sizeof(s.sun_path), "%s%s", upath, port);
     if (n < 0 || (size_t) n >= sizeof(s.sun_path))
 	return -1;
     return 0;
+}
+
+/*
+ * A leftover socket file at `path` is ambiguous: it may be stale (left
+ * behind by a server that crashed or was killed without unlinking it), or
+ * it may belong to a server that is still very much alive. The path alone
+ * can't tell the two apart. Linux's abstract-socket bind() used to answer
+ * this for free (EADDRINUSE iff someone is actually listening); now that
+ * the local transport always uses a real filesystem path, connect() to it
+ * is the only way to find out - if that succeeds, someone is listening.
+ */
+static Bool
+unix_socket_is_live(const char *path)
+{
+    int fd;
+    struct sockaddr_un addr;
+    Bool live;
+
+    fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+	return FALSE;
+    }
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    /* `path` is always `sockname.sun_path` from a struct sockaddr_un at the
+     * call site, i.e. exactly sizeof(addr.sun_path) bytes, already
+     * NUL-terminated by set_sun_path() - copy it verbatim. */
+    memcpy(addr.sun_path, path, sizeof(addr.sun_path));
+
+    live = connect(fd, (struct sockaddr *) &addr, sizeof(addr)) == 0;
+
+    close(fd);
+    return live;
 }
 #endif
 
@@ -833,11 +855,6 @@ static int _XSERVTransSocketUNIXCreateListener (
     unsigned int	mode;
     char		tmpport[108];
 
-    int			abstract = 0;
-#ifdef HAVE_ABSTRACT_SOCKETS
-    abstract = ciptr->transptr->flags & TRANS_ABSTRACT;
-#endif
-
     prmsg (2, "SocketUNIXCreateListener(%s)\n",
 	port ? port : "NULL");
 
@@ -851,7 +868,7 @@ static int _XSERVTransSocketUNIXCreateListener (
 #else
     mode = 0777;
 #endif
-    if (!abstract && trans_mkdir(UNIX_DIR, mode) == -1) {
+    if (trans_mkdir(UNIX_DIR, mode) == -1) {
 	prmsg (1, "SocketUNIXCreateListener: mkdir(%s) failed, errno = %d\n",
 	       UNIX_DIR, errno);
 	(void) umask (oldUmask);
@@ -866,7 +883,7 @@ static int _XSERVTransSocketUNIXCreateListener (
 	snprintf (tmpport, sizeof(tmpport), "%s%ld", UNIX_PATH, (long)getpid());
 	port = tmpport;
     }
-    if (set_sun_path(port, UNIX_PATH, sockname.sun_path, abstract) != 0) {
+    if (set_sun_path(port, UNIX_PATH, sockname.sun_path) != 0) {
 	prmsg (1, "SocketUNIXCreateListener: path too long\n");
 	return TRANS_CREATE_LISTENER_FAILED;
     }
@@ -881,12 +898,18 @@ static int _XSERVTransSocketUNIXCreateListener (
     namelen = strlen(sockname.sun_path) + offsetof(struct sockaddr_un, sun_path);
 #endif
 
-    if (abstract) {
-	sockname.sun_path[0] = '\0';
-	namelen = offsetof(struct sockaddr_un, sun_path) + 1 + strlen(&sockname.sun_path[1]);
+    /*
+     * Don't blindly unlink a pre-existing socket file: it may belong to a
+     * server that's still running (see unix_socket_is_live()). Only clean
+     * up and rebind if nobody answers there.
+     */
+    if (unix_socket_is_live(sockname.sun_path)) {
+	prmsg (1, "SocketUNIXCreateListener: %s already in use\n",
+	       sockname.sun_path);
+	(void) umask (oldUmask);
+	return TRANS_ADDR_IN_USE;
     }
-    else
-	unlink (sockname.sun_path);
+    unlink (sockname.sun_path);
 
     if ((status = _XSERVTransSocketCreateListener (ciptr,
 	(struct sockaddr *) &sockname, namelen, flags)) < 0)
@@ -914,9 +937,6 @@ static int _XSERVTransSocketUNIXCreateListener (
         return TRANS_CREATE_LISTENER_FAILED;
     }
 
-    if (abstract)
-	sockname.sun_path[0] = '@';
-
     ciptr->family = sockname.sun_family;
     ciptr->addrlen = namelen;
     memcpy (ciptr->addr, &sockname, ciptr->addrlen);
@@ -937,22 +957,17 @@ static int _XSERVTransSocketUNIXResetListener (XtransConnInfo ciptr)
     struct stat		statb;
     int 		status = TRANS_RESET_NOOP;
     unsigned int	mode;
-    int abstract = 0;
-#ifdef HAVE_ABSTRACT_SOCKETS
-    abstract = ciptr->transptr->flags & TRANS_ABSTRACT;
-#endif
 
     prmsg (3, "SocketUNIXResetListener(%p,%d)\n", (void *) ciptr, ciptr->fd);
 
-    if (!abstract && (
-	stat (unsock->sun_path, &statb) == -1 ||
+    if (stat (unsock->sun_path, &statb) == -1 ||
         ((statb.st_mode & S_IFMT) !=
 #if !defined(S_IFSOCK)
 	  		S_IFIFO
 #else
 			S_IFSOCK
 #endif
-				)))
+				))
     {
 	int oldUmask = umask (0);
 
@@ -1109,11 +1124,6 @@ static XtransConnInfo _XSERVTransSocketUNIXAccept (
 	free (newciptr);
         return NULL;
     }
-
-    /*
-     * if the socket is abstract, we already modified the address to have a
-     * @ instead of the initial NUL, so no need to do that again here.
-     */
 
     newciptr->addrlen = ciptr->addrlen;
     memcpy (newciptr->addr, ciptr->addr, newciptr->addrlen);
@@ -1388,8 +1398,7 @@ static int _XSERVTransSocketUNIXClose (XtransConnInfo ciptr)
        && sockname->sun_family == AF_UNIX
        && sockname->sun_path[0])
     {
-	if (!(ciptr->flags & TRANS_NOUNLINK
-	    || ciptr->transptr->flags & TRANS_ABSTRACT))
+	if (!(ciptr->flags & TRANS_NOUNLINK))
 		unlink (sockname->sun_path);
     }
 
@@ -1498,11 +1507,7 @@ static Xtransport _XSERVTransSocketINET6Funcs = {
 static Xtransport _XSERVTransSocketLocalFuncs = {
 	/* Socket Interface */
 	"local",
-#ifdef HAVE_ABSTRACT_SOCKETS
-	TRANS_ABSTRACT,
-#else
 	0,
-#endif
 	NULL,
 	_XSERVTransSocketOpenCOTSServer,
 	_XSERVTransSocketReopenCOTSServer,
@@ -1526,11 +1531,7 @@ static const char* unix_nolisten[] = { "local" , NULL };
 static Xtransport _XSERVTransSocketUNIXFuncs = {
 	/* Socket Interface */
 	"unix",
-#if !defined(HAVE_ABSTRACT_SOCKETS)
         TRANS_ALIAS,
-#else
-	0,
-#endif
 	unix_nolisten,
 	_XSERVTransSocketOpenCOTSServer,
 	_XSERVTransSocketReopenCOTSServer,


### PR DESCRIPTION
The Unix-domain socket transport optionally bound a Linux "abstract"
socket (the @/tmp/.X11-unix/Xn variant with a leading NUL in sun_path)
in addition to the classic filesystem socket. Remove that abstract
variant; on Linux the local transport now behaves exactly like on every
other platform: a single Unix-domain socket under /tmp/.X11-unix.

Reasons:

  - It is Linux-only. Abstract sockets are a Linux extension that does
    not exist on the BSDs, Solaris, macOS, Cygwin, etc., so the feature
    was already carried behind #ifdef __linux__ and only ever benefited
    one platform while the code had to be maintained for all.

  - It carries a fair amount of extra, special-case code for that single
    platform: an abstract flag threaded through set_sun_path(),
    CreateListener and ResetListener, the leading-NUL / trailing-'@'
    sun_path fixups and their bespoke namelen computation, a dedicated
    TRANS_ABSTRACT transport flag, and a second ("unix" vs "local")
    transport-table entry whose semantics flipped depending on whether
    abstract sockets were available. All of that is now gone.

  - The classic filesystem socket has to exist anyway. libX11/libxcb
    only *prefer* the abstract socket and fall back to the path socket,
    and non-abstract clients (and every non-Linux client) need the path
    socket regardless. So the abstract socket was never load-bearing:
    it was a second, parallel endpoint duplicating one we must keep.

  - It is problematic for containers. Abstract sockets live in the
    network namespace rather than the mount namespace, so they cannot be
    bind-mounted into a container/sandbox and leak across the netns
    boundary, unlike the filesystem socket which can be shared (or
    withheld) via a bind mount and constrained by filesystem
    permissions. Sandboxes (flatpak, firejail, ...) already suppress the
    abstract socket for exactly this reason.

  - It does not fit the Unix philosophy. "Everything is a file" is the
    whole point of a Unix-domain socket; an abstract socket is a name in
    an opaque kernel namespace with no filesystem presence, no path, no
    ownership and no permission bits. It exists to paper over userspace
    lifecycle issues (stale socket files, cleanup on crash) by pushing
    them into the kernel instead of solving them in userspace -- the same
    kind of "work around a userspace problem inside the kernel" design
    that got kdbus rejected [1]. Those userspace problems are already
    handled for the path socket (stat/unlink on reset, mkdir of the
    socket dir).

No client-visible behaviour changes on a normal desktop: clients that
tried the abstract socket first simply fall back to the filesystem
socket that the server has always also created.

[1] https://lkml.iu.edu/hypermail/linux/kernel/1504.3/02040.html

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
