### PR TITLE
CI: pin go-x11proto to v0.0.8 instead of master

### DIFF
--- a/.github/scripts/conf.sh
+++ b/.github/scripts/conf.sh
@@ -13,7 +13,7 @@ export PKG_CONFIG_PATH="$X11_PREFIX/lib/x86_64-linux-gnu/pkgconfig:$X11_PREFIX/l
 
 export PKG_PIGLIT_REF=59111996534f875ca88bce51f21fa2e6564895da
 export PKG_XTS_REF=6cf94400a09abecd6b86e4eb6441741acecd51f6
-export PKG_GOXPROTO_REF="${GOXPROTO_REF:-v0.0.7}"
+export PKG_GOXPROTO_REF="${GOXPROTO_REF:-v0.0.8}"
 export PKG_RENDERCHECK_REF=rendercheck-1.6
 export PKG_LIBDRM_REF=libdrm-2.4.121
 export PKG_LIBXCVT_REF=libxcvt-0.1.0

--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -7,7 +7,7 @@ env:
     MESON_BUILDDIR:  "__BUILD"
     X11_PREFIX:      /home/runner/x11
     X11_BUILD_DIR:   /home/runner/work/xserver/xserver/WORK/sources/3rdparty
-    GOXPROTO_REF:    v0.0.7
+    GOXPROTO_REF:    v0.0.8
 
 on:
     push:
@@ -129,7 +129,7 @@ jobs:
               uses: actions/checkout@v4
               with:
                   repository: X11Libre/go-x11proto
-                  ref: master
+                  ref: ${{ env.GOXPROTO_REF }}
                   path: go-x11proto
 
             - name: install Go toolchain


### PR DESCRIPTION
The xnamespace conformance-test checkout used an unpinned `ref: master`
while the module deps used `v0.0.7`. That split let CI build against an
unreviewed go-x11proto master — the source of the recent xnamespace
conformance breakage (wrong ListAuthTokens opcode / CapAdmin bit).

Unify everything on a single pinned tag, `v0.0.8`, driven by the
`GOXPROTO_REF` env so there is one source of truth:

- `.github/workflows/build-xserver.yml`: `GOXPROTO_REF: v0.0.7` -> `v0.0.8`
- `.github/workflows/build-xserver.yml`: conformance checkout `ref: master`
  -> `ref: ${{ env.GOXPROTO_REF }}`
- `.github/scripts/conf.sh`: `PKG_GOXPROTO_REF` default `v0.0.7` -> `v0.0.8`
  (consumed by `install-prereq.sh`)

go-x11proto `v0.0.8` (X11Libre/go-x11proto@v0.0.8) contains the namespace
proto fixes (ListAuthTokens opcode = 8, CapAdmin bit = 1<<5 to match the
server) and the `-skip-if-unavailable` conformance flag.