### PR TITLE
(backport 25.2) xf86bigfont: fix the cross-platform build (from #3202)

### DIFF
--- a/Xext/xf86bigfont/xf86bigfont.c
+++ b/Xext/xf86bigfont/xf86bigfont.c
@@ -46,7 +46,6 @@
 # if defined(__CYGWIN__)
 #  include <sys/param.h>
 # endif
-#include <sys/sysmacros.h>
 #include <sys/ipc.h>
 #include <sys/shm.h>
 #include <sys/stat.h>

--- a/Xext/xf86bigfont/xf86bigfont.c
+++ b/Xext/xf86bigfont/xf86bigfont.c
@@ -277,8 +277,10 @@ ProcXF86BigfontQueryVersion(ClientPtr client)
     xXF86BigfontQueryVersionReply reply = {
         .majorVersion = SERVER_XF86BIGFONT_MAJOR_VERSION,
         .minorVersion = SERVER_XF86BIGFONT_MINOR_VERSION,
+#if !defined(WIN32) || defined(__CYGWIN__)
         .uid = geteuid(),
         .gid = getegid(),
+#endif
 #ifdef CONFIG_MITSHM
         .signature = signature,
         .capabilities = (client->local && !client->swapped)
@@ -329,7 +331,9 @@ ProcXF86BigfontQueryFont(ClientPtr client)
     X_REQUEST_FIELD_CARD32(id);
 
     FontPtr pFont;
+#ifdef CONFIG_MITSHM
     CARD32 stuff_flags;
+#endif
     xCharInfo *pmax;
     xCharInfo *pmin;
     int nCharInfos;
@@ -348,11 +352,15 @@ ProcXF86BigfontQueryFont(ClientPtr client)
     /* protocol version is decided based on request packet size */
     switch (client->req_len) {
     case 2:                    /* client with version 1.0 libX11 */
+#ifdef CONFIG_MITSHM
         stuff_flags = (client->local &&
                        !client->swapped ? XF86Bigfont_FLAGS_Shm : 0);
+#endif
         break;
     case 3:                    /* client with version 1.1 libX11 */
+#ifdef CONFIG_MITSHM
         stuff_flags = stuff->flags;
+#endif
         break;
     default:
         return BadLength;


### PR DESCRIPTION
Backport of the **compile fixes** from #3202 (master) to `release/25.2` — makes the `xf86bigfont` extension build again on non-Linux platforms when it is enabled.

- `drop the Linux-only <sys/sysmacros.h> include` (master `c504e16903`) — fatal `'sys/sysmacros.h' file not found` on macOS/*BSD (also fixed the solaris `ARRAY_SIZE` clash, since that header defined it).
- `guard the Unix-only bits for mingw` (master `43143d82e9`) — `geteuid`/`getegid` + unused `stuff_flags` under mingw.

**Only `release/25.2` is affected** — its `Xext/xf86bigfont/xf86bigfont.c` matches master's newer code (has the `sys/sysmacros.h` include). `release/25.1`/`25.0` carry an older bigfont.c without that include → not applicable.

Compile-break justification: 25.2 CI doesn't build bigfont (default off), but a downstream enabling `-Dxf86bigfont=true` on 25.2 + building on BSD/macOS hits the break. **Not** backporting #3202's meson default-flip (master keeps default off via #3205).

Master PR: #3202

> 🤖 Backport prepared by Claude Code on behalf of @metux. **Do not auto-merge** — release-line merges are manual/maintainer-only.
