### PR TITLE
(master) Xext: composite: make compAllocPixmap() bool

### DIFF
--- a/Xext/composite/compalloc.c
+++ b/Xext/composite/compalloc.c
@@ -50,6 +50,7 @@
 #include "Xext/damage/damageext_priv.h"
 
 #include "compint.h"
+#include "compositeext_intern.h"
 
 static Bool
 compScreenUpdate(ClientPtr pClient, void *closure)
@@ -612,8 +613,7 @@ compNewPixmap(WindowPtr pWin, int x, int y, int w, int h)
     return pPixmap;
 }
 
-Bool
-compAllocPixmap(WindowPtr pWin)
+bool compAllocPixmap(WindowPtr pWin)
 {
     int bw = (int) pWin->borderWidth;
     int x = pWin->drawable.x - bw;
@@ -622,7 +622,7 @@ compAllocPixmap(WindowPtr pWin)
     int h = pWin->drawable.height + (bw << 1);
     PixmapPtr pPixmap = compNewPixmap(pWin, x, y, w, h);
     CompWindowPtr cw = GetCompWindow(pWin);
-    Bool status;
+    bool status;
 
     if (!pPixmap) {
         status = FALSE;

--- a/Xext/composite/compint.h
+++ b/Xext/composite/compint.h
@@ -206,9 +206,6 @@ int
 int
  compUnredirectOneSubwindow(WindowPtr pParent, WindowPtr pWin);
 
-Bool
- compAllocPixmap(WindowPtr pWin);
-
 void
  compSetParentPixmap(WindowPtr pWin);
 

--- a/Xext/composite/compositeext_intern.h
+++ b/Xext/composite/compositeext_intern.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3+
+ *
+ * Copyright © 2026 Enrico Weigelt, metux IT consult <info@metux.net>
+ *
+ * This header holds definitions that are only used within the composite
+ * extensions - other parts of the Xserver should never include it.
+ */
+#ifndef _XSERVER_COMPOSITEEXT_INTERN_H_
+#define _XSERVER_COMPOSITEEXT_INTERN_H_
+
+#include <stdbool.h>
+
+#include "include/xlibre_ptrtypes.h"
+
+bool compAllocPixmap(WindowPtr pWin);
+
+#endif /* _XSERVER_COMPOSITEEXT_INTERN_H_ */

--- a/Xext/composite/compositeext_priv.h
+++ b/Xext/composite/compositeext_priv.h
@@ -1,7 +1,6 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3+
  *
- * Copyright © 1987, 1998  The Open Group
- * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
+ * Copyright © 2026 Enrico Weigelt, metux IT consult <info@metux.net>
  */
 #ifndef _XSERVER_COMPOSITEEXT_PRIV_H_
 #define _XSERVER_COMPOSITEEXT_PRIV_H_

--- a/Xext/composite/compwindow.c
+++ b/Xext/composite/compwindow.c
@@ -53,6 +53,7 @@
 
 #include "compint.h"
 #include "compositeext_priv.h"
+#include "compositeext_intern.h"
 
 typedef struct _compPixmapVisit {
     WindowPtr pWindow;
@@ -130,9 +131,9 @@ compCheckRedirect(WindowPtr pWin)
     }
 
     if (should != (pWin->redirectDraw != RedirectDrawNone)) {
-        if (should)
-            return compAllocPixmap(pWin);
-        else {
+        if (should) {
+            return (!!compAllocPixmap(pWin));
+        } else {
             ScreenPtr pScreen = pWin->drawable.pScreen;
             PixmapPtr pPixmap = (*pScreen->GetWindowPixmap) (pWin);
 


### PR DESCRIPTION
use stdbool's bool type instead of our own.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
