### PR TITLE
(master) config/udev: guard against NULL subsystem in fallback bus id

### DIFF
--- a/config/udev.c
+++ b/config/udev.c
@@ -514,13 +514,15 @@ static char*
 config_udev_get_fallback_bus_id(struct udev_device *udev_device)
 {
     const char *sysname;
+    const char *subsys;
     char *busid;
 
     udev_device = udev_device_get_parent(udev_device);
     if (udev_device == NULL)
         return NULL;
 
-    if (strcmp(udev_device_get_subsystem(udev_device), "pci") != 0)
+    subsys = udev_device_get_subsystem(udev_device);
+    if (!subsys || strcmp(subsys, "pci") != 0)
         return NULL;
 
     sysname = udev_device_get_sysname(udev_device);


### PR DESCRIPTION
config_udev_get_fallback_bus_id() passes the result of
udev_device_get_subsystem() straight into strcmp(). That accessor can return
NULL when the device has no subsystem, so strcmp(NULL, "pci") dereferences a
NULL pointer and the server crashes with a SIGSEGV.

The path is reached for any DRM device with no udev ID_PATH property, where
config_udev_odev_setup_attribs() falls back to this function. DisplayLink/evdi
virtual cards have no ID_PATH; a udev remove of such a card during teardown can
present a parent whose subsystem is already gone (reported NULL), and the
unchecked strcmp faults.

The same NULL-subsystem-into-strcmp class was fixed for the four sibling callers
in this file by commit 429ee86a; config_udev_get_fallback_bus_id() was added
later (commit 2f53d1cf) without the guard. The preceding parent==NULL case is
already guarded here; extend the same defensiveness to the subsystem lookup.

Related to: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1905

Signed-off-by: Gary T. Giesen <ggiesen@giesen.me>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2245>


---

**Backport dashboard**

| Branch | PR | Status |
|---|---|---|
| release/25.2 | #3221 | 🔄 Open |
| release/25.1 | #3222 | 🔄 Open |
| release/25.0 | #3223 | 🔄 Open |

`config_udev_get_fallback_bus_id()` is byte-for-byte identical (same unguarded `strcmp`) on all
three release lines, so the fix applies cleanly everywhere. This is a real SIGSEGV/DoS crash fix,
so it's being backported ahead of this PR's own merge — the backport PRs cherry-pick the same
upstream xorg commit directly.
