### PR TITLE
.github: build xf86bigfont on CI lanes, keep meson default off

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -39,7 +39,7 @@ jobs:
 
     xserver-build-ubuntu-no-gbm:
         env:
-            MESON_ARGS: -Dprefix=/usr -Dxephyr=true -Dwerror=true -Dxcsecurity=true -Dgbm=false -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=true -Dtest_xephyr_gles=false
+            MESON_ARGS: -Dprefix=/usr -Dxephyr=true -Dwerror=true -Dxcsecurity=true -Dgbm=false -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=true -Dtest_xephyr_gles=false -Dxf86bigfont=true
             LIBGL_ALWAYS_SOFTWARE: 1
             GALLIUM_DRIVER: llvmpipe
             PIGLIT_PLATFORM: x11_egl
@@ -82,7 +82,7 @@ jobs:
 
     xserver-build-ubuntu:
         env:
-            MESON_ARGS: -Dprefix=/usr -Dxephyr=true -Dwerror=true -Dxcsecurity=true -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=true -Dtest_xephyr_gles=false
+            MESON_ARGS: -Dprefix=/usr -Dxephyr=true -Dwerror=true -Dxcsecurity=true -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=true -Dtest_xephyr_gles=false -Dxf86bigfont=true
             LIBGL_ALWAYS_SOFTWARE: 1
             GALLIUM_DRIVER: llvmpipe
             PIGLIT_PLATFORM: x11_egl
@@ -146,7 +146,7 @@ jobs:
 
     xserver-build-ubuntu-debug:
         env:
-            MESON_ARGS: --buildtype=debug -Dprefix=/usr -Dxephyr=true -Dwerror=true -Dxcsecurity=true -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=true -Dtest_xephyr_gles=false
+            MESON_ARGS: --buildtype=debug -Dprefix=/usr -Dxephyr=true -Dwerror=true -Dxcsecurity=true -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=true -Dtest_xephyr_gles=false -Dxf86bigfont=true
             LIBGL_ALWAYS_SOFTWARE: 1
             GALLIUM_DRIVER: llvmpipe
             PIGLIT_PLATFORM: x11_egl
@@ -347,7 +347,7 @@ jobs:
     xserver-build-mingw32-ubuntu:
         runs-on: ubuntu-latest
         env:
-            MESON_ARGS: -Dprefix=/home/runner/x11 --cross-file=.github/scripts/mingw32/cross-i686-w64-mingw32.txt -Dwerror=true -Dglx=false -Dlisten_tcp=true -Dxvmc=true -Dxv=true -Dxvfb=true -Dxnest=true -Dxephyr=true -Dxfbdev=false
+            MESON_ARGS: -Dprefix=/home/runner/x11 --cross-file=.github/scripts/mingw32/cross-i686-w64-mingw32.txt -Dwerror=true -Dglx=false -Dlisten_tcp=true -Dxvmc=true -Dxv=true -Dxvfb=true -Dxnest=true -Dxephyr=true -Dxfbdev=false -Dxf86bigfont=true
         needs: ubuntu-fetch-pkg
         steps:
             - name: Check out repository code
@@ -386,7 +386,7 @@ jobs:
             github.event_name != 'pull_request' ||
             github.event.pull_request.head.repo.full_name != github.repository
         env:
-            MESON_ARGS: -Dprefix=/tmp -Dglx=false -Dxnest=false -Dxfbdev=false
+            MESON_ARGS: -Dprefix=/tmp -Dglx=false -Dxnest=false -Dxfbdev=false -Dxf86bigfont=true
             X11_PREFIX: /Users/runner/x11
             X11_BUILD_DIR: /Users/runner/build-deps
         runs-on: macos-latest
@@ -448,7 +448,7 @@ jobs:
         timeout-minutes: 90
         env:
             MYTOKEN : ${{ secrets.MYTOKEN }}
-            MESON_ARGS: -Dprefix=/usr -Dxephyr=true -Dwerror=true -Dxcsecurity=true -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=false
+            MESON_ARGS: -Dprefix=/usr -Dxephyr=true -Dwerror=true -Dxcsecurity=true -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=false -Dxf86bigfont=true
         steps:
             - uses: actions/checkout@v6
             - uses: ./.github/actions/ubuntu-pkg-cache
@@ -504,7 +504,7 @@ jobs:
         needs: ubuntu-fetch-pkg
         timeout-minutes: 90
         env:
-            MESON_ARGS: -Dwerror=true -Dxephyr=true -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=false
+            MESON_ARGS: -Dwerror=true -Dxephyr=true -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=false -Dxf86bigfont=true
         steps:
             - uses: actions/checkout@v6
             - uses: ./.github/actions/ubuntu-pkg-cache
@@ -561,7 +561,7 @@ jobs:
         needs: ubuntu-fetch-pkg
         timeout-minutes: 90
         env:
-            MESON_ARGS: -Dwerror=true -Dxephyr=true -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=false
+            MESON_ARGS: -Dwerror=true -Dxephyr=true -Dxorg=true -Dxvfb=true -Dxnest=true -Dxfbdev=false -Dxf86bigfont=true
         steps:
             - uses: actions/checkout@v6
             - uses: ./.github/actions/ubuntu-pkg-cache
