### PR TITLE
(master) panoramiX: zero-init xAllocColorReply to avoid leaking uninitialised bytes

### DIFF
--- a/Xext/panoramiX/panoramiXprocs.c
+++ b/Xext/panoramiX/panoramiXprocs.c
@@ -2509,11 +2509,16 @@ PanoramiXAllocColor(ClientPtr client)
 
         /* only send out reply for on first screen */
         if (!walkScreenIdx) {
-            xAllocColorReply reply; /* static init would confuse preprocessor */
-            reply.red = red;
-            reply.green = green;
-            reply.blue = blue;
-            reply.pixel = pixel;
+            /* Designated initialiser zeroes the reply's pad/reserved bytes,
+               which were previously left uninitialised and sent to the
+               client. (The XINERAMA_FOR_EACH_SCREEN_* macros are variadic, so
+               the initialiser's commas no longer confuse the preprocessor.) */
+            xAllocColorReply reply = {
+                .red = red,
+                .green = green,
+                .blue = blue,
+                .pixel = pixel,
+            };
 
             if (client->swapped) {
                 swaps(&reply.red);


### PR DESCRIPTION
The reply struct was declared bare (uninitialised auto storage) and then
filled field-by-field (red/green/blue/pixel only), leaving pad1/pad2 and
any trailing padding uninitialised. Those bytes were then sent to the
client via X_SEND_REPLY_SIMPLE, an information disclosure.

A designated-initialiser cannot be used here: this block sits inside the
comma-containing XINERAMA_FOR_EACH_SCREEN_BACKWARD() macro, whose
argument parser is broken by a top-level '{ .red = ..., ... }' literal
(the existing comment 'static init would confuse preprocessor' already
noted this, and the compiler confirms: 'macro ... passed 5 arguments,
but takes just 1'). Use memset(&reply, 0, sizeof(reply)) instead, which
has no top-level commas and compiles inside the macro.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>


---
**Backport dashboard**

| Release | PR | Status |
|---|---|---|
| 25.2 | #3233 | 🔄 Open (#3232 merged; #3233 rebased onto current release/25.2, now just the reply-init fix) |
| 25.1 | #3235 | 🔄 Open (#3234 merged; #3235 rebased onto current release/25.1, now just the reply-init fix) |
| 25.0 | — | N/A — `PanoramiXAllocColor` there just calls `(*SavedProcVector[X_AllocColor])(client)` per screen; it never builds its own reply struct, so this leak doesn't exist on 25.0 |

Applicability confirmed by reading the actual code on each branch (`Xext/panoramiXprocs.c` on 25.1, `Xext/panoramiX/panoramiXprocs.c` on 25.2 — identical `xAllocColorReply reply;` bare-declare + field-by-field fill as this branch pre-fix; 25.0's handler is structurally different, delegates to core). Each release backport applies its branch's #3231-equivalent macro PR first, then this fix — same merge order as intended here once #3231 lands. #3231 is merged into master; #3227 is still open (pending a rebase to drop its now-redundant macro hunk). These backports are open only, not merged — release-line merges are manual/maintainer-only per policy.

## Backport dashboard

| Branch | PR | Status |
|--------|----|--------|
| `release/25.2` | [#3233](https://github.com/X11Libre/xserver/pull/3233) | 🔄 Open |
| `release/25.1` | [#3235](https://github.com/X11Libre/xserver/pull/3235) | 🔄 Open |
| `release/25.0` | — | — |
