### PR TITLE
(master) panoramiX: use X_REQUEST_HEAD_*() macros in Xinerama request handlers

### DIFF
--- a/Xext/panoramiX/panoramiXprocs.c
+++ b/Xext/panoramiX/panoramiXprocs.c
@@ -67,13 +67,11 @@ PanoramiXCreateWindow(ClientPtr client)
     PanoramiXRes *bordPix = NULL;
     PanoramiXRes *cmap = NULL;
 
-    REQUEST(xCreateWindowReq);
+    X_REQUEST_HEAD_AT_LEAST(xCreateWindowReq);
     int pback_offset = 0, pbord_offset = 0, cmap_offset = 0;
     int result, len;
     int orig_x, orig_y;
     XID orig_visual, tmp;
-
-    REQUEST_AT_LEAST_SIZE(xCreateWindowReq);
 
     len = client->req_len - bytes_to_int32(sizeof(xCreateWindowReq));
     if (Ones(stuff->mask) != len)
@@ -178,12 +176,10 @@ PanoramiXChangeWindowAttributes(ClientPtr client)
     PanoramiXRes *bordPix = NULL;
     PanoramiXRes *cmap = NULL;
 
-    REQUEST(xChangeWindowAttributesReq);
+    X_REQUEST_HEAD_AT_LEAST(xChangeWindowAttributesReq);
     int pback_offset = 0, pbord_offset = 0, cmap_offset = 0;
     int result, len;
     XID tmp;
-
-    REQUEST_AT_LEAST_SIZE(xChangeWindowAttributesReq);
 
     len = client->req_len - bytes_to_int32(sizeof(xChangeWindowAttributesReq));
     if (Ones(stuff->valueMask) != len)
@@ -250,9 +246,7 @@ PanoramiXDestroyWindow(ClientPtr client)
     PanoramiXRes *win;
     int result;
 
-    REQUEST(xResourceReq);
-
-    REQUEST_SIZE_MATCH(xResourceReq);
+    X_REQUEST_HEAD_STRUCT(xResourceReq);
 
     result = dixLookupResourceByType((void **) &win, stuff->id, XRT_WINDOW,
                                      client, DixDestroyAccess);
@@ -278,9 +272,7 @@ PanoramiXDestroySubwindows(ClientPtr client)
     PanoramiXRes *win;
     int result;
 
-    REQUEST(xResourceReq);
-
-    REQUEST_SIZE_MATCH(xResourceReq);
+    X_REQUEST_HEAD_STRUCT(xResourceReq);
 
     result = dixLookupResourceByType((void **) &win, stuff->id, XRT_WINDOW,
                                      client, DixDestroyAccess);
@@ -306,9 +298,7 @@ PanoramiXChangeSaveSet(ClientPtr client)
     PanoramiXRes *win;
     int result;
 
-    REQUEST(xChangeSaveSetReq);
-
-    REQUEST_SIZE_MATCH(xChangeSaveSetReq);
+    X_REQUEST_HEAD_STRUCT(xChangeSaveSetReq);
 
     result = dixLookupResourceByType((void **) &win, stuff->window,
                                      XRT_WINDOW, client, DixReadAccess);
@@ -332,9 +322,7 @@ PanoramiXReparentWindow(ClientPtr client)
     int result;
     int x, y;
 
-    REQUEST(xReparentWindowReq);
-
-    REQUEST_SIZE_MATCH(xReparentWindowReq);
+    X_REQUEST_HEAD_STRUCT(xReparentWindowReq);
 
     result = dixLookupResourceByType((void **) &win, stuff->window,
                                      XRT_WINDOW, client, DixWriteAccess);
@@ -375,9 +363,7 @@ PanoramiXMapWindow(ClientPtr client)
     PanoramiXRes *win;
     int result;
 
-    REQUEST(xResourceReq);
-
-    REQUEST_SIZE_MATCH(xResourceReq);
+    X_REQUEST_HEAD_STRUCT(xResourceReq);
 
     result = dixLookupResourceByType((void **) &win, stuff->id,
                                      XRT_WINDOW, client, DixReadAccess);
@@ -400,9 +386,7 @@ PanoramiXMapSubwindows(ClientPtr client)
     PanoramiXRes *win;
     int result;
 
-    REQUEST(xResourceReq);
-
-    REQUEST_SIZE_MATCH(xResourceReq);
+    X_REQUEST_HEAD_STRUCT(xResourceReq);
 
     result = dixLookupResourceByType((void **) &win, stuff->id,
                                      XRT_WINDOW, client, DixReadAccess);
