### PR TITLE
(master) GLX: fix stale returnBufSize leading to NULL deref in __GLX_GET_ANSWER_BUFFER

### DIFF
--- a/Xext/glx/unpack.h
+++ b/Xext/glx/unpack.h
@@ -59,16 +59,27 @@
 ** NOTE: the cast (long)res below assumes a long is large enough to hold a
 ** pointer.
 */
+/*
+** realloc() into a temporary first, and only commit it (pointer + size
+** together) to (cl)->returnBuf/returnBufSize on success -- realloc()ing
+** straight into (cl)->returnBuf, as this used to, left returnBuf NULL but
+** returnBufSize at its stale (prior, smaller) value on failure. A later
+** call whose size+align fit under that stale returnBufSize would then
+** skip reallocating (since returnBufSize looks "big enough") and
+** dereference the NULL returnBuf. The sibling __glXGetAnswerBuffer() in
+** indirect_util.c already uses this same temporary-first idiom.
+*/
 #define __GLX_GET_ANSWER_BUFFER(res,cl,size,align)			 \
     if ((size) < 0) return BadLength;                                    \
     else if ((size) > sizeof(answerBuffer)) {				 \
 	int bump;							 \
 	if ((cl)->returnBufSize < (size)+(align)) {			 \
-	    (cl)->returnBuf = (GLbyte*)realloc((cl)->returnBuf,	 	 \
+	    GLbyte *newBuf = (GLbyte*)realloc((cl)->returnBuf,	 	 \
 						(size)+(align));         \
-	    if (!(cl)->returnBuf) {					 \
+	    if (!newBuf) {						 \
 		return BadAlloc;					 \
 	    }								 \
+	    (cl)->returnBuf = newBuf;					 \
 	    (cl)->returnBufSize = (size)+(align);			 \
 	}								 \
 	(res) = (char*)(cl)->returnBuf;					 \


### PR DESCRIPTION
realloc()'d straight into (cl)->returnBuf: on failure this left returnBuf
NULL but returnBufSize untouched at its prior (successful, smaller) value.
A later call whose size+align fits under that stale returnBufSize then
skips reallocating entirely (returnBufSize "looks" big enough) and
dereferences/writes through the NULL returnBuf.

Trigger (indirect GLX only): (1) a request causes a successful large
allocation, setting returnBufSize high; (2) a later request causes
realloc() to fail (OOM), leaving returnBuf NULL while returnBufSize stays
at the earlier high value; (3) a third request with size+align <= that
stale returnBufSize skips the realloc branch and derefs the NULL
returnBuf -- server crash.

Fix: realloc into a temporary first, only committing it (pointer + size
together) to (cl)->returnBuf/returnBufSize on success -- the same idiom
the sibling __glXGetAnswerBuffer() in indirect_util.c already uses
correctly for the same operation.

Found via a fleet-directed alloc-fail/UAF sweep of Xext/, not from a live
crash report. Confirmed this header is actually compiled into libxserver_glx
in this build (singlepix.c/indirect_program.c include it; both object
files recompiled after this header edit) and the full ninja build + meson
test suite (45/45, including pyxtest-test_glx.py) still pass -- but the
actual indirect-GLX request path this macro serves was not exercised at
runtime (no indirect-GLX client available in this environment), so this is
a lighter-weight verification than the other fixes in this sweep.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
