### PR TITLE
(master) ci: bump go-x11proto (go-xts) pin v0.0.4 -> v0.0.7

### DIFF
--- a/.github/scripts/conf.sh
+++ b/.github/scripts/conf.sh
@@ -13,7 +13,7 @@ export PKG_CONFIG_PATH="$X11_PREFIX/lib/x86_64-linux-gnu/pkgconfig:$X11_PREFIX/l
 
 export PKG_PIGLIT_REF=59111996534f875ca88bce51f21fa2e6564895da
 export PKG_XTS_REF=6cf94400a09abecd6b86e4eb6441741acecd51f6
-export PKG_GOXPROTO_REF="${GOXPROTO_REF:-v0.0.4}"
+export PKG_GOXPROTO_REF="${GOXPROTO_REF:-v0.0.7}"
 export PKG_RENDERCHECK_REF=rendercheck-1.6
 export PKG_LIBDRM_REF=libdrm-2.4.121
 export PKG_LIBXCVT_REF=libxcvt-0.1.0

--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -7,7 +7,7 @@ env:
     MESON_BUILDDIR:  "__BUILD"
     X11_PREFIX:      /home/runner/x11
     X11_BUILD_DIR:   /home/runner/work/xserver/xserver/WORK/sources/3rdparty
-    GOXPROTO_REF:    v0.0.4
+    GOXPROTO_REF:    v0.0.7
 
 on:
     push:


### PR DESCRIPTION
The go-xts CI suite is built against the go-x11proto client library, pinned
via PKG_GOXPROTO_REF/GOXPROTO_REF. Raise it from v0.0.4 to the current
release v0.0.7 (fresh tag pushed upstream).

Both pin sites must move together: install-prereq.sh consumes
PKG_GOXPROTO_REF (conf.sh), which defaults to $GOXPROTO_REF from the
workflow env.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
