### PR TITLE
(master) dix: registry: fix crash + leak on realloc failure in double_size()

### DIFF
--- a/dix/registry.c
+++ b/dix/registry.c
@@ -58,6 +58,7 @@ static int
 double_size(void *p, unsigned n, unsigned size)
 {
     char **ptr = (char **) p;
+    char *grown;
     unsigned s, f;
 
     if (n) {
@@ -70,11 +71,16 @@ double_size(void *p, unsigned n, unsigned size)
         n = f = BASE_SIZE * size;
     }
 
-    *ptr = realloc(*ptr, n);
-    if (!*ptr) {
-        dixResetRegistry();
+    grown = realloc(*ptr, n);
+    if (!grown) {
+        /* Leave the still-valid old buffer/count in place on failure,
+         * instead of overwriting *ptr with the failed realloc()'s NULL
+         * (which would leak the old buffer and desync the caller's size
+         * counter from it) and nuking the whole registry via
+         * dixResetRegistry() over one failed growth. */
         return FALSE;
     }
+    *ptr = grown;
     memset(*ptr + s, 0, f - s);
     return TRUE;
 }


### PR DESCRIPTION
double_size() assigned realloc()'s result directly into *ptr. On
failure this (a) overwrote the only pointer to the still-valid old
buffer with NULL, leaking it and leaving the caller's size counter
(nmajor/nevent/nerror) out of sync with the now-NULL data pointer, and
(b) called dixResetRegistry() -> dixFreeRegistry(), whose free loops
walk requests[]/events[]/errors[] up to that stale nonzero counter --
dereferencing the just-NULLed array before ever reaching a free().

Trigger: RegisterRequestName() (building the request/extension
registry from protocol.txt at server startup) hits OOM on a growth
call after the tables have already grown past the first size class
(nmajor > 0) -- gated on X_REGISTRY_REQUEST (SELinux/XSecurity/dtrace/
namespace-enabled builds), on the normal startup path there.

Use a temporary for realloc()'s result and only commit it to *ptr on
success, so a failed growth leaves the existing buffer and count
untouched and simply aborts that one registration (matching how
RegisterRequestName/RegisterEventName/RegisterErrorName already just
return on a double_size() failure) instead of nuking and potentially
crashing on the whole registry.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
