### PR TITLE
os: Xtranssock: brace set_sun_path()'s if bodies

### DIFF
--- a/os/Xtranssock.c
+++ b/os/Xtranssock.c
@@ -613,22 +613,26 @@ set_sun_path(const char *port, const char *upath, char *path, int abstract)
     const char *at = "";
     int n;
 
-    if (!port || !*port || !path)
+    if (!port || !*port || !path) {
 	return -1;
+    }
 
 #ifdef HAVE_ABSTRACT_SOCKETS
-    if (port[0] == '@')
+    if (port[0] == '@') {
 	upath = "";
-    else if (abstract)
+    } else if (abstract) {
 	at = "@";
+    }
 #endif
 
-    if (*port == '/') /* a full pathname */
+    if (*port == '/') { /* a full pathname */
 	upath = "";
+    }
 
     n = snprintf(path, sizeof(s.sun_path), "%s%s%s", at, upath, port);
-    if (n < 0 || (size_t) n >= sizeof(s.sun_path))
+    if (n < 0 || (size_t) n >= sizeof(s.sun_path)) {
 	return -1;
+    }
     return 0;
 }
 #endif


### PR DESCRIPTION
First batch of the always-brace-`if`/`while`/`for`/`else` coding-style conversion (policy confirmed on master, see the project's coding-style notes) — this is a small, self-contained, mechanical brace-only diff, no logic changes.

Converts `set_sun_path()`'s previously unbraced single-statement `if`/`else if` bodies to braced form, matching the surrounding file's already-dominant same-line brace style. Build-verified (`meson setup` + `ninja hw/vfb/Xvfb hw/xnest/Xnest`).

Part of an ongoing successive conversion of the existing tree's unbraced bodies, done in small per-file/per-function batches rather than one mass reformat — see the project's DASHBOARD.md "if/while/for brace-everywhere conversion" row for the initiative's status across sessions.