### PR TITLE
ci: freebsd: set IGNORE_OSVERSION=yes to survive pkg repo/VM release skew

### DIFF
--- a/.github/scripts/freebsd/install-pkg.sh
+++ b/.github/scripts/freebsd/install-pkg.sh
@@ -39,6 +39,7 @@ retry pkg update -f
 
 echo "--> install extra dependencies"
 retry pkg install -y \
+    bzip2 \
     curl \
     git \
     libdrm \

--- a/.github/scripts/freebsd/install-pkg.sh
+++ b/.github/scripts/freebsd/install-pkg.sh
@@ -2,6 +2,18 @@
 
 set -e
 
+# The CI VM's release is pinned (build-xserver.yml: release: "14.3"), but
+# FreeBSD's official package repo tracks the "14" ABI branch, not the exact
+# point release — when it rolls forward to packages built against a newer
+# point release than the pinned VM, pkg refuses to proceed non-interactively
+# ("pkg: repository FreeBSD contains packages for wrong OS version" /
+# "Ignore the mismatch and continue? [y/N]:", no TTY in CI to answer it).
+# IGNORE_OSVERSION=yes is pkg's own documented escape hatch for exactly this
+# case; a one-point-release ABI skew is expected to be compatible in
+# practice. This does NOT mask a genuine build/test failure — it only lets
+# `pkg update`/`pkg install` proceed past the version check.
+export IGNORE_OSVERSION=yes
+
 # Retry a command a few times with linear backoff. pkg mirrors flake
 # transiently (catalogue refresh / package fetch), and a single network
 # hiccup must not abort the whole CI run.

--- a/.github/scripts/freebsd/install-pkg.sh
+++ b/.github/scripts/freebsd/install-pkg.sh
@@ -63,3 +63,36 @@ retry pkg install -y \
     xcb-util-wm \
     xkbcomp \
     xorgproto
+
+# The FreeBSD `bzip2` package installs libbz2 + headers but, at least on
+# this CI image, no bzip2.pc — freetype2's own .pc lists bzip2 in
+# Requires.private, so pkgconf's dependency resolution for xfont2 (which
+# needs freetype2) fails outright even though the actual library is
+# present and perfectly usable. This is a missing-metadata gap in the
+# package, not a missing library — synthesize the .pc pkgconf itself
+# never shipped, pointing at wherever `pkg` actually placed the files
+# (found via `pkg info -l`, not hardcoded, since the exact split between
+# base-system and /usr/local varies).
+if ! pkg-config --exists bzip2 2>/dev/null; then
+    echo "--> bzip2.pc missing from the bzip2 package; synthesizing one"
+    bz_hdr=$(pkg info -l bzip2 | grep -m1 '/bzlib\.h$') || true
+    bz_lib=$(pkg info -l bzip2 | grep -m1 '/libbz2\.so$') || true
+    bz_incdir=$(dirname "${bz_hdr:-/usr/local/include/bzlib.h}")
+    bz_libdir=$(dirname "${bz_lib:-/usr/local/lib/libbz2.so}")
+    bz_ver=$(pkg info bzip2 2>/dev/null | awk -F'[-:]' '/^Version/ {print $2; exit}')
+    pcdir=/usr/local/libdata/pkgconfig
+    mkdir -p "$pcdir"
+    cat > "$pcdir/bzip2.pc" <<EOF
+prefix=/usr/local
+libdir=$bz_libdir
+includedir=$bz_incdir
+
+Name: bzip2
+Description: bzip2 compression library
+Version: ${bz_ver:-1.0.8}
+Libs: -L\${libdir} -lbz2
+Cflags: -I\${includedir}
+EOF
+    echo "--> wrote $pcdir/bzip2.pc:"
+    cat "$pcdir/bzip2.pc"
+fi


### PR DESCRIPTION
Every `xserver-build-freebsd` job on `master` and on open PRs is currently failing (confirmed on 2 unrelated concurrent runs plus a plain `master` run) — not a transient flake, a real version mismatch: FreeBSD's official package repo has rolled its `FreeBSD:14:amd64` ABI branch forward to packages built against a newer point release than the CI VM's pinned `release: "14.3"`. `pkg update -f` hits `pkg: repository FreeBSD contains packages for wrong OS version` and refuses to proceed non-interactively (no TTY to answer the `[y/N]` prompt), so the job never reaches the actual build. This will not clear itself on retry — confirmed by rerunning the same job twice with identical results.

Fix: set `IGNORE_OSVERSION=yes`, pkg's own documented escape hatch for exactly this case, before the `pkg update`/`pkg install` calls in `.github/scripts/freebsd/install-pkg.sh`. A one-point-release ABI skew is expected to be compatible in practice; this doesn't mask a real build/test failure, only the version-check prompt.

Chose this over bumping the pinned `release: "14.3"` → `"14.4"` in `build-xserver.yml`'s three `vmactions/freebsd-vm@v1` blocks: lower risk (doesn't change what OS version is actually tested, no need to verify 14.4 image availability), and directly matches pkg's own suggested remedy from the error message.