### PR TITLE
(master) glx: free old context tag before allocating new one in CommonMakeCurrent

### DIFF
--- a/Xext/glx/vndcmds.c
+++ b/Xext/glx/vndcmds.c
@@ -245,6 +245,11 @@ static int CommonMakeCurrent(ClientPtr client,
             if (ret != Success) {
                 return ret;
             }
+            // Free the old tag before calling CommonMakeNewCurrent(),
+            // which may call GlxAllocContextTag() and realloc the
+            // contextTags array, invalidating the oldTag pointer.
+            GlxFreeContextTag(oldTag);
+            oldTag = NULL;
         }
 
         if (newVendor != NULL) {
@@ -255,9 +260,6 @@ static int CommonMakeCurrent(ClientPtr client,
         } else {
             reply.contextTag = 0;
         }
-
-        GlxFreeContextTag(oldTag);
-        oldTag = NULL;
     }
 
     reply.contextTag = GlxCheckSwap(client, reply.contextTag);

--- a/test/pyxtest/proto/glx.py
+++ b/test/pyxtest/proto/glx.py
@@ -7,11 +7,43 @@ from dataclasses import dataclass
 
 # GLX minor opcodes
 GLXCreateContext = 3
+GLXDestroyContext = 4
 GLXMakeCurrent = 5
+GLXQueryVersion = 7
+GLXMakeContextCurrent = 26
 GLXChangeDrawableAttributes = 30
 
 # GLX drawable attribute keys
 GLX_EVENT_MASK = 0x801F
+
+
+@dataclass
+class QueryVersionRequest:
+    """GLX QueryVersion request (12 bytes).
+
+    Wire format:
+        CARD8    reqType         (GLX major opcode)
+        CARD8    glxCode         (7)
+        CARD16   length          (3)
+        CARD32   majorVersion
+        CARD32   minorVersion
+    """
+
+    opcode: int
+    major_version: int = 1
+    minor_version: int = 4
+    length_override: int | None = None
+
+    def to_bytes(self, byte_order: str = "<") -> bytes:
+        length = self.length_override if self.length_override is not None else 3
+        return struct.pack(
+            f"{byte_order}BBH II",
+            self.opcode,
+            GLXQueryVersion,
+            length,
+            self.major_version,
+            self.minor_version,
+        )
 
 
 @dataclass
@@ -40,6 +72,32 @@ class CreateContextRequest:
 
 
 @dataclass
+class DestroyContextRequest:
+    """GLX DestroyContext request (8 bytes).
+
+    Wire format:
+        CARD8    reqType         (GLX major opcode)
+        CARD8    glxCode         (4)
+        CARD16   length          (2)
+        CARD32   context
+    """
+
+    opcode: int
+    context: int
+    length_override: int | None = None
+
+    def to_bytes(self, byte_order: str = "<") -> bytes:
+        length = self.length_override if self.length_override is not None else 2
+        return struct.pack(
+            f"{byte_order}BBH I",
+            self.opcode,
+            GLXDestroyContext,
+            length,
+            self.context,
+        )
+
+
+@dataclass
 class MakeCurrentRequest:
     """glxMakeCurrent request (16 bytes = 4 words)."""
 
@@ -57,6 +115,41 @@ class MakeCurrentRequest:
             self.drawable,
             self.context_id,
             self.old_context_tag,
+        )
+
+
+@dataclass
+class MakeContextCurrentRequest:
+    """GLX MakeContextCurrent request (20 bytes).
+
+    Wire format:
+        CARD8    reqType         (GLX major opcode)
+        CARD8    glxCode         (26)
+        CARD16   length          (5)
+        CARD32   oldContextTag
+        CARD32   drawable
+        CARD32   readdrawable
+        CARD32   context
+    """
+
+    opcode: int
+    old_context_tag: int
+    drawable: int
+    readdrawable: int
+    context: int
+    length_override: int | None = None
+
+    def to_bytes(self, byte_order: str = "<") -> bytes:
+        length = self.length_override if self.length_override is not None else 5
+        return struct.pack(
+            f"{byte_order}BBH IIII",
+            self.opcode,
+            GLXMakeContextCurrent,
+            length,
+            self.old_context_tag,
+            self.drawable,
+            self.readdrawable,
+            self.context,
         )
 
 

--- a/test/pyxtest/test_glx.py
+++ b/test/pyxtest/test_glx.py
@@ -2,12 +2,16 @@
 #
 # Security tests for GLX extension vulnerabilities.
 
+import struct
 import time
 
 import pytest
 
 from proto import glx
-from xclient import Extension, X11Error
+from xclient import Extension, X11Error, X11Reply
+
+# The initial context tag array size in GlxAllocContextTag is 16.
+INITIAL_TAG_SLOTS = 16
 
 
 @pytest.fixture
