### PR TITLE
(release/25.2) enhance: popen-fdopen-error-handling

### DIFF
--- a/os/utils.c
+++ b/os/utils.c
@@ -1117,10 +1117,23 @@ Popen(const char *command, const char *type)
     if (*type == 'r') {
         iop = fdopen(pdes[0], type);
         close(pdes[1]);
+        if (!iop)
+            close(pdes[0]);
     }
     else {
         iop = fdopen(pdes[1], type);
         close(pdes[0]);
+        if (!iop)
+            close(pdes[1]);
+    }
+
+    if (!iop) {
+        free(cur);
+#ifdef HAVE_SETITIMER
+        if (SmartScheduleEnable() < 0)
+            perror("signal");
+#endif
+        return NULL;
     }
 
     cur->fp = iop;


### PR DESCRIPTION
If fdopen() fails, close the unused pipe fd, free the pid list node,
and restore the smart scheduler signal before returning NULL.
Previously the fd would leak and the node would be added to pidlist
with a NULL fp.

Signed-off-by: dongshengyuan <545258830@qq.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2236>
