### PR TITLE
(master) ci/netbsd: host a scoped pkgsrc + X11-sets mirror on GitHub, use it first

### DIFF
--- a/.github/scripts/netbsd/install-pkg.sh
+++ b/.github/scripts/netbsd/install-pkg.sh
@@ -3,21 +3,46 @@
 set -ex
 
 . .github/scripts/util.sh
+. .github/scripts/netbsd/mirror-conf.sh
 
 export PATH="$PATH:/usr/sbin:/sbin:/usr/local/sbin"
 
-NETBSD_RELEASE="10.1"
-NETBSD_ARCH="amd64"
-PKGSRC_ARCH="x86_64"
+# NETBSD_RELEASE / NETBSD_ARCH / PKGSRC_ARCH and all mirror URLs + the package
+# list come from mirror-conf.sh (shared with the mirror-sync workflow).
 
-# Install pkgin if not present
+PKGIN_CONF_DIRS="/usr/pkg/etc/pkgin /etc/pkgin"
+
+# Write repositories.conf (one URL per line) everywhere pkgin looks for it.
+write_repos_conf() {
+    for d in $PKGIN_CONF_DIRS; do
+        mkdir -p "$d"
+        rm -f "$d/repositories.conf"
+        for u in "$@"; do
+            printf '%s\n' "$u"
+        done > "$d/repositories.conf"
+    done
+    # Unset PKG_REPOS so pkgin reads repositories.conf instead.
+    unset PKG_REPOS
+}
+
+# Update the pkgin db from the configured repos and install the package set.
+# Returns non-zero on any failure so the caller can fall back to another repo
+# set. (Invoked in an `if` condition, so `set -e` is suspended for its body.)
+pkgin_install_from() {
+    write_repos_conf "$@"
+    echo "pkgin update from: $*"
+    if ! pkgin update; then
+        return 1
+    fi
+    # shellcheck disable=SC2086
+    pkgin -y install $PKGIN_PACKAGES
+}
+
+# Install pkgin itself if the VM image ships without it. Try the GitHub mirror
+# first (its .tgz + deps are mirrored for exactly this), then official.
 if ! command -v pkgin >/dev/null 2>&1; then
     echo "Installing pkgin..."
-    MIRRORS="
-    https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
-    https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
-    "
-    for mirror in $MIRRORS; do
+    for mirror in "$MIRROR_BASE_URL" $PKGSRC_REPOS_OFFICIAL; do
         echo "Trying pkgin from $mirror"
         export PKG_PATH="$mirror"
         if pkg_add -v pkgin; then
@@ -25,58 +50,38 @@ if ! command -v pkgin >/dev/null 2>&1; then
             break
         fi
     done
+    unset PKG_PATH
     if ! command -v pkgin >/dev/null 2>&1; then
         echo "Failed to install pkgin"
         exit 1
     fi
 fi
 
-# Configure pkgin repositories (use .conf extension)
-rm -f /usr/pkg/etc/pkgin/repositories.conf
-rm -f /etc/pkgin/repositories.conf
-mkdir -p /usr/pkg/etc/pkgin
-mkdir -p /etc/pkgin
-
-{
-cat <<EOF
-https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
-https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
-EOF
-    } > /usr/pkg/etc/pkgin/repositories.conf
-cp /usr/pkg/etc/pkgin/repositories.conf /etc/pkgin/repositories.conf
-
-# Unset PKG_REPOS so pkgin reads repositories.conf (one URL per line)
-unset PKG_REPOS
-
-# Update package database
-echo "Updating pkgin..."
-if ! pkgin update; then
-    echo "pkgin update had partial mirror failures, falling back to NetBSD 10.0 repositories..."
-    {
-    cat <<EOF
-https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/All
-https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/All
-EOF
-    } > /usr/pkg/etc/pkgin/repositories.conf
-    cp /usr/pkg/etc/pkgin/repositories.conf /etc/pkgin/repositories.conf
-    pkgin update || true
+# Install build dependencies: try the GitHub-hosted scoped mirror FIRST (so a
+# green run never depends on ftp/cdn.netbsd.org being up), and only fall back to
+# the official mirrors if our mirror is unreachable, stale, or missing a package
+# (e.g. the list above was extended but the mirror has not re-synced yet). This
+# is a soft fallback, deliberately NOT a hard cutover.
+echo "Installing build dependencies (GitHub mirror first, official fallback)..."
+if pkgin_install_from "$MIRROR_BASE_URL"; then
+    echo "build dependencies installed from GitHub mirror"
+else
+    echo "GitHub mirror unavailable/incomplete — falling back to official NetBSD mirrors"
+    if ! pkgin_install_from $PKGSRC_REPOS_OFFICIAL; then
+        echo "official ${NETBSD_RELEASE} repos had failures — trying 10.0 fallback..."
+        write_repos_conf $PKGSRC_REPOS_FALLBACK
+        pkgin update || true
+        # shellcheck disable=SC2086
+        pkgin -y install $PKGIN_PACKAGES || true
+    fi
 fi
 
