### PR TITLE
(master) randr: free/terminate resource structs on AddResource() OOM failure

### DIFF
--- a/Xext/randr/rrcrtc.c
+++ b/Xext/randr/rrcrtc.c
@@ -98,8 +98,10 @@ RRCrtcCreate(ScreenPtr pScreen, void *devPrivate)
     pixman_f_transform_init_identity(&crtc->f_transform);
     pixman_f_transform_init_identity(&crtc->f_inverse);
 
-    if (!AddResource(crtc->id, RRCrtcType, (void *) crtc))
+    if (!AddResource(crtc->id, RRCrtcType, (void *) crtc)) {
+        free(crtc);
         return NULL;
+    }
 
     /* attach the screen and crtc together */
     crtc->pScreen = pScreen;

--- a/Xext/randr/rrlease.c
+++ b/Xext/randr/rrlease.c
@@ -331,6 +331,18 @@ leaseReturned:
     xorg_list_add(&lease->list, &scr_priv->leases);
 
     if (!AddResource(stuff->lid, RRLeaseType, lease)) {
+        /*
+         * lease was already linked into scr_priv->leases above.
+         * RRLeaseDestroyResource() (the delete callback AddResource()
+         * would invoke on a *successfully-registered* resource) only
+         * clears lease->id -- it doesn't unlink or free the lease, so
+         * without this, a lease that never got a live XID would stay on
+         * scr_priv->leases forever, permanently marking its outputs/crtcs
+         * as leased (RROutputIsLeased()/RRCrtcIsLeased()) with no way for
+         * the client to free it. Mirror the WriteFdToClient() failure
+         * branch below, which already does this correctly.
+         */
+        RRTerminateLease(lease);
         close(fd);
         return BadAlloc;
     }

--- a/Xext/randr/rrmode.c
+++ b/Xext/randr/rrmode.c
@@ -95,6 +95,7 @@ RRModeCreate(xRRModeInfo * modeInfo, const char *name, ScreenPtr userScreen)
     mode->mode.id = dixAllocServerXID();
     if (!AddResource(mode->mode.id, RRModeType, (void *) mode)) {
         free(newModes);
+        free(mode);
         return NULL;
     }
     modes = newModes;

--- a/Xext/randr/rroutput.c
+++ b/Xext/randr/rroutput.c
@@ -98,8 +98,10 @@ RROutputCreate(ScreenPtr pScreen,
     output->subpixelOrder = SubPixelUnknown;
     output->devPrivate = devPrivate;
 
-    if (!AddResource(output->id, RROutputType, (void *) output))
+    if (!AddResource(output->id, RROutputType, (void *) output)) {
+        free(output);
         return NULL;
+    }
 
     pScrPriv->outputs[pScrPriv->numOutputs++] = output;
 

--- a/Xext/randr/rrprovider.c
+++ b/Xext/randr/rrprovider.c
@@ -397,8 +397,10 @@ RRProviderCreate(ScreenPtr pScreen, const char *name,
     provider->name[nameLength] = '\0';
     provider->changed = FALSE;
 
-    if (!AddResource (provider->id, RRProviderType, (void *) provider))
+    if (!AddResource (provider->id, RRProviderType, (void *) provider)) {
+        free(provider);
         return NULL;
+    }
     pScrPriv->provider = provider;
     return provider;
 }


### PR DESCRIPTION
Five constructors in Xext/randr/ leaked or permanently pinned their struct
when AddResource()'s internal calloc() failed (memory pressure):

- ProcRRCreateLease() (rrlease.c): links 'lease' into scr_priv->leases
  *before* AddResource(). RRLeaseDestroyResource() (the delete callback
  AddResource() invokes on a successfully-*started*-but-failed
  registration) only clears lease->id -- it doesn't unlink or free the
  lease. Without terminating it explicitly, the lease stays on
  scr_priv->leases forever, permanently marking its outputs/crtcs as leased
  (RROutputIsLeased()/RRCrtcIsLeased()) with no XID for the client to ever
  free it by. Fixed by calling RRTerminateLease(lease), mirroring the
  WriteFdToClient() failure branch a few lines below, which already does
  this correctly.

- RRModeGet() (rrmode.c), RRCrtcCreate() (rrcrtc.c), RROutputCreate()
  (rroutput.c), RRProviderCreate() (rrprovider.c): all four 'return NULL'
  directly on AddResource() failure without freeing the struct they just
  calloc'd. None of the four are linked into their owning screen-private
  array/field yet at that point (verified: each is only stored into
  pScrPriv->{modes,crtcs,outputs,provider} a few lines *after* the
  AddResource() check), so a plain free() is safe. rrmode.c already freed
  its secondary 'newModes' array allocation on this path but forgot 'mode'
  itself.

All five are narrow (OOM-gated) but real leaks/dangling-reference bugs, not
crashes -- bundled as one fix since they're the same missing-cleanup shape
in the same subsystem.

Found via a fleet-directed alloc-fail/UAF sweep of Xext/, not from a live
crash report.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