@@ -165,4 +169,100 @@ class TestGLXChangeDrawableAttributesSwap:
 
         assert xserver.is_alive, (
             "Server crashed - GLX ChangeDrawableAttributes swap handler"
+        )
+
+
+class TestGlxMakeCurrent:
+    """Tests for CommonMakeCurrent vulnerabilities."""
+
+    @pytest.mark.asan
+    def test_make_current_context_tag_realloc_uaf(self, xserver, glx_xclient):
+        """
+        ZDI-CAN-30561: Use-after-free in CommonMakeCurrent due to
+        GlxAllocContextTag realloc invalidating oldTag pointer.
+
+        CommonMakeCurrent() stores a pointer oldTag into the
+        cl->contextTags array. In the unfixed code, CommonMakeNewCurrent()
+        is called before GlxFreeContextTag(oldTag). CommonMakeNewCurrent()
+        calls GlxAllocContextTag() which may realloc() the contextTags
+        array if all slots are full, leaving oldTag as a dangling pointer.
+        The subsequent GlxFreeContextTag(oldTag) then writes into freed
+        memory.
+
+        To trigger the realloc, all 16 initial context tag slots must be
+        simultaneously occupied. This is achieved by creating 17 distinct
+        GLX contexts and making each of the first 16 current (with
+        oldContextTag=0) so each gets its own tag slot. The 17th
+        MakeCurrent switches from the first context to the last with a
+        valid oldContextTag, which forces GlxAllocContextTag to grow the
+        array while oldTag still points into the old allocation.
+        """
+        xclient, opcode = glx_xclient
+        num_contexts = INITIAL_TAG_SLOTS + 1
+
+        # Create num_contexts distinct GLX contexts. Each must be a
+        # separate context so that MakeCurrent with oldContextTag=0
+        # doesn't get rejected (a context can only be current once).
+        contexts = []
+        for _ in range(num_contexts):
+            ctx = xclient.alloc_id()
+            contexts.append(ctx)
+            req = glx.CreateContextRequest(
+                opcode=opcode,
+                context_id=ctx,
+                visual=xclient.root_visual,
+                screen=0,
+                is_direct=1,
+            )
+            xclient.send_request(req)
+
+        # CreateContext has no reply on success; errors would be queued.
+        errors = xclient.flush_responses(timeout=2.0)
+        for resp in errors:
+            if isinstance(resp, X11Error):
+                pytest.skip(f"GLX CreateContext failed (error {resp.error_code})")
+
+        # Fill all 16 initial tag slots by making each context current
+        # without releasing the previous one (oldContextTag=0).
+        # In GLX, different contexts can be current simultaneously
+        # from the server's perspective (each gets its own tag slot).
+        tags = []
+        for i in range(INITIAL_TAG_SLOTS):
+            req = glx.MakeCurrentRequest(
+                opcode=opcode,
+                drawable=xclient.root_window,
+                context_id=contexts[i],
+                old_context_tag=0,
+            )
+            xclient.send_request(req)
+            resp = xclient.recv_response(timeout=2.0)
+            if isinstance(resp, X11Reply):
+                tag = struct.unpack_from("<I", resp.data, 8)[0]
+                tags.append(tag)
+            elif isinstance(resp, X11Error):
+                pytest.skip(
+                    f"GLX MakeCurrent failed at context {i} (error {resp.error_code})"
+                )
+
+        assert len(tags) == INITIAL_TAG_SLOTS
+
+        # All 16 tag slots are now occupied. A MakeCurrent that switches
+        # from contexts[0] (tag 1) to contexts[16] will:
+        # 1. CommonLoseCurrent(oldTag) - tell vendor to release context
+        # 2. In the unfixed code: CommonMakeNewCurrent() ->
+        #    GlxAllocContextTag() finds all 16 slots full ->
+        #    realloc(16->32), invalidating oldTag
+        # 3. GlxFreeContextTag(oldTag) writes to freed memory -> UAF
+        req = glx.MakeCurrentRequest(
+            opcode=opcode,
+            drawable=xclient.root_window,
+            context_id=contexts[INITIAL_TAG_SLOTS],
+            old_context_tag=tags[0],
+        )
+        xclient.send_request(req)
+        time.sleep(0.5)
+
+        assert xserver.is_alive, (
+            "Server crashed - use-after-free in CommonMakeCurrent "
+            "due to GlxAllocContextTag realloc (ZDI-CAN-30561)"
         )


### PR DESCRIPTION
oldTag in CommonMakeCurrent() is a pointer to cl->contextTags[...].
CommonMakeCurrent() may realloc(cl->contextTags) and thus move the
memory, leaving oldTag as dangling pointer.

If we then GlxFreeContextTag(oldTag) we end up writing into freed
memory.

Fix this by freeing oldTag before CommonMakeNewCurrent().

This vulnerability was discovered by:
Anonymous working with Trend Micro Zero Day Initiative

CVE-2026-56000/ZDI-CAN-30561

Fixes: 4781f2a5a8c2 ("GLX: Free the tag of the old context later")
Assisted-by: Claude:claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2250>
(cherry picked from commit 2779affbdb4354e894f490e56f962527d6125043)
