### PR TITLE
(master) xext: dpms: make DPMSSupported() static and let it return bool

### DIFF
--- a/Xext/dpms/dpms.c
+++ b/Xext/dpms/dpms.c
@@ -162,8 +162,15 @@ SendDPMSInfoNotify(void)
     }
 }
 
-Bool
-DPMSSupported(void)
+/**
+ * Query whether DPMS is supported by any screen.
+ *
+ * Returns TRUE if at least one screen (or GPU screen) has a non-NULL
+ * DPMS function pointer.  Called during DPMSExtensionInit to decide
+ * whether to register the extension at all, and by the Info request
+ * to report the DPMS state.
+ */
+static bool DPMSSupported(void)
 {
     /* For each screen, check if DPMS is supported */
     DIX_FOR_EACH_SCREEN({

--- a/Xext/dpms/dpms_priv.h
+++ b/Xext/dpms/dpms_priv.h
@@ -56,16 +56,6 @@
 extern int DPMSSet(ClientPtr client, int level);
 
 /**
- * Query whether DPMS is supported by any screen.
- *
- * Returns TRUE if at least one screen (or GPU screen) has a non-NULL
- * DPMS function pointer.  Called during DPMSExtensionInit to decide
- * whether to register the extension at all, and by the Info request
- * to report the DPMS state.
- */
-extern Bool DPMSSupported(void);
-
-/**
  * Standby timeout in milliseconds.
  *
  * The idle time after which the server transitions to DPMS standby


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
