### PR TITLE
(master) xf86: drop dead `#define termio termios`

### DIFF
--- a/include/xf86_OSlib.h
+++ b/include/xf86_OSlib.h
@@ -141,7 +141,6 @@
 #include <signal.h>
 
 #include <termios.h>
-#define termio termios
 
 #include <errno.h>
 


### PR DESCRIPTION
The SysV `struct termio` type is used nowhere in the tree — the only
`termio` occurrence is the unrelated `#include <termio.h>` in the
SVR4/Sun block — so this BSD-only alias mapping `termio` to `termios`
under `#ifdef CSRG_BASED` is dead code and can be removed.

The rest of the `#ifdef CSRG_BASED` block is left intact: it is a
legitimate structural BSD-header block, to be dealt with in a later
xf86_OSlib.h restructure.

The CSRG_BASED block isn't compiled on Linux; a `-Dwerror=true` Linux
build links Xvfb and Xnest cleanly, confirming no accidental damage.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
