### PR TITLE
xfree86/parser: remove obsolete tokens from Files.c

### DIFF
--- a/hw/xfree86/parser/Files.c
+++ b/hw/xfree86/parser/Files.c
@@ -1,59 +1,5 @@
-/*
- * Copyright (c) 1997  Metro Link Incorporated
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
- * THE X CONSORTIUM BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
- * OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- * Except as contained in this notice, the name of the Metro Link shall not be
- * used in advertising or otherwise to promote the sale, use or other dealings
- * in this Software without prior written authorization from Metro Link.
- *
- */
-/*
- * Copyright (c) 1997-2003 by The XFree86 Project, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
- *
- * Except as contained in this notice, the name of the copyright holder(s)
- * and author(s) shall not be used in advertising or otherwise to promote
- * the sale, use or other dealings in this Software without prior written
- * authorization from the copyright holder(s) and author(s).
- */
 #include <xorg-config.h>
-
 #include <assert.h>
-
 #include <X11/Xos.h>
 #include "xf86Parser.h"
 #include "xf86tokens.h"
@@ -66,9 +12,6 @@ static const xf86ConfigSymTabRec FilesTab[] = {
     {MODULEPATH, "modulepath"},
     {LOGFILEPATH, "logfile"},
     {XKBDIR, "xkbdir"},
-    /* Obsolete keywords that aren't used but shouldn't cause errors: */
-    {OBSOLETE_TOKEN, "rgbpath"},
-    {OBSOLETE_TOKEN, "inputdevices"},
     {-1, ""},
 };
 
@@ -159,10 +102,6 @@ xf86parseFilesSection(XF86ConfFilesPtr ptr)
             break;
         case EOF_TOKEN:
             Error(UNEXPECTED_EOF_MSG);
-            break;
-        case OBSOLETE_TOKEN:
-            xf86parseError(OBSOLETE_MSG, xf86tokenString());
-            xf86getSubToken(&(ptr->file_comment));
             break;
         default:
             Error(INVALID_KEYWORD_MSG, xf86tokenString());

--- a/hw/xfree86/parser/read.c
+++ b/hw/xfree86/parser/read.c
@@ -64,8 +64,6 @@ static const xf86ConfigSymTabRec TopLevelTab[] = {
     {-1, ""},
 };
 
