### PR TITLE
(master) Implement XFixes 6.1

### DIFF
--- a/Xext/xfixes/disconnect.c
+++ b/Xext/xfixes/disconnect.c
@@ -48,6 +48,7 @@
 #include "dix/request_priv.h"
 
 #include "xfixesint.h"
+#include "xace.h"
 
 static DevPrivateKeyRec ClientDisconnectPrivateKeyRec;
 
@@ -60,6 +61,7 @@ typedef struct _ClientDisconnect {
 #define GetClientDisconnect(s) \
     ((ClientDisconnectPtr) dixLookupPrivate(&(s)->devPrivates, \
                                             ClientDisconnectPrivateKey))
+Bool allowForceTerminate;
 
 int
 ProcXFixesSetClientDisconnectMode(ClientPtr client)
@@ -68,9 +70,35 @@ ProcXFixesSetClientDisconnectMode(ClientPtr client)
     X_REQUEST_FIELD_CARD32(disconnect_mode);
 
     ClientDisconnectPtr pDisconnect = GetClientDisconnect(client);
+
+    int rc = Success;
+
+    if (stuff->disconnect_mode &
+        ~(CARD32)(XFixesClientDisconnectFlagTerminate |
+                  XFixesClientDisconnectFlagForceTerminate))
+        return BadValue;
+    /*
+     * To force the server to terminate, the client must be local
+     * and have permission to manage the server.
+     */
+    if (stuff->disconnect_mode & XFixesClientDisconnectFlagForceTerminate) {
+        if (!ClientIsLocal(client)) {
+            LogMessage(X_WARNING, "Forced server termination request refused because client is not local");
+            return BadAccess;
+        }
+        if ((rc = XaceHookServerAccess(client, DixManageAccess))) {
+            LogMessage(X_WARNING, "Forced server termination request blocked by X Access Control Extension");
+            return rc;
+        }
+        if (!allowForceTerminate) {
+            LogMessage(X_WARNING, "Forced server termination request blocked by server configuration (remove NoAllowForceTerminate to enable)");
+            return BadAccess;
+        }
+    }
+
     pDisconnect->disconnect_mode = stuff->disconnect_mode;
 
-    return Success;
+    return rc;
 }
 
 int
@@ -101,6 +129,17 @@ XFixesShouldDisconnectClient(ClientPtr client)
         return (pDisconnect->disconnect_mode & XFixesClientDisconnectFlagTerminate);
 
     return FALSE;
+}
+
+Bool
+XFixesMustTerminateServerOnDisconnect(ClientPtr client)
+{
+    ClientDisconnectPtr pDisconnect = GetClientDisconnect(client);
+
+    if (!pDisconnect)
+        return FALSE;
+
+    return (pDisconnect->disconnect_mode & XFixesClientDisconnectFlagForceTerminate);
 }
 
 Bool

--- a/Xext/xfixes/xfixesint.h
+++ b/Xext/xfixes/xfixesint.h
@@ -201,6 +201,13 @@ int
 Bool
  XFixesShouldDisconnectClient(ClientPtr client);
 
+Bool
+ XFixesMustTerminateServerOnDisconnect(ClientPtr client);
+
+#ifndef XFixesClientDisconnectFlagForceTerminate
+#define XFixesClientDisconnectFlagForceTerminate (1L << 1)
+#endif
+
 /* Xinerama */
 #ifdef XINERAMA
 void PanoramiXFixesInit(void);

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -3637,6 +3637,15 @@ CloseDownClient(ClientPtr client)
     Bool really_close_down = client->clientGone ||
         client->closeDownMode == DestroyAll;
 
