### PR TITLE
CI: pass -skip-if-unavailable to the xnamespace conformance test

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -140,7 +140,7 @@ jobs:
             - name: X-NAMESPACE conformance test (Xvfb)
               env:
                   XNS_XSERVER: ${{ github.workspace }}/__BUILD/hw/vfb/Xvfb
-                  XNS_TEST_FLAGS: -v
+                  XNS_TEST_FLAGS: -v -skip-if-unavailable
               run: |
                   export LD_LIBRARY_PATH="$X11_PREFIX/lib/$MACHINE:$X11_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
                   ./go-x11proto/contrib/xnamespace/run-xnamespace-test.sh
@@ -150,7 +150,7 @@ jobs:
             # a real /dev/fb0, which CI runners don't have.
             - name: X-NAMESPACE conformance test (Xephyr, Xnest)
               env:
-                  XNS_TEST_FLAGS: -v
+                  XNS_TEST_FLAGS: -v -skip-if-unavailable
               run: |
                   export LD_LIBRARY_PATH="$X11_PREFIX/lib/$MACHINE:$X11_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
                   build="$PWD/__BUILD"


### PR DESCRIPTION
## Summary

The X-NAMESPACE conformance step (`.github/workflows/build-xserver.yml`) checks out go-x11proto at `ref: master` and builds `cmd/xnamespace-test` from it. When the X server under test was built without the X-NAMESPACE extension (`CONFIG_NAMESPACE`), the tool `bail()`s and the step fails even though the omission is environmental.

Pass `-skip-if-unavailable` (added in go-x11proto, https://github.com/X11Libre/go-x11proto/pull/3) via `XNS_TEST_FLAGS` so the test emits a TAP SKIP and exits 0 when the extension is absent, while still running (and failing) the full suite when it is present.

## Dependency

Requires the go-x11proto flag (PR #3) to be merged to go-x11proto `master` first, since the xserver CI checks out go-x11proto at `ref: master`.

## Verification

`XNS_TEST_FLAGS` is set to `-v -skip-if-unavailable` for both the Xvfb and the Xephyr/Xnest conformance steps.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>