### PR TITLE
(release/25.0) Xi: xiselectev: fix OOB read in ProcXISelectEvents' non-swapped path

### DIFF
--- a/Xi/xiselectev.c
+++ b/Xi/xiselectev.c
@@ -174,6 +174,14 @@ ProcXISelectEvents(ClientPtr client)
     evmask = (xXIEventMask *) &stuff[1];
     num_masks = stuff->num_masks;
     while (num_masks--) {
+        /* Make sure the fixed xXIEventMask header is inside the request
+         * before dereferencing evmask->mask_len below.  A request with
+         * num_masks >= 1 and no trailing data would otherwise read mask_len
+         * one element past the request buffer.  (The swapped path above
+         * already performs the equivalent pre-check.) */
+        if (bytes_to_int32(len + sizeof(xXIEventMask)) > client->req_len)
+            return BadLength;
+
         len += sizeof(xXIEventMask) + evmask->mask_len * 4;
 
         if (bytes_to_int32(len) > client->req_len)


### PR DESCRIPTION
The per-mask loop read evmask->mask_len to compute the next mask's
length before checking that the fixed xXIEventMask header itself was
still within the request buffer - a request with num_masks >= 1 and
insufficient trailing data reads one xXIEventMask-header's worth past
the end of the request. The byte-swapped path just above already
performs the equivalent pre-check ('len < bytes_to_int32(sizeof
(xXIEventMask))') before touching evmask->mask_len; this brings the
non-swapped path in line with it.

Signed-off-by: Enrico Weigelt, metux IT consult <enrico.weigelt@vnc.biz>
(cherry picked from commit bf6b62648d9dc6249c00373e7d23e3a22246ef04)

Backport of #3244 (master) — `Xi/xiselectev.c` OOB-read fix.