-# Install curl for downloading sets
-echo "Installing curl..."
-pkgin -y install curl || true
-
-# X11 binary sets
-SETS_MIRRORS="
-https://ftp.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
-https://ftp.us.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
-https://cdn.netbsd.org/pub/NetBSD/NetBSD-$NETBSD_RELEASE/$NETBSD_ARCH/binary/sets
-"
-
-echo "Downloading and installing X11 sets..."
-for i in xbase xetc xfont xcomp xserver; do
+# X11 OS-release binary sets (not pkgsrc). Try the GitHub mirror first, then the
+# official NetBSD release mirrors.
+echo "Downloading and installing X11 sets (GitHub mirror first)..."
+for i in $X11_SETS; do
     ok=0
-    for urlbase in $SETS_MIRRORS; do
+    for urlbase in "$MIRROR_BASE_URL" $SETS_MIRRORS_OFFICIAL; do
         url="$urlbase/$i.tar.xz"
         echo "Fetching $url"
         if curl -L --retry 3 --connect-timeout 20 -f -o "/$i.tar.xz" "$url"; then
@@ -92,14 +97,7 @@ for i in xbase xetc xfont xcomp xserver; do
     rm -f "/$i.tar.xz"
 done
 
-# Install build dependencies
-echo "Installing build dependencies..."
-pkgin -y install \
-    bash git pkgconf autoconf automake libtool xorgproto meson pixman xtrans \
-    libxkbfile libxcvt libpciaccess font-util libepoll-shim libepoxy nettle \
-    xkbcomp xcb-util libXcursor libXScrnSaver spice-protocol fontconfig \
-    mkfontscale python311 gmake curl || true
-
+# Build the couple of autotools deps that are not packaged / need a pinned rev.
 mkdir -p "$X11_BUILD_DIR"
 cd "$X11_BUILD_DIR"
 

