### PR TITLE
Xext/xf86bigfont: drop redundant SHM page-rounding and pagesize

### DIFF
--- a/Xext/xf86bigfont/xf86bigfont.c
+++ b/Xext/xf86bigfont/xf86bigfont.c
@@ -41,6 +41,7 @@
 #include <unistd.h>
 #include <time.h>
 #include <errno.h>
+#include <stdbool.h>
 
 #ifdef CONFIG_MITSHM
 # if defined(__CYGWIN__)
@@ -86,8 +87,6 @@ static CARD32 signature;
 /* Index for additional information stored in a FontRec's devPrivates array. */
 static int FontShmdescIndex;
 
-static unsigned int pagesize;
-
 static Bool badSysCall = FALSE;
 
 #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__CYGWIN__) || defined(__DragonFly__)
@@ -123,6 +122,10 @@ CheckForShmSyscall(void)
 
 #define MUST_CHECK_FOR_SHM_SYSCALL
 
+/* Set once the SHM syscall probe above has succeeded; gates the
+   local-client shm optimisation in shmalloc(). */
+static bool shmSupported;
+
 #endif
 
 /* ========== Management of shared memory segments ========== */
@@ -150,7 +153,7 @@ shmalloc(unsigned int size)
     char *addr;
 
 #ifdef MUST_CHECK_FOR_SHM_SYSCALL
-    if (pagesize == 0) {
+    if (!shmSupported) {
         return (ShmDescPtr) NULL;
     }
 #endif
@@ -170,7 +173,6 @@ shmalloc(unsigned int size)
         return (ShmDescPtr) NULL;
     }
 
-    size = (size + pagesize - 1) & -pagesize;
     shmid = shmget(IPC_PRIVATE, size, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH);
     if (shmid == -1) {
         ErrorF(XF86BIGFONTNAME " extension: shmget() failed, size = %u, %s\n",
@@ -651,6 +653,7 @@ XFree86BigfontExtensionInit(void)
                    " extension local-client optimization disabled due to lack of shared memory support in the kernel\n");
             return;
         }
+        shmSupported = true;
 #endif
 
         srand((unsigned int) time(NULL));
@@ -659,16 +662,6 @@ XFree86BigfontExtensionInit(void)
         /* fprintf(stderr, "signature = 0x%08X\n", signature); */
 
         FontShmdescIndex = xfont2_allocate_font_private_index();
-
-#if !defined(CSRG_BASED) && !defined(__CYGWIN__)
-        pagesize = SHMLBA;
-#else
-#ifdef _SC_PAGESIZE
-        pagesize = sysconf(_SC_PAGESIZE);
-#else
-        pagesize = getpagesize();
-#endif
-#endif
 #endif /* CONFIG_MITSHM */
     }
 }


### PR DESCRIPTION
Removes the `pagesize` global from `xf86bigfont` and the redundant SHM page-rounding it fed.

- `shmalloc()` did `size = (size + pagesize - 1) & -pagesize` before `shmget()`. **Redundant** — SysV `shmget()` already rounds the segment to a page, and the rounded size is never handed to the client (it gets the `shmid` and reads the real glyph size). No observable effect.
- `pagesize`'s only other role was the `pagesize == 0` sentinel ("SHM syscall probe failed") on `MUST_CHECK_FOR_SHM_SYSCALL` platforms (BSD/Cygwin). Replaced with a `bool shmSupported` set after `CheckForShmSyscall()` passes.
- This deletes the `#if !defined(CSRG_BASED) && !defined(__CYGWIN__) … SHMLBA … #else sysconf …` block — the **only** `CSRG_BASED` user in this file — with no replacement symbol needed.

New boolean uses `bool` (`<stdbool.h>`), per the ongoing `Bool`→`bool` phase-out.

**CI note:** `xf86bigfont` is `option('xf86bigfont', value: false)` — **no CI lane builds it**. Verified locally with `-Dxf86bigfont=true` (CONFIG_MITSHM on, gcc 14.2): `libxserver_xf86bigfont.a` compiles clean under `-Dwerror=true`. The BSD/Cygwin `MUST_CHECK_FOR_SHM_SYSCALL` path (shmSupported) can't be built locally; the change there is symmetric (sentinel rename).
