### PR TITLE
(master) present: unlink pending notifies before freeing their window's list head

### DIFF
--- a/Xext/present/present_notify.c
+++ b/Xext/present/present_notify.c
@@ -32,14 +32,24 @@
 void
 present_clear_window_notifies(WindowPtr window)
 {
-    present_notify_ptr          notify;
+    present_notify_ptr          notify, tmp;
     present_window_priv_ptr     window_priv = present_window_priv(window);
 
     if (!window_priv)
         return;
 
-    xorg_list_for_each_entry(notify, &window_priv->notifies, window_list) {
+    xorg_list_for_each_entry_safe(notify, tmp, &window_priv->notifies, window_list) {
         notify->window = NULL;
+        /*
+         * Unlink now: window_priv (and the list head this entry points
+         * into) is about to be freed by the caller, but 'notify' may
+         * outlive it (owned by a pending vblank on another window) and
+         * will still go through present_free_window_notify()'s
+         * xorg_list_del() later. xorg_list_del() leaves the entry
+         * self-referencing, so that later del is then a safe no-op
+         * instead of writing through freed memory.
+         */
+        xorg_list_del(&notify->window_list);
     }
 }
 


### PR DESCRIPTION
present_clear_window_notifies() only set notify->window = NULL for each
entry on a destroyed window, without unlinking it from window_priv->notifies.
present_destroy_window() then frees window_priv right after, but a notify
can outlive it -- it's owned by a pending vblank on a *different* window,
and stays linked into the now-freed list. When that vblank later completes,
present_destroy_notifies() -> present_free_window_notify() calls
xorg_list_del() on it, writing through prev/next pointers into freed memory.

Trigger: PresentPixmap on window A naming a notify list on window B with a
far-future target_msc so it stays pending; destroy B before it fires; when
A's presentation completes, the freed memory is corrupted. Single client,
deterministic, no OOM needed.

Fix: unlink each notify (xorg_list_del(), which leaves it self-referencing)
while clearing it, so present_free_window_notify()'s later del is a safe
no-op instead of touching freed memory. Switch to the _safe iterator since
xorg_list_del() invalidates the plain iterator's cached next pointer.

Found via a fleet-directed alloc-fail/UAF sweep of Xext/, not from a live
crash report.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
