### PR TITLE
(release/25.2) glamor: reject fonts with per-glyph metrics exceeding maxbounds

### DIFF
--- a/glamor/glamor_font.c
+++ b/glamor/glamor_font.c
@@ -75,6 +75,9 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
     glyph_width_pixels = font->info.maxbounds.rightSideBearing - font->info.minbounds.leftSideBearing;
     glyph_height = font->info.maxbounds.ascent + font->info.maxbounds.descent;
 
+    if (glyph_width_pixels <= 0 || glyph_height <= 0)
+        return NULL;
+
     glyph_width_bytes = (glyph_width_pixels + 7) >> 3;
 
     glamor_font->glyph_width_pixels = glyph_width_pixels;
@@ -134,7 +137,28 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
             if (count) {
                 char *dst;
                 char *src = glyph->bits;
-                unsigned y;
+                int gw = GLYPHWIDTHBYTES(glyph);
+                int gh = GLYPHHEIGHTPIXELS(glyph);
+
+                /* Reject fonts where any per-glyph metric is negative
+                 * or exceeds the atlas slot size derived from maxbounds.
+                 * The PCF parser in libXfont2 does not recompute
+                 * maxbounds from per-glyph data, so a crafted PCF file
+                 * can violate the maxbounds invariant.
+                 *
+                 * gw is passed as size_t to memcpy and a negative value
+                 * would thus result in OOB access.
+                 *
+                 * Returning NULL makes glamor fall back to software
+                 * rendering.
+                 */
+                if (gw < 0 || gh < 0 ||
+                    gw > glyph_width_bytes || gh > glyph_height) {
+                    glDeleteTextures(1, &glamor_font->texture_id);
+                    glamor_font->texture_id = 0;
+                    free(bits);
+                    return NULL;
+                }
 
                 dst = bits;
                 /* get offset of start of first row */
@@ -143,8 +167,8 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
                 dst += (row & 1) ? glamor_font->row_width : 0;
 
                 dst += col * glyph_width_bytes;
-                for (y = 0; y < GLYPHHEIGHTPIXELS(glyph); y++) {
-                    memcpy(dst, src, GLYPHWIDTHBYTES(glyph));
+                for (int y = 0; y < gh; y++) {
+                    memcpy(dst, src, gw);
                     dst += overall_width;
                     src += GLYPHWIDTHBYTESPADDED(glyph);
                 }

--- a/test/pyxtest/meson.build
+++ b/test/pyxtest/meson.build
@@ -52,6 +52,7 @@ if pytest.found()
     # This needs to be kept in sync with the test_foo.py files in the tree
     tests_pyxtest = [
         'test_font.py',
+        'test_glamor.py',
         'test_glx.py',
         'test_present.py',
         'test_randr.py',

--- a/test/pyxtest/proto/pcf.py
+++ b/test/pyxtest/proto/pcf.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: MIT
+#
+# Minimal PCF (Portable Compiled Format) font builder for testing.
+#
+# Directly constructs the binary PCF format matching what libXfont2
+# expects, based on the proven PoC generator from ZDI-CAN-30498.
+
+import struct
+
+# PCF table types
+PCF_PROPERTIES = 1
+PCF_ACCELERATORS = 2
+PCF_METRICS = 4
+PCF_BITMAPS = 8
+PCF_BDF_ENCODINGS = 32
+
+# Format: glyph pad index 2 → pad 4 (matches server GLYPHPADBYTES=4).
+# This avoids the RepadBitmap path inside libXfont2.
+BITMAP_FORMAT = 0x00000002
+DEFAULT_FORMAT = 0x00000000
+
+
+def _u32(v):
+    return struct.pack("<I", v & 0xFFFFFFFF)
+
+
+def _s32(v):
+    return struct.pack("<i", v)
+
+
+def _u16(v):
+    return struct.pack("<H", v & 0xFFFF)
+
+
+def _s16(v):
+    return struct.pack("<h", v)
+
+
+def _u8(v):
+    return struct.pack("<B", v & 0xFF)
+
+
+def _metric(lsb, rsb, cw, asc, desc, attr=0):
+    """Pack an uncompressed xCharInfo (6 x INT16LE = 12 bytes)."""
+    return _s16(lsb) + _s16(rsb) + _s16(cw) + _s16(asc) + _s16(desc) + _u16(attr)
+
+
+def build_evil_pcf(
+    max_lsb=0,
+    max_rsb=4,
+    max_ascent=4,
+    max_descent=0,
+    glyph_lsb=0,
+    glyph_rsb=100,
+    glyph_ascent=100,
+    glyph_descent=0,
+    char_code=0x21,
+):
+    """Build a malicious PCF font file.
+
+    Creates a PCF font where the declared maxbounds are small but
+    the per-glyph metrics are large.  When glamor_font_get() builds
+    the font atlas, it allocates based on maxbounds but copies based
+    on per-glyph metrics, causing a heap buffer overflow.
+
+    The bitmap section is deliberately oversized so that source-side
+    reads in glamor's memcpy loop stay in-bounds, ensuring ASAN
+    reports the OOB write (not an OOB read).
+
+    Args:
+        max_lsb: maxbounds left side bearing (the lie)
+        max_rsb: maxbounds right side bearing (the lie)
+        max_ascent: maxbounds ascent (the lie)
+        max_descent: maxbounds descent (the lie)
+        glyph_lsb: per-glyph left side bearing (the truth)
+        glyph_rsb: per-glyph right side bearing (the truth)
+        glyph_ascent: per-glyph ascent (the truth)
+        glyph_descent: per-glyph descent (the truth)
+        char_code: character code for the single glyph
+
+    Returns:
+        Tuple of (pcf_bytes, xlfd_name) where xlfd_name is the XLFD
+        string to use with OpenFont.
+    """
+
+    # Compute bitmap size: large enough for all source reads
+    glyph_height = glyph_ascent + glyph_descent
+    glyph_padded = (((glyph_rsb - glyph_lsb + 7) >> 3) + 3) & ~3
+    bitmap_size = max(2048, glyph_padded * glyph_height + 16)
+
+    # ---- PROPERTIES table ----
+    props = _u32(DEFAULT_FORMAT)
+    props += _u32(1)  # nprops = 1
+    props += _u32(0)  # prop[0].name offset
+    props += _u8(0)  # prop[0].isStringProp = 0
+    props += _u32(0)  # prop[0].value = 0
+    props += b"\x00" * 3  # padding (nprops & 3 = 1 → 3 pad bytes)
+    props += _u32(1)  # string_size = 1
+    props += b"\x00"  # strings = "\0"
+
+    # ---- ACCELERATORS table ----
+    accel = _u32(DEFAULT_FORMAT)
+    accel += _u8(0) * 8  # 7 flags + 1 padding
+    accel += _u32(max_ascent)  # fontAscent
+    accel += _u32(max_descent)  # fontDescent
+    accel += _u32(0)  # maxOverlap
+    accel += _metric(max_lsb, max_rsb, max_rsb, max_ascent, max_descent)  # minbounds
+    accel += _metric(
+        max_lsb, max_rsb, max_rsb, max_ascent, max_descent
+    )  # maxbounds (THE LIE)
+
+    # ---- METRICS table (uncompressed) ----
+    metrics = _u32(DEFAULT_FORMAT)
+    metrics += _u32(1)  # nmetrics = 1
+    metrics += _metric(glyph_lsb, glyph_rsb, glyph_rsb, glyph_ascent, glyph_descent)
+
+    # ---- BITMAPS table ----
+    bitmaps = _u32(BITMAP_FORMAT)
+    bitmaps += _u32(1)  # nbitmaps = 1
+    bitmaps += _u32(0)  # offsets[0] = 0
+    bitmaps += _u32(0) * 2  # bitmapSizes[0..1] (unused)
+    bitmaps += _u32(bitmap_size)  # bitmapSizes[2] (pad=4, the one used)
+    bitmaps += _u32(0)  # bitmapSizes[3] (unused)
+    bitmaps += b"\xaa" * bitmap_size  # recognizable fill pattern
+
+    # ---- BDF_ENCODINGS table ----
+    encodings = _u32(DEFAULT_FORMAT)
+    encodings += _s16(char_code)  # firstCol
+    encodings += _s16(char_code)  # lastCol
+    encodings += _s16(0)  # firstRow
+    encodings += _s16(0)  # lastRow
+    encodings += _s16(char_code)  # defaultCh
+    encodings += _u16(0)  # encoding[0] = 0 (points to metrics[0])
+
+    # ---- Assemble ----
+    tables = [
+        (PCF_PROPERTIES, DEFAULT_FORMAT, props),
+        (PCF_ACCELERATORS, DEFAULT_FORMAT, accel),
+        (PCF_METRICS, DEFAULT_FORMAT, metrics),
+        (PCF_BITMAPS, BITMAP_FORMAT, bitmaps),
+        (PCF_BDF_ENCODINGS, DEFAULT_FORMAT, encodings),
+    ]
+
+    ntables = len(tables)
+    header_size = 8 + 16 * ntables
+    offset = header_size
+
+    toc = b""
+    data = b""
+    for ttype, tformat, tbody in tables:
+        size = len(tbody)
+        toc += _u32(ttype) + _u32(tformat) + _u32(size) + _u32(offset)
+        data += tbody
+        offset += size
+
+    pcf = _u32(0x70636601) + _u32(ntables) + toc + data
+
+    xlfd = (
+        f"-evil-test-medium-r-normal--"
+        f"{max_ascent + max_descent}-"
+        f"{(max_ascent + max_descent) * 10}-75-75-c-"
+        f"{max_rsb * 10}-iso8859-1"
+    )
+
+    return pcf, xlfd

--- a/test/pyxtest/proto/x11.py
+++ b/test/pyxtest/proto/x11.py
@@ -3,15 +3,22 @@
 # Core X11 protocol request builders
 
 import struct
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 # Core protocol opcodes
 CreateWindow = 1
+ChangeWindowAttributes = 2
 CreatePixmap = 53
 InternAtom = 16
 ListFonts = 49
+OpenFont = 45
+CloseFont = 46
 SetFontPath = 51
 GetFontPath = 52
+CreateGC = 55
+ChangeGC = 56
+PolyText8 = 74
+ImageText8 = 76
 QueryExtension = 98
 ChangeKeyboardMapping = 100
 ForceScreenSaverOpcode = 115
@@ -122,6 +129,143 @@ class QueryExtensionRequest:
         return (
             struct.pack(
                 f"{byte_order}BBHHxx", QueryExtension, 0, req_len, len(name_bytes)
+            )
+            + padded
+        )
+
+
+@dataclass
+class OpenFontRequest:
+    """X11 OpenFont request.
+
+    Wire format:
+        CARD8    opcode      (45)
+        CARD8    unused
+        CARD16   length
+        CARD32   fid
+        CARD16   nbytes
+        CARD16   unused
+        STRING8  name        (padded to 4 bytes)
+    """
+
+    fid: int
+    name: str
+
+    def to_bytes(self, byte_order: str = "<") -> bytes:
+        name_bytes = self.name.encode("ascii")
+        padded = _pad(name_bytes)
+        req_len = (12 + len(padded)) // 4
+        return (
+            struct.pack(
+                f"{byte_order}BBH I Hxx",
+                OpenFont,
+                0,
+                req_len,
+                self.fid,
+                len(name_bytes),
+            )
+            + padded
+        )
+
+
+@dataclass
+class CloseFontRequest:
+    """X11 CloseFont request."""
+
+    fid: int
+
+    def to_bytes(self, byte_order: str = "<") -> bytes:
+        return struct.pack(
+            f"{byte_order}BBH I",
+            CloseFont,
+            0,
+            2,
+            self.fid,
+        )
+
+
+@dataclass
+class CreateGCRequest:
+    """X11 CreateGC request.
+
+    Wire format:
+        CARD8    opcode      (55)
+        CARD8    unused
+        CARD16   length
+        CARD32   cid
+        CARD32   drawable
+        CARD32   value_mask
+        LISTofVALUE values
+    """
+
+    cid: int
+    drawable: int
+    values: dict = field(default_factory=dict)
+
+    # GC value mask bits
+    GCFont = 1 << 14
+    GCForeground = 1 << 2
+    GCBackground = 1 << 3
+
+    def to_bytes(self, byte_order: str = "<") -> bytes:
+        # Build value list in mask order
+        mask_bits = sorted(self.values.keys())
+        value_mask = 0
+        value_data = b""
+        for bit in mask_bits:
+            value_mask |= bit
+            value_data += struct.pack(f"{byte_order}I", self.values[bit])
+
+        req_len = (16 + len(value_data)) // 4
+        return (
+            struct.pack(
+                f"{byte_order}BBH III",
+                CreateGC,
+                0,
+                req_len,
+                self.cid,
+                self.drawable,
+                value_mask,
+            )
+            + value_data
+        )
+
+
+@dataclass
+class ImageText8Request:
+    """X11 ImageText8 request.
+
+    Wire format:
+        CARD8    opcode      (76)
+        CARD8    n           (string length)
+        CARD16   length
+        CARD32   drawable
+        CARD32   gc
+        INT16    x
+        INT16    y
+        STRING8  string      (padded to 4 bytes)
+    """
+
+    drawable: int
+    gc: int
+    x: int
+    y: int
+    string: str
+
+    def to_bytes(self, byte_order: str = "<") -> bytes:
+        string_bytes = self.string.encode("latin-1")
+        padded = _pad(string_bytes)
+        req_len = (16 + len(padded)) // 4
+        return (
+            struct.pack(
+                f"{byte_order}BBH II hh",
+                ImageText8,
+                len(string_bytes),
+                req_len,
+                self.drawable,
+                self.gc,
+                self.x,
+                self.y,
             )
             + padded
         )
@@ -261,6 +405,50 @@ class GetFontPathReply:
             paths.append(data[offset : offset + slen].decode("ascii", errors="replace"))
             offset += slen
         return cls(paths)
+
+
+@dataclass
+class PolyText8Request:
+    """X11 PolyText8 request.
+
+    Wire format:
+        CARD8    opcode      (74)
+        CARD8    unused
+        CARD16   length
+        CARD32   drawable
+        CARD32   gc
+        INT16    x
+        INT16    y
+        TEXTITEM8s           (padded to 4 bytes)
+
+    Each TEXTITEM8: CARD8 len + INT8 delta + STRING8[len]
+    """
+
+    drawable: int
+    gc: int
+    x: int
+    y: int
+    string: str
+
+    def to_bytes(self, byte_order: str = "<") -> bytes:
+        string_bytes = self.string.encode("latin-1")
+        # TEXTITEM8: len(1) + delta(1) + string(N)
+        text_item = struct.pack("Bb", len(string_bytes), 0) + string_bytes
+        padded = _pad(text_item)
+        req_len = (16 + len(padded)) // 4
+        return (
+            struct.pack(
+                f"{byte_order}BBH II hh",
+                PolyText8,
+                0,
+                req_len,
+                self.drawable,
+                self.gc,
+                self.x,
+                self.y,
+            )
+            + padded
+        )
 
 
 @dataclass

--- a/test/pyxtest/test_glamor.py
+++ b/test/pyxtest/test_glamor.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: MIT
+#
+# Security tests for glamor font rendering vulnerabilities.
+
+import os
+import tempfile
+import time
+
+import pytest
+
+from proto import pcf, x11
+from xclient import X11Error
+
+
+class TestGlamorFontAtlas:
+    """Tests for glamor_font_get atlas overflow vulnerabilities.
+
+    ZDI-CAN-30498: glamor_font_get() computes the atlas slot size from
+    the font's declared maxbounds, but copies each glyph's bitmap
+    using the per-glyph metrics (GLYPHHEIGHTPIXELS/GLYPHWIDTHBYTES).
+
+    The PCF parser in libXfont2 does not recompute maxbounds from
+    per-glyph data (only the BDF parser does), so the file's declared
+    maxbounds values are trusted as-is.  A crafted PCF font can set
+    per-glyph metrics that exceed or underflow maxbounds, causing
+    heap buffer overflows or integer wrapping in the atlas memcpy
+    loop.
+
+    The fix rejects fonts where any per-glyph metric exceeds maxbounds
+    (or is negative), falling back to software rendering.
+    """
+
+    @pytest.mark.xorg_only
+    @pytest.mark.asan
+    @pytest.mark.parametrize(
+        "max_lsb, max_rsb, max_ascent, max_descent, "
+        "glyph_lsb, glyph_rsb, glyph_ascent, glyph_descent",
+        [
+            pytest.param(
+                0,
+                4,
+                4,
+                0,
+                0,
+                100,
+                100,
+                0,
+                id="exceeds_maxbounds",
+            ),
+            pytest.param(
+                0,
+                8,
+                8,
+                0,
+                0,
+                8,
+                10,
+                -20,
+                id="negative_height",
+            ),
+            pytest.param(
+                0,
+                8,
+                8,
+                0,
+                10,
+                0,
+                8,
+                0,
+                id="negative_width",
+            ),
+        ],
+    )
+    def test_malicious_glyph_metrics(
+        self,
+        xserver,
+        xclient,
+        max_lsb,
+        max_rsb,
+        max_ascent,
+        max_descent,
+        glyph_lsb,
+        glyph_rsb,
+        glyph_ascent,
+        glyph_descent,
+    ):
+        """
+        Crafted PCF font with per-glyph metrics that violate the
+        maxbounds invariant.  Without the fix, glamor_font_get()
+        overflows the atlas buffer or wraps unsigned loop counters.
+
+        Three variants:
+        - exceeds_maxbounds: per-glyph 100x100 vs maxbounds 4x4,
+          memcpy writes past the atlas buffer.
+        - negative_height: ascent + descent < 0, loop counter wraps
+          to ~4 billion via ``(unsigned) gh``.
+        - negative_width: rsb - lsb < 0, GLYPHWIDTHBYTES is negative,
+          memcpy size wraps to SIZE_MAX.
+
+        Fixed in commit bb9b4f2333 ("glamor: clamp per-glyph metrics
+        to maxbounds in font atlas").
+        """
+        font_data, xlfd = pcf.build_evil_pcf(
+            max_lsb=max_lsb,
+            max_rsb=max_rsb,
+            max_ascent=max_ascent,
+            max_descent=max_descent,
+            glyph_lsb=glyph_lsb,
+            glyph_rsb=glyph_rsb,
+            glyph_ascent=glyph_ascent,
+            glyph_descent=glyph_descent,
+            char_code=0x21,
+        )
+
+        with tempfile.TemporaryDirectory(prefix="pyxtest-font-") as font_dir:
+            font_path = os.path.join(font_dir, "evil.pcf")
+            with open(font_path, "wb") as f:
+                f.write(font_data)
+
+            fonts_dir_path = os.path.join(font_dir, "fonts.dir")
+            with open(fonts_dir_path, "w") as f:
+                f.write("1\n")
+                f.write(f"evil.pcf {xlfd}\n")
+
+            # Prepend our malicious font directory to the font path,
+            # keeping built-ins so the server can still find cursor
+            # fonts etc.
+            xclient.send_request(x11.SetFontPathRequest(paths=[font_dir, "built-ins"]))
+            time.sleep(0.5)
+            for r in xclient.flush_responses(timeout=2.0):
+                if isinstance(r, X11Error):
+                    pytest.skip(f"SetFontPath failed (error {r.error_code})")
+
+            # Open the malicious font
+            fid = xclient.alloc_id()
+            xclient.send_request(x11.OpenFontRequest(fid=fid, name=xlfd))
+            time.sleep(0.5)
+            for r in xclient.flush_responses(timeout=2.0):
+                if isinstance(r, X11Error):
+                    pytest.skip(f"OpenFont failed (error {r.error_code})")
+
+            # Create a pixmap on the default screen (glamor-backed).
+            # Drawing on a pixmap ensures the glamor acceleration path
+            # is used rather than a potential fallback.
+            pix_id = xclient.alloc_id()
+            xclient.send_request(
+                x11.CreatePixmapRequest(
+                    pid=pix_id,
+                    drawable=xclient.root_window,
+                    width=64,
+                    height=64,
+                    depth=xclient.root_depth,
+                )
+            )
+
+            # Create a GC with the malicious font
+            gc_id = xclient.alloc_id()
+            xclient.send_request(
+                x11.CreateGCRequest(
+                    cid=gc_id,
+                    drawable=pix_id,
+                    values={x11.CreateGCRequest.GCFont: fid},
+                )
+            )
+            time.sleep(0.5)
+            for r in xclient.flush_responses(timeout=2.0):
+                if isinstance(r, X11Error):
+                    pytest.skip(f"CreatePixmap/CreateGC failed (error {r.error_code})")
+
+            # Draw text using the malicious font on the pixmap.
+            # This triggers glamor_font_get() which builds the font
+            # atlas.  Character '!' is at code point 0x21 which
+            # matches our font's single encoded glyph.
+            xclient.send_request(
+                x11.PolyText8Request(
+                    drawable=pix_id,
+                    gc=gc_id,
+                    x=10,
+                    y=30,
+                    string="!",
+                )
+            )
+            time.sleep(0.5)
+
+            assert xserver.is_alive, (
+                "Server crashed - glamor_font_get heap corruption "
+                "due to malicious per-glyph metrics (ZDI-CAN-30498)"
+            )


### PR DESCRIPTION
glamor_font_get() computes the atlas slot size from the font's declared
maxbounds, but copies each glyph's bitmap using the per-glyph metrics
(GLYPHHEIGHTPIXELS/GLYPHWIDTHBYTES macros). When a malicious PCF font
has per-glyph metrics exceeding maxbounds, the memcpy writes past the
heap-allocated atlas buffer. Negative per-glyph metrics are even worse:
the loop counter wraps to ~4 billion iterations (via unsigned cast) or
memcpy's size parameter wraps to SIZE_MAX.

The PCF parser in libXfont2 does not recompute maxbounds from per-glyph
data (only the BDF parser does), so the file's declared maxbounds values
are trusted as-is.

Reject fonts where any per-glyph metric is negative or exceeds the
atlas slot size, falling back to software rendering which uses per-glyph
metrics directly without an atlas.

This vulnerability was discovered by:
Anonymous working with Trend Micro Zero Day Initiative

CVE-2026-55999/ZDI-CAN-30498

Assisted-by: Claude:claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2250>
(cherry picked from commit fbf7bac22e2c6bd627fb042742a23318263edae1)
