### PR TITLE
test: fix exit status tracking

### DIFF
--- a/test/tests-common.c
+++ b/test/tests-common.c
@@ -18,14 +18,16 @@ run_test_in_child(const testfunc_t* (*suite)(void), const char *funcname)
 
     while (*func)
     {
+        fflush(stdout);
         cpid = fork();
         if (cpid) {
             waitpid(cpid, &csts, 0);
-            if (!WIFEXITED(csts))
-                goto child_failed;
-            exit_code = WEXITSTATUS(csts);
+            if (WIFEXITED(csts))
+                exit_code = WEXITSTATUS(csts);
+            else
+                exit_code = WIFSIGNALED(csts) ? 128 + WTERMSIG(csts) : 1;
+
             if (exit_code != 0) {
-    child_failed:
                 printf(" FAIL\n");
                 exit(exit_code);
             }


### PR DESCRIPTION
I found a bug with the unit test runner that is not currently reporting the exit status of the tests. You can add a bogus assertion like `assert(0 == 1);` inside of a test and `meson test -C build unit` will still report ok status. This patch fixes that so meson will report fail status now, but unfortunately it uncovered a few preexisting failures inside the testing suite.