@@ -623,7 +623,7 @@ jobs:
             # libdrm-backed direct-rendering extensions can't work (and OI's
             # xf86drm.h pulls a drm.h that only exists for Linux). glx stays on
             # (Mesa is packaged) for indirect/software GLX.
-            MESON_ARGS: -Dwerror=true -Dxvfb=true -Dxnest=true -Dxorg=false -Dxephyr=false -Dxfbdev=false -Ddri2=false -Ddri3=false
+            MESON_ARGS: -Dwerror=true -Dxvfb=true -Dxnest=true -Dxorg=false -Dxephyr=false -Dxfbdev=false -Ddri2=false -Ddri3=false -Dxf86bigfont=true
         steps:
             - uses: actions/checkout@v6
             - uses: ./.github/actions/ubuntu-pkg-cache
@@ -645,7 +645,7 @@ jobs:
         needs: ubuntu-fetch-pkg
         timeout-minutes: 90
         env:
-            MESON_ARGS: -Dwerror=true -Dxvfb=true -Dxnest=true -Dxorg=false -Dxephyr=false -Dxfbdev=false -Ddri2=false -Ddri3=false
+            MESON_ARGS: -Dwerror=true -Dxvfb=true -Dxnest=true -Dxorg=false -Dxephyr=false -Dxfbdev=false -Ddri2=false -Ddri3=false -Dxf86bigfont=true
         steps:
             - uses: actions/checkout@v6
             - uses: ./.github/actions/ubuntu-pkg-cache
@@ -720,7 +720,7 @@ jobs:
             # deprecated") that -Werror (-Werror=cpp) turns fatal in every TU using
             # libbsd. That's a musl/libbsd toolchain quirk, not an xserver warning, so
             # it can't be fixed in-tree (unlike solaris/gentoo/openbsd, now tightened).
-            MESON_ARGS: -Dprefix=/usr -Dxcsecurity=true -Dxorg=true -Dxephyr=true -Dxvfb=true -Dxnest=true -Dxfbdev=false -Dsystemd_logind=false -Dwerror=false
+            MESON_ARGS: -Dprefix=/usr -Dxcsecurity=true -Dxorg=true -Dxephyr=true -Dxvfb=true -Dxnest=true -Dxfbdev=false -Dsystemd_logind=false -Dwerror=false -Dxf86bigfont=true
         steps:
             # actions/checkout is a JS action; GitHub's bundled Node is
             # glibc-linked, so musl-based Alpine needs gcompat to run it.
@@ -775,7 +775,7 @@ jobs:
         container:
             image: ghcr.io/x11libre/xserver-gentoo-deps:${{ needs.gentoo-deps-image.outputs.tag }}
         env:
-            MESON_ARGS: -Dprefix=/usr -Dwerror=true -Dxcsecurity=true -Dxorg=true -Dxephyr=true -Dxvfb=true -Dxnest=true -Dxfbdev=false -Dsystemd_logind=false
+            MESON_ARGS: -Dprefix=/usr -Dwerror=true -Dxcsecurity=true -Dxorg=true -Dxephyr=true -Dxvfb=true -Dxnest=true -Dxfbdev=false -Dsystemd_logind=false -Dxf86bigfont=true
         steps:
             - name: Check out repository code
               uses: actions/checkout@v6
@@ -795,7 +795,7 @@ jobs:
             # an entitlement on public runners.
             image: almalinux:${{ matrix.rhelver }}
         env:
-            MESON_ARGS: -Dprefix=/usr -Dwerror=true -Dxcsecurity=true -Dxorg=true -Dxephyr=true -Dxvfb=true -Dxnest=true -Dxfbdev=false -Dsystemd_logind=false
+            MESON_ARGS: -Dprefix=/usr -Dwerror=true -Dxcsecurity=true -Dxorg=true -Dxephyr=true -Dxvfb=true -Dxnest=true -Dxfbdev=false -Dsystemd_logind=false -Dxf86bigfont=true
         steps:
             - name: Check out repository code
               uses: actions/checkout@v6

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -93,7 +93,7 @@ option('vgahw', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto'
        description: 'Xorg VGA access module')
 option('dpms', type: 'boolean', value: true,
        description: 'Xorg DPMS extension')
-option('xf86bigfont', type: 'boolean', value: true,
+option('xf86bigfont', type: 'boolean', value: false,
        description: 'XF86 Big Font extension')
 option('screensaver', type: 'boolean', value: true,
        description: 'ScreenSaver extension')


### PR DESCRIPTION
Follow-up to #3202. That PR fixed xf86bigfont's cross-platform build **and** flipped the meson default to `true`. This keeps the build alive in CI but **restores the shipped default to `false`**.

- `meson_options.txt`: `xf86bigfont` `true` → `false` (back to the deliberate historical default-off; the extension is a low-relevance legacy optimisation — server-side core fonts, which modern toolkits don't use).
- `build-xserver.yml`: add `-Dxf86bigfont=true` to all 13 CI build lanes, so the extension is still compiled/validated everywhere (guarding against re-bit-rot) without re-enabling it for downstream/shipped builds.

The compile fixes from #3202 (drop Linux-only `<sys/sysmacros.h>`, guard the mingw Unix-only bits) stay on master. Net effect: **CI builds bigfont on every lane; default builds don't.**

(Parallel: whether to drop the extension entirely is under discussion — see `BIGFONT.md`.)
