### PR TITLE
(master) xkeyboard: fix unchecked/self-overwriting reallocarray() on OOM

### DIFF
--- a/Xext/xkeyboard/maprules.c
+++ b/Xext/xkeyboard/maprules.c
@@ -100,7 +100,10 @@ InputLineAddChar(InputLine * line, int ch)
             memcpy(line->line, line->buf, line->sz_line);
         }
         else {
-            line->line = reallocarray(line->line, line->sz_line, 2);
+            char *newline = reallocarray(line->line, line->sz_line, 2);
+            if (newline == NULL)
+                return -1;
+            line->line = newline;
         }
         line->sz_line *= 2;
     }

--- a/Xext/xkeyboard/xkb.c
+++ b/Xext/xkeyboard/xkb.c
@@ -2283,19 +2283,29 @@ SetKeyBehaviors(XkbSrvInfoPtr xkbi,
     }
 
     if (maxRG > (int) xkbi->nRadioGroups) {
+        XkbRadioGroupPtr newRG;
+
         if (xkbi->radioGroups)
-            xkbi->radioGroups = reallocarray(xkbi->radioGroups, maxRG,
-                                             sizeof(XkbRadioGroupRec));
+            newRG = reallocarray(xkbi->radioGroups, maxRG,
+                                 sizeof(XkbRadioGroupRec));
         else
-            xkbi->radioGroups = calloc(maxRG, sizeof(XkbRadioGroupRec));
-        if (xkbi->radioGroups) {
+            newRG = calloc(maxRG, sizeof(XkbRadioGroupRec));
+        /*
+         * Only commit newRG on success: reallocarray() returning NULL on
+         * failure leaves the original allocation untouched, but assigning
+         * straight into xkbi->radioGroups either way (as this used to)
+         * loses that pointer, leaking it. Keeping the existing (smaller,
+         * still-valid) radioGroups/nRadioGroups on failure is also just
+         * better than the old behavior of dropping nRadioGroups to 0 and
+         * discarding all radio group data server-wide.
+         */
+        if (newRG) {
+            xkbi->radioGroups = newRG;
             if (xkbi->nRadioGroups)
                 memset(&xkbi->radioGroups[xkbi->nRadioGroups], 0,
                        (maxRG - xkbi->nRadioGroups) * sizeof(XkbRadioGroupRec));
             xkbi->nRadioGroups = maxRG;
         }
-        else
-            xkbi->nRadioGroups = 0;
         /* should compute members here */
     }
     if (changes->map.changed & XkbKeyBehaviorsMask) {
@@ -3021,14 +3031,25 @@ _XkbSetCompatMap(ClientPtr client, DeviceIntPtr dev,
         if ((unsigned) (req->firstSI + req->nSI) > USHRT_MAX)
             return BadValue;
         if ((unsigned) (req->firstSI + req->nSI) > compat->size_si) {
-            compat->num_si = compat->size_si = req->firstSI + req->nSI;
-            compat->sym_interpret = reallocarray(compat->sym_interpret,
-                                                 compat->size_si,
-                                                 sizeof(XkbSymInterpretRec));
-            if (!compat->sym_interpret) {
-                compat->num_si = compat->size_si = 0;
+            /*
+             * Compute the new size and realloc into a temporary first:
+             * the old code set num_si/size_si to the *new* size and
+             * reallocated straight into compat->sym_interpret before
+             * checking success, so a failed reallocarray() (which leaves
+             * the original block untouched) both leaked that original
+             * block (the pointer was already overwritten with NULL) and
+             * discarded otherwise-still-valid existing interpretations by
+             * resetting num_si/size_si to 0. Only commit on success now,
+             * so a transient OOM here loses nothing.
+             */
+            unsigned int newSize = req->firstSI + req->nSI;
+            XkbSymInterpretPtr newSI = reallocarray(compat->sym_interpret,
+                                                    newSize,
+                                                    sizeof(XkbSymInterpretRec));
+            if (!newSI)
                 return BadAlloc;
-            }
+            compat->sym_interpret = newSI;
+            compat->num_si = compat->size_si = newSize;
         }
         else if (req->truncateSI || req->firstSI + req->nSI > compat->num_si) {
             compat->num_si = req->firstSI + req->nSI;


### PR DESCRIPTION
Three call sites in Xext/xkeyboard/ lost data or crashed on a failed
reallocarray():

- maprules.c, InputLineAddChar(): the reallocarray() growth branch (unlike
  the sibling calloc() branch just above it) had no NULL check at all --
  assigns straight into line->line, then unconditionally writes through it
  a few lines later. Reachable while parsing an XKB rules/mapping file.
  Fixed by checking into a temporary first.

- xkb.c, SetKeyBehaviors() (via XkbSetMap): xkbi->radioGroups was
  reallocarray()'d directly into itself; on failure this both leaked the
  original (still valid, smaller) buffer and unconditionally reset
  nRadioGroups to 0, discarding all existing radio-group data server-wide
  on a transient OOM. Fixed by reallocating into a temporary and only
  committing on success, so a failure now leaves the existing data intact
  instead of throwing it away and leaking the old block.

- xkb.c, _XkbSetCompatMap() (via XkbSetCompatMap, client-controlled size
  req->firstSI + req->nSI): same shape as SetKeyBehaviors() -- num_si/
  size_si were bumped to the new size and sym_interpret reallocated
  straight into itself *before* checking success, losing the old buffer
  and discarding existing sym-interpret entries on failure. Same fix:
  realloc into a temporary, only commit (pointer + both counters together)
  on success.

Found via a fleet-directed alloc-fail/UAF sweep of Xext/, not from a live
crash report.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
