### PR TITLE
(release/25.2) dix: rpcbuf: write empty counted string for NULL str

### DIFF
--- a/dix/rpcbuf_priv.h
+++ b/dix/rpcbuf_priv.h
@@ -343,20 +343,23 @@ static inline void x_rpcbuf_pad(x_rpcbuf_t *rpcbuf) {
  * write a Pascal-like counted string, starting with CARD16 couter,
  * followed by the char bytes, padded to full protocol units (4-bytes).
  *
- * if str is NULL, don't write anything
+ * A NULL str is written as an empty counted string (length 0 + padding, i.e.
+ * 4 bytes), NOT omitted: the counted-string wire format always carries the
+ * 16-bit length, so a reader (e.g. the XKB geometry reader _GetCountedString)
+ * unconditionally consumes those bytes. Omitting them for NULL would desync
+ * every following field.
  *
  * @param rpcbuf    pointer to the x_rpcbuf_t to operate on
- * @param str       zero-terminated string to write into the buffer
+ * @param str       zero-terminated string to write into the buffer, or NULL
  */
 static inline void x_rpcbuf_write_counted_string_pad(
         x_rpcbuf_t *rpcbuf, const char *str)
 {
-    if (str) {
-        CARD16 len = (CARD16)strlen(str); /* 64k should really be enough */
-        x_rpcbuf_write_CARD16(rpcbuf, len);
+    CARD16 len = str ? (CARD16)strlen(str) : 0; /* 64k should really be enough */
+    x_rpcbuf_write_CARD16(rpcbuf, len);
+    if (len)
         x_rpcbuf_write_CARD8s(rpcbuf, (CARD8*)str, len);
-        x_rpcbuf_pad(rpcbuf);
-    }
+    x_rpcbuf_pad(rpcbuf);
 }
 
 /*


### PR DESCRIPTION
x_rpcbuf_write_counted_string_pad() wrote nothing at all when str was NULL.
But a counted string is a fixed wire element - a 16-bit length, the bytes,
then padding to a 4-byte unit. The matching reader (XKB's _GetCountedString)
unconditionally consumes that 16-bit length (an empty string is length 0 +
pad = 4 bytes), and XkbSizeCountedString() budgets 4 bytes for NULL too.

Omitting the field for NULL therefore produced a short, malformed
XkbGetGeometry reply whenever a geometry string field was NULL (label_font,
a doodad text/font/logo_name, a colour spec, or a property name/value),
desyncing every following field for the reading client.

Write an empty counted string (length 0 + padding) for NULL instead, so the
writer matches the reader and the size accounting.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit e113dab26fe2381e36a67d0ae1c84523ab67e208)