--- a/.github/scripts/netbsd/mirror-conf.sh
+++ b/.github/scripts/netbsd/mirror-conf.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright © 2026 Enrico Weigelt, metux IT consult
+#
+# Shared configuration for the NetBSD CI build-dependency mirror.
+#
+# The `xserver-build-netbsd` CI lane installs its build deps from the official
+# NetBSD pkgsrc / OS-release mirrors (ftp.netbsd.org, cdn.netbsd.org). Those
+# servers flake intermittently (e.g. `pkg_add: ... Undefined error: 0`), which
+# reds an otherwise-green PR for reasons unrelated to its diff. To insulate the
+# lane we host a SCOPED mirror — just the packages + X11 sets this job actually
+# needs (~230 MB), not the full ~65 GB pkgsrc archive — as GitHub Release
+# assets, refreshed weekly by `.github/workflows/netbsd-pkg-mirror.yml`.
+#
+# This file is the single source of truth sourced by BOTH consumers, so the
+# mirror and the build job can never drift on which packages / release / arch
+# they mean:
+#   - .github/scripts/netbsd/install-pkg.sh   (build job: install from mirror,
+#                                               fall back to official)
+#   - .github/scripts/netbsd/sync-pkg-mirror.sh (weekly sync: resolve+download
+#                                               the closure, build the mirror)
+#
+# POSIX sh — sourced inside the NetBSD VM (usesh: true). No bashisms.
+
+# --- target NetBSD release / architecture -----------------------------------
+# Must match the `release:` of the vmactions/netbsd-vm step in
+# build-xserver.yml (and the sync workflow).
+NETBSD_RELEASE="10.1"
+NETBSD_ARCH="amd64"      # OS-release binary-set arch (X11 sets path)
+PKGSRC_ARCH="x86_64"     # pkgsrc package arch
+
+# --- GitHub-hosted scoped mirror --------------------------------------------
+# Release assets are served flat under the tag, which is exactly the layout
+# pkgin expects for a repository base URL (pkg_summary.gz + <FILE_NAME> by
+# relative name). The tag is stable/non-versioned; assets are replaced in place
+# each sync (gh release upload --clobber).
+MIRROR_REPO="X11Libre/xserver"
+MIRROR_TAG="netbsd-pkgsrc-mirror"
+MIRROR_BASE_URL="https://github.com/${MIRROR_REPO}/releases/download/${MIRROR_TAG}"
+
+# --- official upstream mirrors (fallback for the build job; source for sync) -
+# NOTE: the `<rel>/All` path 302-redirects to a dated quarterly snapshot
+# (e.g. 10.0_2026Q1/All); curl -L / pkgin follow it dynamically — do NOT
+# hardcode the dated path here, it moves over time.
+PKGSRC_REPOS_OFFICIAL="\
+https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All
+https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/${NETBSD_RELEASE}/All"
+
+# Last-ditch fallback if the target release's repo is unreachable entirely.
+PKGSRC_REPOS_FALLBACK="\
+https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/All
+https://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/${PKGSRC_ARCH}/10.0/All"
+
+# OS-release X11 binary sets (NOT pkgsrc — NetBSD's own release sets).
+SETS_MIRRORS_OFFICIAL="\
+https://cdn.netbsd.org/pub/NetBSD/NetBSD-${NETBSD_RELEASE}/${NETBSD_ARCH}/binary/sets
+https://ftp.netbsd.org/pub/NetBSD/NetBSD-${NETBSD_RELEASE}/${NETBSD_ARCH}/binary/sets
+https://ftp.us.netbsd.org/pub/NetBSD/NetBSD-${NETBSD_RELEASE}/${NETBSD_ARCH}/binary/sets"
+
+# --- the actual dependency set ----------------------------------------------
+# X11 OS-release binary sets fetched as <name>.tar.xz and extracted into /.
+X11_SETS="xbase xetc xfont xcomp xserver"
+
+# pkgin packages the build needs. KEEP THIS IN SYNC with what the build
+# actually requires — this is the list both install-pkg.sh installs and
+# sync-pkg-mirror.sh resolves+mirrors. Editing it is safe: the next mirror
+# sync picks it up; until then the build job just falls back to official for
+# any not-yet-mirrored package.
+#
+# `pkgin` itself is listed so its .tgz (+ deps) are mirrored for the pkg_add
+# bootstrap in install-pkg.sh when the VM image ships without it.
+PKGIN_PACKAGES="\
+pkgin \
+bash git pkgconf autoconf automake libtool xorgproto meson pixman xtrans \
+libxkbfile libxcvt libpciaccess font-util libepoll-shim libepoxy nettle \
+xkbcomp xcb-util libXcursor libXScrnSaver spice-protocol fontconfig \
+mkfontscale python311 gmake curl"

