### PR TITLE
(release/25.0) glx: free old context tag before allocating new one in CommonMakeCurrent

### DIFF
--- a/glx/vndcmds.c
+++ b/glx/vndcmds.c
@@ -255,6 +255,11 @@ static int CommonMakeCurrent(ClientPtr client,
             if (ret != Success) {
                 return ret;
             }
+            // Free the old tag before calling CommonMakeNewCurrent(),
+            // which may call GlxAllocContextTag() and realloc the
+            // contextTags array, invalidating the oldTag pointer.
+            GlxFreeContextTag(oldTag);
+            oldTag = NULL;
         }
 
         if (newVendor != NULL) {
@@ -265,9 +270,6 @@ static int CommonMakeCurrent(ClientPtr client,
         } else {
             reply.contextTag = 0;
         }
-
-        GlxFreeContextTag(oldTag);
-        oldTag = NULL;
     }
 
     reply.contextTag = GlxCheckSwap(client, reply.contextTag);


### PR DESCRIPTION
oldTag in CommonMakeCurrent() is a pointer to cl->contextTags[...].
CommonMakeCurrent() may realloc(cl->contextTags) and thus move the
memory, leaving oldTag as dangling pointer.

If we then GlxFreeContextTag(oldTag) we end up writing into freed
memory.

Fix this by freeing oldTag before CommonMakeNewCurrent().

This vulnerability was discovered by:
Anonymous working with Trend Micro Zero Day Initiative

CVE-2026-56000/ZDI-CAN-30561

Fixes: 4781f2a5a8c2 ("GLX: Free the tag of the old context later")
Assisted-by: Claude:claude-opus-4-6
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2250>
