### PR TITLE
(master) dix: lookup function for WindowPtr by XID

### DIFF
--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -829,4 +829,15 @@ ClientPtr dixGetGrabClient(void);
  */
 bool dixAnyOtherGrabbed(ClientPtr client);
 
+/*
+ * @brief lookup window by XID
+ *
+ * This globally looks for Window with given XID (all screens, all clients)
+ * and returns a pointer to it. If not found, returns NULL.
+ *
+ * Unlike ::dixLookupWindow() it doesn't scan only one given client, nor does
+ * it do any XACE calls.
+ */
+WindowPtr dixLookupWindowByXID(Window window);
+
 #endif /* _XSERVER_DIX_PRIV_H */

--- a/dix/lookup.c
+++ b/dix/lookup.c
@@ -39,3 +39,35 @@ ClientPtr dixClientForOtherClients(OtherClientsPtr pOtherClients) {
 
     return dixClientForXID(pOtherClients->resource);
 }
+
+struct window_xid_match {
+    WindowPtr pWin;
+    Window id;
+};
+
+static int dix_match_window_xid(WindowPtr pWin, void *ptr)
+{
+    struct window_xid_match *walk = (struct window_xid_match*) ptr;
+
+    if (walk->id == pWin->drawable.id) {
+        walk->pWin = pWin;
+        return WT_STOPWALKING;
+    }
+    else
+        return WT_WALKCHILDREN;
+}
+
+WindowPtr dixLookupWindowByXID(Window window)
+{
+    struct window_xid_match walk = {
+        .id = window,
+    };
+
+    for (int i = 0; i < screenInfo.numScreens; i++) {
+        WalkTree(screenInfo.screens[i], dix_match_window_xid, &walk);
+        if (walk.pWin)
+            break;
+    }
+
+    return walk.pWin;
+}


### PR DESCRIPTION
This new lookup function retrieves a pointer to WindowRec structure by
associated XID. Unlike dixLookupWindow(), this one works globally, instead
of just on one specific client, and it doesn't do any XACE calls.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit 4606043ae49cbf91dd1f2c4249eaaa7860089f03)
