### PR TITLE
render/Xi: fix integer-overflow and OOB-read input-validation bugs

### DIFF
--- a/Xext/render/filter.c
+++ b/Xext/render/filter.c
@@ -275,7 +275,11 @@ convolutionFilterValidateParams(ScreenPtr pScreen,
     h = xFixedToInt(params[1]);
 
     nparams -= 2;
-    if (w * h > nparams)
+    /* w and h come from client xFixed values via the sign-extending
+     * xFixedToInt(); reject negatives and use a 64-bit product so the
+     * comparison cannot be defeated by signed overflow before w/h are
+     * handed back to the caller. */
+    if (w < 0 || h < 0 || (int64_t) w * h > nparams)
         return FALSE;
 
     *width = w;

--- a/Xext/xinput/xiselectev.c
+++ b/Xext/xinput/xiselectev.c
@@ -157,6 +157,14 @@ ProcXISelectEvents(ClientPtr client)
     xXIEventMask *evmask = (xXIEventMask *) &stuff[1];
     int num_masks = stuff->num_masks;
     while (num_masks--) {
+        /* Make sure the fixed xXIEventMask header is inside the request
+         * before dereferencing evmask->mask_len below.  A request with
+         * num_masks >= 1 and no trailing data would otherwise read mask_len
+         * one element past the request buffer.  (The swapped path above
+         * already performs the equivalent pre-check.) */
+        if (bytes_to_int32(len + sizeof(xXIEventMask)) > client->req_len)
+            return BadLength;
+
         len += sizeof(xXIEventMask) + evmask->mask_len * 4;
 
         if (bytes_to_int32(len) > client->req_len)


### PR DESCRIPTION
Two independent input-validation hardening fixes, found while verifying two unpublished hardening
patches that had been sitting uncommitted on release-line worktrees (`rfc/security-fixes-release-25.0`/`-25.1`) — checking whether the same issue exists on `master` surfaced that it does, in both cases.

1. **`render/filter.c`** (`Xext/render/filter.c`): `convolutionFilterValidateParams()` compares
   `w * h > nparams` as a plain signed `int` product, where `w`/`h` come straight from
   client-supplied `xFixed` values. A client can pick negative `w`/`h` so the mathematical
   product is huge but the signed `int` product wraps, defeating the bounds check that's meant to
   reject an oversized convolution kernel. Fixed by rejecting negative `w`/`h` and comparing as
   `int64_t`.
2. **`Xi/xiselectev.c`** (`Xext/xinput/xiselectev.c`): `ProcXISelectEvents()`'s non-swapped path
   read `evmask->mask_len` to advance to the next mask *before* checking that the fixed
   `xXIEventMask` header was actually within the request buffer — a request with `num_masks >= 1`
   and insufficient trailing data reads one header's worth past the end of the request. The
   byte-swapped path just above already has the equivalent check; this brings the non-swapped path
   in line with it.

Both build-verified (`ninja hw/vfb/Xvfb`). Merged as `6a97f6d38e` (filter.c) and `bf6b62648d` (xiselectev.c).

## Backport dashboard

| Branch | filter.c fix | xiselectev.c fix |
|---|---|---|
| `release/25.2` | #3245 🔄 Open | #3246 🔄 Open |
| `release/25.1` | #3247 🔄 Open | #3248 🔄 Open |
| `release/25.0` | #3249 🔄 Open | #3250 🔄 Open |

