### PR TITLE
(release/25.0) xorg.conf.man: Fix escape sequence typo

### DIFF
--- a/hw/xfree86/man/xorg.conf.man
+++ b/hw/xfree86/man/xorg.conf.man
@@ -2114,7 +2114,7 @@ use for the screen. This may be used to select an alternate implementation
 for development, debugging, or alternate feature sets.
 Default: mesa.
 .TP 7
-.BI "Option \*RenderingAPI\*q \*q" string \*q
+.BI "Option \*qRenderingAPI\*q \*q" string \*q
 This option specifies an rendering API for use in conjunction with Glamor
 accel method. You can specify OpenGL with a value "gl" and OpenGL ES with a
 value "es", and the default is both, when Glamor fallbacks to GLES if GL 2.1 is


### PR DESCRIPTION
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2257>
