### PR TITLE
(master) Xi: fix wrong/late NULL check on touch-class alloc in DeepCopyPointerClasses()

### DIFF
--- a/Xext/xinput/exevents.c
+++ b/Xext/xinput/exevents.c
@@ -678,10 +678,17 @@ DeepCopyPointerClasses(DeviceIntPtr from, DeviceIntPtr to)
                 to->touch->num_touches = from->touch->num_touches;
                 to->touch->touches = calloc(to->touch->num_touches,
                                             sizeof(TouchPointInfoRec));
+                /*
+                 * Checking 'to->touch' here (as this used to) is always
+                 * true -- it was just allocated a few lines above. The
+                 * allocation that can actually fail is 'touches', right
+                 * above, which TouchInitTouchPoint() then indexes
+                 * unconditionally.
+                 */
+                if (!to->touch->touches)
+                    FatalError("[Xi] no memory for class shift.\n");
                 for (i = 0; i < to->touch->num_touches; i++)
                     TouchInitTouchPoint(to->touch, to->valuator, i);
-                if (!to->touch)
-                    FatalError("[Xi] no memory for class shift.\n");
             }
             else
                 classes->touch = NULL;


### PR DESCRIPTION
The failure check after allocating a new master device's touch class tested
'to->touch' (always true -- it was just calloc'd a few lines above and
already checked), not 'to->touch->touches' (the allocation that can
actually fail), and ran *after* the loop that indexes through it via
TouchInitTouchPoint() rather than before.

Trigger: reached via normal device-hierarchy-change processing
(ChangeMasterDeviceClasses -> DeepCopyDeviceClasses) whenever the
'touches' calloc() fails (memory pressure) while promoting a device's
touch class onto a master device that doesn't have one allocated yet.

Fix: check to->touch->touches before the loop, in the right order.

Found via a fleet-directed alloc-fail/UAF sweep of Xext/, not from a live
crash report.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>

## Backport dashboard

| Release | PR | Status |
|---------|-----|--------|
| `release/25.2` | [#3367](https://github.com/X11Libre/xserver/pull/3367) | 🔄 Open |
| `release/25.1` | [#3366](https://github.com/X11Libre/xserver/pull/3366) | 🔄 Open |
| `release/25.0` | [#3368](https://github.com/X11Libre/xserver/pull/3368) | 🔄 Open |
