### PR TITLE
glx: fix DrawableGone use-after-free without rejecting duplicate drawables

### DIFF
--- a/Xext/glx/glxcmds.c
+++ b/Xext/glx/glxcmds.c
@@ -1135,33 +1135,6 @@ DoCreateGLXDrawable(ClientPtr client, __GLXscreen * pGlxScreen,
     if (pGlxScreen->pScreen != pDraw->pScreen)
         return BadMatch;
 
-    if (type == GLX_DRAWABLE_WINDOW) {
-        /* The GLX window id is a fresh, client-allocated resource id, so
-         * validate it like any other new resource (in the client's id range
-         * and not already in use). */
-        LEGAL_NEW_RESOURCE(glxDrawableId, client);
-
-        /* A window may have only a single GLX drawable associated with it. We
-         * register the __GLXdrawable under both the GLX window id and the X
-         * window id (see below) so DrawableGone() runs regardless of teardown
-         * order. If the client calls glXCreateWindow() again for the same X
-         * window, the second AddResource() below would register a duplicate
-         * (pDraw->id, __glXDrawableRes) resource aliasing a *different*
-         * __GLXdrawable. Tearing the window down then frees one __GLXdrawable
-         * via FreeResourceByType() while leaving the other resource entry
-         * pointing at it, causing a use-after-free / double free in
-         * DrawableGone() (issue #1491). The GLX spec disallows associating two
-         * GLX windows with one X window, so reject it up front with BadAlloc. */
-        if (drawableId != glxDrawableId) {
-            __GLXdrawable *existing;
-
-            if (dixLookupResourceByType((void **) &existing, pDraw->id,
-                                        __glXDrawableRes, client,
-                                        DixGetAttrAccess) == Success)
-                return BadAlloc;
-        }
-    }
-
     pGlxDraw = pGlxScreen->createDrawable(client, pGlxScreen, pDraw,
                                           drawableId, type,
                                           glxDrawableId, config);

--- a/Xext/glx/glxext.c
+++ b/Xext/glx/glxext.c
@@ -33,6 +33,7 @@
 #include <string.h>
 
 #include "dix/dix_priv.h"
+#include "dix/resource_priv.h"
 #include "dix/screenint_priv.h"
 #include "os/client_priv.h"
 
@@ -98,12 +99,19 @@ DrawableGone(__GLXdrawable * glxPriv, XID xid)
     __GLXcontext *c, *next;
 
     if (glxPriv->type == GLX_DRAWABLE_WINDOW) {
-        /* If this was created by glXCreateWindow, free the matching resource */
+        /* If this was created by glXCreateWindow, free the matching resource.
+         * A window may have more than one GLX drawable registered under its X
+         * id, so free the partner entry that points at *this* drawable rather
+         * than an arbitrary one sharing the id+type; otherwise the survivor
+         * would dangle and DrawableGone() would later run on freed memory
+         * (use-after-free, issue #1491). */
         if (glxPriv->drawId != glxPriv->pDraw->id) {
             if (xid == glxPriv->drawId)
-                FreeResourceByType(glxPriv->pDraw->id, __glXDrawableRes, TRUE);
+                FreeResourceByTypeValue(glxPriv->pDraw->id, __glXDrawableRes,
+                                        glxPriv, TRUE);
             else
-                FreeResourceByType(glxPriv->drawId, __glXDrawableRes, TRUE);
+                FreeResourceByTypeValue(glxPriv->drawId, __glXDrawableRes,
+                                        glxPriv, TRUE);
         }
         /* otherwise this window was implicitly created by MakeCurrent */
     }

--- a/dix/resource.c
+++ b/dix/resource.c
@@ -964,6 +964,42 @@ FreeResourceByType(XID id, RESTYPE type, Bool skipFree)
 }
 
 /*
+ * Like FreeResourceByType(), but only frees the entry whose value also matches.
+ * Needed when several resources share an id and type (e.g. a GLX window
+ * drawable registered under both its GLX id and the backing X window id):
+ * matching on id+type alone would free an arbitrary one of them.
+ */
+void
+FreeResourceByTypeValue(XID id, RESTYPE type, void *value, Bool skipFree)
+{
+    int cid;
+    ResourcePtr res;
+    ResourcePtr *prev, *head;
+
+    if (((cid = dixClientIdForXID(id)) < LimitClients) && clientTable[cid].buckets) {
+        head = &clientTable[cid].resources[HashResourceID(id, clientTable[cid].hashsize)];
+
+        prev = head;
+        while ((res = *prev)) {
+            if (res->id == id && res->type == type && res->value == value) {
+#ifdef XSERVER_DTRACE
+                XSERVER_RESOURCE_FREE(res->id, res->type,
+                                      res->value, TypeNameString(res->type));
+#endif
+                *prev = res->next;
+                clientTable[cid].elements--;
+
+                doFreeResource(res, skipFree);
+
+                break;
+            }
+            else
+                prev = &res->next;
+        }
+    }
+}
+
+/*
  * Change the value associated with a resource id.  Caller
  * is responsible for "doing the right thing" with the old
  * data

--- a/dix/resource_priv.h
+++ b/dix/resource_priv.h
@@ -157,6 +157,25 @@ void GetXIDRange(int client,
                  XID *minp,
                  XID *maxp);
 
+/*
+ * @brief free a specific resource among several sharing an id and type
+ *
+ * Like FreeResourceByType(), but only frees the entry whose value matches the
+ * one supplied. Needed when more than one resource is registered under the same
+ * id and type (e.g. a GLX window drawable, registered under both its GLX id and
+ * the backing X window id): matching on id+type alone frees an arbitrary one.
+ *
+ * @param id the resource id to free
+ * @param type the resource type to match
+ * @param value the resource value to match
+ * @param skipFree if TRUE, unlink the entry without calling its delete function
+ *
+ * Exported (like FreeResourceByType) because loadable dix modules such as glx
+ * call it across the dlopen boundary, even though it stays out of the SDK.
+ */
+extern _X_EXPORT void FreeResourceByTypeValue(XID id, RESTYPE type,
+                                              void *value, Bool skipFree);
+
 /* Resource state callback */
 extern CallbackListPtr ResourceStateCallback;
 


### PR DESCRIPTION
This draft has another approach to fix https://github.com/X11Libre/xserver/issues/1491 while allowing duplicate GLX drawables for a window. Instead of rejecting their creation, we added a new function that frees exactly them, as the crash was happening in their teardown, not creation.

I'm no expert and can't guarantee this code is bulletproof, but in the only machine mine that can trigger the crash from https://github.com/X11Libre/xserver/issues/1491, the code in this PR makes not crash anymore, while still allowing clients broken by https://github.com/X11Libre/xserver/pull/3145 to keep working, even if they're working "wrongly" :)

This could fix https://github.com/X11Libre/xserver/issues/3284 and its duplicates.

## Backport dashboard

| Target branch | Backport PR | Status |
|---------------|-------------|--------|
| `release/25.2` | #3333 | 🔄 Open |
| `release/25.1` | #3334 | 🔄 Open |
| `release/25.0` | #3335 | 🔄 Open |
