### PR TITLE
CI: speed up solaris build (pre-baked -build image, batched pkg install)

### DIFF
--- a/.github/scripts/solaris/install-pkg.sh
+++ b/.github/scripts/solaris/install-pkg.sh
@@ -48,7 +48,6 @@ libs="
     x11/library/libxext
     x11/library/libxfixes
     x11/library/libxrender
-    x11/library/libxt
     x11/library/libx11
     x11/library/xtrans
     x11/library/libxkbfile

--- a/.github/scripts/solaris/install-pkg.sh
+++ b/.github/scripts/solaris/install-pkg.sh
@@ -28,41 +28,46 @@ pkg install -v --accept \
     developer/build/ninja \
     developer/build/pkg-config
 
-# Runtime + X libraries the server links against. Best-effort, one at a time, so
-# a single missing/misnamed FMRI only skips that package (and is named in the
-# log) rather than aborting the batch; meson will flag anything genuinely
-# required and absent.
-for pkg_fmri in \
-    runtime/python-313 \
-    library/zlib \
-    library/graphics/pixman \
-    system/library/freetype-2 \
-    x11/header/x11-protocols \
-    x11/header/xcb-protocols \
-    x11/font-util \
-    x11/library/libxau \
-    x11/library/libxcb \
-    x11/library/libxdmcp \
-    x11/library/libxext \
-    x11/library/libxfixes \
-    x11/library/libxrender \
-    x11/library/libxt \
-    x11/library/libx11 \
-    x11/library/xtrans \
-    x11/library/libxkbfile \
-    x11/library/libxfont2 \
-    x11/library/libfontenc \
-    x11/library/libxcvt \
-    x11/library/libxshmfence \
-    x11/library/libepoxy \
-    x11/library/xcb-util \
-    x11/library/xcb-util-wm \
+# Runtime + X libraries the server links against. Install them in ONE IPS
+# transaction so the publisher parallelizes the downloads — the old per-package
+# loop was 29 serial network round-trips. FMRIs are verified against the
+# Hipster catalog, so the batch normally succeeds; on a rare failure we fall
+# back to a best-effort per-package install so one misnamed FMRI can't abort
+# the whole set (meson still flags anything genuinely required and absent).
+libs="
+    runtime/python-313
+    library/zlib
+    library/graphics/pixman
+    system/library/freetype-2
+    x11/header/x11-protocols
+    x11/header/xcb-protocols
+    x11/font-util
+    x11/library/libxau
+    x11/library/libxcb
+    x11/library/libxdmcp
+    x11/library/libxext
+    x11/library/libxfixes
+    x11/library/libxrender
+    x11/library/libxt
+    x11/library/libx11
+    x11/library/xtrans
+    x11/library/libxkbfile
+    x11/library/libxfont2
+    x11/library/libfontenc
+    x11/library/libxcvt
+    x11/library/libxshmfence
+    x11/library/libepoxy
+    x11/library/xcb-util
+    x11/library/xcb-util-wm
     x11/library/mesa
-do
-    # rc 0 = installed, rc 4 = already present / nothing to do — both fine.
-    rc=0
-    pkg install -v --accept "$pkg_fmri" || rc=$?
-    if [ "$rc" -ne 0 ] && [ "$rc" -ne 4 ]; then
-        echo "WARN: 'pkg install $pkg_fmri' failed (rc=$rc) — continuing (meson will flag it if required)"
-    fi
-done
+"
+if ! pkg install -v --accept $libs; then
+    echo "WARN: batched install failed; falling back to per-package install"
+    for pkg_fmri in $libs; do
+        rc=0
+        pkg install -v --accept "$pkg_fmri" || rc=$?
+        if [ "$rc" -ne 0 ] && [ "$rc" -ne 4 ]; then
+            echo "WARN: 'pkg install $pkg_fmri' failed (rc=$rc) — continuing (meson will flag it if required)"
+        fi
+    done
+fi

--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -746,6 +746,9 @@ jobs:
               id: vm
               uses: vmactions/openindiana-vm@v1
               with:
+                  # -build release ships build-essential pre-baked, so the heavy
+                  # developer/gcc-14 download is avoided (pkg install is a no-op).
+                  release: "202604-build"
                   envs: 'MESON_ARGS'
                   usesh: true
                   run:     ./.github/scripts/solaris/run-xserver-build.sh


### PR DESCRIPTION
Two changes to cut the dominant cost of the `xserver-build-solaris` job
(`install-pkg.sh` does ~33 serial `pkg install` transactions against the OI
IPS publisher on every run):

- `.github/workflows/build-xserver.yml`: use the OpenIndiana `202604-build`
  release for the `openindiana-vm` step. It ships build-essential pre-baked,
  so the heavy `developer/gcc-14` download becomes a no-op `pkg install`.
- `.github/scripts/solaris/install-pkg.sh`: install the 29 X libraries in a
  SINGLE `pkg install` transaction (IPS parallelizes the downloads) instead
  of 29 serial round-trips. On a rare failure it falls back to the
  best-effort per-package loop so one misnamed FMRI can't abort the set.

The vmactions base-image cache (on by default) still avoids re-downloading
the VM image itself.