### PR TITLE
(release/25.2) fb/mi/glamor: reject glyphs with negative dimensions

### DIFF
--- a/fb/fbglyph.c
+++ b/fb/fbglyph.c
@@ -94,7 +94,7 @@ fbPolyGlyphBlt(DrawablePtr pDrawable,
         pglyph = FONTGLYPHBITS(pglyphBase, pci);
         gWidth = GLYPHWIDTHPIXELS(pci);
         gHeight = GLYPHHEIGHTPIXELS(pci);
-        if (gWidth && gHeight) {
+        if (gWidth > 0 && gHeight > 0) {
             gx = x + pci->metrics.leftSideBearing;
             gy = y - pci->metrics.ascent;
             if (glyph && gWidth <= sizeof(FbStip) * 8 &&
@@ -196,7 +196,7 @@ fbImageGlyphBlt(DrawablePtr pDrawable,
         pglyph = FONTGLYPHBITS(pglyphBase, pci);
         gWidth = GLYPHWIDTHPIXELS(pci);
         gHeight = GLYPHHEIGHTPIXELS(pci);
-        if (gWidth && gHeight) {
+        if (gWidth > 0 && gHeight > 0) {
             gx = x + pci->metrics.leftSideBearing;
             gy = y - pci->metrics.ascent;
             if (glyph && gWidth <= sizeof(FbStip) * 8 &&

--- a/glamor/glamor_glyphblt.c
+++ b/glamor/glamor_glyphblt.c
@@ -95,7 +95,7 @@ glamor_poly_glyph_blt_gl(DrawablePtr drawable, GCPtr gc,
             int h = GLYPHHEIGHTPIXELS(charinfo);
             uint8_t *glyphbits = FONTGLYPHBITS(NULL, charinfo);
 
-            if (w && h) {
+            if (w > 0 && h > 0) {
                 int glyph_x = x + charinfo->metrics.leftSideBearing;
                 int glyph_y = y - charinfo->metrics.ascent;
                 int glyph_stride = GLYPHWIDTHBYTESPADDED(charinfo);

--- a/mi/miglblt.c
+++ b/mi/miglblt.c
@@ -143,7 +143,7 @@ miPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int ngly
         pglyph = FONTGLYPHBITS(pglyphBase, pci);
         gWidth = GLYPHWIDTHPIXELS(pci);
         gHeight = GLYPHHEIGHTPIXELS(pci);
-        if (gWidth && gHeight) {
+        if (gWidth > 0 && gHeight > 0) {
             nbyGlyphWidth = GLYPHWIDTHBYTESPADDED(pci);
             nbyPadGlyph = BitmapBytePad(gWidth);
 

--- a/test/pyxtest/meson.build
+++ b/test/pyxtest/meson.build
@@ -51,6 +51,7 @@ if pytest.found()
 
     # This needs to be kept in sync with the test_foo.py files in the tree
     tests_pyxtest = [
+        'test_fb.py',
         'test_font.py',
         'test_glx.py',
         'test_present.py',

--- a/test/pyxtest/test_fb.py
+++ b/test/pyxtest/test_fb.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: MIT
+#
+# Security tests for fb (software) font rendering vulnerabilities.
+
+import os
+import tempfile
+import time
+
+import pytest
+
+from proto import pcf, x11
+from xclient import X11Error
+
+
+class TestFbGlyphBlt:
+    """Tests for fbPolyGlyphBlt/fbImageGlyphBlt with malicious fonts.
+
+    The GLYPHWIDTHPIXELS and GLYPHHEIGHTPIXELS macros compute glyph
+    dimensions from signed INT16 fields.  A crafted PCF font can
+    produce negative results (e.g. rightSideBearing < leftSideBearing
+    or descent negative enough to underflow ascent + descent).
+
+    Negative gWidth/gHeight passes the ``if (gWidth && gHeight)``
+    check (any non-zero value is truthy in C), then:
+    - fbGlyph8/16/32: ``while (height--)`` with negative height
+      wraps through all negative values before reaching zero,
+      running for ~2 billion iterations and writing out of bounds.
+    - memcpy-based paths: negative width cast to size_t wraps to
+      SIZE_MAX.
+
+    The fix changes the check to ``if (gWidth > 0 && gHeight > 0)``
+    to explicitly reject negative dimensions.
+    """
+
+    @pytest.mark.asan
+    @pytest.mark.parametrize(
+        "max_lsb, max_rsb, max_ascent, max_descent, "
+        "glyph_lsb, glyph_rsb, glyph_ascent, glyph_descent",
+        [
+            pytest.param(
+                0,
+                8,
+                8,
+                0,
+                0,
+                8,
+                10,
+                -20,
+                id="negative_height",
+            ),
+            pytest.param(
+                0,
+                8,
+                8,
+                0,
+                10,
+                0,
+                8,
+                0,
+                id="negative_width",
+            ),
+        ],
+    )
+    def test_negative_glyph_metrics(
+        self,
+        xserver,
+        xclient,
+        max_lsb,
+        max_rsb,
+        max_ascent,
+        max_descent,
+        glyph_lsb,
+        glyph_rsb,
+        glyph_ascent,
+        glyph_descent,
+    ):
+        """
+        Crafted PCF font with negative per-glyph dimensions exercising
+        the fb software rendering path (Xvfb, no glamor).
+
+        Without the fix, negative gWidth or gHeight passes the
+        ``if (gWidth && gHeight)`` truthiness check in fbPolyGlyphBlt
+        and fbImageGlyphBlt, leading to integer wrapping in
+        downstream loops and out-of-bounds memory access.
+        """
+        font_data, xlfd = pcf.build_evil_pcf(
+            max_lsb=max_lsb,
+            max_rsb=max_rsb,
+            max_ascent=max_ascent,
+            max_descent=max_descent,
+            glyph_lsb=glyph_lsb,
+            glyph_rsb=glyph_rsb,
+            glyph_ascent=glyph_ascent,
+            glyph_descent=glyph_descent,
+            char_code=0x21,
+        )
+
+        with tempfile.TemporaryDirectory(prefix="pyxtest-font-") as font_dir:
+            font_path = os.path.join(font_dir, "evil.pcf")
+            with open(font_path, "wb") as f:
+                f.write(font_data)
+
+            fonts_dir_path = os.path.join(font_dir, "fonts.dir")
+            with open(fonts_dir_path, "w") as f:
+                f.write("1\n")
+                f.write(f"evil.pcf {xlfd}\n")
+
+            xclient.send_request(x11.SetFontPathRequest(paths=[font_dir, "built-ins"]))
+            time.sleep(0.5)
+            for r in xclient.flush_responses(timeout=2.0):
+                if isinstance(r, X11Error):
+                    pytest.skip(f"SetFontPath failed (error {r.error_code})")
+
+            fid = xclient.alloc_id()
+            xclient.send_request(x11.OpenFontRequest(fid=fid, name=xlfd))
+            time.sleep(0.5)
+            for r in xclient.flush_responses(timeout=2.0):
+                if isinstance(r, X11Error):
+                    pytest.skip(f"OpenFont failed (error {r.error_code})")
+
+            pix_id = xclient.alloc_id()
+            xclient.send_request(
+                x11.CreatePixmapRequest(
+                    pid=pix_id,
+                    drawable=xclient.root_window,
+                    width=64,
+                    height=64,
+                    depth=xclient.root_depth,
+                )
+            )
+
+            gc_id = xclient.alloc_id()
+            xclient.send_request(
+                x11.CreateGCRequest(
+                    cid=gc_id,
+                    drawable=pix_id,
+                    values={x11.CreateGCRequest.GCFont: fid},
+                )
+            )
+            time.sleep(0.5)
+            for r in xclient.flush_responses(timeout=2.0):
+                if isinstance(r, X11Error):
+                    pytest.skip(f"CreatePixmap/CreateGC failed (error {r.error_code})")
+
+            # PolyText8 exercises fbPolyGlyphBlt
+            xclient.send_request(
+                x11.PolyText8Request(
+                    drawable=pix_id,
+                    gc=gc_id,
+                    x=10,
+                    y=30,
+                    string="!",
+                )
+            )
+            time.sleep(0.5)
+
+            assert xserver.is_alive, (
+                "Server crashed - fb glyph rendering with negative per-glyph metrics"
+            )
+
+            # ImageText8 exercises fbImageGlyphBlt
+            xclient.send_request(
+                x11.ImageText8Request(
+                    drawable=pix_id,
+                    gc=gc_id,
+                    x=10,
+                    y=30,
+                    string="!",
+                )
+            )
+            time.sleep(0.5)
+
+            assert xserver.is_alive, (
+                "Server crashed - fb image glyph rendering with "
+                "negative per-glyph metrics"
+            )


### PR DESCRIPTION
GLYPHWIDTHPIXELS and GLYPHHEIGHTPIXELS compute glyph dimensions from
signed INT16 fields. A crafted PCF font can produce negative results
(e.g. rightSideBearing < leftSideBearing).

All callees have a while (height--) loop which will end up in OOB writes
for negative height values.

In the case of a negative height, some callees cast to size_t or end up
with negative strides.

The same pattern exists in fbPoloyGlyphBit, miPolyGlyphBlt and
glamor_poly_glyph_blt_gl, so let's fix all of them in one go.

Assisted-by: Claude:claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2250>
(cherry picked from commit e31efd3e106e53bfc29d499ff0a34b0d20013f2d)
