### PR TITLE
(release/25.2) xquartz/GL: Log failures on the indirect GLX make-current path

### DIFF
--- a/hw/xquartz/GL/indirect.c
+++ b/hw/xquartz/GL/indirect.c
@@ -297,15 +297,21 @@ attach(__GLXAquaContext *context, __GLXAquaDrawable *draw)
         //if (!quartzProcs->CreateSurface(pDraw->pScreen, pDraw->id, pDraw,
         if (!DRICreateSurface(pDraw->pScreen, pDraw->id, pDraw,
                               0, &draw->sid, NULL,
-                              surface_notify, draw))
+                              surface_notify, draw)) {
+            ErrorF("%s: DRICreateSurface failed for drawable 0x%x\n",
+                   __func__, (unsigned int)pDraw->id);
             return TRUE;
+        }
         draw->pDraw = pDraw;
     }
 
     if (!context->isAttached || context->sid != draw->sid) {
         x_list *lst;
+        xp_error xp_err = xp_attach_gl_context(context->ctx, draw->sid);
 
-        if (xp_attach_gl_context(context->ctx, draw->sid) != Success) {
+        if (xp_err != Success) {
+            ErrorF("%s: xp_attach_gl_context(ctx %p, sid 0x%x) failed: %d\n",
+                   __func__, context->ctx, (unsigned int)draw->sid, xp_err);
             //quartzProcs->DestroySurface(pDraw->pScreen, pDraw->id, pDraw,
             DRIDestroySurface(pDraw->pScreen, pDraw->id, pDraw,
                               surface_notify, draw);
@@ -350,8 +356,12 @@ __glXAquaContextMakeCurrent(__GLXcontext *baseContext)
 
     GLAQUA_DEBUG_MSG("glAquaMakeCurrent (ctx 0x%p)\n", baseContext);
 
-    if (context->base.drawPriv != context->base.readPriv)
+    if (context->base.drawPriv != context->base.readPriv) {
+        ErrorF("%s: separate read/draw drawables are unsupported "
+               "(draw %p, read %p)\n", __func__,
+               context->base.drawPriv, context->base.readPriv);
         return 0;
+    }
 
     if (attach(context, drawPriv))
         return /*error*/ 0;

--- a/hw/xquartz/xpr/appledri.c
+++ b/hw/xquartz/xpr/appledri.c
@@ -299,7 +299,7 @@ ProcAppleDRICreatePixmap(ClientPtr client)
     CARD32 stringLength = strlen(path) + 1;
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
-    x_rpcbuf_write_CARD8s(&rpcbuf, path, stringLength);
+    x_rpcbuf_write_CARD8s(&rpcbuf, (CARD8*)path, stringLength);
 
     xAppleDRICreatePixmapReply reply = {
         .stringLength = stringLength,

--- a/hw/xquartz/xpr/dri.c
+++ b/hw/xquartz/xpr/dri.c
@@ -48,6 +48,7 @@
 
 #include "include/misc.h"
 #include "miext/extinit_priv.h"
+#include "os/log_priv.h"
 
 #include "dixstruct.h"
 #include "extnsionst.h"
@@ -279,6 +280,10 @@ CreateSurfaceForWindow(ScreenPtr pScreen, WindowPtr pWin,
         wid = x_cvt_vptr_to_uint(RootlessFrameForWindow(pWin, TRUE));
 
         if (wid == 0) {
+            ErrorF("%s: RootlessFrameForWindow returned 0 for window 0x%x "
+                   "(realized=%d, mapped=%d, viewable=%d)\n", __func__,
+                   (unsigned int)pWin->drawable.id, pWin->realized,
+                   pWin->mapped, pWin->viewable);
             free(pDRIDrawablePriv);
             return NULL;
         }
@@ -287,6 +292,8 @@ CreateSurfaceForWindow(ScreenPtr pScreen, WindowPtr pWin,
         err = xp_create_surface(wid, &pDRIDrawablePriv->sid);
 
         if (err != Success) {
+            ErrorF("%s: xp_create_surface(wid 0x%x) failed: %d\n", __func__,
+                   (unsigned int)wid, err);
             free(pDRIDrawablePriv);
             return NULL;
         }
@@ -296,7 +303,15 @@ CreateSurfaceForWindow(ScreenPtr pScreen, WindowPtr pWin,
         wc.sibling = 0;
         err = xp_configure_surface(pDRIDrawablePriv->sid, XP_STACKING, &wc);
 
+        DebugF("%s: window 0x%x wid 0x%x sid 0x%x "
+               "(realized=%d mapped=%d viewable=%d): xp_configure_surface -> %d\n",
+               __func__, (unsigned int)pWin->drawable.id, (unsigned int)wid,
+               (unsigned int)pDRIDrawablePriv->sid, pWin->realized, pWin->mapped,
+               pWin->viewable, err);
+
         if (err != Success) {
+            ErrorF("%s: xp_configure_surface(sid 0x%x) failed: %d\n", __func__,
+                   (unsigned int)pDRIDrawablePriv->sid, err);
             xp_destroy_surface(pDRIDrawablePriv->sid);
             free(pDRIDrawablePriv);
             return NULL;


### PR DESCRIPTION
The indirect GLX make-current path failed silently: an unsuccessful surface creation or context attach
surfaced only as a generic GLXBadContext to the client, with nothing in the server log to indicate which
Xplugin call rejected the request. Add error logging on each failure branch of the make-current, surface
creation, and surface configuration code so the offending call and its error code are visible.

Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