-#define CLEANUP xf86freeConfig
-
 /*
  * This function resolves name references and reports errors if the named
  * objects cannot be found.
@@ -103,7 +101,7 @@ xf86readConfigFile(void)
         case SECTION:
             if (xf86getSubToken(&(ptr->conf_comment)) != XF86_TOKEN_STRING) {
                 xf86parseError(QUOTE_MSG, "Section");
-                CLEANUP(ptr);
+                clearConfig(ptr);
                 return NULL;
             }
             xf86setSection(xf86_lex_val.str);
@@ -214,12 +212,10 @@ xf86readConfigFile(void)
     if (xf86validateConfig(ptr))
         return ptr;
     else {
-        CLEANUP(ptr);
+        clearConfig(ptr);
         return NULL;
     }
 }
-
-#undef CLEANUP
 
 /*
  * adds an item to the end of the linked list. Any record whose first field
@@ -283,26 +279,28 @@ XF86ConfigPtr xf86allocateConfig(void)
     return xf86configptr;
 }
 
-void
-xf86freeConfig(XF86ConfigPtr p)
+static void
+clearConfig(XF86ConfigPtr config_pointer)
 {
-    if (p == NULL)
+    if(config_pointer == NULL)
+    {
         return;
+    }
 
-    xf86freeFiles(p->conf_files);
-    xf86freeModules(p->conf_modules);
-    xf86freeFlags(p->conf_flags);
-    xf86freeMonitorList(p->conf_monitor_lst);
-    xf86freeModesList(p->conf_modes_lst);
-    xf86freeVideoAdaptorList(p->conf_videoadaptor_lst);
-    xf86freeDeviceList(p->conf_device_lst);
-    xf86freeScreenList(p->conf_screen_lst);
-    xf86freeLayoutList(p->conf_layout_lst);
-    xf86freeInputList(p->conf_input_lst);
-    xf86freeVendorList(p->conf_vendor_lst);
-    xf86freeDRI(p->conf_dri);
-    xf86freeExtensions(p->conf_extensions);
-    TestFree(p->conf_comment);
+    xf86freeFiles(config_pointer->conf_files);
+    xf86freeModules(config_pointer->conf_modules);
+    xf86freeFlags(config_pointer->conf_flags);
+    xf86freeMonitorList(config_pointer->conf_monitor_lst);
+    xf86freeModesList(config_pointer->conf_modes_lst);
+    xf86freeVideoAdaptorList(config_pointer->conf_videoadaptor_lst);
+    xf86freeDeviceList(config_pointer->conf_device_lst);
+    xf86freeScreenList(config_pointer->conf_screen_lst);
+    xf86freeLayoutList(config_pointer->conf_layout_lst);
+    xf86freeInputList(config_pointer->conf_input_lst);
+    xf86freeVendorList(config_pointer->conf_vendor_lst);
+    xf86freeDRI(config_pointer->conf_dri);
+    xf86freeExtensions(config_pointer->conf_extensions);
+    TestFree(config_pointer->conf_comment);
 
-    free(p);
+    free(config_pointer);
 }

--- a/hw/xfree86/parser/read.c
+++ b/hw/xfree86/parser/read.c
@@ -58,6 +58,33 @@
 #include "xf86tokens.h"
 #include "Configint.h"
 
+static void
+clearConfig(XF86ConfigPtr config_pointer)
+{
+    if(config_pointer == NULL)
+    {
+        return;
+    }
+
+    xf86freeFiles(config_pointer->conf_files);
+    xf86freeModules(config_pointer->conf_modules);
+    xf86freeFlags(config_pointer->conf_flags);
+    xf86freeMonitorList(config_pointer->conf_monitor_lst);
+    xf86freeModesList(config_pointer->conf_modes_lst);
+    xf86freeVideoAdaptorList(config_pointer->conf_videoadaptor_lst);
+    xf86freeDeviceList(config_pointer->conf_device_lst);
+    xf86freeScreenList(config_pointer->conf_screen_lst);
+    xf86freeLayoutList(config_pointer->conf_layout_lst);
+    xf86freeInputList(config_pointer->conf_input_lst);
+    xf86freeVendorList(config_pointer->conf_vendor_lst);
+    xf86freeDRI(config_pointer->conf_dri);
+    xf86freeExtensions(config_pointer->conf_extensions);
+    TestFree(config_pointer->conf_comment);
+
+    free(config_pointer);
+}
+
+#define CLEANUP clearConfig
 
 static const xf86ConfigSymTabRec TopLevelTab[] = {
     {SECTION, "section"},
@@ -216,7 +243,7 @@ xf86readConfigFile(void)
         return NULL;
     }
 }
-
+#undef CLEANUP
 /*
  * adds an item to the end of the linked list. Any record whose first field
  * is a GenericListRec can be cast to this type and used with this function.
@@ -277,30 +304,4 @@ XF86ConfigPtr xf86allocateConfig(void)
         xf86configptr = calloc(1, sizeof(XF86ConfigRec));
     }
     return xf86configptr;
-}
-
-static void
-clearConfig(XF86ConfigPtr config_pointer)
-{
-    if(config_pointer == NULL)
-    {
-        return;
-    }
-
-    xf86freeFiles(config_pointer->conf_files);
-    xf86freeModules(config_pointer->conf_modules);
-    xf86freeFlags(config_pointer->conf_flags);
-    xf86freeMonitorList(config_pointer->conf_monitor_lst);
-    xf86freeModesList(config_pointer->conf_modes_lst);
-    xf86freeVideoAdaptorList(config_pointer->conf_videoadaptor_lst);
-    xf86freeDeviceList(config_pointer->conf_device_lst);
-    xf86freeScreenList(config_pointer->conf_screen_lst);
-    xf86freeLayoutList(config_pointer->conf_layout_lst);
-    xf86freeInputList(config_pointer->conf_input_lst);
-    xf86freeVendorList(config_pointer->conf_vendor_lst);
-    xf86freeDRI(config_pointer->conf_dri);
-    xf86freeExtensions(config_pointer->conf_extensions);
-    TestFree(config_pointer->conf_comment);
-
-    free(config_pointer);
 }

--- a/hw/xfree86/parser/xf86Parser_priv.h
+++ b/hw/xfree86/parser/xf86Parser_priv.h
@@ -21,7 +21,6 @@ void xf86setBuiltinConfig(const char *config[]);
 XF86ConfigPtr xf86readConfigFile(void);
 void xf86closeConfigFile(void);
 XF86ConfigPtr xf86allocateConfig(void);
-void xf86freeConfig(XF86ConfigPtr p);
 int xf86writeConfigFile(const char *filename, XF86ConfigPtr cptr);
 int xf86layoutAddInputDevices(XF86ConfigPtr config, XF86ConfLayoutPtr layout);
 


### PR DESCRIPTION
The rgbpath and inputdevices tokens that are obsolete do not have any importante and are collection dust.

I also removed the blob of text from the start of the file, is it fine? I find annoying having to deal with it every time i want to code and see that.

Signed-off-by: RotaryBoot58 <petersoncraft20@proton.me>