### PR TITLE
fb/mi/glamor: reject glyphs with negative dimensions

### DIFF
--- a/fb/fbglyph.c
+++ b/fb/fbglyph.c
@@ -21,12 +21,13 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
+#ifdef HAVE_DIX_CONFIG_H
 #include <dix-config.h>
+#endif
 
-#include <X11/fonts/fontstruct.h>
-
-#include "fb/fb_priv.h"
-#include "include/dixfontstr.h"
+#include "fb.h"
+#include	<X11/fonts/fontstruct.h>
+#include	"dixfontstr.h"
 
 static Bool
 fbGlyphIn(RegionPtr pRegion, int x, int y, int width, int height)

--- a/fb/fbglyph.c
+++ b/fb/fbglyph.c
@@ -94,7 +94,7 @@ fbPolyGlyphBlt(DrawablePtr pDrawable,
         pglyph = FONTGLYPHBITS(pglyphBase, pci);
         gWidth = GLYPHWIDTHPIXELS(pci);
         gHeight = GLYPHHEIGHTPIXELS(pci);
-        if (gWidth && gHeight) {
+        if (gWidth > 0 && gHeight > 0) {
             gx = x + pci->metrics.leftSideBearing;
             gy = y - pci->metrics.ascent;
             if (glyph && gWidth <= sizeof(FbStip) * 8 &&
@@ -196,7 +196,7 @@ fbImageGlyphBlt(DrawablePtr pDrawable,
         pglyph = FONTGLYPHBITS(pglyphBase, pci);
         gWidth = GLYPHWIDTHPIXELS(pci);
         gHeight = GLYPHHEIGHTPIXELS(pci);
-        if (gWidth && gHeight) {
+        if (gWidth > 0 && gHeight > 0) {
             gx = x + pci->metrics.leftSideBearing;
             gy = y - pci->metrics.ascent;
             if (glyph && gWidth <= sizeof(FbStip) * 8 &&

--- a/glamor/glamor_font.c
+++ b/glamor/glamor_font.c
@@ -30,6 +30,7 @@
 #include "glamor_font.h"
 #include <dixfontstr.h>
 
+static int glamor_font_generation;
 static int glamor_font_private_index;
 static int glamor_font_screen_count;
 
@@ -50,6 +51,7 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
     unsigned char       c[2];
     CharInfoPtr         glyph;
     unsigned long       count;
+    char                *bits;
 
     if (!glamor_glsl_has_ints(glamor_priv))
         return NULL;
@@ -103,7 +105,7 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
         /* fallback if we don't fit inside a texture */
         return NULL;
     }
-    char *bits = calloc(overall_width, overall_height);
+    bits = malloc(overall_width * overall_height);
     if (!bits)
         return NULL;
 
@@ -244,10 +246,13 @@ glamor_font_init(ScreenPtr screen)
     if (!glamor_glsl_has_ints(glamor_priv))
         return TRUE;
 
-    glamor_font_private_index = xfont2_allocate_font_private_index();
-    if (glamor_font_private_index == -1)
-        return FALSE;
-    glamor_font_screen_count = 0;
+    if (glamor_font_generation != serverGeneration) {
+        glamor_font_private_index = xfont2_allocate_font_private_index();
+        if (glamor_font_private_index == -1)
+            return FALSE;
+        glamor_font_screen_count = 0;
+        glamor_font_generation = serverGeneration;
+    }
 
     if (screen->myNum >= glamor_font_screen_count)
         glamor_font_screen_count = screen->myNum + 1;

--- a/glamor/glamor_font.c
+++ b/glamor/glamor_font.c
@@ -75,6 +75,9 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
     glyph_width_pixels = font->info.maxbounds.rightSideBearing - font->info.minbounds.leftSideBearing;
     glyph_height = font->info.maxbounds.ascent + font->info.maxbounds.descent;
 
+    if (glyph_width_pixels <= 0 || glyph_height <= 0)
+        return NULL;
+
     glyph_width_bytes = (glyph_width_pixels + 7) >> 3;
 
     glamor_font->glyph_width_pixels = glyph_width_pixels;
@@ -134,7 +137,28 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
             if (count) {
                 char *dst;
                 char *src = glyph->bits;
-                unsigned y;
+                int gw = GLYPHWIDTHBYTES(glyph);
+                int gh = GLYPHHEIGHTPIXELS(glyph);
+
+                /* Reject fonts where any per-glyph metric is negative
+                 * or exceeds the atlas slot size derived from maxbounds.
+                 * The PCF parser in libXfont2 does not recompute
+                 * maxbounds from per-glyph data, so a crafted PCF file
+                 * can violate the maxbounds invariant.
+                 *
+                 * gw is passed as size_t to memcpy and a negative value
+                 * would thus result in OOB access.
+                 *
+                 * Returning NULL makes glamor fall back to software
+                 * rendering.
+                 */
+                if (gw < 0 || gh < 0 ||
+                    gw > glyph_width_bytes || gh > glyph_height) {
+                    glDeleteTextures(1, &glamor_font->texture_id);
+                    glamor_font->texture_id = 0;
+                    free(bits);
+                    return NULL;
+                }
 
                 dst = bits;
                 /* get offset of start of first row */
@@ -143,8 +167,8 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
                 dst += (row & 1) ? glamor_font->row_width : 0;
 
                 dst += col * glyph_width_bytes;
-                for (y = 0; y < GLYPHHEIGHTPIXELS(glyph); y++) {
-                    memcpy(dst, src, GLYPHWIDTHBYTES(glyph));
+                for (int y = 0; y < gh; y++) {
+                    memcpy(dst, src, gw);
                     dst += overall_width;
                     src += GLYPHWIDTHBYTESPADDED(glyph);
                 }

--- a/glamor/glamor_glyphblt.c
+++ b/glamor/glamor_glyphblt.c
@@ -25,9 +25,6 @@
  *    Zhigang Gong <zhigang.gong@gmail.com>
  *
  */
-#include <dix-config.h>
-
-#include "os/bug_priv.h"
 
 #include "glamor_priv.h"
 #include <dixfontstr.h>
@@ -71,8 +68,6 @@ glamor_poly_glyph_blt_gl(DrawablePtr drawable, GCPtr gc,
 
     start_x += drawable->x;
     y += drawable->y;
-
-    BUG_RETURN_VAL(!pixmap_priv, FALSE);
 
     glamor_pixmap_loop(pixmap_priv, box_index) {
         int x;
@@ -237,8 +232,6 @@ glamor_push_pixels_gl(GCPtr gc, PixmapPtr bitmap,
                           GL_FALSE, 0, vbo_offset);
 
     glamor_put_vbo_space(screen);
-
-    BUG_RETURN_VAL(!pixmap_priv, FALSE);
 
     glamor_pixmap_loop(pixmap_priv, box_index) {
         if (!glamor_set_destination_drawable(drawable, box_index, FALSE, TRUE,

--- a/glamor/glamor_glyphblt.c
+++ b/glamor/glamor_glyphblt.c
@@ -95,7 +95,7 @@ glamor_poly_glyph_blt_gl(DrawablePtr drawable, GCPtr gc,
             int h = GLYPHHEIGHTPIXELS(charinfo);
             uint8_t *glyphbits = FONTGLYPHBITS(NULL, charinfo);
 
-            if (w && h) {
+            if (w > 0 && h > 0) {
                 int glyph_x = x + charinfo->metrics.leftSideBearing;
                 int glyph_y = y - charinfo->metrics.ascent;
                 int glyph_stride = GLYPHWIDTHBYTESPADDED(charinfo);

--- a/glx/vndcmds.c
+++ b/glx/vndcmds.c
@@ -29,8 +29,6 @@
 
 #include <dix-config.h>
 
-#include "dix/request_priv.h"
-
 #include "hashtable.h"
 #include "vndserver_priv.h"
 #include "vndservervendor.h"
@@ -49,7 +47,7 @@ typedef struct GlxVendorPrivDispatchRec {
     HashTable hh;
 } GlxVendorPrivDispatch;
 
-static GlxServerDispatchProc dispatchFuncs[OPCODE_ARRAY_LEN] = { 0 };
+static GlxServerDispatchProc dispatchFuncs[OPCODE_ARRAY_LEN] = {};
 static HashTable vendorPrivHash = NULL;
 static HtGenericHashSetupRec vendorPrivSetup = {
     .keySize = sizeof(CARD32)
@@ -89,6 +87,17 @@ static GlxServerDispatchProc GetVendorDispatchFunc(CARD8 opcode, CARD32 vendorCo
     return DispatchBadRequest;
 }
 
+static void SetReplyHeader(ClientPtr client, void *replyPtr)
+{
+    xGenericReply *rep = (xGenericReply *) replyPtr;
+    rep->type = X_Reply;
+    rep->sequenceNumber = client->sequence;
+    if (client->swapped) {
+	swaps(&rep->sequenceNumber);
+    }
+    rep->length = 0;
+}
+
 /* Include the trivial dispatch handlers */
 #include "vnd_dispatch_stubs.c"
 
@@ -97,10 +106,12 @@ static int dispatch_GLXQueryVersion(ClientPtr client)
     xGLXQueryVersionReply reply;
     REQUEST_SIZE_MATCH(xGLXQueryVersionReq);
 
+    SetReplyHeader(client, &reply);
     reply.majorVersion = GlxCheckSwap(client, 1);
     reply.minorVersion = GlxCheckSwap(client, 4);
 
-    return X_SEND_REPLY_SIMPLE(client, reply);
+    WriteToClient(client, sz_xGLXQueryVersionReply, &reply);
+    return Success;
 }
 
 /* broken header workaround */
@@ -115,6 +126,7 @@ static int dispatch_GLXQueryVersion(ClientPtr client)
 static int dispatch_GLXClientInfo(ClientPtr client)
 {
     GlxServerVendor *vendor;
+    void *requestCopy = NULL;
     size_t requestSize = client->req_len * 4;
 
     if (client->minorOp == X_GLXClientInfo) {
@@ -130,7 +142,7 @@ static int dispatch_GLXClientInfo(ClientPtr client)
     // We'll forward this request to each vendor library. Since a vendor might
     // modify the request data in place (e.g., for byte swapping), make a copy
     // of the request first.
-    void *requestCopy = calloc(1, requestSize);
+    requestCopy = malloc(requestSize);
     if (requestCopy == NULL) {
         return BadAlloc;
     }
@@ -193,7 +205,7 @@ static int CommonMakeCurrent(ClientPtr client,
         GLXDrawable readdrawable,
         GLXContextID context)
 {
-    xGLXMakeCurrentReply reply = { 0 };
+    xGLXMakeCurrentReply reply = {};
     GlxContextTagInfo *oldTag = NULL;
     GlxServerVendor *newVendor = NULL;
 
@@ -201,6 +213,8 @@ static int CommonMakeCurrent(ClientPtr client,
     drawable = GlxCheckSwap(client, drawable);
     readdrawable = GlxCheckSwap(client, readdrawable);
     context = GlxCheckSwap(client, context);
+
+    SetReplyHeader(client, &reply);
 
     if (oldContextTag != 0) {
         oldTag = GlxLookupContextTag(client, oldContextTag);
@@ -229,8 +243,6 @@ static int CommonMakeCurrent(ClientPtr client,
         // TODO: For switching contexts in a single vendor, just make one
         // makeCurrent call?
 
-        // Apparently, the answer is 'no': https://github.com/X11Libre/xserver/issues/1246
-
         // TODO: When changing vendors, would it be better to do the
         // MakeCurrent(new) first, then the LoseCurrent(old)?
         // If the MakeCurrent(new) fails, then the old context will still be current.
@@ -244,6 +256,11 @@ static int CommonMakeCurrent(ClientPtr client,
             if (ret != Success) {
                 return ret;
             }
+            // Free the old tag before calling CommonMakeNewCurrent(),
+            // which may call GlxAllocContextTag() and realloc the
+            // contextTags array, invalidating the oldTag pointer.
+            GlxFreeContextTag(oldTag);
+            oldTag = NULL;
         }
 
         if (newVendor != NULL) {
@@ -254,14 +271,11 @@ static int CommonMakeCurrent(ClientPtr client,
         } else {
             reply.contextTag = 0;
         }
-
-        GlxFreeContextTag(oldTag);
-        oldTag = NULL;
     }
 
     reply.contextTag = GlxCheckSwap(client, reply.contextTag);
-
-    return X_SEND_REPLY_SIMPLE(client, reply);
+    WriteToClient(client, sz_xGLXMakeCurrentReply, &reply);
+    return Success;
 }
 
 static int dispatch_GLXMakeCurrent(ClientPtr client)

--- a/hw/xfree86/common/xf86pciBus.c
+++ b/hw/xfree86/common/xf86pciBus.c
@@ -1156,7 +1156,16 @@ xf86VideoPtrToDriverList(struct pci_device *dev, XF86MatchedDrivers *md)
 		case 0x0bef:
 			/* Use fbdev/vesa driver on Oaktrail, Medfield, CDV */
 			break;
-		default:
+		/* Default to intel only on pre-gen3 chips */
+		case 0x7121:
+		case 0x7123:
+		case 0x7125:
+		case 0x1132:
+		case 0x3577:
+		case 0x2562:
+		case 0x3582:
+		case 0x358e:
+		case 0x2572:
 			driverList[0] = "intel";
 			break;
         }

--- a/mi/miglblt.c
+++ b/mi/miglblt.c
@@ -140,7 +140,7 @@ miPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int ngly
         pglyph = FONTGLYPHBITS(pglyphBase, pci);
         gWidth = GLYPHWIDTHPIXELS(pci);
         gHeight = GLYPHHEIGHTPIXELS(pci);
-        if (gWidth && gHeight) {
+        if (gWidth > 0 && gHeight > 0) {
             nbyGlyphWidth = GLYPHWIDTHBYTESPADDED(pci);
             nbyPadGlyph = BitmapBytePad(gWidth);
 

--- a/mi/miglblt.c
+++ b/mi/miglblt.c
@@ -44,7 +44,9 @@ SOFTWARE.
 
 ******************************************************************/
 
+#ifdef HAVE_DIX_CONFIG_H
 #include <dix-config.h>
+#endif
 
 #include	<X11/X.h>
 #include	<X11/Xmd.h>
@@ -79,7 +81,7 @@ with the sample server.
 */
 
 void
-miPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int nglyph, CharInfoPtr * ppci,  /* array of character info */
+miPolyGlyphBlt(DrawablePtr pDrawable, GC * pGC, int x, int y, unsigned int nglyph, CharInfoPtr * ppci,  /* array of character info */
                void *pglyphBase       /* start of array of glyphs */
     )
 {
@@ -118,7 +120,7 @@ miPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int ngly
 
     pGCtmp = GetScratchGC(1, pDrawable->pScreen);
     if (!pGCtmp) {
-        dixDestroyPixmap(pPixmap, 0);
+        (*pDrawable->pScreen->DestroyPixmap) (pPixmap);
         return;
     }
 
@@ -126,12 +128,13 @@ miPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int ngly
     gcvals[1].val = 1;
     gcvals[2].val = 0;
 
-    ChangeGC(NULL, pGCtmp, GCFunction | GCForeground | GCBackground, gcvals);
+    ChangeGC(NullClient, pGCtmp, GCFunction | GCForeground | GCBackground,
+             gcvals);
 
     nbyLine = BitmapBytePad(width);
-    pbits = calloc(height, nbyLine);
+    pbits = xallocarray(height, nbyLine);
     if (!pbits) {
-        dixDestroyPixmap(pPixmap, 0);
+        (*pDrawable->pScreen->DestroyPixmap) (pPixmap);
         FreeScratchGC(pGCtmp);
         return;
     }
@@ -173,13 +176,13 @@ miPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int ngly
         }
         x += pci->metrics.characterWidth;
     }
-    dixDestroyPixmap(pPixmap, 0);
+    (*pDrawable->pScreen->DestroyPixmap) (pPixmap);
     free(pbits);
     FreeScratchGC(pGCtmp);
 }
 
 void
-miImageGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int nglyph, CharInfoPtr * ppci, /* array of character info */
+miImageGlyphBlt(DrawablePtr pDrawable, GC * pGC, int x, int y, unsigned int nglyph, CharInfoPtr * ppci, /* array of character info */
                 void *pglyphBase      /* start of array of glyphs */
     )
 {
@@ -210,13 +213,13 @@ miImageGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int ngl
     gcvals[0].val = GXcopy;
     gcvals[1].val = pGC->bgPixel;
     gcvals[2].val = FillSolid;
-    ChangeGC(NULL, pGC, GCFunction | GCForeground | GCFillStyle, gcvals);
+    ChangeGC(NullClient, pGC, GCFunction | GCForeground | GCFillStyle, gcvals);
     ValidateGC(pDrawable, pGC);
     (*pGC->ops->PolyFillRect) (pDrawable, pGC, 1, &backrect);
 
     /* put down the glyphs */
     gcvals[0].val = oldFG;
-    ChangeGC(NULL, pGC, GCForeground, gcvals);
+    ChangeGC(NullClient, pGC, GCForeground, gcvals);
     ValidateGC(pDrawable, pGC);
     (*pGC->ops->PolyGlyphBlt) (pDrawable, pGC, x, y, nglyph, ppci, pglyphBase);
 
@@ -224,7 +227,7 @@ miImageGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int ngl
     gcvals[0].val = oldAlu;
     gcvals[1].val = oldFG;
     gcvals[2].val = oldFS;
-    ChangeGC(NULL, pGC, GCFunction | GCForeground | GCFillStyle, gcvals);
+    ChangeGC(NullClient, pGC, GCFunction | GCForeground | GCFillStyle, gcvals);
     ValidateGC(pDrawable, pGC);
 
 }


### PR DESCRIPTION
fb/mi/glamor: reject glyphs with negative dimensions

GLYPHWIDTHPIXELS and GLYPHHEIGHTPIXELS compute glyph dimensions from
signed INT16 fields. A crafted PCF font can produce negative results
(e.g. rightSideBearing < leftSideBearing).

All callees have a while (height--) loop which will end up in OOB writes
for negative height values.

In the case of a negative height, some callees cast to size_t or end up
with negative strides.

The same pattern exists in fbPoloyGlyphBit, miPolyGlyphBlt and
glamor_poly_glyph_blt_gl, so let's fix all of them in one go.

Assisted-by: Claude:claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2250>
(cherry picked from commit e31efd3e106e53bfc29d499ff0a34b0d20013f2d)

(cherry picked from commit e31efd3e106e53bfc29d499ff0a34b0d20013f2d)