### PR TITLE
(master) xvfb: Extend -crtcs to accept optional size (N@WxH)

### DIFF
--- a/hw/vfb/InitOutput.c
+++ b/hw/vfb/InitOutput.c
@@ -170,38 +170,40 @@ static char *render_node = NULL;
     else (_dst) = (_src);
 
 static void
-vfbAddCrtcInfo(vfbScreenInfoPtr screen, int numCrtcs)
+vfbSetCrtcInfo(vfbScreenInfoPtr screen, int numCrtcs, int crtcWidth,
+               int crtcHeight)
 {
     int i;
-    int count = numCrtcs - screen->numCrtcs;
 
-    if (count > 0) {
-        vfbCrtcInfoPtr crtcs =
-            reallocarray(screen->crtcs, numCrtcs, sizeof(*crtcs));
-        if (!crtcs)
-            FatalError("Not enough memory for %d CRTCs", numCrtcs);
+    vfbCrtcInfoPtr crtcs =
+        reallocarray(screen->crtcs, numCrtcs, sizeof(*crtcs));
+    if (!crtcs)
+        FatalError("Not enough memory for %d CRTCs", numCrtcs);
 
-        memset(crtcs + screen->numCrtcs, 0, count * sizeof(*crtcs));
+    memset(crtcs, 0, numCrtcs * sizeof(*crtcs));
 
-        for (i = screen->numCrtcs; i < numCrtcs; ++i) {
-            crtcs[i].width = screen->width;
-            crtcs[i].height = screen->height;
-        }
-
-        screen->crtcs = crtcs;
-        screen->numCrtcs = numCrtcs;
+    for (i = 0; i < numCrtcs; ++i) {
+        crtcs[i].width = crtcWidth;
+        crtcs[i].height = crtcHeight;
     }
+
+    /* First CRTC starts with one output */
+    if (numCrtcs > 0)
+        crtcs[0].numOutputs = 1;
+
+    screen->crtcs = crtcs;
+    screen->numCrtcs = numCrtcs;
 }
 
 static vfbScreenInfoPtr
 vfbInitializeScreenInfo(vfbScreenInfoPtr screen)
 {
     *screen = defaultScreenInfo;
-    vfbAddCrtcInfo(screen, VFB_DEFAULT_NUM_CRTCS);
 
-    /* First CRTC initializes with one output */
-    if (screen->numCrtcs > 0)
-        screen->crtcs[0].numOutputs = 1;
+    if (screen->numCrtcs == 0) {
+        vfbSetCrtcInfo(screen, VFB_DEFAULT_NUM_CRTCS, screen->width,
+                       screen->height);
+    }
 
     return screen;
 }
@@ -321,7 +323,8 @@ ddxUseMsg(void)
     ErrorF("-dri </dev/dri/renderDxxx>  render device to use\n");
 #endif
 
-    ErrorF("-crtcs n               number of CRTCs per screen (default: %d)\n",
+    ErrorF("-crtcs n[@WxH]         CRTC count with optional size "
+           "(default: %d @ screen's WxH)\n",
            VFB_DEFAULT_NUM_CRTCS);
 }
 
@@ -457,11 +460,32 @@ ddxProcessArgument(int argc, char *argv[], int i)
     }
 #endif
 
-    if (strcmp(argv[i], "-crtcs") == 0) {       /* -crtcs n */
-        int numCrtcs;
-
+    if (strcmp(argv[i], "-crtcs") == 0) {       /* -crtcs N[@WxH] */
         CHECK_FOR_REQUIRED_ARGUMENTS(1);
-        numCrtcs = atoi(argv[i + 1]);
+
+        int numCrtcs = VFB_DEFAULT_NUM_CRTCS;
+        int crtcWidth = currentScreen->width;
+        int crtcHeight = currentScreen->height;
+
+        if (strchr(argv[i + 1], '@')) {
+            if (sscanf(argv[i + 1], "%d@%dx%d",
+                       &numCrtcs, &crtcWidth, &crtcHeight) != 3 ||
+                crtcWidth <= 0 || crtcHeight <= 0) {
+                ErrorF("Invalid -crtcs argument '%s'\n", argv[i + 1]);
+                UseMsg();
+                FatalError("Invalid -crtcs argument '%s', expected N@WxH\n",
+                           argv[i + 1]);
+            }
+        }
+        else {
+            if (strchr(argv[i + 1], 'x')) {
+                ErrorF("Invalid -crtcs argument '%s'\n", argv[i + 1]);
+                UseMsg();
+                FatalError("Invalid -crtcs argument '%s', expected N or N@WxH\n",
+                           argv[i + 1]);
+            }
+            numCrtcs = atoi(argv[i + 1]);
+        }
 
         if (numCrtcs < 1) {
             ErrorF("Invalid number of CRTCs %d\n", numCrtcs);
@@ -471,7 +495,16 @@ ddxProcessArgument(int argc, char *argv[], int i)
 
         }
 
-        vfbAddCrtcInfo(currentScreen, numCrtcs);
+        if (crtcWidth > currentScreen->width ||
+            crtcHeight > currentScreen->height) {
+            ErrorF("CRTC size cannot exceed screen size\n");
+            UseMsg();
+            FatalError("CRTC size %dx%d exceeds screen size %dx%d\n",
+                       crtcWidth, crtcHeight,
+                       currentScreen->width, currentScreen->height);
+        }
+
+        vfbSetCrtcInfo(currentScreen, numCrtcs, crtcWidth, crtcHeight);
         return 2;
     }
 

--- a/hw/vfb/man/Xvfb.man
+++ b/hw/vfb/man/Xvfb.man
@@ -96,6 +96,14 @@ possible with the fb code.
 .TP 4
 .B "\-blackpixel \fIpixel-value\fP, \-whitepixel \fIpixel-value\fP"
 These options specify the black and white pixel values the server should use.
+.TP 4
+.BI "\-crtcs " n[@\fIW\fPx\fIH\fP]
+Sets the number of screen CRTCs to \fIn\fP and, optionally, sets each CRTC to
+the width \fIW\fP and height \fIH\fP.  When \fIW\fP and \fIH\fP are omitted,
+each CRTC uses the full screen size.  If \fB\-crtcs\fP is not supplied, a
+single CRTC matching the screen dimensions is created.  Unless overridden by
+\fB\-screen\fP, this is equivalent to \fB1@1280x1024\fP.  In all cases, only the
+first CRTC has a mode set at start\-up.
 .SH FILES
 The following files are created if the \-fbdir option is given.
 .TP 4


### PR DESCRIPTION
The -crtcs command line switch now understands an optional geometry
specification, N@WxH. When present, W×H is applied to each CRTC created for
the screen, allowing them to be smaller than the underlying screen.

If no size is given, the original behavior is preserved: each CRTC,
and the initial RandR mode, match the screen dimensions.

Help output and the man page have been updated accordingly.

Signed-off-by: Andy Myers <andy.myers@zetier.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2043>
