### PR TITLE
(master) glamor: clamp CopyArea source boxes to the source pixmap (workaround #3136)

### DIFF
--- a/glamor/glamor_copy.c
+++ b/glamor/glamor_copy.c
@@ -270,9 +270,52 @@ glamor_copy_cpu_fbo(DrawablePtr src,
         int src_xoff, src_yoff;
 
         fbGetDrawable(src, src_bits, src_stride, src_bpp, src_xoff, src_yoff);
-        glamor_upload_boxes(dst, box, nbox, src_xoff + dx, src_yoff + dy,
-                            dst_xoff, dst_yoff,
-                            (uint8_t *) src_bits, src_stride * sizeof (FbBits));
+
+        /*
+         * Workaround for #3136 (fullscreen Present crash): glamor_upload_boxes()
+         * back-projects the destination-clamped box coordinates into the source
+         * buffer (bits + ofs) but never bounds them against the source
+         * allocation. A copy whose geometry maps outside the source pixmap
+         * therefore reads out of bounds and crashes in the GL driver
+         * (util_copy_rect / memcpy on an unmapped address). Clamp the boxes to
+         * the source pixmap's backing store here so an out-of-range copy turns
+         * into a missing region instead of a crash.
+         *
+         * NOTE: intermediate defensive workaround, not the root-cause fix. It
+         * does not cover the separate depth-24-in-32 tmp_bits path inside
+         * glamor_upload_boxes(). See issue #3136.
+         */
+        PixmapPtr src_pixmap = glamor_get_drawable_pixmap(src);
+        uint32_t byte_stride = src_stride * sizeof(FbBits);
+        int dx_src = src_xoff + dx;
+        int dy_src = src_yoff + dy;
+        /* Physical bounds of the source buffer, in source coordinates.
+         * Use a conservative 4 bytes/pixel for the width so the bound holds
+         * for whatever render format glamor_upload_boxes() selects (<= 32bpp). */
+        int src_w = MIN((int) src_pixmap->drawable.width, (int) (byte_stride / 4));
+        int src_h = (int) src_pixmap->drawable.height;
+
+        BoxPtr clamped = XNFcallocarray(nbox, sizeof(BoxRec));
+        int nclamped = 0;
+        for (int i = 0; i < nbox; i++) {
+            BoxRec b = box[i];
+            if (b.x1 < -dx_src)
+                b.x1 = -dx_src;
+            if (b.y1 < -dy_src)
+                b.y1 = -dy_src;
+            if (b.x2 > src_w - dx_src)
+                b.x2 = src_w - dx_src;
+            if (b.y2 > src_h - dy_src)
+                b.y2 = src_h - dy_src;
+            if (b.x2 > b.x1 && b.y2 > b.y1)
+                clamped[nclamped++] = b;
+        }
+
+        if (nclamped)
+            glamor_upload_boxes(dst, clamped, nclamped, dx_src, dy_src,
+                                dst_xoff, dst_yoff,
+                                (uint8_t *) src_bits, byte_stride);
+        free(clamped);
     }
     glamor_finish_access(src);
 

--- a/glamor/glamor_copy.c
+++ b/glamor/glamor_copy.c
@@ -272,9 +272,52 @@ glamor_copy_cpu_fbo(DrawablePtr src,
         int src_xoff, src_yoff;
 
         fbGetDrawable(src, src_bits, src_stride, src_bpp, src_xoff, src_yoff);
-        glamor_upload_boxes(dst, box, nbox, src_xoff + dx, src_yoff + dy,
-                            dst_xoff, dst_yoff,
-                            (uint8_t *) src_bits, src_stride * sizeof (FbBits));
+
+        /*
+         * Workaround for #3136 (fullscreen Present crash): glamor_upload_boxes()
+         * back-projects the destination-clamped box coordinates into the source
+         * buffer (bits + ofs) but never bounds them against the source
+         * allocation. A copy whose geometry maps outside the source pixmap
+         * therefore reads out of bounds and crashes in the GL driver
+         * (util_copy_rect / memcpy on an unmapped address). Clamp the boxes to
+         * the source pixmap's backing store here so an out-of-range copy turns
+         * into a missing region instead of a crash.
+         *
+         * NOTE: intermediate defensive workaround, not the root-cause fix. It
+         * does not cover the separate depth-24-in-32 tmp_bits path inside
+         * glamor_upload_boxes(). See issue #3136.
+         */
+        PixmapPtr src_pixmap = glamor_get_drawable_pixmap(src);
+        uint32_t byte_stride = src_stride * sizeof(FbBits);
+        int dx_src = src_xoff + dx;
+        int dy_src = src_yoff + dy;
+        /* Physical bounds of the source buffer, in source coordinates.
+         * Use a conservative 4 bytes/pixel for the width so the bound holds
+         * for whatever render format glamor_upload_boxes() selects (<= 32bpp). */
+        int src_w = MIN((int) src_pixmap->drawable.width, (int) (byte_stride / 4));
+        int src_h = (int) src_pixmap->drawable.height;
+
+        BoxPtr clamped = XNFcallocarray(nbox, sizeof(BoxRec));
+        int nclamped = 0;
+        for (int i = 0; i < nbox; i++) {
+            BoxRec b = box[i];
+            if (b.x1 < -dx_src)
+                b.x1 = -dx_src;
+            if (b.y1 < -dy_src)
+                b.y1 = -dy_src;
+            if (b.x2 > src_w - dx_src)
+                b.x2 = src_w - dx_src;
+            if (b.y2 > src_h - dy_src)
+                b.y2 = src_h - dy_src;
+            if (b.x2 > b.x1 && b.y2 > b.y1)
+                clamped[nclamped++] = b;
+        }
+
+        if (nclamped)
+            glamor_upload_boxes(dst, clamped, nclamped, dx_src, dy_src,
+                                dst_xoff, dst_yoff,
+                                (uint8_t *) src_bits, byte_stride);
+        free(clamped);
     }
     glamor_finish_access(src);
 


### PR DESCRIPTION
Fullscreen Present of some clients (e.g. veloren) crashes the server
with an out-of-bounds read inside the GL driver
(util_copy_rect/memcpy on an unmapped address), reached via
present -> glamor_copy_area -> glamor_copy_cpu_fbo ->
glamor_upload_boxes -> glTexSubImage2D.

glamor_upload_boxes() computes the source read offset
(bits + ofs) from box coordinates that are only clamped to the
destination FBO tile, never to the source pixmap's backing store. When
the copy geometry maps outside the source (the fullscreen Present case),
ofs and the row count walk past the source allocation and the GL driver
faults.

Clamp the copy boxes to the source pixmap's physical bounds before
handing them to glamor_upload_boxes() in the plain CPU->FBO path. An
out-of-range copy then produces a missing region instead of a crash.
The width bound uses a conservative 4 bytes/pixel so it holds for any
render format glamor_upload_boxes() selects (all <= 32bpp here).

Intermediate defensive workaround, NOT the root-cause fix:
 - it does not address the separate depth-24-in-32 tmp_bits path inside
   glamor_upload_boxes() (a differently-sized allocation);
 - the underlying "source offset never bounded to the source buffer" is
   pre-existing glamor design; the fullscreen regression vs xorg 21.1
   still wants a proper root-cause fix (see #3136).

Needs confirmation from the reporter that it turns the crash into a
(possibly clipped) render, and review from the glamor/HW maintainers.
Build-verified on Linux (-Dwerror -Dglamor -Dxephyr, Xephyr links).

Link: https://github.com/X11Libre/xserver/issues/3136
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