--- a/.github/scripts/netbsd/publish-mirror.sh
+++ b/.github/scripts/netbsd/publish-mirror.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright © 2026 Enrico Weigelt, metux IT consult
+#
+# Host (ubuntu) half of the NetBSD build-dependency mirror sync (see
+# .github/workflows/netbsd-pkg-mirror.yml). Runs AFTER the vmactions VM step has
+# staged the mirror into $MIRROR_OUTDIR (copied back to the host). It publishes
+# the staged files as assets of a single, stable, non-versioned GitHub Release
+# (tag $MIRROR_TAG), replacing assets in place (--clobber) and pruning assets no
+# longer part of the set so the release does not grow unbounded.
+#
+# Requires: gh (authenticated with contents:write on $MIRROR_REPO).
+
+set -euo pipefail
+
+# mirror-conf.sh is POSIX sh; source it here to get MIRROR_REPO / MIRROR_TAG /
+# the expected file set without duplicating them.
+# shellcheck disable=SC1091
+. .github/scripts/netbsd/mirror-conf.sh
+
+MIRROR_OUTDIR="${MIRROR_OUTDIR:-${1:-$PWD/netbsd-mirror-out}}"
+
+if [ ! -d "$MIRROR_OUTDIR" ]; then
+    echo "FATAL: staging dir $MIRROR_OUTDIR does not exist (did the VM step run / copy back?)"
+    exit 1
+fi
+
+# Collect the assets to publish (skip dotfiles / scratch).
+assets=()
+while IFS= read -r f; do
+    assets+=("$f")
+done < <(find "$MIRROR_OUTDIR" -maxdepth 1 -type f ! -name '.*' | sort)
+
+if [ "${#assets[@]}" -eq 0 ]; then
+    echo "FATAL: no files to publish in $MIRROR_OUTDIR"
+    exit 1
+fi
+
+# Sanity: the mirror is useless without the index and at least the X11 sets.
+if [ ! -f "$MIRROR_OUTDIR/pkg_summary.gz" ]; then
+    echo "FATAL: $MIRROR_OUTDIR/pkg_summary.gz missing — refusing to publish a mirror with no index"
+    exit 1
+fi
+
+echo "publishing ${#assets[@]} assets to ${MIRROR_REPO} release ${MIRROR_TAG}"
+
+# Ensure the release exists (stable tag; created once, reused thereafter).
+if ! gh release view "$MIRROR_TAG" --repo "$MIRROR_REPO" >/dev/null 2>&1; then
+    echo "creating release $MIRROR_TAG"
+    gh release create "$MIRROR_TAG" \
+        --repo "$MIRROR_REPO" \
+        --title "NetBSD CI build-dependency mirror" \
+        --notes "Scoped mirror of the pkgsrc packages + X11 OS-release binary sets consumed by the \`xserver-build-netbsd\` CI lane, so the lane does not depend on ftp/cdn.netbsd.org being reachable. Auto-refreshed by \`.github/workflows/netbsd-pkg-mirror.yml\`; do not edit assets by hand. Layout is a flat pkgin repository base (pkg_summary.gz + <FILE_NAME>.tgz) plus <set>.tar.xz." \
+        --latest=false
+fi
+
+# Upload (replace in place).
+echo "uploading assets..."
+gh release upload "$MIRROR_TAG" --repo "$MIRROR_REPO" --clobber "${assets[@]}"
+
+# Prune assets that are no longer part of the current set.
+declare -A want=()
+for a in "${assets[@]}"; do
+    want["$(basename "$a")"]=1
+done
+
+echo "pruning stale assets..."
+while IFS= read -r existing; do
+    [ -n "$existing" ] || continue
+    if [ -z "${want[$existing]:-}" ]; then
+        echo "  deleting stale asset: $existing"
+        gh release delete-asset "$MIRROR_TAG" "$existing" --repo "$MIRROR_REPO" -y || echo "    (delete failed for $existing)"
+    fi
+done < <(gh release view "$MIRROR_TAG" --repo "$MIRROR_REPO" --json assets --jq '.assets[].name')
+
+echo "done. current mirror assets:"
+gh release view "$MIRROR_TAG" --repo "$MIRROR_REPO" --json assets \
+    --jq '.assets[] | "  \(.name)\t\(.size) bytes"'

