### PR TITLE
(release/25.1) panoramiX: zero-init xAllocColorReply to avoid leaking uninitialised bytes

### DIFF
--- a/Xext/panoramiXprocs.c
+++ b/Xext/panoramiXprocs.c
@@ -2528,11 +2528,16 @@ PanoramiXAllocColor(ClientPtr client)
 
         /* only send out reply for on first screen */
         if (!walkScreenIdx) {
-            xAllocColorReply reply; /* static init would confuse preprocessor */
-            reply.red = red;
-            reply.green = green;
-            reply.blue = blue;
-            reply.pixel = pixel;
+            /* Designated initialiser zeroes the reply's pad/reserved bytes,
+               which were previously left uninitialised and sent to the
+               client. (The XINERAMA_FOR_EACH_SCREEN_* macros are variadic, so
+               the initialiser's commas no longer confuse the preprocessor.) */
+            xAllocColorReply reply = {
+                .red = red,
+                .green = green,
+                .blue = blue,
+                .pixel = pixel,
+            };
 
             if (client->swapped) {
                 swaps(&reply.red);


### PR DESCRIPTION
The reply struct was declared bare (uninitialised auto storage) and then
filled field-by-field (red/green/blue/pixel only), leaving pad1/pad2 and
any trailing padding uninitialised. Those bytes were then sent to the
client via X_SEND_REPLY_SIMPLE, an information disclosure.

Fix it with a designated initialiser so the pad/reserved bytes are
zeroed. This block sits inside XINERAMA_FOR_EACH_SCREEN_BACKWARD(), which
took a single macro parameter — so a top-level '{ .a = x, .b = y }'
initialiser was split at its commas into multiple macro arguments (the
old "static init would confuse preprocessor" caveat). Rather than work
around that per call site, make the XINERAMA_FOR_EACH_SCREEN_* macros
variadic (pass the body as __VA_ARGS__); commas in the body are then
preserved, and an ordinary designated initialiser can be used with no
compound-literal cast or extra parentheses.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit 7badd1eec2843eb060d569b4b4cc36545c67cdd2)


---
Backport of master PR #3227 ("panoramiX: zero-init xAllocColorReply to avoid leaking uninitialised bytes") — a real client-triggerable info-leak fix. **#3234 merged.** This PR has been rebased onto the current release/25.1 (which now has the variadic macro), so it's slimmed to just the reply-init fix in panoramiXprocs.c. Master PR #3227 was also rebased the same way onto master. Ready for review/merge.


