### PR TITLE
(master) os: client: check calloc() result before sysctl(KERN_PROC_ARGS)

### DIFF
--- a/os/client.c
+++ b/os/client.c
@@ -288,6 +288,11 @@ DetermineClientCmd(pid_t pid, const char **cmdname, const char **cmdargs)
         /* Read KERN_PROC_ARGS contents. Similar to /proc/pid/cmdline
          * the process name and each argument are separated by NUL byte. */
         char *const procargs = calloc(1, len);
+        if (!procargs) {
+            ErrorF("Failed to allocate memory (%zu bytes) for KERN_PROC_ARGS result for pid %d: %s\n", len, pid, strerror(errno));
+            return;
+        }
+
         if (sysctl(mib, ARRAY_SIZE(mib), procargs, &len, NULL, 0) != 0) {
             ErrorF("Failed to get KERN_PROC_ARGS for PID %d: %s\n", pid, strerror(errno));
             free(procargs);


### PR DESCRIPTION
DetermineClientCmd()'s FreeBSD/DragonFly branch passed calloc()'s
result straight to sysctl() as the output buffer, then unconditionally
strlen()/strdup()'d it, with no NULL check in between. A failed
allocation (OOM) would hand sysctl() a NULL buffer pointer and, should
that not fault on its own, fall through to strlen(NULL)/strdup(NULL).

Add the same NULL check already used for the equivalent macOS
KERN_PROCARGS2 buffer a few lines up in this same function.

Not locally compile-tested (no FreeBSD/DragonFly toolchain available
in this environment) -- mirrors the exact, already-working pattern
from the macOS branch above it; relying on this project's FreeBSD CI
lane to confirm.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
