### PR TITLE
(master) hw/xfree86/glamor_egl: do not link statically glx library 

### DIFF
--- a/Xext/glx/extension_string.h
+++ b/Xext/glx/extension_string.h
@@ -34,6 +34,8 @@
 #ifndef GLX_EXTENSION_STRING_H
 #define GLX_EXTENSION_STRING_H
 
+#include <X11/Xfuncproto.h>
+
 enum {
 /*   GLX_ARB_get_proc_address is implemented on the client. */
     ARB_context_flush_control_bit = 0,
@@ -74,9 +76,16 @@ enum {
 
 #define __GLX_EXT_BYTES ((__NUM_GLX_EXTS + 7) / 8)
 
+/* exported for glamor */
+_X_EXPORT
 extern int __glXGetExtensionString(const unsigned char *enable_bits,
                                    char *buffer);
+/* exported for glamor */
+_X_EXPORT
 extern void __glXEnableExtension(unsigned char *enable_bits, const char *ext);
+
+/* exported for glamor */
+_X_EXPORT
 extern void __glXInitExtensionEnableBits(unsigned char *enable_bits);
 
 #endif                          /* GLX_EXTENSION_STRING_H */

--- a/Xext/glx/glxscreens.h
+++ b/Xext/glx/glxscreens.h
@@ -146,7 +146,10 @@ struct __GLXscreen {
     unsigned char glx_enable_bits[__GLX_EXT_BYTES];
 };
 
-void __glXScreenInit(__GLXscreen * screen, ScreenPtr pScreen);
-void __glXScreenDestroy(__GLXscreen * screen);
+/* exported for glamor */
+_X_EXPORT void __glXScreenInit(__GLXscreen * screen, ScreenPtr pScreen);
+
+/* exported for glamor */
+_X_EXPORT void __glXScreenDestroy(__GLXscreen * screen);
 
 #endif                          /* !__GLX_screens_h__ */

--- a/Xext/glx/glxserver.h
+++ b/Xext/glx/glxserver.h
@@ -93,7 +93,9 @@ void glxResumeClients(void);
 
 typedef void (*glx_func_ptr)(void);
 typedef glx_func_ptr (*glx_gpa_proc)(const char *);
-void __glXsetGetProcAddress(glx_gpa_proc get_proc_address);
+
+/* exported for glamor */
+_X_EXPORT void __glXsetGetProcAddress(glx_gpa_proc get_proc_address);
 void *__glGetProcAddress(const char *);
 
 void

--- a/Xext/glx/glxutil.h
+++ b/Xext/glx/glxutil.h
@@ -33,6 +33,8 @@
 
 #include "Xext/glx/glxserver.h"
 
+/* exported for glamor */
+_X_EXPORT
 extern GLboolean __glXDrawableInit(__GLXdrawable * drawable,
                                    __GLXscreen * screen,
                                    DrawablePtr pDraw, int type, XID drawID,

--- a/hw/xfree86/glamor_egl/meson.build
+++ b/hw/xfree86/glamor_egl/meson.build
@@ -15,7 +15,7 @@ shared_module(
         libdrm_dep,
         gbm_dep,
     ],
-    link_with: [glamor, libxserver_glx],
+    link_with: [glamor ],
 
     install: true,
     install_dir: module_abi_dir,

--- a/include/glx_extinit.h
+++ b/include/glx_extinit.h
@@ -41,6 +41,8 @@ struct __GLXprovider {
 };
 extern __GLXprovider __glXDRISWRastProvider;
 
+/* exported for glamor */
+_X_EXPORT
 void GlxPushProvider(__GLXprovider * provider);
 
 /**


### PR DESCRIPTION
In https://github.com/X11Libre/xserver/commit/a987fc7c360fa1c59efa0dde61316d84c171801b commit glx library is
statically linked which makes all glx library variables dublicated in
glx.so and glamoregl.so files

for context: https://github.com/X11Libre/xserver/pull/3174#issuecomment-4859274655

---

### Backport dashboard

| Target branch | Backport PR | Status |
|---|---|---|
| `release/25.2` | #3471 | 🔄 Open |
| `release/25.1` | #3472 | 🔄 Open |
| `release/25.0` | #3473 | 🔄 Open |

<sub>🤖 Backport assessment on behalf of @metux. All three release branches are
vulnerable (identical `link_with: [glamor, libxserver_glx]` in
`hw/xfree86/glamor_egl/meson.build`). Note: PR #3213 carries **two** commits
(merge `6c75731752`); each backport includes both the meson fix and its
prerequisite `_X_EXPORT` header-export commit (`9b74a3a7f9a2`). On 25.1/25.0
the headers were remapped to the `glx/` layout and `glx/glxutil.h` gained an
explicit `#include <X11/Xfuncproto.h>` since it no longer includes
`glxserver.h` there.</sub>
