### PR TITLE
(master) os: log: reset saved_log_fname/saved_log_backup to NULL after free

### DIFF
--- a/os/log.c
+++ b/os/log.c
@@ -385,6 +385,11 @@ LogSetDisplay(void)
         free(logFileName);
         free(saved_log_fname);
         free(saved_log_backup);
+        /* Reset to NULL: if LogSetDisplay() were ever called again, the
+         * "%s" check above would otherwise read these two freed pointers,
+         * and this block would free them a second time. */
+        saved_log_fname = NULL;
+        saved_log_backup = NULL;
     }
     initSyslog();
 }


### PR DESCRIPTION
LogSetDisplay() frees these two module-level globals without resetting
them to NULL. Currently harmless -- it has exactly one call site
(CreateWellKnownSockets() in os/connection.c), itself called exactly
once per process -- but it's a real defensive gap: were the function
ever called a second time (e.g. a future re-init/reload path), the
top-of-function "saved_log_fname && strstr(...)" check would read
freed memory, LogFilePrep() would receive both freed pointers as
arguments, and this same block would free them a second time.

Reset both to NULL right after freeing, matching how the rest of this
file already treats a freed pointer as something that must not be
read or freed again.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
