### PR TITLE
(release/25.0) glx: fix DrawableGone use-after-free without rejecting duplicate drawables

### DIFF
--- a/dix/resource.c
+++ b/dix/resource.c
@@ -119,6 +119,7 @@ Equipment Corporation.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 
 #include "dix/colormap_priv.h"
@@ -964,6 +965,42 @@ FreeResourceByType(XID id, RESTYPE type, Bool skipFree)
             }
             else
                 prev = &res->next;
+        }
+    }
+}
+
+/*
+ * Like FreeResourceByType(), but only frees the entry whose value also matches.
+ * Needed when several resources share an id and type (e.g. a GLX window
+ * drawable registered under both its GLX id and the backing X window id):
+ * matching on id+type alone would free an arbitrary one of them.
+ */
+void FreeResourceByTypeValue(XID id, RESTYPE type, void *value, bool skipFree)
+{
+    int cid;
+    ResourcePtr res;
+    ResourcePtr *prev, *head;
+
+    if (((cid = dixClientIdForXID(id)) < LimitClients) && clientTable[cid].buckets) {
+        head = &clientTable[cid].resources[HashResourceID(id, clientTable[cid].hashsize)];
+
+        prev = head;
+        while ((res = *prev)) {
+            if (res->id == id && res->type == type && res->value == value) {
+#ifdef XSERVER_DTRACE
+                XSERVER_RESOURCE_FREE(res->id, res->type,
+                                      res->value, TypeNameString(res->type));
+#endif
+                *prev = res->next;
+                clientTable[cid].elements--;
+
+                doFreeResource(res, skipFree);
+
+                break;
+            }
+            else {
+                prev = &res->next;
+            }
         }
     }
 }

--- a/dix/resource.c
+++ b/dix/resource.c
@@ -119,6 +119,7 @@ Equipment Corporation.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 
 #include "dix/colormap_priv.h"
@@ -964,6 +965,42 @@ FreeResourceByType(XID id, RESTYPE type, Bool skipFree)
             }
             else
                 prev = &res->next;
+        }
+    }
+}
+
+/*
+ * Like FreeResourceByType(), but only frees the entry whose value also matches.
+ * Needed when several resources share an id and type (e.g. a GLX window
+ * drawable registered under both its GLX id and the backing X window id):
+ * matching on id+type alone would free an arbitrary one of them.
+ */
+_X_EXPORT void FreeResourceByTypeValue(XID id, RESTYPE type, void *value, bool skipFree)
+{
+    int cid;
+    ResourcePtr res;
+    ResourcePtr *prev, *head;
+
+    if (((cid = dixClientIdForXID(id)) < LimitClients) && clientTable[cid].buckets) {
+        head = &clientTable[cid].resources[HashResourceID(id, clientTable[cid].hashsize)];
+
+        prev = head;
+        while ((res = *prev)) {
+            if (res->id == id && res->type == type && res->value == value) {
+#ifdef XSERVER_DTRACE
+                XSERVER_RESOURCE_FREE(res->id, res->type,
+                                      res->value, TypeNameString(res->type));
+#endif
+                *prev = res->next;
+                clientTable[cid].elements--;
+
+                doFreeResource(res, skipFree);
+
+                break;
+            }
+            else {
+                prev = &res->next;
+            }
         }
     }
 }

--- a/dix/resource_priv.h
+++ b/dix/resource_priv.h
@@ -5,6 +5,7 @@
 #ifndef _XSERVER_DIX_RESOURCE_PRIV_H
 #define _XSERVER_DIX_RESOURCE_PRIV_H
 
+#include <stdbool.h>
 #include <X11/Xdefs.h>
 
 #include "include/dix.h"
@@ -155,5 +156,23 @@ void GetXIDRange(int client,
                  Bool server,
                  XID *minp,
                  XID *maxp);
+
+/*
+ * @brief free a specific resource among several sharing an id and type
+ *
+ * Like FreeResourceByType(), but only frees the entry whose value matches the
+ * one supplied. Needed when more than one resource is registered under the same
+ * id and type (e.g. a GLX window drawable, registered under both its GLX id and
+ * the backing X window id): matching on id+type alone frees an arbitrary one.
+ *
+ * @param id the resource id to free
+ * @param type the resource type to match
+ * @param value the resource value to match
+ * @param skipFree if TRUE, unlink the entry without calling its delete function
+ *
+ * Exported (like FreeResourceByType) because loadable dix modules such as glx
+ * call it across the dlopen boundary, even though it stays out of the SDK.
+ */
+void FreeResourceByTypeValue(XID id, RESTYPE type, void *value, bool skipFree);
 
 #endif /* _XSERVER_DIX_RESOURCE_PRIV_H */

--- a/glx/glxext.c
+++ b/glx/glxext.c
@@ -33,6 +33,7 @@
 #include <string.h>
 
 #include "dix/dix_priv.h"
+#include "dix/resource_priv.h"
 #include "os/client_priv.h"
 
 #include "glxserver.h"
@@ -98,12 +99,19 @@ DrawableGone(__GLXdrawable * glxPriv, XID xid)
     __GLXcontext *c, *next;
 
     if (glxPriv->type == GLX_DRAWABLE_WINDOW) {
-        /* If this was created by glXCreateWindow, free the matching resource */
+        /* If this was created by glXCreateWindow, free the matching resource.
+         * A window may have more than one GLX drawable registered under its X
+         * id, so free the partner entry that points at *this* drawable rather
+         * than an arbitrary one sharing the id+type; otherwise the survivor
+         * would dangle and DrawableGone() would later run on freed memory
+         * (use-after-free, issue #1491). */
         if (glxPriv->drawId != glxPriv->pDraw->id) {
             if (xid == glxPriv->drawId)
-                FreeResourceByType(glxPriv->pDraw->id, __glXDrawableRes, TRUE);
+                FreeResourceByTypeValue(glxPriv->pDraw->id, __glXDrawableRes,
+                                        glxPriv, TRUE);
             else
-                FreeResourceByType(glxPriv->drawId, __glXDrawableRes, TRUE);
+                FreeResourceByTypeValue(glxPriv->drawId, __glXDrawableRes,
+                                        glxPriv, TRUE);
         }
         /* otherwise this window was implicitly created by MakeCurrent */
     }


### PR DESCRIPTION
XORG BACKPORT

A window can have more than one __GLXdrawable registered under its X id.
On teardown DrawableGone() freed the partner with FreeResourceByType(),
which matches only id+type and so frees an arbitrary one, leaving the
survivor dangling -> later use-after-free (issue #1491).

Add FreeResourceByTypeValue() (internal, dix/resource_priv.h) that also
matches the value, and use it in DrawableGone() to free the entry for
this exact drawable. Fixes the UAF while keeping duplicate glXCreateWindow
working, unlike the previous fix that rejected it and broke clients.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Kiyoshi Spreclerg <kiyoshi_pip@protonmail.com>
(cherry picked from commit 36b8a3323ca9025fb2497808b4229d5122c837eb)


Backport of **#3329** (master). Cherry-picked from commit 36b8a3323c.
