### PR TITLE
(master) glx: zero-init xGLXQueryVersionReply to avoid leaking uninitialised bytes

### DIFF
--- a/Xext/glx/vndcmds.c
+++ b/Xext/glx/vndcmds.c
@@ -94,11 +94,12 @@ static GlxServerDispatchProc GetVendorDispatchFunc(CARD8 opcode, CARD32 vendorCo
 
 static int dispatch_GLXQueryVersion(ClientPtr client)
 {
-    xGLXQueryVersionReply reply;
     REQUEST_SIZE_MATCH(xGLXQueryVersionReq);
 
-    reply.majorVersion = GlxCheckSwap(client, 1);
-    reply.minorVersion = GlxCheckSwap(client, 4);
+    xGLXQueryVersionReply reply = {
+        .majorVersion = GlxCheckSwap(client, 1),
+        .minorVersion = GlxCheckSwap(client, 4),
+    };
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }


### PR DESCRIPTION
The reply struct was declared bare (uninitialised auto storage) and then
filled field-by-field (majorVersion/minorVersion only), leaving pad1 and
any trailing padding uninitialised. Those bytes were then sent to the
client via X_SEND_REPLY_SIMPLE, an information disclosure.

Use a designated initialiser so all omitted fields and padding are zeroed;
type/sequenceNumber/length are still set by X_SEND_REPLY_SIMPLE afterward.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>


---

### Backport dashboard

Same leak (bare `xGLXQueryVersionReply` + field-by-field fill → uninitialised pad sent to client) is present on all maintained release lines.

| Branch | Backport PR | Status |
|---|---|---|
| `release/25.2` | #3236 | 🔄 Open (adapt: same idiom) |
| `release/25.1` | #3237 | 🔄 Open (adapt: same idiom) |
| `release/25.0` | #3238 | 🔄 Open (adapted: older `SetReplyHeader`/`WriteToClient` idiom) |

Release-line merges are maintainer-only.
