### PR TITLE
(release/25.0) config/udev: guard against NULL subsystem in fallback bus id

### DIFF
--- a/config/udev.c
+++ b/config/udev.c
@@ -513,13 +513,15 @@ static char*
 config_udev_get_fallback_bus_id(struct udev_device *udev_device)
 {
     const char *sysname;
+    const char *subsys;
     char *busid;
 
     udev_device = udev_device_get_parent(udev_device);
     if (udev_device == NULL)
         return NULL;
 
-    if (strcmp(udev_device_get_subsystem(udev_device), "pci") != 0)
+    subsys = udev_device_get_subsystem(udev_device);
+    if (!subsys || strcmp(subsys, "pci") != 0)
         return NULL;
 
     sysname = udev_device_get_sysname(udev_device);


### PR DESCRIPTION
config_udev_get_fallback_bus_id() passes the result of
udev_device_get_subsystem() straight into strcmp(). That accessor can return
NULL when the device has no subsystem, so strcmp(NULL, "pci") dereferences a
NULL pointer and the server crashes with a SIGSEGV.

The path is reached for any DRM device with no udev ID_PATH property, where
config_udev_odev_setup_attribs() falls back to this function. DisplayLink/evdi
virtual cards have no ID_PATH; a udev remove of such a card during teardown can
present a parent whose subsystem is already gone (reported NULL), and the
unchecked strcmp faults.

The same NULL-subsystem-into-strcmp class was fixed for the four sibling callers
in this file by commit 429ee86a; config_udev_get_fallback_bus_id() was added
later (commit 2f53d1cf) without the guard. The preceding parent==NULL case is
already guarded here; extend the same defensiveness to the subsystem lookup.

Related to: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1905

Signed-off-by: Gary T. Giesen <ggiesen@giesen.me>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2245>
(cherry picked from commit 9babe7e7f687b0342c8ab726d01a658d590d7c54)


---

Backport of the xorg-upstream fix tracked on master as #3217 (not yet merged there; this is a
direct cherry-pick of the same upstream commit since the crash is release-relevant).
