### PR TITLE
(master) dix: ptrveloc: fix NULL-deref/div-by-zero on tracker alloc failure

### DIFF
--- a/dix/ptrveloc.c
+++ b/dix/ptrveloc.c
@@ -142,6 +142,16 @@ InitPredictableAccelerationScheme(DeviceIntPtr dev,
         return FALSE;
     }
     InitVelocityData(vel);
+    if (!vel->tracker) {
+        /* InitVelocityData()'s InitTrackers(vel, 16) call failed to
+         * allocate the initial tracker buffer -- don't let the device go
+         * live with num_tracker == 0, which every tracker access divides
+         * by (TRACKER_INDEX()). */
+        FreeVelocityData(vel);
+        free(vel);
+        free(schemeData);
+        return FALSE;
+    }
     schemeData->vel = vel;
     scheme.accelData = schemeData;
     if (!InitializePredictableAccelerationProperties(dev, vel, schemeData)) {
@@ -427,12 +437,29 @@ DeletePredictableAccelerationProperties(DeviceIntPtr dev,
 void
 InitTrackers(DeviceVelocityPtr vel, int ntracker)
 {
+    MotionTrackerPtr tracker;
+
     if (ntracker < 1) {
         ErrorF("invalid number of trackers\n");
         return;
     }
+
+    tracker = (MotionTrackerPtr) calloc(ntracker, sizeof(MotionTracker));
+    if (!tracker) {
+        /* Keep whatever tracker buffer/count vel already had (NULL/0 on
+         * the very first, calloc-fed InitVelocityData() call; the previous
+         * valid one on a later resize, e.g. the "VelocityTrackerCount"
+         * driver option in hw/xfree86/common/xf86Xinput.c) instead of
+         * freeing it and leaving num_tracker pointing at a NULL buffer --
+         * every tracker access divides by num_tracker (TRACKER_INDEX()),
+         * so a stale nonzero count over a NULL buffer is a NULL deref *and*
+         * a division-by-zero the moment num_tracker itself gets zeroed.
+         */
+        ErrorF("[dix] Failed to alloc %d motion trackers.\n", ntracker);
+        return;
+    }
     free(vel->tracker);
-    vel->tracker = (MotionTrackerPtr) calloc(ntracker, sizeof(MotionTracker));
+    vel->tracker = tracker;
     vel->num_tracker = ntracker;
 }
 


### PR DESCRIPTION
InitTrackers() freed the old tracker buffer and then unconditionally
overwrote vel->tracker with calloc()'s result and vel->num_tracker
with the new count, even on allocation failure. Every tracker access
(FeedTrackers(), QueryTrackers(), the TRACKER()/TRACKER_INDEX() macros)
divides by num_tracker with no zero-guard anywhere in this subsystem,
so a failed alloc left a device either dereferencing a NULL tracker
buffer or dividing by zero on num_tracker on the very next motion
event.

Reachable two ways: the first-ever call from InitVelocityData() (fixed
ntracker=16, calloc-fed vel with no prior buffer), and a later resize
via the "VelocityTrackerCount" driver option
(hw/xfree86/common/xf86Xinput.c).

Fix InitTrackers() to only replace the old buffer/count together on
success, keeping the previous valid state on failure (matches the
resize case; harmless no-op distance from the initial NULL/0 state on
the first-call case). For the first-call case specifically, propagate
the failure out of InitPredictableAccelerationScheme() -- which already
models "return FALSE, free vel/schemeData" for its other two allocation
failures -- instead of letting the device go live with num_tracker == 0.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
