### PR TITLE
(master) xf86: drop dead HAS_SETPRIORITY / <sys/resource.h> block

### DIFF
--- a/hw/xfree86/common/xf86Helper.c
+++ b/hw/xfree86/common/xf86Helper.c
@@ -65,12 +65,6 @@
 #include "xf86Config.h"
 #include "xf86Module_priv.h"
 
-/* For xf86GetClocks */
-#if defined(CSRG_BASED) || defined(__GNU__)
-#define HAS_SETPRIORITY
-#include <sys/resource.h>
-#endif
-
 static int xf86ScrnInfoPrivateCount = 0;
 
 /* Add a pointer to a new DriverRec to xf86DriverList */


### PR DESCRIPTION
xf86Helper.c defined HAS_SETPRIORITY and included <sys/resource.h>
under `#if defined(CSRG_BASED) || defined(__GNU__)`, commented "For
xf86GetClocks". But nothing in the tree uses any of it:

  - `setpriority()` is called nowhere,
  - the HAS_SETPRIORITY macro is referenced nowhere,
  - xf86GetClocks no longer touches process priority at all.

It is a leftover from when xf86GetClocks temporarily raised its
priority while measuring dot clocks; that code is long gone. Remove the
orphaned block rather than convert its OS-family guard to a feature
flag — there is no feature left to gate.

Verified: Linux build with -Dwerror=true compiles xf86Helper.c and
links Xorg cleanly.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