@@ -425,9 +409,7 @@ PanoramiXUnmapWindow(ClientPtr client)
     PanoramiXRes *win;
     int result;
 
-    REQUEST(xResourceReq);
-
-    REQUEST_SIZE_MATCH(xResourceReq);
+    X_REQUEST_HEAD_STRUCT(xResourceReq);
 
     result = dixLookupResourceByType((void **) &win, stuff->id,
                                      XRT_WINDOW, client, DixReadAccess);
@@ -450,9 +432,7 @@ PanoramiXUnmapSubwindows(ClientPtr client)
     PanoramiXRes *win;
     int result;
 
-    REQUEST(xResourceReq);
-
-    REQUEST_SIZE_MATCH(xResourceReq);
+    X_REQUEST_HEAD_STRUCT(xResourceReq);
 
     result = dixLookupResourceByType((void **) &win, stuff->id,
                                      XRT_WINDOW, client, DixReadAccess);
@@ -479,9 +459,7 @@ PanoramiXConfigureWindow(ClientPtr client)
     int x_offset = -1;
     int y_offset = -1;
 
-    REQUEST(xConfigureWindowReq);
-
-    REQUEST_AT_LEAST_SIZE(xConfigureWindowReq);
+    X_REQUEST_HEAD_AT_LEAST(xConfigureWindowReq);
 
     len = client->req_len - bytes_to_int32(sizeof(xConfigureWindowReq));
     if (Ones(stuff->mask) != len)
@@ -548,9 +526,7 @@ PanoramiXCirculateWindow(ClientPtr client)
     PanoramiXRes *win;
     int result;
 
-    REQUEST(xCirculateWindowReq);
-
-    REQUEST_SIZE_MATCH(xCirculateWindowReq);
+    X_REQUEST_HEAD_STRUCT(xCirculateWindowReq);
 
     result = dixLookupResourceByType((void **) &win, stuff->window,
                                      XRT_WINDOW, client, DixWriteAccess);
