### PR TITLE
(master) Xi: fix double-free in AddExtensionClient() on AddResource() failure

### DIFF
--- a/Xext/xinput/exevents.c
+++ b/Xext/xinput/exevents.c
@@ -2739,7 +2739,15 @@ AddExtensionClient(WindowPtr pWin, ClientPtr client, Mask mask, int mskidx)
     others->next = pWin->optional->inputMasks->inputClients;
     pWin->optional->inputMasks->inputClients = others;
     if (!AddResource(others->resource, RT_INPUTCLIENT, (void *) pWin))
-        goto bail;
+        /*
+         * Do NOT 'goto bail' here: 'others' is already linked into
+         * pWin->optional->inputMasks->inputClients above, so on failure
+         * AddResource() itself already invoked the RT_INPUTCLIENT delete
+         * callback (InputClientGone()), which found 'others' as the list
+         * head and freed it. Falling through to bail's FreeInputClient()
+         * would free it a second time.
+         */
+        return BadAlloc;
     return Success;
 
  bail:


### PR DESCRIPTION
'others' is linked into pWin->optional->inputMasks->inputClients as the
list head *before* AddResource() is called. If AddResource()'s internal
calloc() fails, it invokes the RT_INPUTCLIENT delete callback
(InputClientGone()) on the value being registered -- which finds 'others'
at the head of that list (matching the resource id already assigned to it)
and frees it via FreeInputClient(). AddExtensionClient() then falls through
to its own 'bail:' path, which calls FreeInputClient() on the same,
already-freed pointer again.

Trigger: reachable from any client's normal XISelectEvents/input-mask
selection request path whenever AddResource()'s internal calloc() fails
(memory pressure) -- a double-free landing on structural list logic, not
just a benign OOM leak.

Fix: return directly on AddResource() failure instead of falling through to
the shared bail: cleanup, which is still correct and needed for the two
earlier failure points in this function (before 'others' is linked/
registered).

Found via a fleet-directed alloc-fail/UAF sweep of Xext/, not from a live
crash report.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
