### PR TITLE
xquartz/GL: advertise GLX_ARB_create_context and silence deprecation warnings

### DIFF
--- a/hw/xquartz/GL/indirect.c
+++ b/hw/xquartz/GL/indirect.c
@@ -509,6 +509,27 @@ __glXAquaScreenProbe(ScreenPtr pScreen)
         &screen->base.numFBConfigs, pScreen->myNum);
 
     __glXInitExtensionEnableBits(screen->base.glx_enable_bits);
+
+    /* Advertise GLX_ARB_create_context so clients can call
+     * glXCreateContextAttribsARB.  XQuartz uses AppleDRI + client-side CGL
+     * (direct rendering), which means the server-side createContext hook
+     * (__glXAquaScreenCreateContext) only fires for indirect requests --
+     * those are still capped at GL 1.4 by createcontext.c:validate_GL_version.
+     * The direct path routes to __glXdirectContextCreate in the core dispatch
+     * and the requested profile/version is honored on the client side.
+     *
+     * GLX_ARB_create_context_robustness is advertised for compatibility with
+     * clients that always ask for it, but CGL has no GPU-reset notification
+     * mechanism: GLX_CONTEXT_ROBUST_ACCESS_BIT_ARB /
+     * GLX_LOSE_CONTEXT_ON_RESET_ARB are silently accepted and never signal
+     * a reset.
+     *
+     * This is needed for OpenGL core profile support.
+     */
+    __glXEnableExtension(screen->base.glx_enable_bits, "GLX_ARB_create_context");
+    __glXEnableExtension(screen->base.glx_enable_bits, "GLX_ARB_create_context_profile");
+    __glXEnableExtension(screen->base.glx_enable_bits, "GLX_ARB_create_context_robustness");
+
     __glXScreenInit(&screen->base, pScreen);
 
     return &screen->base;

--- a/hw/xquartz/GL/meson.build
+++ b/hw/xquartz/GL/meson.build
@@ -1,5 +1,6 @@
 libcglcore = static_library('CGLCore',
      ['indirect.c', 'capabilities.c', 'visualConfigs.c'],
+     c_args: ['-DGL_SILENCE_DEPRECATION'],
      include_directories: [inc, '..', '../xpr'],
      dependencies: [xproto_dep, pixman_dep],
 )


### PR DESCRIPTION
Two related upstream xorg/main commits for the XQuartz (macOS) backend, picked
up via the `tracking/xorg/main-on-master` upstream-tracking workflow:

- `609e7d9421` — advertise `GLX_ARB_create_context`/`_profile`/`_robustness` so
  XQuartz clients can request a specific GL version/profile via
  `glXCreateContextAttribsARB` (needed for OpenGL core profile support).
- `31060c9506` — silence the OpenGL/CGL deprecation warnings the macOS SDK
  emits (`-DGL_SILENCE_DEPRECATION`).

**Conflict note:** the second commit's `hw/xquartz/GL/meson.build` hunk
conflicted with our tree, since XLibre already dropped the (stale) `glx_inc`
include from this target in `dd4c8d4ecb` ("glx: move it under Xext/"). Resolved
by keeping our `include_directories` (no `glx_inc`) and only taking the new
`c_args: ['-DGL_SILENCE_DEPRECATION']` line.

Not build-verified locally (XQuartz only builds on Darwin); the
`xserver-build-macos` CI lane builds `hw/xquartz/GL/` unconditionally
(independent of `-Dglx`), so this will be exercised there.