### PR TITLE
os: drop the never-defined XTHREADS_NEEDS_BYNAMEPARAMS blocks

### DIFF
--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -717,9 +717,6 @@ static int _XSERVTransSocketINETCreateListener (
     SOCKLEN_T	namelen = sizeof(sockname);
     int		status;
     long	tmpport;
-#ifdef XTHREADS_NEEDS_BYNAMEPARAMS
-    _Xgetservbynameparams sparams;
-#endif
     struct servent *servp;
 
     char	portbuf[PORTBUFSIZE];

--- a/os/access.c
+++ b/os/access.c
@@ -422,10 +422,6 @@ DefineSelf(int fd)
 #endif
     struct sockaddr_in broad_addr;
 
-#ifdef XTHREADS_NEEDS_BYNAMEPARAMS
-    _Xgethostbynameparams hparams;
-#endif
-
     /* Why not use gethostname()?  Well, at least on my system, I've had to
      * make an ugly kernel patch to get a name longer than 8 characters, and
      * uname() lets me access to the whole string (it smashes release, you
@@ -985,9 +981,6 @@ ResetHosts(const char *display)
                     }
                 }
 #else                           /* HAVE_GETADDRINFO */
-#ifdef XTHREADS_NEEDS_BYNAMEPARAMS
-                _Xgethostbynameparams hparams;
-#endif
                 register struct hostent *hp;
 
                 /* host name */
@@ -1792,9 +1785,6 @@ siHostnameAddrMatch(int family, void *addr, int len,
     if (family == FamilyInternet) {
         register struct hostent *hp;
 
-#ifdef XTHREADS_NEEDS_BYNAMEPARAMS
-        _Xgethostbynameparams hparams;
-#endif
         char hostname[SI_HOSTNAME_MAXLEN];
         int f, hostaddrlen;
         void *hostaddr;

--- a/os/utils.c
+++ b/os/utils.c
@@ -814,10 +814,6 @@ set_font_authorizations(char **authorizations, int *authlen, void *client)
         struct addrinfo hints, *ai = NULL;
 #else
         struct hostent *host;
-
-#ifdef XTHREADS_NEEDS_BYNAMEPARAMS
-        _Xgethostbynameparams hparams;
-#endif
 #endif
 
         struct xhostname hn;

--- a/os/xdmcp.c
+++ b/os/xdmcp.c
@@ -1384,9 +1384,6 @@ get_addr_by_name(const char *argtype,
 #else /* HAVE_GETADDRINFO */
     struct hostent *hep;
 
-#ifdef XTHREADS_NEEDS_BYNAMEPARAMS
-    _Xgethostbynameparams hparams;
-#endif
     ossock_init();
     if (!(hep = _XGethostbyname(namestr, hparams))) {
         FatalError("Xserver: %s unknown host: %s\n", argtype, namestr);


### PR DESCRIPTION
Removes the six `#ifdef XTHREADS_NEEDS_BYNAMEPARAMS` blocks in `os/` (access.c ×3, Xtranssock.c, utils.c, xdmcp.c).

`XTHREADS_NEEDS_BYNAMEPARAMS` is defined **nowhere** in the tree — not by meson, not by any header. Each block only declared a `_Xget{host,serv}bynameparams` buffer for the old reentrant `_XGethostbyname`/`_XGetservbyname` wrappers. Since the guard is never true, the declaration was never compiled, and the buffer is only referenced inside the equally-uncompiled pre-`getaddrinfo` `gethostbyname` fallbacks. Pure dead code.

Verified: `access.c` / `transport.c` (Xtranssock) / `utils.c` / `xdmcp.c` objects build clean with `-Dwerror=true` (gcc 14.2).
