### PR TITLE
(master) xext: composite: drop obsolete DeleteWindowNoInputDevices() declaration

### DIFF
--- a/Xext/composite/compint.h
+++ b/Xext/composite/compint.h
@@ -283,9 +283,6 @@ WindowPtr
  CompositeRealChildHead(WindowPtr pWin);
 
 int
- DeleteWindowNoInputDevices(void *value, XID wid);
-
-int
 
 compConfigNotify(WindowPtr pWin, int x, int y, int w, int h,
                  int bw, WindowPtr pSib);


### PR DESCRIPTION
the function doesn't exist anymore.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
