### PR TITLE
(master) test: add XLIBRE_TEST env var to select which unit test suites run

### DIFF
--- a/test/tests-common.c
+++ b/test/tests-common.c
@@ -3,6 +3,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <string.h>
+#include <stdbool.h>
 
 #include "tests-common.h"
 
@@ -13,6 +15,31 @@ run_test_in_child(const testfunc_t* (*suite)(void), const char *funcname)
     int csts;
     int exit_code = -1;
     const testfunc_t *func = suite();
+
+    char *xlibre_testenv = getenv("XLIBRE_TEST");
+
+    if (xlibre_testenv != NULL) {
+        bool run_this_test = false;
+        char *tok_r;
+        char *tok;
+
+        xlibre_testenv = strdup(xlibre_testenv);
+        tok = strtok_r(xlibre_testenv, ",", &tok_r);
+
+        while (tok != NULL) {
+            if (strcmp(tok, funcname) == 0) {
+                run_this_test = true;
+                break;
+            }
+            tok = strtok_r(NULL, ",", &tok_r);
+        }
+
+        free(xlibre_testenv);
+
+        if (!run_this_test) {
+            return; /* not selected via XLIBRE_TEST, skip it */
+        }
+    }
 
     printf("\n---------------------\n%s...\n", funcname);
 


### PR DESCRIPTION
run_test_in_child() now checks XLIBRE_TEST (a comma-separated list of
suite function names, e.g. "ddc_tests,xkb_test") and skips any suite
not named in it. Unset/empty behaves exactly as before (run
everything).

Handy for iterating on a single new test suite without wading through
the rest of test/tests' output every run, and for isolating one
suite when an unrelated one in the sequence is flaky (run_test_in_child
exit()s the whole binary on the first failing suite, so a single flaky
suite ahead of the one you care about currently blocks everything
after it).

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
