### PR TITLE
(master) xext: composite: move some function declarations

### DIFF
--- a/Xext/composite/compext.c
+++ b/Xext/composite/compext.c
@@ -50,6 +50,7 @@
 #include "Xext/panoramiX/panoramiXsrv.h"
 
 #include "compint.h"
+#include "compositeext_priv.h"
 #include "xace.h"
 #include "protocol-versions.h"
 

--- a/Xext/composite/compint.h
+++ b/Xext/composite/compint.h
@@ -285,12 +285,6 @@ Bool
 void compWindowDestroy(CallbackListPtr *pcbl, ScreenPtr pScreen, WindowPtr pWin);
 
 void
- compSetRedirectBorderClip(WindowPtr pWin, RegionPtr pRegion);
-
-RegionPtr
- compGetRedirectBorderClip(WindowPtr pWin);
-
-void
  compCopyWindow(WindowPtr pWin, xPoint ptOldOrg, RegionPtr prgnSrc);
 
 void
@@ -306,8 +300,5 @@ int
 
 compConfigNotify(WindowPtr pWin, int x, int y, int w, int h,
                  int bw, WindowPtr pSib);
-
-void PanoramiXCompositeInit(void);
-void PanoramiXCompositeReset(void);
 
 #endif                          /* _COMPINT_H_ */

--- a/Xext/composite/compositeext_priv.h
+++ b/Xext/composite/compositeext_priv.h
@@ -7,6 +7,12 @@
 
 #include <X11/X.h>
 
-#include "screenint.h"
+#include "include/xlibre_ptrtypes.h"
+
+void compSetRedirectBorderClip(WindowPtr pWin, RegionPtr pRegion);
+RegionPtr compGetRedirectBorderClip(WindowPtr pWin);
+
+void PanoramiXCompositeInit(void);
+void PanoramiXCompositeReset(void);
 
 #endif /* _XSERVER_COMPOSITEEXT_PRIV_H_ */

--- a/Xext/panoramiX/panoramiX.c
+++ b/Xext/panoramiX/panoramiX.c
@@ -41,7 +41,7 @@ Equipment Corporation.
 #include "include/misc.h"
 #include "miext/extinit_priv.h"
 #include "os/osdep.h"
-#include "Xext/composite/compint.h"
+#include "Xext/composite/compositeext_priv.h"
 #include "Xext/damage/damageext_priv.h"
 #include "Xext/render/picturestr_priv.h"
 #include "Xext/xfixes/xfixesint.h"

--- a/mi/mivaltree.c
+++ b/mi/mivaltree.c
@@ -94,7 +94,7 @@ Equipment Corporation.
 
 #include "dix/window_priv.h"
 #include "mi/mi_priv.h"
-#include "Xext/composite/compint.h"
+#include "Xext/composite/compositeext_priv.h"
 
 #include    "scrnintstr.h"
 #include    "validate.h"


### PR DESCRIPTION
move it them the compositeext_priv.h header, which is supposed to be
the one included by other parts of the Xserver.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
