### PR TITLE
glx: free old context tag before allocating new one in CommonMakeCurrent

### DIFF
--- a/Xext/glx/vndcmds.c
+++ b/Xext/glx/vndcmds.c
@@ -1,0 +1,495 @@
+/*
+ * Copyright (c) 2016, NVIDIA CORPORATION.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and/or associated documentation files (the
+ * "Materials"), to deal in the Materials without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Materials, and to
+ * permit persons to whom the Materials are furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * unaltered in all copies or substantial portions of the Materials.
+ * Any additions, deletions, or changes to the original source files
+ * must be clearly indicated in accompanying documentation.
+ *
+ * If only executable code is distributed, then the accompanying
+ * documentation must state that "this software is based in part on the
+ * work of the Khronos Group."
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+ */
+
+#include <dix-config.h>
+
+#include "hashtable.h"
+#include "vndserver_priv.h"
+#include "vndservervendor.h"
+
+/**
+ * The length of the dispatchFuncs array. Every opcode above this is a
+ * X_GLsop_* code, which all can use the same handler.
+ */
+#define OPCODE_ARRAY_LEN 100
+
+// This hashtable is used to keep track of the dispatch stubs for
+// GLXVendorPrivate and GLXVendorPrivateWithReply.
+typedef struct GlxVendorPrivDispatchRec {
+    CARD32 vendorCode;
+    GlxServerDispatchProc proc;
+    HashTable hh;
+} GlxVendorPrivDispatch;
+
+static GlxServerDispatchProc dispatchFuncs[OPCODE_ARRAY_LEN] = {};
+static HashTable vendorPrivHash = NULL;
+static HtGenericHashSetupRec vendorPrivSetup = {
+    .keySize = sizeof(CARD32)
+};
+
+static int DispatchBadRequest(ClientPtr client)
+{
+    return BadRequest;
+}
+
+static GlxVendorPrivDispatch *LookupVendorPrivDispatch(CARD32 vendorCode, Bool create)
+{
+    GlxVendorPrivDispatch *disp = NULL;
+
+    disp = ht_find(vendorPrivHash, &vendorCode);
+    if (disp == NULL && create) {
+        if ((disp = ht_add(vendorPrivHash, &vendorCode))) {
+            disp->vendorCode = vendorCode;
+            disp->proc = NULL;
+        }
+    }
+
+    return disp;
+}
+
+static GlxServerDispatchProc GetVendorDispatchFunc(CARD8 opcode, CARD32 vendorCode)
+{
+    GlxServerVendor *vendor;
+
+    xorg_list_for_each_entry(vendor, &GlxVendorList, entry) {
+        GlxServerDispatchProc proc = vendor->glxvc.getDispatchAddress(opcode, vendorCode);
+        if (proc != NULL) {
+            return proc;
+        }
+    }
+
+    return DispatchBadRequest;
+}
+
+static void SetReplyHeader(ClientPtr client, void *replyPtr)
+{
+    xGenericReply *rep = (xGenericReply *) replyPtr;
+    rep->type = X_Reply;
+    rep->sequenceNumber = client->sequence;
+    if (client->swapped) {
+	swaps(&rep->sequenceNumber);
+    }
+    rep->length = 0;
+}
+
+/* Include the trivial dispatch handlers */
+#include "vnd_dispatch_stubs.c"
+
+static int dispatch_GLXQueryVersion(ClientPtr client)
+{
+    xGLXQueryVersionReply reply;
+    REQUEST_SIZE_MATCH(xGLXQueryVersionReq);
+
+    SetReplyHeader(client, &reply);
+    reply.majorVersion = GlxCheckSwap(client, 1);
+    reply.minorVersion = GlxCheckSwap(client, 4);
+
+    WriteToClient(client, sz_xGLXQueryVersionReply, &reply);
+    return Success;
+}
+
+/* broken header workaround */
+#ifndef X_GLXSetClientInfo2ARB
+#define X_GLXSetClientInfo2ARB X_GLXSetConfigInfo2ARB
+#endif
+
+/**
+ * This function is used for X_GLXClientInfo, X_GLXSetClientInfoARB, and
+ * X_GLXSetClientInfo2ARB.
+ */
+static int dispatch_GLXClientInfo(ClientPtr client)
+{
+    GlxServerVendor *vendor;
+    void *requestCopy = NULL;
+    size_t requestSize = client->req_len * 4;
+
+    if (client->minorOp == X_GLXClientInfo) {
+        REQUEST_AT_LEAST_SIZE(xGLXClientInfoReq);
+    } else if (client->minorOp == X_GLXSetClientInfoARB) {
+        REQUEST_AT_LEAST_SIZE(xGLXSetClientInfoARBReq);
+    } else if (client->minorOp == X_GLXSetClientInfo2ARB) {
+        REQUEST_AT_LEAST_SIZE(xGLXSetClientInfo2ARBReq);
+    } else {
+        return BadImplementation;
+    }
+
+    // We'll forward this request to each vendor library. Since a vendor might
+    // modify the request data in place (e.g., for byte swapping), make a copy
+    // of the request first.
+    requestCopy = malloc(requestSize);
+    if (requestCopy == NULL) {
+        return BadAlloc;
+    }
+    memcpy(requestCopy, client->requestBuffer, requestSize);
+
+    xorg_list_for_each_entry(vendor, &GlxVendorList, entry) {
+        vendor->glxvc.handleRequest(client);
+        // Revert the request buffer back to our copy.
+        memcpy(client->requestBuffer, requestCopy, requestSize);
+    }
+    free(requestCopy);
+    return Success;
+}
+
+static int CommonLoseCurrent(ClientPtr client, GlxContextTagInfo *tagInfo)
+{
+    int ret;
+
+    ret = tagInfo->vendor->glxvc.makeCurrent(client,
+            tagInfo->tag, // No old context tag,
+            None, None, None, 0);
+
+    return ret;
+}
+
+static int CommonMakeNewCurrent(ClientPtr client,
+        GlxServerVendor *vendor,
+        GLXDrawable drawable,
+        GLXDrawable readdrawable,
+        GLXContextID context,
+        GLXContextTag *newContextTag)
+{
+    int ret = BadAlloc;
+    GlxContextTagInfo *tagInfo;
+
+    tagInfo = GlxAllocContextTag(client, vendor);
+
+    if (tagInfo) {
+        ret = vendor->glxvc.makeCurrent(client,
+                0, // No old context tag,
+                drawable, readdrawable, context,
+                tagInfo->tag);
+
+        if (ret == Success) {
+            tagInfo->drawable = drawable;
+            tagInfo->readdrawable = readdrawable;
+            tagInfo->context = context;
+            *newContextTag = tagInfo->tag;
+        } else {
+            GlxFreeContextTag(tagInfo);
+        }
+    }
+
+    return ret;
+}
+
+static int CommonMakeCurrent(ClientPtr client,
+        GLXContextTag oldContextTag,
+        GLXDrawable drawable,
+        GLXDrawable readdrawable,
+        GLXContextID context)
+{
+    xGLXMakeCurrentReply reply = {};
+    GlxContextTagInfo *oldTag = NULL;
+    GlxServerVendor *newVendor = NULL;
+
+    oldContextTag = GlxCheckSwap(client, oldContextTag);
+    drawable = GlxCheckSwap(client, drawable);
+    readdrawable = GlxCheckSwap(client, readdrawable);
+    context = GlxCheckSwap(client, context);
+
+    SetReplyHeader(client, &reply);
+
+    if (oldContextTag != 0) {
+        oldTag = GlxLookupContextTag(client, oldContextTag);
+        if (oldTag == NULL) {
+            return GlxErrorBase + GLXBadContextTag;
+        }
+    }
+    if (context != 0) {
+        newVendor = GlxGetXIDMap(context);
+        if (newVendor == NULL) {
+            return GlxErrorBase + GLXBadContext;
+        }
+    }
+
+    if (oldTag == NULL && newVendor == NULL) {
+        // Nothing to do here. Just send a successful reply.
+        reply.contextTag = 0;
+    } else if (oldTag != NULL && newVendor != NULL
+            && oldTag->context == context
+            && oldTag->drawable == drawable
+            && oldTag->readdrawable == readdrawable)
+    {
+        // The old and new values are all the same, so send a successful reply.
+        reply.contextTag = oldTag->tag;
+    } else {
+        // TODO: For switching contexts in a single vendor, just make one
+        // makeCurrent call?
+
+        // TODO: When changing vendors, would it be better to do the
+        // MakeCurrent(new) first, then the LoseCurrent(old)?
+        // If the MakeCurrent(new) fails, then the old context will still be current.
+        // If the LoseCurrent(old) fails, then we can (probably) undo the MakeCurrent(new) with
+        // a LoseCurrent(old).
+        // But, if the recovery LoseCurrent(old) fails, then we're really in a bad state.
+
+        // Clear the old context first.
+        if (oldTag != NULL) {
+            int ret = CommonLoseCurrent(client, oldTag);
+            if (ret != Success) {
+                return ret;
+            }
+            // Free the old tag before calling CommonMakeNewCurrent(),
+            // which may call GlxAllocContextTag() and realloc the
+            // contextTags array, invalidating the oldTag pointer.
+            GlxFreeContextTag(oldTag);
+            oldTag = NULL;
+        }
+
+        if (newVendor != NULL) {
+            int ret = CommonMakeNewCurrent(client, newVendor, drawable, readdrawable, context, &reply.contextTag);
+            if (ret != Success) {
+                return ret;
+            }
+        } else {
+            reply.contextTag = 0;
+        }
+    }
+
+    reply.contextTag = GlxCheckSwap(client, reply.contextTag);
+    WriteToClient(client, sz_xGLXMakeCurrentReply, &reply);
+    return Success;
+}
+
+static int dispatch_GLXMakeCurrent(ClientPtr client)
+{
+    REQUEST(xGLXMakeCurrentReq);
+    REQUEST_SIZE_MATCH(*stuff);
+
+    return CommonMakeCurrent(client, stuff->oldContextTag,
+            stuff->drawable, stuff->drawable, stuff->context);
+}
+
+static int dispatch_GLXMakeContextCurrent(ClientPtr client)
+{
+    REQUEST(xGLXMakeContextCurrentReq);
+    REQUEST_SIZE_MATCH(*stuff);
+
+    return CommonMakeCurrent(client, stuff->oldContextTag,
+            stuff->drawable, stuff->readdrawable, stuff->context);
+}
+
+static int dispatch_GLXMakeCurrentReadSGI(ClientPtr client)
+{
+    REQUEST(xGLXMakeCurrentReadSGIReq);
+    REQUEST_SIZE_MATCH(*stuff);
+
+    return CommonMakeCurrent(client, stuff->oldContextTag,
+            stuff->drawable, stuff->readable, stuff->context);
+}
+
+static int dispatch_GLXCopyContext(ClientPtr client)
+{
+    REQUEST(xGLXCopyContextReq);
+    GlxServerVendor *vendor;
+    REQUEST_SIZE_MATCH(*stuff);
+
+    // If we've got a context tag, then we'll use it to select a vendor. If we
+    // don't have a tag, then we'll look up one of the contexts. In either
+    // case, it's up to the vendor library to make sure that the context ID's
+    // are valid.
+    if (stuff->contextTag != 0) {
+        GlxContextTagInfo *tagInfo = GlxLookupContextTag(client, GlxCheckSwap(client, stuff->contextTag));
+        if (tagInfo == NULL) {
+            return GlxErrorBase + GLXBadContextTag;
+        }
+        vendor = tagInfo->vendor;
+    } else {
+        vendor = GlxGetXIDMap(GlxCheckSwap(client, stuff->source));
+        if (vendor == NULL) {
+            return GlxErrorBase + GLXBadContext;
+        }
+    }
+    return vendor->glxvc.handleRequest(client);
+}
+
+static int dispatch_GLXSwapBuffers(ClientPtr client)
+{
+    GlxServerVendor *vendor = NULL;
+    REQUEST(xGLXSwapBuffersReq);
+    REQUEST_SIZE_MATCH(*stuff);
+
+    if (stuff->contextTag != 0) {
+        // If the request has a context tag, then look up a vendor from that.
+        // The vendor library is then responsible for validating the drawable.
+        GlxContextTagInfo *tagInfo = GlxLookupContextTag(client, GlxCheckSwap(client, stuff->contextTag));
+        if (tagInfo == NULL) {
+            return GlxErrorBase + GLXBadContextTag;
+        }
+        vendor = tagInfo->vendor;
+    } else {
+        // We don't have a context tag, so look up the vendor from the
+        // drawable.
+        vendor = GlxGetXIDMap(GlxCheckSwap(client, stuff->drawable));
+        if (vendor == NULL) {
+            return GlxErrorBase + GLXBadDrawable;
+        }
+    }
+
+    return vendor->glxvc.handleRequest(client);
+}
+
+/**
+ * This is a generic handler for all of the X_GLXsop* requests.
+ */
+static int dispatch_GLXSingle(ClientPtr client)
+{
+    REQUEST(xGLXSingleReq);
+    GlxContextTagInfo *tagInfo;
+    REQUEST_AT_LEAST_SIZE(*stuff);
+
+    tagInfo = GlxLookupContextTag(client, GlxCheckSwap(client, stuff->contextTag));
+    if (tagInfo != NULL) {
+        return tagInfo->vendor->glxvc.handleRequest(client);
+    } else {
+        return GlxErrorBase + GLXBadContextTag;
+    }
+}
+
+static int dispatch_GLXVendorPriv(ClientPtr client)
+{
+    GlxVendorPrivDispatch *disp;
+    REQUEST(xGLXVendorPrivateReq);
+    REQUEST_AT_LEAST_SIZE(*stuff);
+
+    disp = LookupVendorPrivDispatch(GlxCheckSwap(client, stuff->vendorCode), TRUE);
+    if (disp == NULL) {
+        return BadAlloc;
+    }
+
+    if (disp->proc == NULL) {
+        // We don't have a dispatch function for this request yet. Check with
+        // each vendor library to find one.
+        // Note that even if none of the vendors provides a dispatch stub,
+        // we'll still add an entry to the dispatch table, so that we don't
+        // have to look it up again later.
+
+        disp->proc = GetVendorDispatchFunc(stuff->glxCode,
+                                           GlxCheckSwap(client,
+                                                        stuff->vendorCode));
+    }
+    return disp->proc(client);
+}
+
+Bool GlxDispatchInit(void)
+{
+    GlxVendorPrivDispatch *disp;
+
+    vendorPrivHash = ht_create(sizeof(CARD32), sizeof(GlxVendorPrivDispatch),
+                               ht_generic_hash, ht_generic_compare,
+                               (void *) &vendorPrivSetup);
+    if (!vendorPrivHash) {
+        return FALSE;
+    }
+
+    // Assign a custom dispatch stub GLXMakeCurrentReadSGI. This is the only
+    // vendor private request that we need to deal with in libglvnd itself.
+    disp = LookupVendorPrivDispatch(X_GLXvop_MakeCurrentReadSGI, TRUE);
+    if (disp == NULL) {
+        return FALSE;
+    }
+    disp->proc = dispatch_GLXMakeCurrentReadSGI;
+
+    // Assign the dispatch stubs for requests that need special handling.
+    dispatchFuncs[X_GLXQueryVersion] = dispatch_GLXQueryVersion;
+    dispatchFuncs[X_GLXMakeCurrent] = dispatch_GLXMakeCurrent;
+    dispatchFuncs[X_GLXMakeContextCurrent] = dispatch_GLXMakeContextCurrent;
+    dispatchFuncs[X_GLXCopyContext] = dispatch_GLXCopyContext;
+    dispatchFuncs[X_GLXSwapBuffers] = dispatch_GLXSwapBuffers;
+
+    dispatchFuncs[X_GLXClientInfo] = dispatch_GLXClientInfo;
+    dispatchFuncs[X_GLXSetClientInfoARB] = dispatch_GLXClientInfo;
+    dispatchFuncs[X_GLXSetClientInfo2ARB] = dispatch_GLXClientInfo;
+
+    dispatchFuncs[X_GLXVendorPrivate] = dispatch_GLXVendorPriv;
+    dispatchFuncs[X_GLXVendorPrivateWithReply] = dispatch_GLXVendorPriv;
+
+    // Assign the trivial stubs
+    dispatchFuncs[X_GLXRender] = dispatch_Render;
+    dispatchFuncs[X_GLXRenderLarge] = dispatch_RenderLarge;
+    dispatchFuncs[X_GLXCreateContext] = dispatch_CreateContext;
+    dispatchFuncs[X_GLXDestroyContext] = dispatch_DestroyContext;
+    dispatchFuncs[X_GLXWaitGL] = dispatch_WaitGL;
+    dispatchFuncs[X_GLXWaitX] = dispatch_WaitX;
+    dispatchFuncs[X_GLXUseXFont] = dispatch_UseXFont;
+    dispatchFuncs[X_GLXCreateGLXPixmap] = dispatch_CreateGLXPixmap;
+    dispatchFuncs[X_GLXGetVisualConfigs] = dispatch_GetVisualConfigs;
+    dispatchFuncs[X_GLXDestroyGLXPixmap] = dispatch_DestroyGLXPixmap;
+    dispatchFuncs[X_GLXQueryExtensionsString] = dispatch_QueryExtensionsString;
+    dispatchFuncs[X_GLXQueryServerString] = dispatch_QueryServerString;
+    dispatchFuncs[X_GLXChangeDrawableAttributes] = dispatch_ChangeDrawableAttributes;
+    dispatchFuncs[X_GLXCreateNewContext] = dispatch_CreateNewContext;
+    dispatchFuncs[X_GLXCreatePbuffer] = dispatch_CreatePbuffer;
+    dispatchFuncs[X_GLXCreatePixmap] = dispatch_CreatePixmap;
+    dispatchFuncs[X_GLXCreateWindow] = dispatch_CreateWindow;
+    dispatchFuncs[X_GLXCreateContextAttribsARB] = dispatch_CreateContextAttribsARB;
+    dispatchFuncs[X_GLXDestroyPbuffer] = dispatch_DestroyPbuffer;
+    dispatchFuncs[X_GLXDestroyPixmap] = dispatch_DestroyPixmap;
+    dispatchFuncs[X_GLXDestroyWindow] = dispatch_DestroyWindow;
+    dispatchFuncs[X_GLXGetDrawableAttributes] = dispatch_GetDrawableAttributes;
+    dispatchFuncs[X_GLXGetFBConfigs] = dispatch_GetFBConfigs;
+    dispatchFuncs[X_GLXQueryContext] = dispatch_QueryContext;
+    dispatchFuncs[X_GLXIsDirect] = dispatch_IsDirect;
+
+    return TRUE;
+}
+
+void GlxDispatchReset(void)
+{
+    memset(dispatchFuncs, 0, sizeof(dispatchFuncs));
+
+    ht_destroy(vendorPrivHash);
+    vendorPrivHash = NULL;
+}
+
+int GlxDispatchRequest(ClientPtr client)
+{
+    REQUEST(xReq);
+    int result;
+
+    if (GlxExtensionEntry->base == 0)
+        return BadRequest;
+
+    GlxSetRequestClient(client);
+
+    if (stuff->data < OPCODE_ARRAY_LEN) {
+        if (dispatchFuncs[stuff->data] == NULL) {
+            // Try to find a dispatch stub.
+            dispatchFuncs[stuff->data] = GetVendorDispatchFunc(stuff->data, 0);
+        }
+        result = dispatchFuncs[stuff->data](client);
+    } else {
+        result = dispatch_GLXSingle(client);
+    }
+
+    GlxSetRequestClient(NULL);
+
+    return result;
+}

