### PR TITLE
(release/25.0) render: filter: fix integer-overflow bypass of convolution size check

### DIFF
--- a/render/filter.c
+++ b/render/filter.c
@@ -273,7 +273,11 @@ convolutionFilterValidateParams(ScreenPtr pScreen,
     h = xFixedToInt(params[1]);
 
     nparams -= 2;
-    if (w * h > nparams)
+    /* w and h come from client xFixed values via the sign-extending
+     * xFixedToInt(); reject negatives and use a 64-bit product so the
+     * comparison cannot be defeated by signed overflow before w/h are
+     * handed back to the caller. */
+    if (w < 0 || h < 0 || (int64_t) w * h > nparams)
         return FALSE;
 
     *width = w;


### PR DESCRIPTION
convolutionFilterValidateParams() derives w/h from client-supplied
xFixed values via the sign-extending xFixedToInt(), then checked
'w * h > nparams' as a plain (signed) int product. A client can choose
negative w/h so the mathematical product is huge but the signed int
product wraps to a small or negative value, defeating the bounds check
that is supposed to reject a convolution kernel larger than the actual
parameter list.

Reject negative w/h outright and compare the product as int64_t so it
cannot wrap before the comparison.

Signed-off-by: Enrico Weigelt, metux IT consult <enrico.weigelt@vnc.biz>
(cherry picked from commit 6a97f6d38efe1c8ad943cff0d4a9117da1f220ef)

Backport of #3244 (master) — `render/filter.c` integer-overflow fix.
