### PR TITLE
(release/25.1) glx: zero-init xGLXQueryVersionReply to avoid leaking uninitialised bytes

### DIFF
--- a/glx/vndcmds.c
+++ b/glx/vndcmds.c
@@ -94,11 +94,12 @@ static GlxServerDispatchProc GetVendorDispatchFunc(CARD8 opcode, CARD32 vendorCo
 
 static int dispatch_GLXQueryVersion(ClientPtr client)
 {
-    xGLXQueryVersionReply reply;
     REQUEST_SIZE_MATCH(xGLXQueryVersionReq);
 
-    reply.majorVersion = GlxCheckSwap(client, 1);
-    reply.minorVersion = GlxCheckSwap(client, 4);
+    xGLXQueryVersionReply reply = {
+        .majorVersion = GlxCheckSwap(client, 1),
+        .minorVersion = GlxCheckSwap(client, 4),
+    };
 
     return X_SEND_REPLY_SIMPLE(client, reply);
 }


### PR DESCRIPTION
Backport of [#3226](https://github.com/X11Libre/xserver/pull/3226) (master)

The reply struct was declared bare (uninitialised auto storage) and then
filled field-by-field (majorVersion/minorVersion only), leaving pad1 and
any trailing padding uninitialised. Those bytes were then sent to the
client via X_SEND_REPLY_SIMPLE, an information disclosure.

Use a designated initialiser so all omitted fields and padding are zeroed;
type/sequenceNumber/length are still set by X_SEND_REPLY_SIMPLE afterward.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit f045ee09adf40571b34b0955fa55c5c10c4c2833)
