### PR TITLE
(release/25.2) xfree86: set GPU screen FB/DGA defaults on runtime hotplug

### DIFF
--- a/hw/xfree86/common/xf86platformBus.c
+++ b/hw/xfree86/common/xf86platformBus.c
@@ -744,6 +744,15 @@ xf86platformAddDevice(const char *driver_name, int index)
         return -1;
     }
 
+   /*
+    * Almost everything uses these defaults, and many of those that
+    * don't, will wrap them.
+    */
+   xf86GPUScreens[i]->EnableDisableFBAccess = xf86EnableDisableFBAccess;
+#ifdef XFreeXDGA
+   xf86GPUScreens[i]->SetDGAMode = xf86SetDGAMode;
+#endif
+
    scr_index = AddGPUScreen(xf86GPUScreens[i]->ScreenInit, 0, NULL);
    if (scr_index == -1) {
        xf86DeleteScreen(xf86GPUScreens[i]);


### PR DESCRIPTION
When a platform GPU device is added at runtime, xf86platformAddDevice
calls AddGPUScreen without first assigning the EnableDisableFBAccess and
SetDGAMode function-pointer defaults. The boot path in xf86Init.c sets
both of these for every GPU screen before it calls AddGPUScreen, so a
screen added by hotplug is left with SetDGAMode == NULL.

modesetting's ScreenInit reaches xf86CrtcScreenInit, which wraps
DGACloseScreen onto the screen regardless of how the screen was created.
When the device is later removed, xf86platformRemoveDevice tears the GPU
screen down and DGACloseScreen calls pScrn->SetDGAMode(pScrn, 0, NULL).
On a hotplug-added screen that pointer is NULL, so the call faults and
takes down the server with a SIGSEGV.

This is not DisplayLink-specific: any modesetting platform GPU screen
added at runtime and later removed hits it. DisplayLink/evdi just makes
it easy to reproduce, because the evdi platform device is added and
reconfigured at runtime.

Mirror the boot path by assigning the same defaults in
xf86platformAddDevice immediately before the AddGPUScreen call.

Closes: #1904
Signed-off-by: Gary T. Giesen <ggiesen@giesen.me>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2244>
