### PR TITLE
(master) xext: dri2: let DRI2ModuleSetup() return bool

### DIFF
--- a/Xext/dri2/dri2.c
+++ b/Xext/dri2/dri2.c
@@ -49,6 +49,8 @@
 #include "dri2int.h"
 #include "damage.h"
 
+#include "dri2_intern.h"
+
 CARD8 dri2_major;               /* version of DRI2 supported by DDX */
 CARD8 dri2_minor;
 
@@ -1583,8 +1585,7 @@ DRI2CloseScreen(ScreenPtr pScreen)
 }
 
 /* Called by InitExtensions() */
-Bool
-DRI2ModuleSetup(void)
+bool DRI2ModuleSetup(void)
 {
     dri2DrawableRes = CreateNewResourceType(DRI2DrawableGone, "DRI2Drawable");
     if (!dri2DrawableRes)

--- a/Xext/dri2/dri2_intern.h
+++ b/Xext/dri2/dri2_intern.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3+
+ *
+ * Copyright © 2026 Enrico Weigelt, metux IT consult <info@metux.net>
+ *
+ * This header holds definitions that are only used within the dri2
+ * extensions - other parts of the Xserver should never include it.
+ */
+#ifndef _XSERVER_DRI2_INTERN_H_
+#define _XSERVER_DRI2_INTERN_H_
+
+#include <stdbool.h>
+
+#include "include/xlibre_ptrtypes.h"
+
+bool DRI2ModuleSetup(void);
+
+#endif /* _XSERVER_DRI2_INTERN_H_ */

--- a/Xext/dri2/dri2ext.c
+++ b/Xext/dri2/dri2ext.c
@@ -49,6 +49,7 @@
 #include "dri2_priv.h"
 #include "dri2int.h"
 #include "protocol-versions.h"
+#include "dri2_intern.h"
 
 /* For the static extension loader */
 Bool noDRI2Extension = FALSE;

--- a/Xext/dri2/dri2int.h
+++ b/Xext/dri2/dri2int.h
@@ -28,6 +28,4 @@
 
 #include <X11/Xdefs.h>
 
-extern Bool DRI2ModuleSetup(void);
-
 #endif /* XSERVER_XFREE86_DRI2INT_H */


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
