### PR TITLE
glamor: reject fonts with per-glyph metrics exceeding maxbounds

### DIFF
--- a/fb/fbpixmap.c
+++ b/fb/fbpixmap.c
@@ -41,14 +41,29 @@ fbCreatePixmap(ScreenPtr pScreen, int width, int height, int depth,
     int base;
     int bpp = BitsPerPixel(depth);
 
+    /* Check for integer overflow in width * bpp */
+    if (bpp > 0 && width > INT_MAX / (size_t)bpp)
+        return NullPixmap;
+    /* Check for overflow in the calculation of paddedWidth */
+    {
+        size_t width_bytes = (size_t)width * (size_t)bpp;
+        if (width_bytes > (SIZE_MAX - FB_MASK) >> FB_SHIFT)
+            return NullPixmap;
+    }
     paddedWidth = ((width * bpp + FB_MASK) >> FB_SHIFT) * sizeof(FbBits);
     if (paddedWidth / 4 > 32767 || height > 32767)
+        return NullPixmap;
+    /* Check for integer overflow in height * paddedWidth */
+    if (paddedWidth > 0 && (size_t)height > SIZE_MAX / paddedWidth)
         return NullPixmap;
     datasize = height * paddedWidth;
     base = pScreen->totalPixmapSize;
     adjust = 0;
     if (base & 7)
         adjust = 8 - (base & 7);
+    /* Check for overflow in datasize + adjust */
+    if (datasize > SIZE_MAX - (size_t)adjust)
+        return NullPixmap;
     datasize += adjust;
 #ifdef FB_DEBUG
     datasize += 2 * paddedWidth;

--- a/glamor/glamor_font.c
+++ b/glamor/glamor_font.c
@@ -76,6 +76,9 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
     glyph_width_pixels = font->info.maxbounds.rightSideBearing - font->info.minbounds.leftSideBearing;
     glyph_height = font->info.maxbounds.ascent + font->info.maxbounds.descent;
 
+    if (glyph_width_pixels <= 0 || glyph_height <= 0)
+        return NULL;
+
     glyph_width_bytes = (glyph_width_pixels + 7) >> 3;
 
     glamor_font->glyph_width_pixels = glyph_width_pixels;
@@ -135,7 +138,28 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
             if (count) {
                 char *dst;
                 char *src = glyph->bits;
-                unsigned y;
+                int gw = GLYPHWIDTHBYTES(glyph);
+                int gh = GLYPHHEIGHTPIXELS(glyph);
+
+                /* Reject fonts where any per-glyph metric is negative
+                 * or exceeds the atlas slot size derived from maxbounds.
+                 * The PCF parser in libXfont2 does not recompute
+                 * maxbounds from per-glyph data, so a crafted PCF file
+                 * can violate the maxbounds invariant.
+                 *
+                 * gw is passed as size_t to memcpy and a negative value
+                 * would thus result in OOB access.
+                 *
+                 * Returning NULL makes glamor fall back to software
+                 * rendering.
+                 */
+                if (gw < 0 || gh < 0 ||
+                    gw > glyph_width_bytes || gh > glyph_height) {
+                    glDeleteTextures(1, &glamor_font->texture_id);
+                    glamor_font->texture_id = 0;
+                    free(bits);
+                    return NULL;
+                }
 
                 dst = bits;
                 /* get offset of start of first row */
@@ -144,8 +168,8 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
                 dst += (row & 1) ? glamor_font->row_width : 0;
 
                 dst += col * glyph_width_bytes;
-                for (y = 0; y < GLYPHHEIGHTPIXELS(glyph); y++) {
-                    memcpy(dst, src, GLYPHWIDTHBYTES(glyph));
+                for (int y = 0; y < gh; y++) {
+                    memcpy(dst, src, gw);
                     dst += overall_width;
                     src += GLYPHWIDTHBYTESPADDED(glyph);
                 }

--- a/glx/vndcmds.c
+++ b/glx/vndcmds.c
@@ -103,12 +103,14 @@ static void SetReplyHeader(ClientPtr client, void *replyPtr)
 
 static int dispatch_GLXQueryVersion(ClientPtr client)
 {
-    xGLXQueryVersionReply reply;
     REQUEST_SIZE_MATCH(xGLXQueryVersionReq);
 
+    xGLXQueryVersionReply reply = {
+        .majorVersion = GlxCheckSwap(client, 1),
+        .minorVersion = GlxCheckSwap(client, 4),
+    };
+
     SetReplyHeader(client, &reply);
-    reply.majorVersion = GlxCheckSwap(client, 1);
-    reply.minorVersion = GlxCheckSwap(client, 4);
 
     WriteToClient(client, sizeof(xGLXQueryVersionReply), &reply);
     return Success;

--- a/hw/xfree86/common/xf86fbman.c
+++ b/hw/xfree86/common/xf86fbman.c
@@ -876,6 +876,11 @@ localAllocateOffscreenLinear(ScreenPtr pScreen,
             /* pitch and granularity aren't a perfect match, let's allocate
              * a bit more so we can align later on
              */
+            /* Check for integer overflow before addition */
+            if (length > INT_MAX - (gran - 1)) {
+                free(link);
+                return NULL;
+            }
             length += gran - 1;
         }
     }
@@ -886,7 +891,19 @@ localAllocateOffscreenLinear(ScreenPtr pScreen,
     }
     else {
         w = pitch;
-        h = (length + pitch - 1) / pitch;
+        /* Calculate h = ceil(length / pitch) safely without overflow */
+        if (pitch <= 0) {
+            free(link);
+            return NULL;
+        }
+        /* (length + pitch - 1) can overflow, use alternative */
+        h = (length - 1) / pitch + 1;
+    }
+
+    /* Check for overflow in h * w (both int, result stored in int) */
+    if (h > 0 && w > INT_MAX / h) {
+        free(link);
+        return NULL;
     }
 
     if ((area = localAllocateOffscreenArea(pScreen, w, h, gran,

--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
@@ -3690,7 +3690,28 @@ drmmode_xf86crtc_resize(ScrnInfoPtr scrn, int width, int height)
     }
 
     if (drmmode->shadow_enable) {
-        uint32_t size = scrn->displayWidth * scrn->virtualY * cpp;
+        size_t size_bytes;
+        uint32_t size;
+
+        /* Check for zero dimensions */
+        if (scrn->displayWidth == 0 || scrn->virtualY == 0 || cpp == 0)
+            goto fail;
+
+        /* Check for overflow in width * height */
+        if ((size_t)scrn->displayWidth > SIZE_MAX / (size_t)scrn->virtualY)
+            goto fail;
+        size_bytes = (size_t)scrn->displayWidth * (size_t)scrn->virtualY;
+
+        /* Check for overflow in size_bytes * cpp */
+        if (size_bytes > SIZE_MAX / (size_t)cpp)
+            goto fail;
+        size_bytes *= (size_t)cpp;
+
+        /* Ensure the result fits in uint32_t */
+        if (size_bytes > UINT32_MAX)
+            goto fail;
+        size = (uint32_t)size_bytes;
+
         new_pixels = calloc(1, size);
         if (new_pixels == NULL)
             goto fail;
@@ -3699,7 +3720,24 @@ drmmode_xf86crtc_resize(ScrnInfoPtr scrn, int width, int height)
     }
 
     if (drmmode->shadow_enable2) {
-        uint32_t size = scrn->displayWidth * scrn->virtualY * cpp;
+        size_t size_bytes;
+        uint32_t size;
+
+        if (scrn->displayWidth == 0 || scrn->virtualY == 0 || cpp == 0)
+            goto fail;
+
+        if ((size_t)scrn->displayWidth > SIZE_MAX / (size_t)scrn->virtualY)
+            goto fail;
+        size_bytes = (size_t)scrn->displayWidth * (size_t)scrn->virtualY;
+
+        if (size_bytes > SIZE_MAX / (size_t)cpp)
+            goto fail;
+        size_bytes *= (size_t)cpp;
+
+        if (size_bytes > UINT32_MAX)
+            goto fail;
+        size = (uint32_t)size_bytes;
+
         void *fb2 = calloc(1, size);
         free(drmmode->shadow_fb2);
         drmmode->shadow_fb2 = fb2;

--- a/hw/xnest/Color.c
+++ b/hw/xnest/Color.c
@@ -102,7 +102,12 @@ xnestCreateColormap(ColormapPtr pCmap)
     case StaticGray:           /* read only */
     case StaticColor:          /* read only */
     {
-        uint32_t *colors = malloc(ncolors * sizeof(uint32_t));
+        uint32_t *colors;
+        if (ncolors > SIZE_MAX / sizeof(uint32_t))
+            return FALSE;
+        colors = malloc(ncolors * sizeof(uint32_t));
+        if (!colors)
+            return FALSE;
         for (int i = 0; i < ncolors; i++)
             colors[i] = i;
         return load_colormap(pCmap, ncolors, colors);
@@ -111,7 +116,12 @@ xnestCreateColormap(ColormapPtr pCmap)
 
     case TrueColor:            /* read only */
     {
-        uint32_t *colors = malloc(ncolors * sizeof(uint32_t));
+        uint32_t *colors;
+        if (ncolors > SIZE_MAX / sizeof(uint32_t))
+            return FALSE;
+        colors = malloc(ncolors * sizeof(uint32_t));
+        if (!colors)
+            return FALSE;
         Pixel red = 0, redInc = lowbit(pVisual->redMask);
         Pixel green = 0, greenInc = lowbit(pVisual->greenMask);
         Pixel blue = 0, blueInc = lowbit(pVisual->blueMask);

--- a/hw/xquartz/mach-startup/bundle-main.c
+++ b/hw/xquartz/mach-startup/bundle-main.c
@@ -268,7 +268,20 @@ create_socket(char *filename_out)
     size_t try, try_max;
 
     for (try = 0, try_max = 5; try < try_max; try++) {
-        tmpnam(filename_out);
+        /* Generate a unique temporary filename using mkstemp to avoid
+           symlink attacks and race conditions. */
+        char template[PATH_MAX];
+        int fd;
+
+        snprintf(template, sizeof(template), "%s/xorg-XXXXXX", P_tmpdir);
+        fd = mkstemp(template);
+        if (fd == -1) {
+            ErrorF("X11.app: mkstemp failed: %s\n", strerror(errno));
+            continue;
+        }
+        close(fd);
+        unlink(template);
+        strlcpy(filename_out, template, PATH_MAX);
 
         /* Setup servaddr_un */
         memset(&servaddr_un, 0, sizeof(struct sockaddr_un));

--- a/hw/xquartz/xpr/xprScreen.c
+++ b/hw/xquartz/xpr/xprScreen.c
@@ -224,6 +224,8 @@ xprAddPseudoramiXScreens(int *x, int *y, int *width, int *height,
     if (CGDisplayIsCaptured(kCGDirectMainDisplay))
         displayCount = 1;
 
+    if (displayCount > SIZE_MAX / sizeof(CGDirectDisplayID))
+        FatalError("Invalid display count for allocation.\n");
     displayList = malloc(displayCount * sizeof(CGDirectDisplayID));
     if (!displayList)
         FatalError("Unable to allocate memory for list of displays.\n");

--- a/hw/xwin/winmultiwindowwm.c
+++ b/hw/xwin/winmultiwindowwm.c
@@ -902,6 +902,7 @@ winMultiWindowWMProc(void *pArg)
                -- independently, the WM_TAKE_FOCUS protocol determines whether
                the WM should send a WM_TAKE_FOCUS ClientMessage.
             */
+            if (pNode->msg.iWindow)
             {
               Bool neverFocus = FALSE;
               xcb_get_property_cookie_t cookie;
@@ -924,6 +925,13 @@ winMultiWindowWMProc(void *pArg)
                 SendXMessage(pWMInfo->conn,
                              pNode->msg.iWindow,
                              pWMInfo->atmWmProtos, pWMInfo->atmWmTakeFocus);
+
+            }
+            else
+            /* Set the input focus to none */
+            {
+              xcb_set_input_focus(pWMInfo->conn, XCB_INPUT_FOCUS_NONE,
+                                  XCB_NONE, XCB_CURRENT_TIME);
 
             }
             break;

--- a/hw/xwin/winmultiwindowwndproc.c
+++ b/hw/xwin/winmultiwindowwndproc.c
@@ -821,9 +821,13 @@ winTopLevelWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
         /* Remove our keyboard hook if it is installed */
         winRemoveKeyboardHookLL();
 
-        /* Revert the X focus as well, but only if the Windows focus is going to another window */
-        if (!wParam && pWin)
-            DeleteWindowFromAnyEvents(pWin, FALSE);
+        /* Revert the X focus as well */
+        if (fWMMsgInitialized)
+            {
+                wmMsg.msg = WM_WM_ACTIVATE;
+                wmMsg.iWindow = 0;
+                winSendMessageToWM(s_pScreenPriv->pWMInfo, &wmMsg);
+            }
 
         return 0;
 

--- a/hw/xwin/winprefs.c
+++ b/hw/xwin/winprefs.c
@@ -514,12 +514,21 @@ LoadImageComma(char *fname, char *iconDirectory, int sx, int sy, int flags)
                           MAKEINTRESOURCE(i), IMAGE_ICON, sx, sy, flags);
     }
     else {
-        char *file = calloc(1, PATH_MAX + NAME_MAX + 2);
+        size_t len_icon = 0, len_fname = strlen(fname);
+        size_t needed;
+        char *file;
 
+        if (iconDirectory)
+            len_icon = strlen(iconDirectory);
+        needed = len_icon;
+        if (len_icon > 0 && iconDirectory[len_icon - 1] != '\\')
+            needed++;  // space for backslash
+        needed += len_fname + 1; // +1 for null terminator
+
+        file = malloc(needed);
         if (!file)
             return NULL;
-
-        file[0] = 0;
+        file[0] = '\0';
 
         /* If fname starts 'X:\', it's an absolute Windows path, do nothing */
         if (!(fname[0] && fname[1] == ':' && fname[2] == '\\')) {
@@ -527,9 +536,8 @@ LoadImageComma(char *fname, char *iconDirectory, int sx, int sy, int flags)
                 /* Otherwise, prepend the default icon directory, which
                    currently must be in absolute Windows path form */
                 strcpy(file, iconDirectory);
-                if (iconDirectory[0])
-                    if (iconDirectory[strlen(iconDirectory) - 1] != '\\')
-                        strcat(file, "\\");
+                if (iconDirectory[0] && file[strlen(file) - 1] != '\\')
+                    strcat(file, "\\");
             }
         }
         strcat(file, fname);
@@ -657,11 +665,11 @@ LoadPreferences(void)
     /* Now try and find a ~/.xwinrc file */
     home = getenv("HOME");
     if (home) {
-        strcpy(fname, home);
-        if (fname[strlen(fname) - 1] != '/')
-            strcat(fname, "/");
-        strcat(fname, ".XWinrc");
-        parsed = winPrefsLoadPreferences(fname);
+        if (snprintf(fname, sizeof(fname), "%s/.XWinrc", home) >= (int)sizeof(fname)) {
+            ErrorF("HOME path too long, ignoring ~/.XWinrc\n");
+        } else {
+            parsed = winPrefsLoadPreferences(fname);
+        }
     }
 
     /* No home file found, check system default */

--- a/xkb/ddxLoad.c
+++ b/xkb/ddxLoad.c
@@ -38,6 +38,10 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XKM.h>
 
+#ifdef WIN32
+#include <windows.h>
+#endif
+
 #include "dix/dix_priv.h"
 #include "os/log_priv.h"
 #include "os/osdep.h"
@@ -60,6 +64,32 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #else
 #define PATHSEPARATOR "/"
 #endif
+
+/* Validate that a path contains only safe characters (alphanumeric, /, \, :, ., _, -)
+   to prevent command injection when passed to system() or popen(). */
+static Bool
+safe_path(const char *path)
+{
+    if (!path)
+        return FALSE;
+    for (; *path; path++) {
+        unsigned char c = (unsigned char)*path;
+        if (isalnum(c))
+            continue;
+        switch (c) {
+        case '/':
+        case '\\':
+        case ':':
+        case '.':
+        case '_':
+        case '-':
+            break;
+        default:
+            return FALSE;
+        }
+    }
+    return TRUE;
+}
 
 static unsigned
 LoadXKM(unsigned want, unsigned need, const char *keymap, XkbDescPtr *xkbRtrn);
@@ -121,39 +151,55 @@ RunXkbComp(xkbcomp_buffer_callback callback, void *userdata)
     const char *xkbbindir = emptystring;
     const char *xkbbindirsep = emptystring;
 
-#ifdef WIN32
-    /* WIN32 has no popen. The input must be stored in a file which is
-       used as input for xkbcomp. xkbcomp does not read from stdin. */
-    char tmpname[PATH_MAX] = { 0 };
-    const char *xkmfile = tmpname;
-#else
-    const char *xkmfile = "-";
-#endif
+ #ifdef WIN32
+     /* WIN32 has no popen. The input must be stored in a file which is
+        used as input for xkbcomp. xkbcomp does not read from stdin. */
+     char tmpname[PATH_MAX] = { 0 };
+     const char *xkmfile = tmpname;
+ #else
+     const char *xkmfile = "-";
+ #endif
 
-    snprintf(keymap, sizeof(keymap), "server-%s", display);
+     snprintf(keymap, sizeof(keymap), "server-%s", display);
 
-    OutputDirectory(xkm_output_dir, sizeof(xkm_output_dir));
+     OutputDirectory(xkm_output_dir, sizeof(xkm_output_dir));
 
-#ifdef WIN32
-    strcpy(tmpname, Win32TempDir());
-    strcat(tmpname, "\\xkb_XXXXXX");
-    (void) mktemp(tmpname);
-#endif
+ #ifdef WIN32
+     /* Secure temporary file creation: GetTempFileName atomically creates
+        a unique file, avoiding race conditions and symlink attacks. */
+     if (!GetTempFileNameA(Win32TempDir(), "xkb", 0, tmpname)) {
+         LogMessage(X_ERROR, "XKB: Failed to create temporary file\n");
+         free(buf);
+         return NULL;
+     }
+ #endif
 
-    if (XkbBaseDirectory != NULL) {
-        if (asprintf(&xkbbasedirflag, "\"-R%s\"", XkbBaseDirectory) == -1)
-            xkbbasedirflag = NULL;
-    }
+     if (XkbBaseDirectory != NULL) {
+         /* Validate to prevent command injection */
+         if (!safe_path(XkbBaseDirectory)) {
+             LogMessage(X_ERROR, "XKB: XkbBaseDirectory contains unsafe characters\n");
+             free(buf);
+             return NULL;
+         }
+         if (asprintf(&xkbbasedirflag, "\"-R%s\"", XkbBaseDirectory) == -1)
+             xkbbasedirflag = NULL;
+     }
 
-    if (XkbBinDirectory != NULL) {
-        int ld = strlen(XkbBinDirectory);
-        int lps = strlen(PATHSEPARATOR);
+     if (XkbBinDirectory != NULL) {
+         /* Validate to prevent command injection */
+         if (!safe_path(XkbBinDirectory)) {
+             LogMessage(X_ERROR, "XKB: XkbBinDirectory contains unsafe characters\n");
+             free(buf);
+             return NULL;
+         }
+         int ld = strlen(XkbBinDirectory);
+         int lps = strlen(PATHSEPARATOR);
 
-        xkbbindir = XkbBinDirectory;
+         xkbbindir = XkbBinDirectory;
 
-        if ((ld >= lps) && (strcmp(xkbbindir + ld - lps, PATHSEPARATOR) != 0)) {
-            xkbbindirsep = PATHSEPARATOR;
-        }
+         if ((ld >= lps) && (strcmp(xkbbindir + ld - lps, PATHSEPARATOR) != 0)) {
+             xkbbindirsep = PATHSEPARATOR;
+         }
     }
 
     if (asprintf(&buf,


### PR DESCRIPTION
glamor: reject fonts with per-glyph metrics exceeding maxbounds

glamor_font_get() computes the atlas slot size from the font's declared
maxbounds, but copies each glyph's bitmap using the per-glyph metrics
(GLYPHHEIGHTPIXELS/GLYPHWIDTHBYTES macros). When a malicious PCF font
has per-glyph metrics exceeding maxbounds, the memcpy writes past the
heap-allocated atlas buffer. Negative per-glyph metrics are even worse:
the loop counter wraps to ~4 billion iterations (via unsigned cast) or
memcpy's size parameter wraps to SIZE_MAX.

The PCF parser in libXfont2 does not recompute maxbounds from per-glyph
data (only the BDF parser does), so the file's declared maxbounds values
are trusted as-is.

Reject fonts where any per-glyph metric is negative or exceeds the
atlas slot size, falling back to software rendering which uses per-glyph
metrics directly without an atlas.

This vulnerability was discovered by:
Anonymous working with Trend Micro Zero Day Initiative

CVE-2026-55999/ZDI-CAN-30498

Assisted-by: Claude:claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2250>
(cherry picked from commit fbf7bac22e2c6bd627fb042742a23318263edae1)

CVE-2026-55999/ZDI-CAN-30498

(cherry picked from commit fbf7bac22e2c6bd627fb042742a23318263edae1)

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>