+    if (XFixesMustTerminateServerOnDisconnect(client)) {
+        /* A screen locker has just crashed!  Set stopAllEventDelivery
+	 * to prevent any further delivery of events, then shut down.
+         */
+        ErrorF("Client that set XFixesClientDisconnectFlagForceTerminate exited, aborting!");
+        stopAllEventDelivery = xTrue;
+        dispatchException |= DE_TERMINATE;
+    }
+
     if (!client->clientGone) {
         /* ungrab server if grabbing client dies */
         if (grabState != GrabNone && grabClient == client) {

--- a/dix/events.c
+++ b/dix/events.c
@@ -6034,6 +6034,8 @@ ProcRecolorCursor(ClientPtr client)
     return Success;
 }
 
+Bool stopAllEventDelivery;
+
 /**
  * Write the given events to a client, swapping the byte order if necessary.
  * To swap the byte ordering, a callback is called that has to be set up for
@@ -6056,6 +6058,9 @@ WriteEventsToClient(ClientPtr pClient, int count, xEvent *events)
 #endif /* XINERAMA */
     xEvent *eventTo, *eventFrom;
     int eventlength = sizeof(xEvent);
+
+    if (stopAllEventDelivery)
+        return;
 
     if (!pClient || pClient == serverClient || pClient->clientGone)
         return;

--- a/hw/xfree86/common/xf86Config.c
+++ b/hw/xfree86/common/xf86Config.c
@@ -74,6 +74,7 @@
 #include "loaderProcs.h"
 #include "xf86Xinput_priv.h"
 
+#include "misc.h"
 #include "picture.h"
 
 /*
@@ -629,6 +630,7 @@ typedef enum {
     FLAG_DONTVTSWITCH,
     FLAG_DONTZAP,
     FLAG_DONTZOOM,
+    FLAG_ALLOW_FORCE_TERMINATE,
     FLAG_DISABLEVIDMODE,
     FLAG_ALLOWNONLOCAL,
     FLAG_ALLOWMOUSEOPENFAIL,
@@ -662,6 +664,8 @@ typedef enum {
  * if the parser found the option in the config file.
  */
 static OptionInfoRec FlagOptions[] = {
+    {FLAG_ALLOW_FORCE_TERMINATE, "AllowForceTerminate", OPTV_BOOLEAN,
+     {0}, FALSE},
     {FLAG_DONTVTSWITCH, "DontVTSwitch", OPTV_BOOLEAN,
      {0}, FALSE},
     {FLAG_DONTZAP, "DontZap", OPTV_BOOLEAN,
@@ -734,6 +738,12 @@ configServerFlags(XF86ConfFlagsPtr flagsconf, XF86OptionPtr layoutopts)
     const char *rules;
 
     /*
+     * Allow force terminate by default when running on hardware.
+     * Other DDXs do not set this.
+     */
+    allowForceTerminate = TRUE;
+
+    /*
      * Merge the ServerLayout and ServerFlags options.  The former have
      * precedence over the latter.
      */
@@ -753,6 +763,7 @@ configServerFlags(XF86ConfFlagsPtr flagsconf, XF86OptionPtr layoutopts)
     xf86GetOptValBool(FlagOptions, FLAG_DONTVTSWITCH, &xf86Info.dontVTSwitch);
     xf86GetOptValBool(FlagOptions, FLAG_DONTZAP, &xf86Info.dontZap);
     xf86GetOptValBool(FlagOptions, FLAG_DONTZOOM, &xf86Info.dontZoom);
+    xf86GetOptValBool(FlagOptions, FLAG_ALLOW_FORCE_TERMINATE, &allowForceTerminate);
 
     xf86GetOptValBool(FlagOptions, FLAG_IGNORE_ABI, &xf86Info.ignoreABI);
     if (xf86Info.ignoreABI) {

--- a/include/misc.h
+++ b/include/misc.h
@@ -303,4 +303,10 @@ typedef unsigned long x_server_generation_t;
 extern _X_EXPORT unsigned long globalSerialNumber;
 extern _X_EXPORT x_server_generation_t serverGeneration;
 
+/* Stop all event delivery to clients effective immediately. */
+extern Bool stopAllEventDelivery;
+
+/* Allow clients to force the X server to terminate */
+extern Bool allowForceTerminate;
+
 #endif                          /* MISC_H */

--- a/meson.build
+++ b/meson.build
@@ -98,7 +98,7 @@ xextproto_dep = dependency('xextproto', version: '>= 7.2.99.901', fallback: ['xo
 inputproto_dep = dependency('inputproto', version: '>= 2.3.99.1', fallback: ['xorgproto', 'ext_xorgproto'])
 kbproto_dep = dependency('kbproto', version: '>= 1.0.3', fallback: ['xorgproto', 'ext_xorgproto'])
 fontsproto_dep = dependency('fontsproto', version: '>= 2.1.3', fallback: ['xorgproto', 'ext_xorgproto'])
-fixesproto_dep = dependency('fixesproto', version: '>= 6.0', fallback: ['xorgproto', 'ext_xorgproto'])
+fixesproto_dep = dependency('fixesproto', version: '>= 6.1', fallback: ['xorgproto', 'ext_xorgproto'])
 damageproto_dep = dependency('damageproto', version: '>= 1.1', fallback: ['xorgproto', 'ext_xorgproto'])
 xcmiscproto_dep = dependency('xcmiscproto', version: '>= 1.2.0', fallback: ['xorgproto', 'ext_xorgproto'])
 bigreqsproto_dep = dependency('bigreqsproto', version: '>= 1.1.0', fallback: ['xorgproto', 'ext_xorgproto'])


### PR DESCRIPTION
This adds support for terminating the server when a screen locker exits.
Since this allows a client to cause the server to terminate, the client
must be local and have DixManageAccess on the server.

Signed-off-by: Demi Marie Obenour <demiobenour@gmail.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/719>

Add AllowForceTerminate to xorg.conf

Forced termination is only allowed on bare hardware, not when running in
another window system.

Signed-off-by: Demi Marie Obenour <demiobenour@gmail.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/719>

Add log messages when ForceTerminate is blocked

This allows users to know why a request was blocked, which is useful for
debugging.

Signed-off-by: Demi Marie Obenour <demiobenour@gmail.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/719>

xfree86: correct flag set by AllowForceTerminate option

Fixes: 5967a88f0 ("Add AllowForceTerminate to xorg.conf") from !719
Reported-by: @stefan11111
Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2258>

meson: raise fixesproto required version from 6.0 to 6.1

This was in @DemiMarie's commit 9e06a58a but got lost in one of the
later revisions prior to the final merge.

Fixes: 7c8fec74d ("Implement XFixes 6.1")
Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2258>
