### PR TITLE
(release/25.1) glamor: reject fonts with per-glyph metrics exceeding maxbounds

### DIFF
--- a/glamor/glamor_font.c
+++ b/glamor/glamor_font.c
@@ -30,6 +30,7 @@
 #include "glamor_font.h"
 #include <dixfontstr.h>
 
+static int glamor_font_generation;
 static int glamor_font_private_index;
 static int glamor_font_screen_count;
 
@@ -50,6 +51,7 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
     unsigned char       c[2];
     CharInfoPtr         glyph;
     unsigned long       count;
+    char                *bits;
 
     if (!glamor_glsl_has_ints(glamor_priv))
         return NULL;
@@ -100,7 +102,7 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
         /* fallback if we don't fit inside a texture */
         return NULL;
     }
-    char *bits = calloc(overall_width, overall_height);
+    bits = malloc(overall_width * overall_height);
     if (!bits)
         return NULL;
 
@@ -220,10 +222,13 @@ glamor_font_init(ScreenPtr screen)
     if (!glamor_glsl_has_ints(glamor_priv))
         return TRUE;
 
-    glamor_font_private_index = xfont2_allocate_font_private_index();
-    if (glamor_font_private_index == -1)
-        return FALSE;
-    glamor_font_screen_count = 0;
+    if (glamor_font_generation != serverGeneration) {
+        glamor_font_private_index = xfont2_allocate_font_private_index();
+        if (glamor_font_private_index == -1)
+            return FALSE;
+        glamor_font_screen_count = 0;
+        glamor_font_generation = serverGeneration;
+    }
 
     if (screen->myNum >= glamor_font_screen_count)
         glamor_font_screen_count = screen->myNum + 1;


### PR DESCRIPTION
glamor_font_get() computes the atlas slot size from the font's declared
maxbounds, but copies each glyph's bitmap using the per-glyph metrics
(GLYPHHEIGHTPIXELS/GLYPHWIDTHBYTES macros). When a malicious PCF font
has per-glyph metrics exceeding maxbounds, the memcpy writes past the
heap-allocated atlas buffer. Negative per-glyph metrics are even worse:
the loop counter wraps to ~4 billion iterations (via unsigned cast) or
memcpy's size parameter wraps to SIZE_MAX.

The PCF parser in libXfont2 does not recompute maxbounds from per-glyph
data (only the BDF parser does), so the file's declared maxbounds values
are trusted as-is.

Reject fonts where any per-glyph metric is negative or exceeds the
atlas slot size, falling back to software rendering which uses per-glyph
metrics directly without an atlas.

This vulnerability was discovered by:
Anonymous working with Trend Micro Zero Day Initiative

CVE-2026-55999/ZDI-CAN-30498

Assisted-by: Claude:claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2250>
(cherry picked from commit fbf7bac22e2c6bd627fb042742a23318263edae1)