@@ -572,8 +548,7 @@ PanoramiXGetGeometry(ClientPtr client)
 {
     DrawablePtr pDraw;
 
-    REQUEST(xResourceReq);
-    REQUEST_SIZE_MATCH(xResourceReq);
+    X_REQUEST_HEAD_STRUCT(xResourceReq);
 
     X_CALL_CHECK_ERR(dixLookupDrawable(&pDraw, stuff->id, client, M_ANY, DixGetAttrAccess));
 
@@ -626,10 +601,8 @@ PanoramiXTranslateCoords(ClientPtr client)
 {
     INT16 x, y;
 
-    REQUEST(xTranslateCoordsReq);
+    X_REQUEST_HEAD_STRUCT(xTranslateCoordsReq);
     WindowPtr pWin, pDst;
-
-    REQUEST_SIZE_MATCH(xTranslateCoordsReq);
 
     X_CALL_CHECK_ERR(dixLookupWindow(&pWin, stuff->srcWid, client, DixReadAccess));
     X_CALL_CHECK_ERR(dixLookupWindow(&pDst, stuff->dstWid, client, DixReadAccess));
@@ -704,9 +677,8 @@ PanoramiXCreatePixmap(ClientPtr client)
     PanoramiXRes *refDraw, *newPix;
     int result;
 
-    REQUEST(xCreatePixmapReq);
+    X_REQUEST_HEAD_STRUCT(xCreatePixmapReq);
 
-    REQUEST_SIZE_MATCH(xCreatePixmapReq);
     client->errorValue = stuff->pid;
 
     result = dixLookupResourceByClass((void **) &refDraw, stuff->drawable,
@@ -743,9 +715,7 @@ PanoramiXFreePixmap(ClientPtr client)
     PanoramiXRes *pix;
     int result;
 
-    REQUEST(xResourceReq);
-
-    REQUEST_SIZE_MATCH(xResourceReq);
+    X_REQUEST_HEAD_STRUCT(xResourceReq);
 
     client->errorValue = stuff->id;
 
@@ -776,12 +746,10 @@ PanoramiXCreateGC(ClientPtr client)
     PanoramiXRes *tile = NULL;
     PanoramiXRes *clip = NULL;
 
-    REQUEST(xCreateGCReq);
+    X_REQUEST_HEAD_AT_LEAST(xCreateGCReq);
     int tile_offset = 0, stip_offset = 0, clip_offset = 0;
     int result, len;
     XID tmp;
-
-    REQUEST_AT_LEAST_SIZE(xCreateGCReq);
 
     client->errorValue = stuff->gc;
     len = client->req_len - bytes_to_int32(sizeof(xCreateGCReq));
@@ -857,12 +825,10 @@ PanoramiXChangeGC(ClientPtr client)
     PanoramiXRes *tile = NULL;
     PanoramiXRes *clip = NULL;
 
-    REQUEST(xChangeGCReq);
+    X_REQUEST_HEAD_AT_LEAST(xChangeGCReq);
     int tile_offset = 0, stip_offset = 0, clip_offset = 0;
     int result, len;
     XID tmp;
-
-    REQUEST_AT_LEAST_SIZE(xChangeGCReq);
 
     len = client->req_len - bytes_to_int32(sizeof(xChangeGCReq));
     if (Ones(stuff->mask) != len)
@@ -923,9 +889,7 @@ PanoramiXCopyGC(ClientPtr client)
     PanoramiXRes *srcGC, *dstGC;
     int result;
 
-    REQUEST(xCopyGCReq);
-
-    REQUEST_SIZE_MATCH(xCopyGCReq);
+    X_REQUEST_HEAD_STRUCT(xCopyGCReq);
 
     result = dixLookupResourceByType((void **) &srcGC, stuff->srcGC, XRT_GC,
                                      client, DixReadAccess);
@@ -954,7 +918,7 @@ PanoramiXSetDashes(ClientPtr client)
     PanoramiXRes *gc;
     int result;
 
-    REQUEST(xSetDashesReq);
+    X_REQUEST_HEAD_NO_CHECK(xSetDashesReq);
 
     REQUEST_FIXED_SIZE(xSetDashesReq, stuff->nDashes);
 
@@ -979,9 +943,7 @@ PanoramiXSetClipRectangles(ClientPtr client)
     PanoramiXRes *gc;
     int result;
 
-    REQUEST(xSetClipRectanglesReq);
-
-    REQUEST_AT_LEAST_SIZE(xSetClipRectanglesReq);
+    X_REQUEST_HEAD_AT_LEAST(xSetClipRectanglesReq);
 
     result = dixLookupResourceByType((void **) &gc, stuff->gc, XRT_GC,
                                      client, DixWriteAccess);
@@ -1004,9 +966,7 @@ PanoramiXFreeGC(ClientPtr client)
     PanoramiXRes *gc;
     int result;
 
-    REQUEST(xResourceReq);
-
-    REQUEST_SIZE_MATCH(xResourceReq);
+    X_REQUEST_HEAD_STRUCT(xResourceReq);
 
     result = dixLookupResourceByType((void **) &gc, stuff->id, XRT_GC,
                                      client, DixDestroyAccess);
@@ -1033,9 +993,7 @@ PanoramiXClearToBackground(ClientPtr client)
     int result, x, y;
     Bool isRoot;
 
-    REQUEST(xClearAreaReq);
-
-    REQUEST_SIZE_MATCH(xClearAreaReq);
+    X_REQUEST_HEAD_STRUCT(xClearAreaReq);
 
     result = dixLookupResourceByType((void **) &win, stuff->window,
                                      XRT_WINDOW, client, DixWriteAccess);
@@ -1079,9 +1037,7 @@ PanoramiXCopyArea(ClientPtr client)
     Bool dstIsRoot = FALSE;
     Bool srcShared, dstShared;
 
-    REQUEST(xCopyAreaReq);
-
-    REQUEST_SIZE_MATCH(xCopyAreaReq);
+    X_REQUEST_HEAD_STRUCT(xCopyAreaReq);
 
     result = dixLookupResourceByClass((void **) &src, stuff->srcDrawable,
                                       XRC_DRAWABLE, client, DixReadAccess);
@@ -1284,9 +1240,7 @@ PanoramiXCopyPlane(ClientPtr client)
     GCPtr pGC = NULL;
     RegionRec totalReg;
 
-    REQUEST(xCopyPlaneReq);
-
-    REQUEST_SIZE_MATCH(xCopyPlaneReq);
+    X_REQUEST_HEAD_STRUCT(xCopyPlaneReq);
 
     int rc = dixLookupResourceByClass((void **) &src, stuff->srcDrawable,
                                       XRC_DRAWABLE, client, DixReadAccess);
@@ -1386,9 +1340,7 @@ PanoramiXPolyPoint(ClientPtr client)
     int result, npoint;
     Bool isRoot;
 
-    REQUEST(xPolyPointReq);
-
-    REQUEST_AT_LEAST_SIZE(xPolyPointReq);
+    X_REQUEST_HEAD_AT_LEAST(xPolyPointReq);
 
     result = dixLookupResourceByClass((void **) &draw, stuff->drawable,
                                       XRC_DRAWABLE, client, DixWriteAccess);
@@ -1454,9 +1406,7 @@ PanoramiXPolyLine(ClientPtr client)
     int result, npoint;
     Bool isRoot;
 
-    REQUEST(xPolyLineReq);
-
-    REQUEST_AT_LEAST_SIZE(xPolyLineReq);
+    X_REQUEST_HEAD_AT_LEAST(xPolyLineReq);
 
     result = dixLookupResourceByClass((void **) &draw, stuff->drawable,
                                       XRC_DRAWABLE, client, DixWriteAccess);
@@ -1521,9 +1471,7 @@ PanoramiXPolySegment(ClientPtr client)
     PanoramiXRes *gc, *draw;
     Bool isRoot;
 
-    REQUEST(xPolySegmentReq);
-
-    REQUEST_AT_LEAST_SIZE(xPolySegmentReq);
+    X_REQUEST_HEAD_AT_LEAST(xPolySegmentReq);
 
     result = dixLookupResourceByClass((void **) &draw, stuff->drawable,
                                       XRC_DRAWABLE, client, DixWriteAccess);
@@ -1591,9 +1539,7 @@ PanoramiXPolyRectangle(ClientPtr client)
     PanoramiXRes *gc, *draw;
     Bool isRoot;
 
-    REQUEST(xPolyRectangleReq);
-
-    REQUEST_AT_LEAST_SIZE(xPolyRectangleReq);
+    X_REQUEST_HEAD_AT_LEAST(xPolyRectangleReq);
 
     result = dixLookupResourceByClass((void **) &draw, stuff->drawable,
                                       XRC_DRAWABLE, client, DixWriteAccess);
@@ -1660,9 +1606,7 @@ PanoramiXPolyArc(ClientPtr client)
     PanoramiXRes *gc, *draw;
     Bool isRoot;
 
-    REQUEST(xPolyArcReq);
-
-    REQUEST_AT_LEAST_SIZE(xPolyArcReq);
+    X_REQUEST_HEAD_AT_LEAST(xPolyArcReq);
 
     result = dixLookupResourceByClass((void **) &draw, stuff->drawable,
                                       XRC_DRAWABLE, client, DixWriteAccess);
@@ -1727,9 +1671,7 @@ PanoramiXFillPoly(ClientPtr client)
     PanoramiXRes *gc, *draw;
     Bool isRoot;
 
-    REQUEST(xFillPolyReq);
-
-    REQUEST_AT_LEAST_SIZE(xFillPolyReq);
+    X_REQUEST_HEAD_AT_LEAST(xFillPolyReq);
 
     result = dixLookupResourceByClass((void **) &draw, stuff->drawable,
                                       XRC_DRAWABLE, client, DixWriteAccess);
@@ -1794,9 +1736,7 @@ PanoramiXPolyFillRectangle(ClientPtr client)
     int result, things, i;
     PanoramiXRes *gc, *draw;
     Bool isRoot;
-    REQUEST(xPolyFillRectangleReq);
-
-    REQUEST_AT_LEAST_SIZE(xPolyFillRectangleReq);
+    X_REQUEST_HEAD_AT_LEAST(xPolyFillRectangleReq);
 
     result = dixLookupResourceByClass((void **) &draw, stuff->drawable,
                                       XRC_DRAWABLE, client, DixWriteAccess);
@@ -1863,9 +1803,7 @@ PanoramiXPolyFillArc(ClientPtr client)
     Bool isRoot;
     int result, narcs, i;
 
-    REQUEST(xPolyFillArcReq);
-
-    REQUEST_AT_LEAST_SIZE(xPolyFillArcReq);
+    X_REQUEST_HEAD_AT_LEAST(xPolyFillArcReq);
 
     result = dixLookupResourceByClass((void **) &draw, stuff->drawable,
                                       XRC_DRAWABLE, client, DixWriteAccess);
@@ -1931,9 +1869,7 @@ PanoramiXPutImage(ClientPtr client)
     Bool isRoot;
     int result, orig_x, orig_y;
 
-    REQUEST(xPutImageReq);
-
-    REQUEST_AT_LEAST_SIZE(xPutImageReq);
+    X_REQUEST_HEAD_AT_LEAST(xPutImageReq);
 
     result = dixLookupResourceByClass((void **) &draw, stuff->drawable,
                                       XRC_DRAWABLE, client, DixWriteAccess);
@@ -1979,9 +1915,7 @@ PanoramiXGetImage(ClientPtr client)
     Mask plane = 0, planemask;
     int linesDone, nlines, linesPerBuf;
 
-    REQUEST(xGetImageReq);
-
-    REQUEST_SIZE_MATCH(xGetImageReq);
+    X_REQUEST_HEAD_STRUCT(xGetImageReq);
 
     if ((stuff->format != XYPixmap) && (stuff->format != ZPixmap)) {
         client->errorValue = stuff->format;
@@ -2068,7 +2002,6 @@ PanoramiXGetImage(ClientPtr client)
             linesPerBuf = h;
     }
 
-
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
     /* can become quite big, so make enough room so we don't need to relloc */
@@ -2138,9 +2071,7 @@ PanoramiXPolyText8(ClientPtr client)
     int result;
     int orig_x, orig_y;
 
-    REQUEST(xPolyTextReq);
-
-    REQUEST_AT_LEAST_SIZE(xPolyTextReq);
+    X_REQUEST_HEAD_AT_LEAST(xPolyTextReq);
 
     result = dixLookupResourceByClass((void **) &draw, stuff->drawable,
                                       XRC_DRAWABLE, client, DixWriteAccess);
@@ -2183,9 +2114,7 @@ PanoramiXPolyText16(ClientPtr client)
     int result;
     int orig_x, orig_y;
 
-    REQUEST(xPolyTextReq);
-
-    REQUEST_AT_LEAST_SIZE(xPolyTextReq);
+    X_REQUEST_HEAD_AT_LEAST(xPolyTextReq);
 
     result = dixLookupResourceByClass((void **) &draw, stuff->drawable,
                                       XRC_DRAWABLE, client, DixWriteAccess);
@@ -2228,7 +2157,7 @@ PanoramiXImageText8(ClientPtr client)
     Bool isRoot;
     int orig_x, orig_y;
 
-    REQUEST(xImageTextReq);
+    X_REQUEST_HEAD_NO_CHECK(xImageTextReq);
 
     REQUEST_FIXED_SIZE(xImageTextReq, stuff->nChars);
 
@@ -2273,7 +2202,7 @@ PanoramiXImageText16(ClientPtr client)
     Bool isRoot;
     int orig_x, orig_y;
 
-    REQUEST(xImageTextReq);
+    X_REQUEST_HEAD_NO_CHECK(xImageTextReq);
 
     REQUEST_FIXED_SIZE(xImageTextReq, stuff->nChars << 1);
 
@@ -2316,9 +2245,7 @@ PanoramiXCreateColormap(ClientPtr client)
     PanoramiXRes *win, *newCmap;
     int result, orig_visual;
 
-    REQUEST(xCreateColormapReq);
-
-    REQUEST_SIZE_MATCH(xCreateColormapReq);
+    X_REQUEST_HEAD_STRUCT(xCreateColormapReq);
 
     result = dixLookupResourceByType((void **) &win, stuff->window,
                                      XRT_WINDOW, client, DixReadAccess);
@@ -2356,9 +2283,7 @@ PanoramiXFreeColormap(ClientPtr client)
     PanoramiXRes *cmap;
     int result;
 
-    REQUEST(xResourceReq);
-
-    REQUEST_SIZE_MATCH(xResourceReq);
+    X_REQUEST_HEAD_STRUCT(xResourceReq);
 
     client->errorValue = stuff->id;
 
@@ -2386,9 +2311,7 @@ PanoramiXCopyColormapAndFree(ClientPtr client)
     PanoramiXRes *cmap, *newCmap;
     int result;
 
-    REQUEST(xCopyColormapAndFreeReq);
-
-    REQUEST_SIZE_MATCH(xCopyColormapAndFreeReq);
+    X_REQUEST_HEAD_STRUCT(xCopyColormapAndFreeReq);
 
     client->errorValue = stuff->srcCmap;
 
@@ -2423,11 +2346,9 @@ PanoramiXCopyColormapAndFree(ClientPtr client)
 int
 PanoramiXInstallColormap(ClientPtr client)
 {
-    REQUEST(xResourceReq);
+    X_REQUEST_HEAD_STRUCT(xResourceReq);
     int result;
     PanoramiXRes *cmap;
-
-    REQUEST_SIZE_MATCH(xResourceReq);
 
     client->errorValue = stuff->id;
 
@@ -2449,11 +2370,9 @@ PanoramiXInstallColormap(ClientPtr client)
 int
 PanoramiXUninstallColormap(ClientPtr client)
 {
-    REQUEST(xResourceReq);
+    X_REQUEST_HEAD_STRUCT(xResourceReq);
     int result;
     PanoramiXRes *cmap;
-
-    REQUEST_SIZE_MATCH(xResourceReq);
 
     client->errorValue = stuff->id;
 
@@ -2478,8 +2397,7 @@ PanoramiXAllocColor(ClientPtr client)
     int result;
     PanoramiXRes *cmap;
 
-    REQUEST(xAllocColorReq);
-    REQUEST_SIZE_MATCH(xAllocColorReq);
+    X_REQUEST_HEAD_STRUCT(xAllocColorReq);
 
     if (client->swapped) {
         swapl(&stuff->cmap);
@@ -2538,7 +2456,7 @@ PanoramiXAllocNamedColor(ClientPtr client)
     int result;
     PanoramiXRes *cmap;
 
-    REQUEST(xAllocNamedColorReq);
+    X_REQUEST_HEAD_NO_CHECK(xAllocNamedColorReq);
 
     REQUEST_FIXED_SIZE(xAllocNamedColorReq, stuff->nbytes);
 
@@ -2565,9 +2483,7 @@ PanoramiXAllocColorCells(ClientPtr client)
     int result;
     PanoramiXRes *cmap;
 
-    REQUEST(xAllocColorCellsReq);
-
-    REQUEST_SIZE_MATCH(xAllocColorCellsReq);
+    X_REQUEST_HEAD_STRUCT(xAllocColorCellsReq);
 
     client->errorValue = stuff->cmap;
 
@@ -2592,9 +2508,7 @@ PanoramiXAllocColorPlanes(ClientPtr client)
     int result;
     PanoramiXRes *cmap;
 
-    REQUEST(xAllocColorPlanesReq);
-
-    REQUEST_SIZE_MATCH(xAllocColorPlanesReq);
+    X_REQUEST_HEAD_STRUCT(xAllocColorPlanesReq);
 
     client->errorValue = stuff->cmap;
 
@@ -2619,9 +2533,7 @@ PanoramiXFreeColors(ClientPtr client)
     int result;
     PanoramiXRes *cmap;
 
-    REQUEST(xFreeColorsReq);
-
-    REQUEST_AT_LEAST_SIZE(xFreeColorsReq);
+    X_REQUEST_HEAD_AT_LEAST(xFreeColorsReq);
 
     client->errorValue = stuff->cmap;
 
@@ -2644,9 +2556,7 @@ PanoramiXStoreColors(ClientPtr client)
     int result;
     PanoramiXRes *cmap;
 
-    REQUEST(xStoreColorsReq);
-
-    REQUEST_AT_LEAST_SIZE(xStoreColorsReq);
+    X_REQUEST_HEAD_AT_LEAST(xStoreColorsReq);
 
     client->errorValue = stuff->cmap;
 
@@ -2671,7 +2581,7 @@ PanoramiXStoreNamedColor(ClientPtr client)
     int result;
     PanoramiXRes *cmap;
 
-    REQUEST(xStoreNamedColorReq);
+    X_REQUEST_HEAD_NO_CHECK(xStoreNamedColorReq);
 
     REQUEST_FIXED_SIZE(xStoreNamedColorReq, stuff->nbytes);
 


### PR DESCRIPTION
Convert the Xinerama (PanoramiX) request handlers in panoramiXprocs.c
from the raw REQUEST()/REQUEST_SIZE_MATCH()/REQUEST_AT_LEAST_SIZE()
idiom to the X_REQUEST_HEAD_STRUCT()/X_REQUEST_HEAD_AT_LEAST()/
X_REQUEST_HEAD_NO_CHECK() macros from dix/request_priv.h, matching the
ongoing conversion already done in render, glx, xinput, randr etc.

Purely mechanical and behaviour-preserving: the macros expand to the
same REQUEST() + size check, plus a NULL-request guard (return
BadLength). Request/reply byte-swapping is left untouched, as the
PanoramiX handlers only hook ProcVector[] and rely on the core
dispatch's swap handling / their own explicit swaps.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
