### PR TITLE
(release/25.0) glx: zero-init xGLXQueryVersionReply to avoid leaking uninitialised bytes

### DIFF
--- a/glx/vndcmds.c
+++ b/glx/vndcmds.c
@@ -103,12 +103,14 @@ static void SetReplyHeader(ClientPtr client, void *replyPtr)
 
 static int dispatch_GLXQueryVersion(ClientPtr client)
 {
-    xGLXQueryVersionReply reply;
     REQUEST_SIZE_MATCH(xGLXQueryVersionReq);
 
+    xGLXQueryVersionReply reply = {
+        .majorVersion = GlxCheckSwap(client, 1),
+        .minorVersion = GlxCheckSwap(client, 4),
+    };
+
     SetReplyHeader(client, &reply);
-    reply.majorVersion = GlxCheckSwap(client, 1);
-    reply.minorVersion = GlxCheckSwap(client, 4);
 
     WriteToClient(client, sizeof(xGLXQueryVersionReply), &reply);
     return Success;


### PR DESCRIPTION
Backport of [#3226](https://github.com/X11Libre/xserver/pull/3226) (master)

The reply struct was declared bare (uninitialised auto storage) and then
filled field-by-field (majorVersion/minorVersion only), leaving pad1 and
any trailing padding uninitialised. Those bytes were then sent to the
client, an information disclosure.

Use a designated initialiser so the pad/reserved bytes are zeroed.

Backport note: 25.0 still uses the older SetReplyHeader()/WriteToClient()
idiom (master builds the reply via the vnd dispatch + X_SEND_REPLY_SIMPLE),
so the master patch does not apply verbatim; the same designated-initialiser
fix is applied to this idiom, with SetReplyHeader() filling type/length/
sequenceNumber after the initialiser.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit f045ee09adf40571b34b0955fa55c5c10c4c2833)
