### PR TITLE
meson: build the XF86-BigFont extension by default

### DIFF
--- a/Xext/xf86bigfont/xf86bigfont.c
+++ b/Xext/xf86bigfont/xf86bigfont.c
@@ -46,7 +46,6 @@
 # if defined(__CYGWIN__)
 #  include <sys/param.h>
 # endif
-#include <sys/sysmacros.h>
 #include <sys/ipc.h>
 #include <sys/shm.h>
 #include <sys/stat.h>

--- a/Xext/xf86bigfont/xf86bigfont.c
+++ b/Xext/xf86bigfont/xf86bigfont.c
@@ -277,8 +277,10 @@ ProcXF86BigfontQueryVersion(ClientPtr client)
     xXF86BigfontQueryVersionReply reply = {
         .majorVersion = SERVER_XF86BIGFONT_MAJOR_VERSION,
         .minorVersion = SERVER_XF86BIGFONT_MINOR_VERSION,
+#if !defined(WIN32) || defined(__CYGWIN__)
         .uid = geteuid(),
         .gid = getegid(),
+#endif
 #ifdef CONFIG_MITSHM
         .signature = signature,
         .capabilities = (client->local && !client->swapped)
@@ -329,7 +331,9 @@ ProcXF86BigfontQueryFont(ClientPtr client)
     X_REQUEST_FIELD_CARD32(id);
 
     FontPtr pFont;
+#ifdef CONFIG_MITSHM
     CARD32 stuff_flags;
+#endif
     xCharInfo *pmax;
     xCharInfo *pmin;
     int nCharInfos;
@@ -348,11 +352,15 @@ ProcXF86BigfontQueryFont(ClientPtr client)
     /* protocol version is decided based on request packet size */
     switch (client->req_len) {
     case 2:                    /* client with version 1.0 libX11 */
+#ifdef CONFIG_MITSHM
         stuff_flags = (client->local &&
                        !client->swapped ? XF86Bigfont_FLAGS_Shm : 0);
+#endif
         break;
     case 3:                    /* client with version 1.1 libX11 */
+#ifdef CONFIG_MITSHM
         stuff_flags = stuff->flags;
+#endif
         break;
     default:
         return BadLength;

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -93,7 +93,7 @@ option('vgahw', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto'
        description: 'Xorg VGA access module')
 option('dpms', type: 'boolean', value: true,
        description: 'Xorg DPMS extension')
-option('xf86bigfont', type: 'boolean', value: false,
+option('xf86bigfont', type: 'boolean', value: true,
        description: 'XF86 Big Font extension')
 option('screensaver', type: 'boolean', value: true,
        description: 'ScreenSaver extension')


### PR DESCRIPTION
Flips `option('xf86bigfont')` from `false` to `true` so the **XF86-BigFont** extension is built as part of the standard build — and therefore actually compiled by CI (no lane built it before, since the option defaulted off).

Motivation: gives CI coverage for `Xext/xf86bigfont/` (currently zero), including the pending cleanups there. This PR's own CI run is the first cross-platform build of the extension in a long time — it validates that it still compiles everywhere.

Enabling it adds `xf86bigfontproto (>= 1.2.0)` as a build dependency (with the `xorgproto` subproject fallback). Verified locally: default build now compiles `libxserver_xf86bigfont.a` clean (gcc 14.2, `xf86bigfontproto 1.2.0`).

Note: this also makes the extension part of shipped/default builds (it was historically off by default). Flagging for maintainer awareness.
