### PR TITLE
(master) os/access.c: drop dead <sys/utsname.h> include

### DIFF
--- a/os/access.c
+++ b/os/access.c
@@ -122,9 +122,6 @@ SOFTWARE.
 #include <sys/un.h>
 #endif
 
-#if defined(SVR4) || defined(__GNU__)
-#include <sys/utsname.h>
-#endif
 #ifdef __GNU__
 #undef SIOCGIFCONF
 #include <netdb.h>


### PR DESCRIPTION
The `#if defined(SVR4) || defined(__GNU__)` include of <sys/utsname.h>
is unused: access.c calls neither uname() nor references struct utsname
anywhere. Host-name retrieval was long ago factored out into
xhostname() (os/xhostname.h), which owns the gethostname()/uname()
logic; the include here is a leftover. The explanatory comment above
the xhostname() call (mentioning uname()) is kept — it still documents
why xhostname is preferred over gethostname().

No feature flag needed — there is nothing to gate. Verified: Linux
-Dwerror=true build still links Xvfb and Xnest.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
