### PR TITLE
(master) kdrive/ephyr: fix NULL-deref crash on lost host-display connection during color setup

### DIFF
--- a/hw/kdrive/ephyr/hostx.c
+++ b/hw/kdrive/ephyr/hostx.c
@@ -692,6 +692,9 @@ hostx_init(void)
             xcb_lookup_color(HostX.conn, xscreen->default_colormap, 3, "red");
         xcb_lookup_color_reply_t *reply =
             xcb_lookup_color_reply(HostX.conn, c, NULL);
+        if (!reply) {
+            FatalError("Xephyr: lost connection to host display while allocating colors\n");
+        }
         red = reply->exact_red;
         green = reply->exact_green;
         blue = reply->exact_blue;
@@ -703,6 +706,9 @@ hostx_init(void)
                                                      xscreen->default_colormap,
                                                      red, green, blue);
         xcb_alloc_color_reply_t *r = xcb_alloc_color_reply(HostX.conn, c, NULL);
+        if (!r) {
+            FatalError("Xephyr: lost connection to host display while allocating colors\n");
+        }
         red = r->red;
         green = r->green;
         blue = r->blue;


### PR DESCRIPTION
hostx_init() calls xcb_lookup_color_reply() and xcb_alloc_color_reply()
without checking for a NULL reply, then immediately dereferences it. If
the connection to the host X display dies in between (e.g. a transport
error on the socket Xephyr just connected through), both functions
return NULL and Xephyr crashes with a SIGSEGV instead of failing
cleanly, the same way the adjacent xcb_connect() failure a few lines
above already does.

Found while investigating a CI segfault in the Xephyr -glamor test
that traced back to exactly this NULL deref (offset 0x8 into a NULL
xcb_lookup_color_reply_t), exposed by a local-transport listener race
under concurrent test load.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