--- a/fb/fbglyph.c
+++ b/fb/fbglyph.c
@@ -21,12 +21,13 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
+#ifdef HAVE_DIX_CONFIG_H
 #include <dix-config.h>
+#endif
 
-#include <X11/fonts/fontstruct.h>
-
-#include "fb/fb_priv.h"
-#include "include/dixfontstr.h"
+#include "fb.h"
+#include	<X11/fonts/fontstruct.h>
+#include	"dixfontstr.h"
 
 static Bool
 fbGlyphIn(RegionPtr pRegion, int x, int y, int width, int height)

--- a/fb/fbglyph.c
+++ b/fb/fbglyph.c
@@ -94,7 +94,7 @@ fbPolyGlyphBlt(DrawablePtr pDrawable,
         pglyph = FONTGLYPHBITS(pglyphBase, pci);
         gWidth = GLYPHWIDTHPIXELS(pci);
         gHeight = GLYPHHEIGHTPIXELS(pci);
-        if (gWidth && gHeight) {
+        if (gWidth > 0 && gHeight > 0) {
             gx = x + pci->metrics.leftSideBearing;
             gy = y - pci->metrics.ascent;
             if (glyph && gWidth <= sizeof(FbStip) * 8 &&
@@ -196,7 +196,7 @@ fbImageGlyphBlt(DrawablePtr pDrawable,
         pglyph = FONTGLYPHBITS(pglyphBase, pci);
         gWidth = GLYPHWIDTHPIXELS(pci);
         gHeight = GLYPHHEIGHTPIXELS(pci);
-        if (gWidth && gHeight) {
+        if (gWidth > 0 && gHeight > 0) {
             gx = x + pci->metrics.leftSideBearing;
             gy = y - pci->metrics.ascent;
             if (glyph && gWidth <= sizeof(FbStip) * 8 &&

--- a/glamor/glamor_font.c
+++ b/glamor/glamor_font.c
@@ -30,6 +30,7 @@
 #include "glamor_font.h"
 #include <dixfontstr.h>
 
+static int glamor_font_generation;
 static int glamor_font_private_index;
 static int glamor_font_screen_count;
 
@@ -50,6 +51,7 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
     unsigned char       c[2];
     CharInfoPtr         glyph;
     unsigned long       count;
+    char                *bits;
 
     if (!glamor_glsl_has_ints(glamor_priv))
         return NULL;
@@ -103,7 +105,7 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
         /* fallback if we don't fit inside a texture */
         return NULL;
     }
-    char *bits = calloc(overall_width, overall_height);
+    bits = malloc(overall_width * overall_height);
     if (!bits)
         return NULL;
 
@@ -244,10 +246,13 @@ glamor_font_init(ScreenPtr screen)
     if (!glamor_glsl_has_ints(glamor_priv))
         return TRUE;
 
-    glamor_font_private_index = xfont2_allocate_font_private_index();
-    if (glamor_font_private_index == -1)
-        return FALSE;
-    glamor_font_screen_count = 0;
+    if (glamor_font_generation != serverGeneration) {
+        glamor_font_private_index = xfont2_allocate_font_private_index();
+        if (glamor_font_private_index == -1)
+            return FALSE;
+        glamor_font_screen_count = 0;
+        glamor_font_generation = serverGeneration;
+    }
 
     if (screen->myNum >= glamor_font_screen_count)
         glamor_font_screen_count = screen->myNum + 1;

--- a/glamor/glamor_font.c
+++ b/glamor/glamor_font.c
@@ -75,6 +75,9 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
     glyph_width_pixels = font->info.maxbounds.rightSideBearing - font->info.minbounds.leftSideBearing;
     glyph_height = font->info.maxbounds.ascent + font->info.maxbounds.descent;
 
+    if (glyph_width_pixels <= 0 || glyph_height <= 0)
+        return NULL;
+
     glyph_width_bytes = (glyph_width_pixels + 7) >> 3;
 
     glamor_font->glyph_width_pixels = glyph_width_pixels;
@@ -134,7 +137,28 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
             if (count) {
                 char *dst;
                 char *src = glyph->bits;
-                unsigned y;
+                int gw = GLYPHWIDTHBYTES(glyph);
+                int gh = GLYPHHEIGHTPIXELS(glyph);
+
+                /* Reject fonts where any per-glyph metric is negative
+                 * or exceeds the atlas slot size derived from maxbounds.
+                 * The PCF parser in libXfont2 does not recompute
+                 * maxbounds from per-glyph data, so a crafted PCF file
+                 * can violate the maxbounds invariant.
+                 *
+                 * gw is passed as size_t to memcpy and a negative value
+                 * would thus result in OOB access.
+                 *
+                 * Returning NULL makes glamor fall back to software
+                 * rendering.
+                 */
+                if (gw < 0 || gh < 0 ||
+                    gw > glyph_width_bytes || gh > glyph_height) {
+                    glDeleteTextures(1, &glamor_font->texture_id);
+                    glamor_font->texture_id = 0;
+                    free(bits);
+                    return NULL;
+                }
 
                 dst = bits;
                 /* get offset of start of first row */
@@ -143,8 +167,8 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
                 dst += (row & 1) ? glamor_font->row_width : 0;
 
                 dst += col * glyph_width_bytes;
-                for (y = 0; y < GLYPHHEIGHTPIXELS(glyph); y++) {
-                    memcpy(dst, src, GLYPHWIDTHBYTES(glyph));
+                for (int y = 0; y < gh; y++) {
+                    memcpy(dst, src, gw);
                     dst += overall_width;
                     src += GLYPHWIDTHBYTESPADDED(glyph);
                 }

--- a/glamor/glamor_glyphblt.c
+++ b/glamor/glamor_glyphblt.c
@@ -25,9 +25,6 @@
  *    Zhigang Gong <zhigang.gong@gmail.com>
  *
  */
-#include <dix-config.h>
-
-#include "os/bug_priv.h"
 
 #include "glamor_priv.h"
 #include <dixfontstr.h>
@@ -71,8 +68,6 @@ glamor_poly_glyph_blt_gl(DrawablePtr drawable, GCPtr gc,
 
     start_x += drawable->x;
     y += drawable->y;
-
-    BUG_RETURN_VAL(!pixmap_priv, FALSE);
 
     glamor_pixmap_loop(pixmap_priv, box_index) {
         int x;
@@ -237,8 +232,6 @@ glamor_push_pixels_gl(GCPtr gc, PixmapPtr bitmap,
                           GL_FALSE, 0, vbo_offset);
 
     glamor_put_vbo_space(screen);
-
-    BUG_RETURN_VAL(!pixmap_priv, FALSE);
 
     glamor_pixmap_loop(pixmap_priv, box_index) {
         if (!glamor_set_destination_drawable(drawable, box_index, FALSE, TRUE,

--- a/glamor/glamor_glyphblt.c
+++ b/glamor/glamor_glyphblt.c
@@ -95,7 +95,7 @@ glamor_poly_glyph_blt_gl(DrawablePtr drawable, GCPtr gc,
             int h = GLYPHHEIGHTPIXELS(charinfo);
             uint8_t *glyphbits = FONTGLYPHBITS(NULL, charinfo);
 
-            if (w && h) {
+            if (w > 0 && h > 0) {
                 int glyph_x = x + charinfo->metrics.leftSideBearing;
                 int glyph_y = y - charinfo->metrics.ascent;
                 int glyph_stride = GLYPHWIDTHBYTESPADDED(charinfo);

--- a/glx/vndcmds.c
+++ b/glx/vndcmds.c
@@ -29,8 +29,6 @@
 
 #include <dix-config.h>
 
-#include "dix/request_priv.h"
-
 #include "hashtable.h"
 #include "vndserver_priv.h"
 #include "vndservervendor.h"
@@ -49,7 +47,7 @@ typedef struct GlxVendorPrivDispatchRec {
     HashTable hh;
 } GlxVendorPrivDispatch;
 
-static GlxServerDispatchProc dispatchFuncs[OPCODE_ARRAY_LEN] = { 0 };
+static GlxServerDispatchProc dispatchFuncs[OPCODE_ARRAY_LEN] = {};
 static HashTable vendorPrivHash = NULL;
 static HtGenericHashSetupRec vendorPrivSetup = {
     .keySize = sizeof(CARD32)
@@ -89,6 +87,17 @@ static GlxServerDispatchProc GetVendorDispatchFunc(CARD8 opcode, CARD32 vendorCo
     return DispatchBadRequest;
 }
 
+static void SetReplyHeader(ClientPtr client, void *replyPtr)
+{
+    xGenericReply *rep = (xGenericReply *) replyPtr;
+    rep->type = X_Reply;
+    rep->sequenceNumber = client->sequence;
+    if (client->swapped) {
+	swaps(&rep->sequenceNumber);
+    }
+    rep->length = 0;
+}
+
 /* Include the trivial dispatch handlers */
 #include "vnd_dispatch_stubs.c"
 
@@ -97,10 +106,12 @@ static int dispatch_GLXQueryVersion(ClientPtr client)
     xGLXQueryVersionReply reply;
     REQUEST_SIZE_MATCH(xGLXQueryVersionReq);
 
+    SetReplyHeader(client, &reply);
     reply.majorVersion = GlxCheckSwap(client, 1);
     reply.minorVersion = GlxCheckSwap(client, 4);
 
-    return X_SEND_REPLY_SIMPLE(client, reply);
+    WriteToClient(client, sz_xGLXQueryVersionReply, &reply);
+    return Success;
 }
 
 /* broken header workaround */
@@ -115,6 +126,7 @@ static int dispatch_GLXQueryVersion(ClientPtr client)
 static int dispatch_GLXClientInfo(ClientPtr client)
 {
     GlxServerVendor *vendor;
+    void *requestCopy = NULL;
     size_t requestSize = client->req_len * 4;
 
     if (client->minorOp == X_GLXClientInfo) {
@@ -130,7 +142,7 @@ static int dispatch_GLXClientInfo(ClientPtr client)
     // We'll forward this request to each vendor library. Since a vendor might
     // modify the request data in place (e.g., for byte swapping), make a copy
     // of the request first.
-    void *requestCopy = calloc(1, requestSize);
+    requestCopy = malloc(requestSize);
     if (requestCopy == NULL) {
         return BadAlloc;
     }
@@ -193,7 +205,7 @@ static int CommonMakeCurrent(ClientPtr client,
         GLXDrawable readdrawable,
         GLXContextID context)
 {
-    xGLXMakeCurrentReply reply = { 0 };
+    xGLXMakeCurrentReply reply = {};
     GlxContextTagInfo *oldTag = NULL;
     GlxServerVendor *newVendor = NULL;
 
@@ -201,6 +213,8 @@ static int CommonMakeCurrent(ClientPtr client,
     drawable = GlxCheckSwap(client, drawable);
     readdrawable = GlxCheckSwap(client, readdrawable);
     context = GlxCheckSwap(client, context);
+
+    SetReplyHeader(client, &reply);
 
     if (oldContextTag != 0) {
         oldTag = GlxLookupContextTag(client, oldContextTag);
@@ -229,8 +243,6 @@ static int CommonMakeCurrent(ClientPtr client,
         // TODO: For switching contexts in a single vendor, just make one
         // makeCurrent call?
 
-        // Apparently, the answer is 'no': https://github.com/X11Libre/xserver/issues/1246
-
         // TODO: When changing vendors, would it be better to do the
         // MakeCurrent(new) first, then the LoseCurrent(old)?
         // If the MakeCurrent(new) fails, then the old context will still be current.
@@ -244,6 +256,11 @@ static int CommonMakeCurrent(ClientPtr client,
             if (ret != Success) {
                 return ret;
             }
+            // Free the old tag before calling CommonMakeNewCurrent(),
+            // which may call GlxAllocContextTag() and realloc the
+            // contextTags array, invalidating the oldTag pointer.
+            GlxFreeContextTag(oldTag);
+            oldTag = NULL;
         }
 
         if (newVendor != NULL) {
@@ -254,14 +271,11 @@ static int CommonMakeCurrent(ClientPtr client,
         } else {
             reply.contextTag = 0;
         }
-
-        GlxFreeContextTag(oldTag);
-        oldTag = NULL;
     }
 
     reply.contextTag = GlxCheckSwap(client, reply.contextTag);
-
-    return X_SEND_REPLY_SIMPLE(client, reply);
+    WriteToClient(client, sz_xGLXMakeCurrentReply, &reply);
+    return Success;
 }
 
 static int dispatch_GLXMakeCurrent(ClientPtr client)

--- a/hw/xfree86/common/xf86pciBus.c
+++ b/hw/xfree86/common/xf86pciBus.c
@@ -1156,7 +1156,16 @@ xf86VideoPtrToDriverList(struct pci_device *dev, XF86MatchedDrivers *md)
 		case 0x0bef:
 			/* Use fbdev/vesa driver on Oaktrail, Medfield, CDV */
 			break;
-		default:
+		/* Default to intel only on pre-gen3 chips */
+		case 0x7121:
+		case 0x7123:
+		case 0x7125:
+		case 0x1132:
+		case 0x3577:
+		case 0x2562:
+		case 0x3582:
+		case 0x358e:
+		case 0x2572:
 			driverList[0] = "intel";
 			break;
         }

--- a/mi/miglblt.c
+++ b/mi/miglblt.c
@@ -140,7 +140,7 @@ miPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int ngly
         pglyph = FONTGLYPHBITS(pglyphBase, pci);
         gWidth = GLYPHWIDTHPIXELS(pci);
         gHeight = GLYPHHEIGHTPIXELS(pci);
-        if (gWidth && gHeight) {
+        if (gWidth > 0 && gHeight > 0) {
             nbyGlyphWidth = GLYPHWIDTHBYTESPADDED(pci);
             nbyPadGlyph = BitmapBytePad(gWidth);
 

--- a/mi/miglblt.c
+++ b/mi/miglblt.c
@@ -44,7 +44,9 @@ SOFTWARE.
 
 ******************************************************************/
 
+#ifdef HAVE_DIX_CONFIG_H
 #include <dix-config.h>
+#endif
 
 #include	<X11/X.h>
 #include	<X11/Xmd.h>
@@ -79,7 +81,7 @@ with the sample server.
 */
 
 void
-miPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int nglyph, CharInfoPtr * ppci,  /* array of character info */
+miPolyGlyphBlt(DrawablePtr pDrawable, GC * pGC, int x, int y, unsigned int nglyph, CharInfoPtr * ppci,  /* array of character info */
                void *pglyphBase       /* start of array of glyphs */
     )
 {
@@ -118,7 +120,7 @@ miPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int ngly
 
     pGCtmp = GetScratchGC(1, pDrawable->pScreen);
     if (!pGCtmp) {
-        dixDestroyPixmap(pPixmap, 0);
+        (*pDrawable->pScreen->DestroyPixmap) (pPixmap);
         return;
     }
 
@@ -126,12 +128,13 @@ miPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int ngly
     gcvals[1].val = 1;
     gcvals[2].val = 0;
 
-    ChangeGC(NULL, pGCtmp, GCFunction | GCForeground | GCBackground, gcvals);
+    ChangeGC(NullClient, pGCtmp, GCFunction | GCForeground | GCBackground,
+             gcvals);
 
     nbyLine = BitmapBytePad(width);
-    pbits = calloc(height, nbyLine);
+    pbits = xallocarray(height, nbyLine);
     if (!pbits) {
-        dixDestroyPixmap(pPixmap, 0);
+        (*pDrawable->pScreen->DestroyPixmap) (pPixmap);
         FreeScratchGC(pGCtmp);
         return;
     }
@@ -173,13 +176,13 @@ miPolyGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int ngly
         }
         x += pci->metrics.characterWidth;
     }
-    dixDestroyPixmap(pPixmap, 0);
+    (*pDrawable->pScreen->DestroyPixmap) (pPixmap);
     free(pbits);
     FreeScratchGC(pGCtmp);
 }
 
 void
-miImageGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int nglyph, CharInfoPtr * ppci, /* array of character info */
+miImageGlyphBlt(DrawablePtr pDrawable, GC * pGC, int x, int y, unsigned int nglyph, CharInfoPtr * ppci, /* array of character info */
                 void *pglyphBase      /* start of array of glyphs */
     )
 {
@@ -210,13 +213,13 @@ miImageGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int ngl
     gcvals[0].val = GXcopy;
     gcvals[1].val = pGC->bgPixel;
     gcvals[2].val = FillSolid;
-    ChangeGC(NULL, pGC, GCFunction | GCForeground | GCFillStyle, gcvals);
+    ChangeGC(NullClient, pGC, GCFunction | GCForeground | GCFillStyle, gcvals);
     ValidateGC(pDrawable, pGC);
     (*pGC->ops->PolyFillRect) (pDrawable, pGC, 1, &backrect);
 
     /* put down the glyphs */
     gcvals[0].val = oldFG;
-    ChangeGC(NULL, pGC, GCForeground, gcvals);
+    ChangeGC(NullClient, pGC, GCForeground, gcvals);
     ValidateGC(pDrawable, pGC);
     (*pGC->ops->PolyGlyphBlt) (pDrawable, pGC, x, y, nglyph, ppci, pglyphBase);
 
@@ -224,7 +227,7 @@ miImageGlyphBlt(DrawablePtr pDrawable, GCPtr pGC, int x, int y, unsigned int ngl
     gcvals[0].val = oldAlu;
     gcvals[1].val = oldFG;
     gcvals[2].val = oldFS;
-    ChangeGC(NULL, pGC, GCFunction | GCForeground | GCFillStyle, gcvals);
+    ChangeGC(NullClient, pGC, GCFunction | GCForeground | GCFillStyle, gcvals);
     ValidateGC(pDrawable, pGC);
 
 }


### PR DESCRIPTION
glx: free old context tag before allocating new one in CommonMakeCurrent

oldTag in CommonMakeCurrent() is a pointer to cl->contextTags[...].
CommonMakeCurrent() may realloc(cl->contextTags) and thus move the
memory, leaving oldTag as dangling pointer.

If we then GlxFreeContextTag(oldTag) we end up writing into freed
memory.

Fix this by freeing oldTag before CommonMakeNewCurrent().

This vulnerability was discovered by:
Anonymous working with Trend Micro Zero Day Initiative

CVE-2026-56000/ZDI-CAN-30561

Fixes: 4781f2a5a8c2 ("GLX: Free the tag of the old context later")
Assisted-by: Claude:claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2250>
(cherry picked from commit 2779affbdb4354e894f490e56f962527d6125043)

(cherry picked from commit 2779affbdb4354e894f490e56f962527d6125043)

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>