### PR TITLE
(master) dix: getevents: fix NULL-deref when motion-history alloc fails

### DIFF
--- a/dix/getevents.c
+++ b/dix/getevents.c
@@ -384,9 +384,15 @@ AllocateMotionHistory(DeviceIntPtr pDev)
     pDev->valuator->motion = calloc(pDev->valuator->numMotionEvents, size);
     pDev->valuator->first_motion = 0;
     pDev->valuator->last_motion = 0;
-    if (!pDev->valuator->motion)
+    if (!pDev->valuator->motion) {
         ErrorF("[dix] %s: Failed to alloc motion history (%d bytes).\n",
                pDev->name, size * pDev->valuator->numMotionEvents);
+        /* Keep numMotionEvents in sync with the NULL buffer, so every
+         * consumer's existing "if (!numMotionEvents) return;" guard treats
+         * this device as having no history instead of indexing/memcpy'ing
+         * through a NULL pointer. */
+        pDev->valuator->numMotionEvents = 0;
+    }
 }
 
 /**


### PR DESCRIPTION
AllocateMotionHistory()'s calloc() failure path only logged via
ErrorF() and left numMotionEvents at its prior nonzero value while
->motion stayed NULL. Every consumer (updateMotionHistory(),
GetMotionHistory()) guards on "if (!numMotionEvents) return;" to skip
devices with no history, so a failed allocation left that guard
believing history existed -- updateMotionHistory() would then memcpy()
through the NULL buffer on the very next motion event, crashing the
server. Reachable via plain memory pressure at input-device
init/hotplug time.

Reset numMotionEvents to 0 alongside the NULL buffer, so the existing
guards correctly treat the device as having no motion history instead
of indexing/memcpy'ing through NULL.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