--- a/.github/scripts/netbsd/sync-pkg-mirror.sh
+++ b/.github/scripts/netbsd/sync-pkg-mirror.sh
@@ -1,0 +1,172 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright © 2026 Enrico Weigelt, metux IT consult
+#
+# In-VM half of the NetBSD build-dependency mirror sync (see
+# .github/workflows/netbsd-pkg-mirror.yml). Runs INSIDE a vmactions/netbsd-vm
+# that is the SAME image (release) the xserver-build-netbsd job uses — this is
+# deliberate: pkgin's dependency closure is computed against the identical base
+# system, so the set of .tgz we mirror is exactly the set the build job would
+# otherwise download from the official mirrors. (Packages already present in the
+# base image are skipped by pkgin here AND in the build job, so the mirror stays
+# consistent with what the build actually fetches.)
+#
+# It does NOT reimplement dependency resolution — it drives the real pkgin
+# download-only path (`pkgin -d install`) to get the authoritative closure, then
+# builds a TRIMMED pkg_summary.gz (a strict subset of the official one, so
+# FILE_SIZE and file bytes stay consistent) covering only the mirrored packages.
+#
+# Everything is staged into $MIRROR_OUTDIR (a dir inside the shared workspace),
+# so the host side of the workflow can pick it up after the VM step (copyback)
+# and publish it via `gh release upload`.
+#
+# POSIX sh (usesh: true). No bashisms.
+
+set -eu
+
+. .github/scripts/netbsd/mirror-conf.sh
+
+export PATH="$PATH:/usr/sbin:/sbin:/usr/local/sbin"
+
+MIRROR_OUTDIR="${MIRROR_OUTDIR:-$PWD/netbsd-mirror-out}"
+PKGIN_CACHE="${PKGIN_CACHE:-/var/db/pkgin/cache}"
+PKGIN_CONF_DIRS="/usr/pkg/etc/pkgin /etc/pkgin"
+
+rm -rf "$MIRROR_OUTDIR"
+mkdir -p "$MIRROR_OUTDIR"
+
+write_repos_conf() {
+    for d in $PKGIN_CONF_DIRS; do
+        mkdir -p "$d"
+        rm -f "$d/repositories.conf"
+        for u in "$@"; do
+            printf '%s\n' "$u"
+        done > "$d/repositories.conf"
+    done
+    unset PKG_REPOS
+}
+
+# --- bootstrap pkgin from the official mirrors ------------------------------
+# The sync tolerates official-mirror flakes (it just re-runs next week); it is
+# the build job we insulate, not this one.
+if ! command -v pkgin >/dev/null 2>&1; then
+    echo "Installing pkgin (from official mirrors)..."
+    for mirror in $PKGSRC_REPOS_OFFICIAL; do
+        export PKG_PATH="$mirror"
+        if pkg_add -v pkgin; then
+            break
+        fi
+    done
+    unset PKG_PATH
+    command -v pkgin >/dev/null 2>&1 || { echo "FATAL: could not install pkgin"; exit 1; }
+fi
+
+# --- resolve + download the closure (download-only) -------------------------
+write_repos_conf $PKGSRC_REPOS_OFFICIAL
+if ! pkgin update; then
+    echo "official ${NETBSD_RELEASE} repos unreachable — trying 10.0 fallback..."
+    write_repos_conf $PKGSRC_REPOS_FALLBACK
+    pkgin update
+fi
+
+mkdir -p "$PKGIN_CACHE"
+echo "Downloading package closure (download-only) into $PKGIN_CACHE ..."
+# -d = download only (populate the cache, do not install). Resolves the full
+# dependency closure of $PKGIN_PACKAGES against the base image.
+# shellcheck disable=SC2086
+pkgin -y -d install $PKGIN_PACKAGES
+
+tgz_count=$(find "$PKGIN_CACHE" -maxdepth 1 -name '*.tgz' | wc -l | tr -d ' ')
+if [ "$tgz_count" -eq 0 ]; then
+    echo "FATAL: no .tgz downloaded into $PKGIN_CACHE — nothing to mirror"
+    exit 1
+fi
+echo "downloaded $tgz_count package files"
+
+# Copy the package files into the staging dir and record their names.
+KEEP="$MIRROR_OUTDIR/.keep-filenames"
+: > "$KEEP"
+for f in "$PKGIN_CACHE"/*.tgz; do
+    [ -f "$f" ] || continue
+    cp -f "$f" "$MIRROR_OUTDIR/"
+    basename "$f" >> "$KEEP"
+done
+
+# --- build the trimmed pkg_summary.gz ---------------------------------------
+# Fetch the FULL official summary from the same (redirect-resolved) repo pkgin
+# just used, then keep only the records whose FILE_NAME is one we mirrored. We
+# do NOT regenerate records — a strict subset keeps every FILE_SIZE / metadata
+# byte-identical to upstream, which is what pkgin verifies against.
+FULL_SUMMARY="$MIRROR_OUTDIR/.pkg_summary.full"
+got_summary=0
+for repo in $PKGSRC_REPOS_OFFICIAL $PKGSRC_REPOS_FALLBACK; do
+    for sfx in gz bz2 xz; do
+        echo "fetching $repo/pkg_summary.$sfx ..."
+        if curl -sL --connect-timeout 25 --max-time 300 -f -o "$MIRROR_OUTDIR/.summary.$sfx" "$repo/pkg_summary.$sfx"; then
+            case "$sfx" in
+                gz)  gzip  -dc "$MIRROR_OUTDIR/.summary.$sfx" > "$FULL_SUMMARY" ;;
+                bz2) bzip2 -dc "$MIRROR_OUTDIR/.summary.$sfx" > "$FULL_SUMMARY" ;;
+                xz)  xz    -dc "$MIRROR_OUTDIR/.summary.$sfx" > "$FULL_SUMMARY" ;;
+            esac
+            rm -f "$MIRROR_OUTDIR/.summary.$sfx"
+            got_summary=1
+            break
+        fi
+    done
+    [ "$got_summary" -eq 1 ] && break
+done
+if [ "$got_summary" -ne 1 ]; then
+    echo "FATAL: could not fetch pkg_summary from any official mirror"
+    exit 1
+fi
+
+echo "trimming pkg_summary to the $tgz_count mirrored packages ..."
+awk -v keepfile="$KEEP" '
+    BEGIN {
+        # Read the keep-list under the default RS="\n" (line at a time) BEFORE
+        # switching to paragraph mode — otherwise RS="" would slurp the whole
+        # keepfile as one key and nothing would match.
+        while ((getline l < keepfile) > 0) { keep[l] = 1 }
+        RS = ""; FS = "\n";
+    }
+    {
+        fn = "";
+        for (i = 1; i <= NF; i++) {
+            if ($i ~ /^FILE_NAME=/) { fn = substr($i, 11) }
+        }
+        if (fn != "" && (fn in keep)) { printf "%s\n\n", $0 }
+    }
+' "$FULL_SUMMARY" > "$MIRROR_OUTDIR/pkg_summary"
+
+kept=$(grep -c '^PKGNAME=' "$MIRROR_OUTDIR/pkg_summary" || true)
+echo "trimmed summary has $kept records (of $tgz_count mirrored files)"
+if [ "$kept" -eq 0 ]; then
+    echo "FATAL: trimmed pkg_summary is empty — FILE_NAME mismatch?"
+    exit 1
+fi
+gzip -9 -f "$MIRROR_OUTDIR/pkg_summary"      # -> pkg_summary.gz
+
+# --- fetch the X11 OS-release binary sets -----------------------------------
+echo "fetching X11 sets ..."
+for i in $X11_SETS; do
+    ok=0
+    for urlbase in $SETS_MIRRORS_OFFICIAL; do
+        echo "fetching $urlbase/$i.tar.xz ..."
+        if curl -sL --connect-timeout 25 --max-time 600 -f -o "$MIRROR_OUTDIR/$i.tar.xz" "$urlbase/$i.tar.xz"; then
+            ok=1
+            break
+        fi
+    done
+    if [ "$ok" -ne 1 ]; then
+        echo "FATAL: could not fetch X11 set $i.tar.xz"
+        exit 1
+    fi
+done
+
+# --- clean up staging-only scratch files ------------------------------------
+rm -f "$FULL_SUMMARY" "$KEEP"
+
+echo "mirror staged in $MIRROR_OUTDIR:"
+ls -la "$MIRROR_OUTDIR"
+du -sh "$MIRROR_OUTDIR"

--- a/.github/workflows/netbsd-pkg-mirror.yml
+++ b/.github/workflows/netbsd-pkg-mirror.yml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright © 2026 Enrico Weigelt, metux IT consult
+#
+# Refresh the scoped NetBSD build-dependency mirror used by the
+# xserver-build-netbsd lane.
+#
+# Why: that lane installs its deps from ftp/cdn.netbsd.org, which flake
+# intermittently (e.g. `pkg_add: ... Undefined error: 0`) and red an
+# otherwise-green PR for reasons unrelated to its diff. We host a scoped mirror
+# (just the ~230 MB this job needs, not the ~65 GB full pkgsrc archive) as
+# GitHub Release assets and point install-pkg.sh at it (mirror first, official
+# fallback — see .github/scripts/netbsd/mirror-conf.sh).
+#
+# How: boot the SAME NetBSD VM the build lane uses, drive the real pkgin
+# download-only path to get the authoritative dependency closure (no hand-rolled
+# resolver), build a trimmed pkg_summary.gz, fetch the X11 sets, then publish
+# everything to the stable `netbsd-pkgsrc-mirror` release.
+
+name: Refresh NetBSD pkg mirror
+
+on:
+    workflow_dispatch:
+    schedule:
+        # Weekly, Sunday 04:00 UTC. pkgsrc quarterly branches move slowly, so
+        # weekly is ample; install-pkg.sh falls back to official mirrors for
+        # anything not (yet) mirrored, so a missed run only costs the fallback.
+        - cron: '0 4 * * 0'
+
+# Don't overlap two syncs (each boots a VM and rewrites the same release).
+concurrency:
+    group: netbsd-pkg-mirror
+    cancel-in-progress: false
+
+permissions:
+    contents: write   # create/upload/delete release assets
+
+jobs:
+    refresh-netbsd-mirror:
+        runs-on: ubuntu-latest
+        timeout-minutes: 60
+        steps:
+            - uses: actions/checkout@v6
+
+            # Resolve + download the dependency closure and stage the mirror
+            # inside the workspace (copied back to the host afterwards).
+            - name: resolve + stage mirror in NetBSD VM
+              uses: vmactions/netbsd-vm@v1.2.3
+              with:
+                  release: '10.1'          # MUST match the build lane's VM
+                  usesh: true
+                  copyback: true
+                  mem: 4096
+                  run: ./.github/scripts/netbsd/sync-pkg-mirror.sh
+
+            - name: publish + prune GitHub Release assets
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: ./.github/scripts/netbsd/publish-mirror.sh


### PR DESCRIPTION
## What & why

The `xserver-build-netbsd` lane installs its build deps from the official
NetBSD mirrors (`ftp.netbsd.org` / `cdn.netbsd.org`) via `pkgin` / `pkg_add`.
Those servers flake intermittently — most recently on **#3225** (2026-07-03),
where the job failed all three internal retries with
`pkg_add: Can't process https://ftp.netbsd.org:443/pub/pkgsrc/...: Undefined error: 0`,
reddening a PR whose actual diff was Ubuntu-only. This is the known BSD/Solaris
infra-flake class already documented in `AGENTS.md`.

This PR hosts a **scoped** mirror of *only what this job needs* — the pkgin
dependency closure of the build's package list **plus** the five X11 OS-release
binary sets, ≈ **230 MB** (≈165 MB pkgsrc + ≈65 MB sets), versus the ~65 GB
full pkgsrc archive — as assets of a single stable GitHub Release
(`netbsd-pkgsrc-mirror`), and points the lane at it **first**, with the
official mirrors as a **soft fallback** (not a hard cutover).

## How it works

| file | role |
|------|------|
| `.github/scripts/netbsd/mirror-conf.sh` | single source of truth: release/arch, mirror URLs, the package list, the X11 set names — sourced by **both** the build job and the sync so they can't drift |
| `.github/scripts/netbsd/install-pkg.sh` *(modified)* | try the GitHub mirror first (`pkgin update` + install against it); fall back to official only if it's unreachable / stale / missing a package. X11 sets likewise mirror-first |
| `.github/scripts/netbsd/sync-pkg-mirror.sh` *(new)* | runs **inside the same** `vmactions/netbsd-vm` image the build lane uses; drives the real `pkgin -d install` (download-only) to get the authoritative closure — **no hand-rolled resolver** — then builds a **trimmed** `pkg_summary.gz` (a strict *subset* of the official one, so every `FILE_SIZE`/metadata byte stays consistent) and fetches the X11 sets |
| `.github/scripts/netbsd/publish-mirror.sh` *(new)* | host side: `gh release upload --clobber` + prune assets no longer in the set |
| `.github/workflows/netbsd-pkg-mirror.yml` *(new)* | weekly (`cron: 0 4 * * 0`) + `workflow_dispatch`; boots the VM, runs the sync, publishes |

The mirror layout is exactly a flat pkgin repository base
(`pkg_summary.gz` + `<FILE_NAME>.tgz`), which is what GitHub Release asset URLs
already are. Because the trimmed summary records are a *verbatim subset* of the
official summary, anything `pkgin` accepts from the official mirror it accepts
from ours.

## ⚠️ Please review carefully before merging — this is new CI **infrastructure**

Even if CI goes green, the blast radius is larger than a code change:

- It **creates a GitHub Release + tag** (`netbsd-pkgsrc-mirror`) in this repo
  and uploads ~230 MB of assets to it on a schedule.
- It adds a **scheduled workflow** (weekly VM boot — small but non-zero
  Actions cost) with `contents: write`.
- It changes a **build-dependency source** for the netbsd lane.

### First-run note (expected, not a bug)

The mirror release does **not exist yet**, so the netbsd lane *on this PR* will
find nothing at the mirror and transparently use the **official fallback** —
i.e. this PR does not itself prove the mirror path end-to-end. After merge, run
the `Refresh NetBSD pkg mirror` workflow once via `workflow_dispatch` to
populate the release; subsequent netbsd runs then use the mirror.

## Open design questions flagged for the maintainer

1. **pkgin/libfetch following GitHub's 302 redirect** (github.com →
   objects.githubusercontent.com) for `pkg_summary.gz` and the `.tgz`
   downloads. I could not verify this without a live NetBSD VM. NetBSD's
   `fetch(3)` does follow HTTP redirects, so this *should* work, but it's the
   one assumption the fallback exists to cover if it doesn't.
2. **Sync-VM-image == build-VM-image assumption.** The closure `pkgin`
   computes (and therefore what we mirror) depends on which packages the base
   image already ships. Sync and build both use `vmactions/netbsd-vm@v1.2.3`
   release `10.1`, so the "already installed → skip" set is identical in both —
   the mirror contains exactly what the build would otherwise download. If the
   two images ever diverge, the fallback covers the gap.
3. **Optional size win, left undone deliberately.** The single biggest pkgsrc
   item is `gcc10` (~78 MB), pulled in only because the `libtool` meta-package
   also depends on `libtool-fortran`. Installing `libtool-base` instead would
   likely drop it, but I couldn't verify the autotools deps still build without
   a VM, so I kept the list byte-identical to the current `install-pkg.sh` to
   avoid an unverifiable build break. Easy follow-up once someone can test it.

## Verification done here (no live VM available to me)

- All shell scripts pass `sh -n` / `bash -n`; both workflow YAMLs parse.
- Confirmed against the pkgin man source that `-d` = *"Download only"* and the
  default cache is `/var/db/pkgin/cache` (both load-bearing).
- Confirmed the `10.1/All` → dated-quarterly (`10.0_2026Q1/All`) 302 redirect
  is live and that the sync follows it dynamically (no hardcoded date).
- Ran the `pkg_summary` trimming `awk` against the **real** current
  `pkg_summary.gz` (28 551 records): it produces a correctly blank-line-
  separated subset that gzip-round-trips cleanly. (Caught + fixed a bug where
  paragraph-mode `RS=""` slurped the keep-list as one key.)

Motivating flake: #3225.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
