### PR TITLE
xfree86/parser: Removal of xf86freeConfig() to something local and new

### DIFF
--- a/hw/xfree86/parser/read.c
+++ b/hw/xfree86/parser/read.c
@@ -64,8 +64,6 @@ static const xf86ConfigSymTabRec TopLevelTab[] = {
     {-1, ""},
 };
 
-#define CLEANUP xf86freeConfig
-
 /*
  * This function resolves name references and reports errors if the named
  * objects cannot be found.
@@ -103,7 +101,7 @@ xf86readConfigFile(void)
         case SECTION:
             if (xf86getSubToken(&(ptr->conf_comment)) != XF86_TOKEN_STRING) {
                 xf86parseError(QUOTE_MSG, "Section");
-                CLEANUP(ptr);
+                clearConfig(ptr);
                 return NULL;
             }
             xf86setSection(xf86_lex_val.str);
@@ -214,12 +212,10 @@ xf86readConfigFile(void)
     if (xf86validateConfig(ptr))
         return ptr;
     else {
-        CLEANUP(ptr);
+        clearConfig(ptr);
         return NULL;
     }
 }
-
-#undef CLEANUP
 
 /*
  * adds an item to the end of the linked list. Any record whose first field
@@ -283,26 +279,28 @@ XF86ConfigPtr xf86allocateConfig(void)
     return xf86configptr;
 }
 
-void
-xf86freeConfig(XF86ConfigPtr p)
+static void
+clearConfig(XF86ConfigPtr config_pointer)
 {
-    if (p == NULL)
+    if(config_pointer == NULL)
+    {
         return;
+    }
 
-    xf86freeFiles(p->conf_files);
-    xf86freeModules(p->conf_modules);
-    xf86freeFlags(p->conf_flags);
-    xf86freeMonitorList(p->conf_monitor_lst);
-    xf86freeModesList(p->conf_modes_lst);
-    xf86freeVideoAdaptorList(p->conf_videoadaptor_lst);
-    xf86freeDeviceList(p->conf_device_lst);
-    xf86freeScreenList(p->conf_screen_lst);
-    xf86freeLayoutList(p->conf_layout_lst);
-    xf86freeInputList(p->conf_input_lst);
-    xf86freeVendorList(p->conf_vendor_lst);
-    xf86freeDRI(p->conf_dri);
-    xf86freeExtensions(p->conf_extensions);
-    TestFree(p->conf_comment);
+    xf86freeFiles(config_pointer->conf_files);
+    xf86freeModules(config_pointer->conf_modules);
+    xf86freeFlags(config_pointer->conf_flags);
+    xf86freeMonitorList(config_pointer->conf_monitor_lst);
+    xf86freeModesList(config_pointer->conf_modes_lst);
+    xf86freeVideoAdaptorList(config_pointer->conf_videoadaptor_lst);
+    xf86freeDeviceList(config_pointer->conf_device_lst);
+    xf86freeScreenList(config_pointer->conf_screen_lst);
+    xf86freeLayoutList(config_pointer->conf_layout_lst);
+    xf86freeInputList(config_pointer->conf_input_lst);
+    xf86freeVendorList(config_pointer->conf_vendor_lst);
+    xf86freeDRI(config_pointer->conf_dri);
+    xf86freeExtensions(config_pointer->conf_extensions);
+    TestFree(config_pointer->conf_comment);
 
-    free(p);
+    free(config_pointer);
 }

--- a/hw/xfree86/parser/read.c
+++ b/hw/xfree86/parser/read.c
@@ -58,6 +58,33 @@
 #include "xf86tokens.h"
 #include "Configint.h"
 
+static void
+clearConfig(XF86ConfigPtr config_pointer)
+{
+    if(config_pointer == NULL)
+    {
+        return;
+    }
+
+    xf86freeFiles(config_pointer->conf_files);
+    xf86freeModules(config_pointer->conf_modules);
+    xf86freeFlags(config_pointer->conf_flags);
+    xf86freeMonitorList(config_pointer->conf_monitor_lst);
+    xf86freeModesList(config_pointer->conf_modes_lst);
+    xf86freeVideoAdaptorList(config_pointer->conf_videoadaptor_lst);
+    xf86freeDeviceList(config_pointer->conf_device_lst);
+    xf86freeScreenList(config_pointer->conf_screen_lst);
+    xf86freeLayoutList(config_pointer->conf_layout_lst);
+    xf86freeInputList(config_pointer->conf_input_lst);
+    xf86freeVendorList(config_pointer->conf_vendor_lst);
+    xf86freeDRI(config_pointer->conf_dri);
+    xf86freeExtensions(config_pointer->conf_extensions);
+    TestFree(config_pointer->conf_comment);
+
+    free(config_pointer);
+}
+
+#define CLEANUP clearConfig
 
 static const xf86ConfigSymTabRec TopLevelTab[] = {
     {SECTION, "section"},
@@ -216,7 +243,7 @@ xf86readConfigFile(void)
         return NULL;
     }
 }
-
+#undef CLEANUP
 /*
  * adds an item to the end of the linked list. Any record whose first field
  * is a GenericListRec can be cast to this type and used with this function.
@@ -277,30 +304,4 @@ XF86ConfigPtr xf86allocateConfig(void)
         xf86configptr = calloc(1, sizeof(XF86ConfigRec));
     }
     return xf86configptr;
-}
-
-static void
-clearConfig(XF86ConfigPtr config_pointer)
-{
-    if(config_pointer == NULL)
-    {
-        return;
-    }
-
-    xf86freeFiles(config_pointer->conf_files);
-    xf86freeModules(config_pointer->conf_modules);
-    xf86freeFlags(config_pointer->conf_flags);
-    xf86freeMonitorList(config_pointer->conf_monitor_lst);
-    xf86freeModesList(config_pointer->conf_modes_lst);
-    xf86freeVideoAdaptorList(config_pointer->conf_videoadaptor_lst);
-    xf86freeDeviceList(config_pointer->conf_device_lst);
-    xf86freeScreenList(config_pointer->conf_screen_lst);
-    xf86freeLayoutList(config_pointer->conf_layout_lst);
-    xf86freeInputList(config_pointer->conf_input_lst);
-    xf86freeVendorList(config_pointer->conf_vendor_lst);
-    xf86freeDRI(config_pointer->conf_dri);
-    xf86freeExtensions(config_pointer->conf_extensions);
-    TestFree(config_pointer->conf_comment);
-
-    free(config_pointer);
 }

--- a/hw/xfree86/parser/xf86Parser_priv.h
+++ b/hw/xfree86/parser/xf86Parser_priv.h
@@ -21,7 +21,6 @@ void xf86setBuiltinConfig(const char *config[]);
 XF86ConfigPtr xf86readConfigFile(void);
 void xf86closeConfigFile(void);
 XF86ConfigPtr xf86allocateConfig(void);
-void xf86freeConfig(XF86ConfigPtr p);
 int xf86writeConfigFile(const char *filename, XF86ConfigPtr cptr);
 int xf86layoutAddInputDevices(XF86ConfigPtr config, XF86ConfLayoutPtr layout);
 


### PR DESCRIPTION
it exists on xf86Parser_priv.h and is only used in read.c and there is a simple macro that i dont really see much use of in this context. I also renamed it to clearConfig to be more modern and readable.

Signed-off-by: RotaryBoot58 <petersoncraft20@proton.me>