### PR TITLE
(master) rootless: fix dangling screen pixmap on RootlessUpdateScreenPixmap() OOM

### DIFF
--- a/miext/rootless/rootlessScreen.c
+++ b/miext/rootless/rootlessScreen.c
@@ -113,12 +113,24 @@ RootlessUpdateScreenPixmap(ScreenPtr pScreen)
     rowbytes = PixmapBytePad(pScreen->width, pScreen->rootDepth);
 
     if (s->pixmap_data_size < rowbytes) {
-        free(s->pixmap_data);
-
-        s->pixmap_data_size = rowbytes;
-        s->pixmap_data = calloc(1, s->pixmap_data_size);
-        if (s->pixmap_data == NULL)
+        /*
+         * Allocate the replacement before freeing/resizing the old one:
+         * on failure this used to free s->pixmap_data, bump
+         * pixmap_data_size to the new (larger) size, then return with
+         * s->pixmap_data (and the screen pixmap pPix, still pointing at
+         * the freed block via its old ModifyPixmapHeader() call) left
+         * dangling -- and because pixmap_data_size was already bumped, a
+         * later same-or-smaller-size call would see pixmap_data_size <
+         * rowbytes as false and skip reallocating forever, pinning the
+         * dangling state permanently.
+         */
+        void *new_data = calloc(1, rowbytes);
+        if (new_data == NULL)
             return;
+
+        free(s->pixmap_data);
+        s->pixmap_data_size = rowbytes;
+        s->pixmap_data = new_data;
 
         memset(s->pixmap_data, 0xFF, s->pixmap_data_size);
 


### PR DESCRIPTION
On a calloc() failure while growing the rootless screen pixmap buffer, the
old buffer was already freed and pixmap_data_size already bumped to the new
(larger) size before the failure check -- leaving s->pixmap_data (and the
screen pixmap pPix, still pointing at the freed block via its prior
ModifyPixmapHeader() call) dangling. Worse, because pixmap_data_size was
already bumped, a later same-or-smaller-size call sees pixmap_data_size <
rowbytes as false and skips reallocating forever, permanently pinning the
dangling state instead of retrying.

Trigger: real host memory pressure during a rootless (Xquartz-style DDX)
geometry change.

Fix: allocate the replacement into a temporary first; only free the old
buffer and update pixmap_data_size/pixmap_data together once the new
allocation has succeeded.

Found via a fleet-directed alloc-fail/UAF sweep of Xext/, mi/, and miext/,
not from a live crash report. Verification note: miext/rootless/ only
compiles into hw/xquartz, which this Linux build has disabled -- checked
with a standalone `gcc -fsyntax-only` pass instead of the normal
ninja+meson-test build/test cycle used for the other fixes in this sweep.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>


---

## Backport dashboard

| Branch | Backport PR | Status |
|--------|-------------|--------|
| 25.2 | [#3507](https://github.com/X11Libre/xserver/pull/3507) | 🔄 Open |
| 25.1 | [#3508](https://github.com/X11Libre/xserver/pull/3508) | 🔄 Open |
| 25.0 | [#3509](https://github.com/X11Libre/xserver/pull/3509) | 🔄 Open |
