### PR TITLE
dix: guard ARRAY_SIZE against a platform-provided definition

### DIFF
--- a/include/dix.h
+++ b/include/dix.h
@@ -65,7 +65,11 @@ SOFTWARE.
 #define REQUEST(type)                                                   \
     type * stuff = (type *)client->requestBuffer;
 
+/* Some platforms provide ARRAY_SIZE from a system header (e.g. illumos/Solaris
+ * <sys/sysmacros.h>); don't redefine it there (-Werror). */
+#ifndef ARRAY_SIZE
 #define ARRAY_SIZE(a)  (sizeof((a)) / sizeof((a)[0]))
+#endif
 
 #define REQUEST_SIZE_MATCH(req)                                         \
     do {                                                                \


### PR DESCRIPTION
`include/dix.h` defined `ARRAY_SIZE()` **unconditionally**. `ARRAY_SIZE` is a non-standard macro that some platforms provide from a system header — notably **illumos/Solaris `<sys/sysmacros.h>`** — so any TU that pulls the system one in before `dix.h` gets a redefinition, fatal under `-Werror`:

```
include/dix.h:68: error: "ARRAY_SIZE" redefined [-Werror]
```

Wrap it in `#ifndef ARRAY_SIZE`, matching what `Xext/dri2/pci_ids/pci_id_driver_map.h` already does. Linux/glibc userspace doesn't provide `ARRAY_SIZE`, so nothing changes there; on Solaris it stops clashing.

Build-verified: `dix/dispatch.c.o` compiles clean.

**Not a backport candidate:** no `release/*` line has a Solaris CI lane, so the clash isn't reachable there; this is a master-side robustness fix. (The concrete break that exposed it — `xf86bigfont` pulling `<sys/sysmacros.h>` — is fixed separately.)

Follow-up parked: `ARRAY_SIZE` is defined **9×** across the tree (mostly unguarded) — worth consolidating to one canonical guarded definition later (see `BIGFONT.md` / DASHBOARD Parkplatz).
