### PR TITLE
(master) xf86: gate consType on CONFIG_BSD_CONSOLE, not CSRG_BASED

### DIFF
--- a/hw/xfree86/common/xf86Globals.c
+++ b/hw/xfree86/common/xf86Globals.c
@@ -105,7 +105,7 @@ xf86InfoRec xf86Info = {
     .dontZap = FALSE,
     .dontZoom = FALSE,
     .currentScreen = NULL,
-#ifdef CSRG_BASED
+#ifdef CONFIG_BSD_CONSOLE
     .consType = -1,
 #endif
     .allowMouseOpenFail = FALSE,

--- a/include/meson.build
+++ b/include/meson.build
@@ -343,6 +343,12 @@ conf_data.set_quoted('XCONFIGFILE', 'xorg.conf')
 conf_data.set_quoted('__XSERVERNAME__', 'Xorg')
 conf_data.set('WITH_VGAHW', build_vgahw ? '1' : false)
 conf_data.set('CSRG_BASED', csrg_based ? '1' : false)
+# BSD console-driver support (the xf86Info.consType machinery + the
+# hw/xfree86/os-support/bsd/ console_*.c backends). True on the BSD-derived
+# systems (csrg_based) plus GNU/kFreeBSD, matching the old
+# `CSRG_BASED || __FreeBSD_kernel__` guard exactly.
+conf_data.set('CONFIG_BSD_CONSOLE',
+              (csrg_based or host_machine.system() == 'kfreebsd') ? '1' : false)
 conf_data.set('PCVT_SUPPORT', supports_pcvt ? '1' : false)
 conf_data.set('SYSCONS_SUPPORT', supports_syscons ? '1' : false)
 conf_data.set('WSCONS_SUPPORT', supports_wscons ? '1' : false)

--- a/include/xf86Privstr.h
+++ b/include/xf86Privstr.h
@@ -66,7 +66,7 @@ typedef struct {
 
     /* graphics part */
     ScreenPtr currentScreen;
-#if defined(CSRG_BASED) || defined(__FreeBSD_kernel__)
+#ifdef CONFIG_BSD_CONSOLE
     int consType;               /* Which console driver? */
 #endif
 
@@ -110,7 +110,7 @@ typedef struct {
 #define XCOMP	((unsigned long) 0x00008000)
 
 /* BSD console driver types (consType) */
-#if defined(CSRG_BASED) || defined(__FreeBSD_kernel__)
+#ifdef CONFIG_BSD_CONSOLE
 #define PCCONS		   0
 #define CODRV011	   1
 #define CODRV01X	   2


### PR DESCRIPTION
The xf86Info.consType field and the BSD console-driver-type constants
(PCCONS/SYSCONS/PCVT/WSCONS/...) are the BSD console machinery consumed
by hw/xfree86/os-support/bsd/console_*.c and bsd_VTsw.c. They were
gated on the opaque grab-bag macro CSRG_BASED ("Computer Systems
Research Group", i.e. BSD-derived) OR'd with __FreeBSD_kernel__.

Introduce a self-documenting meson flag CONFIG_BSD_CONSOLE (following
the existing CONFIG_WSCONS/CONFIG_UDEV/... convention) set to exactly
`csrg_based or host_machine.system() == 'kfreebsd'` — i.e. the same set
of platforms the old `CSRG_BASED || __FreeBSD_kernel__` guard matched —
and use it at all three sites (struct field, constants, initializer).

Behaviour / ABI:
  - The flag is true on precisely the same platforms as before, so the
    xf86InfoRec layout is unchanged everywhere. On Linux (and every
    non-BSD target) CONFIG_BSD_CONSOLE is undefined just as CSRG_BASED
    was, so consType stays absent and the struct offsets — hence the
    driver ABI, incl. the nvidia blob — are untouched.
  - Fixes a latent inconsistency on GNU/kFreeBSD: the struct field was
    present there (via __FreeBSD_kernel__) but xf86Globals.c initialised
    .consType only under #ifdef CSRG_BASED, so it defaulted to 0 instead
    of -1. Both are now driven by the single CONFIG_BSD_CONSOLE flag, so
    field presence and initialiser always agree.

Verified: Linux -Dwerror=true build configures (dix-config.h gets
`#undef CONFIG_BSD_CONSOLE`) and links Xorg cleanly.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
