### PR TITLE
(master) xext: composite: drop obsolete include of xace.h

### DIFF
--- a/Xext/composite/compoverlay.c
+++ b/Xext/composite/compoverlay.c
@@ -52,8 +52,6 @@
 
 #include "compositeext_intern.h"
 #include "compint.h"
-#include "xace.h"
-
 
 static void compDestroyOverlayWindow(ScreenPtr pScreen)
 {


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
