### PR TITLE
(master) xext: panoramiX: helpers for checking wether it's enabled/disabled

### DIFF
--- a/Xext/composite/compoverlay.c
+++ b/Xext/composite/compoverlay.c
@@ -49,6 +49,7 @@
 #include "dix/window_priv.h"
 #include "include/extinit.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 
 #include "compositeext_intern.h"
 #include "compint.h"
@@ -143,7 +144,7 @@ bool compCreateOverlayWindow(ScreenPtr pScreen)
     int x = 0, y = 0;
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         x = -pScreen->x;
         y = -pScreen->y;
         w = PanoramiXPixWidth;

--- a/Xext/composite/compwindow.c
+++ b/Xext/composite/compwindow.c
@@ -51,6 +51,7 @@
 #include "dix/window_priv.h"
 #include "include/extinit.h"
 #include "os/osdep.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
 
 #include "compint.h"
@@ -162,7 +163,7 @@ updateOverlayWindow(ScreenPtr pScreen)
     int h = pScreen->height;
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         w = PanoramiXPixWidth;
         h = PanoramiXPixHeight;
     }

--- a/Xext/damage/damageext.c
+++ b/Xext/damage/damageext.c
@@ -37,6 +37,7 @@
 #include "Xext/damage/damageext_priv.h"
 #include "Xext/panoramiX/panoramiX.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/xfixes/xfixes.h"
 
 #include "damagestr.h"
@@ -107,7 +108,7 @@ static void
 damageGetGeometry(DrawablePtr draw, int *x, int *y, int *w, int *h)
 {
 #ifdef XINERAMA
-    if (!noPanoramiXExtension && draw->type == DRAWABLE_WINDOW) {
+    if (PanoramiXIsEnabled() && draw->type == DRAWABLE_WINDOW) {
         WindowPtr win = (WindowPtr)draw;
 
         if (!win->parent) {
@@ -410,7 +411,7 @@ static bool DamageExtSubtract(DamageExtPtr pDamageExt, const RegionPtr pRegion)
     DamagePtr pDamage = pDamageExt->pDamage;
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         RegionPtr damage = DamageRegion(pDamage);
         RegionSubtract(damage, damage, pRegion);
 

--- a/Xext/doublebuffer/dbe.c
+++ b/Xext/doublebuffer/dbe.c
@@ -969,14 +969,13 @@ static void miDbeWindowDestroy(CallbackListPtr *pcbl, ScreenPtr pScreen, WindowP
 void
 DbeExtensionInit(void)
 {
+    if (PanoramiXIsEnabled()) {
+        return;
+    }
+
     ExtensionEntry *extEntry;
     DbeScreenPrivPtr pDbeScreenPriv;
     int nStubbedScreens = 0;
-
-#ifdef XINERAMA
-    if (!noPanoramiXExtension)
-        return;
-#endif /* XINERAMA */
 
     /* Create the resource types. */
     dbeDrawableResType =

--- a/Xext/dri2/dri2ext.c
+++ b/Xext/dri2/dri2ext.c
@@ -40,6 +40,7 @@
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
 #include "include/extinit.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/xfixes/xfixes.h"
 
 #include "dixstruct.h"
@@ -567,10 +568,9 @@ ProcDRI2Dispatch(ClientPtr client)
 void
 DRI2ExtensionInit(void)
 {
-#ifdef XINERAMA
-    if (!noPanoramiXExtension)
+    if (PanoramiXIsEnabled()) {
         return;
-#endif /* XINERAMA */
+    }
 
     /**
      * Advertise the DRI2 extension,

--- a/Xext/dri3/dri3.c
+++ b/Xext/dri3/dri3.c
@@ -85,6 +85,10 @@ static int dri3_syncobj_free(void *data, XID id)
 void
 dri3_extension_init(void)
 {
+    if (PanoramiXIsEnabled()) {
+        return;
+    }
+
     ExtensionEntry *extension;
 
     /* If no screens support DRI3, there's no point offering the
@@ -92,11 +96,6 @@ dri3_extension_init(void)
      */
     if (dri3_screen_generation != serverGeneration)
         return;
-
-#ifdef XINERAMA
-    if (!noPanoramiXExtension)
-        return;
-#endif /* XINERAMA */
 
     extension = AddExtension(DRI3_NAME, DRI3NumberEvents, DRI3NumberErrors,
                              proc_dri3_dispatch, proc_dri3_dispatch,

--- a/Xext/panoramiX/panoramiX.c
+++ b/Xext/panoramiX/panoramiX.c
@@ -43,6 +43,7 @@ Equipment Corporation.
 #include "os/osdep.h"
 #include "Xext/composite/compositeext_priv.h"
 #include "Xext/damage/damageext_priv.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/render/picturestr_priv.h"
 #include "Xext/xfixes/xfixesint.h"
 
@@ -425,7 +426,7 @@ PanoramiXExtensionInit(void)
     Bool success = FALSE;
     ScreenPtr masterScreen = dixGetMasterScreen();
 
-    if (noPanoramiXExtension)
+    if (PanoramiXIsDisabled())
         return;
 
     if (!dixRegisterPrivateKey(&PanoramiXScreenKeyRec, PRIVATE_SCREEN, 0)) {
@@ -901,7 +902,7 @@ ProcPanoramiXGetState(ClientPtr client)
     X_CALL_CHECK_ERR(dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess));
 
     xPanoramiXGetStateReply reply = {
-        .state = !noPanoramiXExtension,
+        .state = PanoramiXIsEnabled(),
         .window = stuff->window
     };
 
@@ -969,9 +970,9 @@ ProcXineramaIsActive(ClientPtr client)
 #if 1
         /* The following hack fools clients into thinking that Xinerama
          * is disabled even though it is not. */
-        .state = !noPanoramiXExtension && !PanoramiXExtensionDisabledHack
+        .state = PanoramiXIsEnabled() && !PanoramiXExtensionDisabledHack
 #else
-        .state = !noPanoramiXExtension;
+        .state = PanoramiXIsEnabled();
 #endif
     };
 
@@ -985,14 +986,14 @@ ProcXineramaQueryScreens(ClientPtr client)
 {
     X_REQUEST_HEAD_STRUCT(xXineramaQueryScreensReq);
 
-    CARD32 number = (noPanoramiXExtension) ? 0 : PanoramiXNumScreens;
+    CARD32 number = PanoramiXIsDisabled() ? 0 : PanoramiXNumScreens;
     xXineramaQueryScreensReply reply = {
         .number = number
     };
 
     x_rpcbuf_t rpcbuf = { .swapped = client->swapped, .err_clear = TRUE };
 
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         XINERAMA_FOR_EACH_SCREEN_BACKWARD({
             /* xXineramaScreenInfo is the same as xRectangle */
             x_rpcbuf_write_rect(&rpcbuf,

--- a/Xext/panoramiX/panoramiX_priv.h
+++ b/Xext/panoramiX/panoramiX_priv.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3+
+ *
+ * Copyright © 2026 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef _XSERVER_PANORAMIX_PRIV_H_
+#define _XSERVER_PANORAMIX_PRIV_H_
+
+#include <stdbool.h>
+
+#include "include/extinit.h"
+
+/*
+ * @brief return TRUE if panoramiX / xinerama extension is enabled
+ */
+static inline bool PanoramiXIsEnabled(void) {
+#ifdef XINERAMA
+    return !noPanoramiXExtension;
+#else
+    return FALSE;
+#endif
+}
+
+/*
+ * @brief return TRUE if panoramiX / xinerama extension is disabled
+ */
+static inline bool PanoramiXIsDisabled(void) {
+    return !PanoramiXIsEnabled();
+}
+
+#endif /* _XSERVER_PANORAMIX_PRIV_H_ */

--- a/Xext/present/present_screen.c
+++ b/Xext/present/present_screen.c
@@ -247,10 +247,9 @@ present_screen_init(ScreenPtr screen, present_screen_info_ptr info)
 void
 present_extension_init(void)
 {
-#ifdef XINERAMA
-    if (!noPanoramiXExtension)
+    if (PanoramiXIsEnabled()) {
         return;
-#endif /* XINERAMA */
+    }
 
     ExtensionEntry *extension = AddExtension(
                              PRESENT_NAME, PresentNumberEvents, PresentNumberErrors,

--- a/Xext/randr/rrxinerama.c
+++ b/Xext/randr/rrxinerama.c
@@ -301,10 +301,9 @@ ProcRRXineramaDispatch(ClientPtr client)
 void
 RRXineramaExtensionInit(void)
 {
-#ifdef XINERAMA
-    if (!noPanoramiXExtension)
+    if (PanoramiXIsEnabled()) {
         return;
-#endif /* XINERAMA */
+    }
 
     if (noRRXineramaExtension)
       return;

--- a/Xext/record/record.c
+++ b/Xext/record/record.c
@@ -722,7 +722,7 @@ RecordSendProtocolEvents(RecordClientsAndProtocolPtr pRCAP,
 #ifdef XINERAMA
             xEvent shiftedEvent;
 
-            if (!noPanoramiXExtension &&
+            if (PanoramiXIsEnabled() &&
                 (pev->u.u.type == MotionNotify ||
                  pev->u.u.type == ButtonPress ||
                  pev->u.u.type == ButtonRelease ||

--- a/Xext/render/picture.c
+++ b/Xext/render/picture.c
@@ -44,9 +44,9 @@
 #include "picturestr_priv.h"
 #include "glyphstr_priv.h"
 #include "xace.h"
-#ifdef XINERAMA
+
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
-#endif /* XINERAMA */
 
 DevPrivateKeyRec PictureScreenPrivateKeyRec;
 DevPrivateKeyRec PictureWindowPrivateKeyRec;
@@ -998,7 +998,7 @@ static int
 cpAlphaMap(void **result, XID id, ScreenPtr screen, ClientPtr client, Mask mode)
 {
 #ifdef XINERAMA
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         PanoramiXRes *res;
         int err = dixLookupResourceByType((void **)&res, id, XRT_PICTURE,
                                           client, mode);
@@ -1017,7 +1017,7 @@ static int
 cpClipMask(void **result, XID id, ScreenPtr screen, ClientPtr client, Mask mode)
 {
 #ifdef XINERAMA
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         PanoramiXRes *res;
         int err = dixLookupResourceByType((void **)&res, id, XRT_PIXMAP,
                                           client, mode);

--- a/Xext/render/render.c
+++ b/Xext/render/render.c
@@ -41,6 +41,7 @@
 #include "miext/extinit_priv.h"
 #include "os/osdep.h"
 #include "Xext/panoramiX/panoramiX.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
 
 #include "os.h"
@@ -200,7 +201,7 @@ ProcRenderQueryPictFormats(ClientPtr client)
     X_REQUEST_HEAD_STRUCT(xRenderQueryPictFormatsReq);
 
 #ifdef XINERAMA
-    if (noPanoramiXExtension)
+    if (PanoramiXIsDisabled())
         numScreens = screenInfo.numScreens;
     else
         numScreens = ((xConnSetup *) ConnectionInfo)->numRoots;

--- a/Xext/saver/saver.c
+++ b/Xext/saver/saver.c
@@ -48,6 +48,7 @@ in this Software without prior written authorization from the X Consortium.
 #include "os/screensaver.h"
 #include "Xext/dpms/dpms_priv.h"
 #include "Xext/panoramiX/panoramiX.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
 
 #include "os.h"
@@ -612,7 +613,7 @@ ScreenSaverHandle(ScreenPtr pScreen, int xstate, Bool force)
 
     }
 #ifdef XINERAMA
-    if (noPanoramiXExtension || !pScreen->myNum)
+    if (PanoramiXIsDisabled() || !pScreen->myNum)
 #endif /* XINERAMA */
     {
         SendScreenSaverNotify(pScreen, state, force);
@@ -1105,7 +1106,7 @@ ProcScreenSaverSetAttributes(ClientPtr client)
     X_REQUEST_REST_CARD32();
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         PanoramiXRes *draw;
         PanoramiXRes *backPix = NULL;
         PanoramiXRes *bordPix = NULL;
@@ -1194,7 +1195,7 @@ ProcScreenSaverUnsetAttributes(ClientPtr client)
     X_REQUEST_FIELD_CARD32(drawable);
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         PanoramiXRes *draw;
         int i;
 

--- a/Xext/shape/shape.c
+++ b/Xext/shape/shape.c
@@ -42,6 +42,7 @@ in this Software without prior written authorization from The Open Group.
 #include "include/misc.h"
 #include "miext/extinit_priv.h"
 #include "Xext/panoramiX/panoramiX.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
 
 #include "os.h"
@@ -312,8 +313,9 @@ ProcShapeRectangles(ClientPtr client)
     X_REQUEST_REST_CARD16();
 
 #ifdef XINERAMA
-    if (noPanoramiXExtension)
+    if (PanoramiXIsDisabled()) {
         return ShapeRectangles(client, stuff);
+    }
 
     PanoramiXRes *win;
     int result;
@@ -410,8 +412,9 @@ ProcShapeMask(ClientPtr client)
     X_REQUEST_FIELD_CARD32(src);
 
 #ifdef XINERAMA
-    if (noPanoramiXExtension)
+    if (PanoramiXIsDisabled()) {
         return ShapeMask(client, stuff);
+    }
 
     PanoramiXRes *win, *pmap;
     int result;
@@ -540,8 +543,9 @@ ProcShapeCombine(ClientPtr client)
     X_REQUEST_FIELD_CARD32(src);
 
 #ifdef XINERAMA
-    if (noPanoramiXExtension)
+    if (PanoramiXIsDisabled()) {
         return ShapeCombine(client, stuff);
+    }
 
     PanoramiXRes *win, *win2;
     int result;
@@ -614,8 +618,9 @@ ProcShapeOffset(ClientPtr client)
     PanoramiXRes *win;
     int result;
 
-    if (noPanoramiXExtension)
+    if (PanoramiXIsDisabled()) {
         return ShapeOffset(client, stuff);
+    }
 
     result = dixLookupResourceByType((void **) &win, stuff->dest, XRT_WINDOW,
                                      client, DixWriteAccess);

--- a/Xext/shm/shm.c
+++ b/Xext/shm/shm.c
@@ -57,6 +57,7 @@ in this Software without prior written authorization from The Open Group.
 #include "os/log_priv.h"
 #include "os/osdep.h"
 #include "Xext/panoramiX/panoramiX.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
 
 #include "shm_priv.h"
@@ -706,7 +707,7 @@ ProcShmPutImage(ClientPtr client)
     PanoramiXRes *draw, *gc;
     Bool sendEvent;
 
-    if (noPanoramiXExtension)
+    if (PanoramiXIsDisabled())
         return ShmPutImage(client, stuff);
 
     int result = dixLookupResourceByClass((void **) &draw, stuff->drawable,
@@ -771,7 +772,7 @@ ProcShmGetImage(ClientPtr client)
     long lenPer = 0, length, widthBytesLine;
     Bool isRoot;
 
-    if (noPanoramiXExtension)
+    if (PanoramiXIsDisabled())
         return ShmGetImage(client, stuff);
 
     if ((stuff->format != XYPixmap) && (stuff->format != ZPixmap)) {
@@ -908,7 +909,7 @@ ProcShmCreatePixmap(ClientPtr client)
         return BadRequest;
 
 #ifdef XINERAMA
-    if (noPanoramiXExtension)
+    if (PanoramiXIsDisabled())
         return ShmCreatePixmap(client, stuff);
 
     PixmapPtr pMap = NULL;

--- a/Xext/xinput/xiquerypointer.c
+++ b/Xext/xinput/xiquerypointer.c
@@ -46,6 +46,7 @@
 #include "dix/screenint_priv.h"
 #include "include/extinit.h"
 #include "os/fmt.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
 #include "handlers.h"
 
@@ -163,7 +164,7 @@ ProcXIQueryPointer(ClientPtr client)
     }
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         ScreenPtr masterScreen = dixGetMasterScreen();
         reply.root_x += double_to_fp1616(masterScreen->x);
         reply.root_y += double_to_fp1616(masterScreen->y);

--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -61,6 +61,7 @@ SOFTWARE.
 #include "include/misc.h"
 #include "os/osdep.h"
 #include "os/bug_priv.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 
 #include "dix.h"
 #include "dixstruct.h"
@@ -470,7 +471,7 @@ TellNoMap(WindowPtr pwin, Colormap * pmid)
         };
         xE.u.u.type = ColormapNotify;
 #ifdef XINERAMA
-        if (noPanoramiXExtension || !pwin->drawable.pScreen->myNum)
+        if (PanoramiXIsDisabled() || !pwin->drawable.pScreen->myNum)
 #endif /* XINERAMA */
             DeliverEvents(pwin, &xE, 1, (WindowPtr) NULL);
         if (pwin->optional) {
@@ -488,10 +489,10 @@ TellLostMap(WindowPtr pwin, void *value)
 {
     Colormap *pmid = (Colormap *) value;
 
-#ifdef XINERAMA
-    if (!noPanoramiXExtension && pwin->drawable.pScreen->myNum)
+    if (PanoramiXIsEnabled() && pwin->drawable.pScreen->myNum) {
         return WT_STOPWALKING;
-#endif /* XINERAMA */
+    }
+
     if (wColormap(pwin) == *pmid) {
         /* This should be call to DeliverEvent */
         xEvent xE = {
@@ -514,9 +515,11 @@ TellGainedMap(WindowPtr pwin, void *value)
     Colormap *pmid = (Colormap *) value;
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension && pwin->drawable.pScreen->myNum)
+    if (PanoramiXIsEnabled() && pwin->drawable.pScreen->myNum) {
         return WT_STOPWALKING;
-#endif /* XINERAMA */
+    }
+#endif
+
     if (wColormap(pwin) == *pmid) {
         /* This should be call to DeliverEvent */
         xEvent xE = {

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -130,6 +130,7 @@ Equipment Corporation.
 #include "os/osdep.h"
 #include "os/probes_priv.h"
 #include "os/screensaver.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/xfixes/xfixesint.h"
 
 #include "windowstr.h"
@@ -2775,8 +2776,9 @@ ProcAllocNamedColor(ClientPtr client)
         swaps(&reply.screenBlue);
     }
 
+    /* if PanoramiX is active, and this isn't the master screen, keep radio silence */
 #ifdef XINERAMA
-    if (noPanoramiXExtension || !pcmp->pScreen->myNum)
+    if (PanoramiXIsDisabled() || !pcmp->pScreen->myNum)
         return X_SEND_REPLY_SIMPLE(client, reply);
     return Success;
 #else
@@ -2825,7 +2827,7 @@ ProcAllocColorCells(ClientPtr client)
             return rc;
         }
 #ifdef XINERAMA
-        if (noPanoramiXExtension || !pcmp->pScreen->myNum)
+        if (PanoramiXIsDisabled() || !pcmp->pScreen->myNum)
 #endif /* XINERAMA */
         {
             xAllocColorCellsReply reply = {
@@ -2901,7 +2903,7 @@ ProcAllocColorPlanes(ClientPtr client)
         }
 
 #ifdef XINERAMA
-        if (noPanoramiXExtension || !pcmp->pScreen->myNum)
+        if (PanoramiXIsDisabled() || !pcmp->pScreen->myNum)
 #endif /* XINERAMA */
         {
             return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
@@ -3878,7 +3880,7 @@ SendConnSetup(ClientPtr client, const char *reason)
     /* fill in the "currentInputMask" */
     root = (xWindowRoot *) (lConnectionInfo + connBlockScreenStart);
 #ifdef XINERAMA
-    if (noPanoramiXExtension)
+    if (PanoramiXIsDisabled())
         numScreens = screenInfo.numScreens;
     else
         numScreens = ((xConnSetup *) ConnectionInfo)->numRoots;

--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -19,33 +19,6 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
 SOFTWARE.
 
-************************************************************************/
-/* The panoramix components contained the following notice */
-/*
-Copyright (c) 1991, 1997 Digital Equipment Corporation, Maynard, Massachusetts.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software.
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
-DIGITAL EQUIPMENT CORPORATION BE LIABLE FOR ANY CLAIM, DAMAGES, INCLUDING,
-BUT NOT LIMITED TO CONSEQUENTIAL OR INCIDENTAL DAMAGES, OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-Except as contained in this notice, the name of Digital Equipment Corporation
-shall not be used in advertising or otherwise to promote the sale, use or other
-dealings in this Software without prior written authorization from Digital
-Equipment Corporation.
-
 ******************************************************************/
 
 #include <dix-config.h>
@@ -71,6 +44,7 @@ Equipment Corporation.
 #include "os/auth.h"
 #include "os/io_priv.h"
 #include "os/log_priv.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/xf86bigfont/xf86bigfontsrv.h"
 
 #include "scrnintstr.h"
@@ -1413,7 +1387,7 @@ doPolyText(ClientPtr client, struct poly_text_closure *c)
         err = c->err;
     if (err != Success && c->client != serverClient) {
 #ifdef XINERAMA
-        if (noPanoramiXExtension || !c->pGC->pScreen->myNum)
+        if (PanoramiXIsDisabled() || !c->pGC->pScreen->myNum)
 #endif /* XINERAMA */
             SendErrorToClient(c->client, c->reqType, 0, 0, err);
     }

--- a/dix/events.c
+++ b/dix/events.c
@@ -142,6 +142,7 @@ Equipment Corporation.
 #include "os/log_priv.h"
 #include "os/probes_priv.h"
 #include "Xext/panoramiX/panoramiX.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
 #include "Xext/xinput/exglobals.h"
 #include "Xext/xkeyboard/xkbsrv_priv.h"
@@ -522,7 +523,7 @@ SyntheticMotion(DeviceIntPtr dev, int x, int y)
     int screenno = 0;
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension)
+    if (PanoramiXIsEnabled())
         screenno = dev->spriteInfo->sprite->screen->myNum;
 #endif /* XINERAMA */
     PostSyntheticMotion(dev, x, y, screenno,
@@ -626,8 +627,6 @@ XineramaConfineCursorToWindow(DeviceIntPtr pDev,
     SpritePtr pSprite = pDev->spriteInfo->sprite;
 
     int x, y, off_x, off_y;
-
-    assert(!noPanoramiXExtension);
 
     if (!XineramaSetWindowPntrs(pDev, pWin))
         return;
@@ -747,7 +746,7 @@ CheckPhysLimits(DeviceIntPtr pDev, CursorPtr cursor, Bool generateEvents,
         return;
     new = pSprite->hotPhys;
 #ifdef XINERAMA
-    if (!noPanoramiXExtension)
+    if (PanoramiXIsEnabled())
         /* I don't care what the DDX has to say about it */
         pSprite->physLimits = pSprite->hotLimits;
     else
@@ -775,13 +774,11 @@ CheckPhysLimits(DeviceIntPtr pDev, CursorPtr cursor, Bool generateEvents,
     if (pSprite->hotShape)
         ConfineToShape(pSprite->hotShape, &new.x, &new.y);
     if ((
-#ifdef XINERAMA
-            noPanoramiXExtension &&
-#endif /* XINERAMA */
+            PanoramiXIsDisabled() &&
             (pScreen != pSprite->hotPhys.pScreen)) ||
         (new.x != pSprite->hotPhys.x) || (new.y != pSprite->hotPhys.y)) {
 #ifdef XINERAMA
-        if (!noPanoramiXExtension)
+        if (PanoramiXIsEnabled())
             XineramaSetCursorPosition(pDev, new.x, new.y, generateEvents);
         else
 #endif /* XINERAMA */
@@ -797,7 +794,7 @@ CheckPhysLimits(DeviceIntPtr pDev, CursorPtr cursor, Bool generateEvents,
 
 #ifdef XINERAMA
     /* Tell DDX what the limits are */
-    if (!noPanoramiXExtension)
+    if (PanoramiXIsEnabled())
         XineramaConstrainCursor(pDev);
 #endif /* XINERAMA */
 }
@@ -834,7 +831,7 @@ CheckVirtualMotion(DeviceIntPtr pDev, QdEventPtr qe, WindowPtr pWin)
         BoxRec lims;
 
 #ifdef XINERAMA
-        if (!noPanoramiXExtension) {
+        if (PanoramiXIsEnabled()) {
             int x, y, off_x, off_y;
 
             if (!XineramaSetWindowPntrs(pDev, pWin))
@@ -882,7 +879,7 @@ CheckVirtualMotion(DeviceIntPtr pDev, QdEventPtr qe, WindowPtr pWin)
             pSprite->hot.y = lims.y2 - 1;
 
 #ifdef XINERAMA
-        if (!noPanoramiXExtension) {
+        if (PanoramiXIsEnabled()) {
             if (RegionNumRects(&pSprite->Reg2) > 1)
                 reg = &pSprite->Reg2;
 
@@ -903,9 +900,7 @@ CheckVirtualMotion(DeviceIntPtr pDev, QdEventPtr qe, WindowPtr pWin)
             ev->root_y = pSprite->hot.y;
         }
     }
-#ifdef XINERAMA
-    if (noPanoramiXExtension)   /* No typo. Only set the root win if disabled */
-#endif /* XINERAMA */
+    if (PanoramiXIsDisabled())   /* No typo. Only set the root win if disabled */
         RootWindow(pDev->spriteInfo->sprite) = pSprite->hot.pScreen->root;
 }
 
@@ -923,7 +918,7 @@ ConfineCursorToWindow(DeviceIntPtr pDev, WindowPtr pWin, Bool generateEvents,
         ScreenPtr pScreen = pWin->drawable.pScreen;
 
 #ifdef XINERAMA
-        if (!noPanoramiXExtension) {
+        if (PanoramiXIsEnabled()) {
             XineramaConfineCursorToWindow(pDev, pWin, generateEvents);
             return;
         }
@@ -965,7 +960,7 @@ ChangeToCursor(DeviceIntPtr pDev, CursorPtr cursor)
                             (ScreenPtr) NULL);
 #ifdef XINERAMA
         /* XXX: is this really necessary?? (whot) */
-        if (!noPanoramiXExtension)
+        if (PanoramiXIsEnabled())
             pScreen = pSprite->screen;
         else
 #endif /* XINERAMA */
@@ -1191,7 +1186,7 @@ EnqueueEvent(InternalEvent *ev, DeviceIntPtr device)
 
     if (event->type == ET_Motion) {
 #ifdef XINERAMA
-        if (!noPanoramiXExtension) {
+        if (PanoramiXIsEnabled()) {
             ScreenPtr masterScreen = dixGetMasterScreen();
             event->root_x += pSprite->screen->x - masterScreen->x;
             event->root_y += pSprite->screen->y - masterScreen->y;
@@ -1261,7 +1256,7 @@ PlayReleasedEvents(void)
             /* Translate back to the sprite screen since processInputProc
                will translate from sprite screen to screen 0 upon reentry
                to the DIX layer */
-            if (!noPanoramiXExtension) {
+            if (PanoramiXIsEnabled()) {
                 DeviceEvent *ev = &qe->event->device_event;
 
                 switch (ev->type) {
@@ -2559,7 +2554,7 @@ Bool MaybeDeliverEventToClient(WindowPtr pWin, xEvent *pEvents,
         if (dixClientForWindow(pWin) == dontClient)
             return FALSE;
 #ifdef XINERAMA
-        if (!noPanoramiXExtension && pWin->drawable.pScreen->myNum)
+        if (PanoramiXIsEnabled() && pWin->drawable.pScreen->myNum)
             return XineramaTryClientEventsResult(dixClientForWindow(pWin), NullGrab,
                                                  pWin->eventMask, filter);
 #endif /* XINERAMA */
@@ -2573,7 +2568,7 @@ Bool MaybeDeliverEventToClient(WindowPtr pWin, xEvent *pEvents,
             if (SameClient(other, dontClient))
                 return FALSE;
 #ifdef XINERAMA
-            if (!noPanoramiXExtension && pWin->drawable.pScreen->myNum)
+            if (PanoramiXIsEnabled() && pWin->drawable.pScreen->myNum)
                 return XineramaTryClientEventsResult(dixClientForOtherClients(other), NullGrab,
                                                      other->mask, filter);
 #endif /* XINERAMA */
@@ -2955,7 +2950,7 @@ DeliverEvents(WindowPtr pWin, xEvent *xE, size_t count, WindowPtr otherParent)
     int deliveries;
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension && pWin->drawable.pScreen->myNum)
+    if (PanoramiXIsEnabled() && pWin->drawable.pScreen->myNum)
         return count;
 #endif /* XINERAMA */
 
@@ -3023,7 +3018,7 @@ PointInBorderSize(WindowPtr pWin, int x, int y)
         return TRUE;
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension &&
+    if (PanoramiXIsEnabled() &&
         XineramaSetWindowPntrs(inputInfo.pointer, pWin)) {
         SpritePtr pSprite = inputInfo.pointer->spriteInfo->sprite;
         ScreenPtr masterScreen = dixGetMasterScreen();
@@ -3178,7 +3173,7 @@ CheckMotion(DeviceEvent *ev, DeviceIntPtr pDev)
         }
 
 #ifdef XINERAMA
-        if (!noPanoramiXExtension) {
+        if (PanoramiXIsEnabled()) {
             /* Motion events entering DIX get translated to Screen 0
                coordinates.  Replayed events have already been
                translated since they've entered DIX before */
@@ -3214,7 +3209,7 @@ CheckMotion(DeviceEvent *ev, DeviceIntPtr pDev)
         if ((pSprite->hotPhys.x != ev->root_x) ||
             (pSprite->hotPhys.y != ev->root_y)) {
 #ifdef XINERAMA
-            if (!noPanoramiXExtension) {
+            if (PanoramiXIsEnabled()) {
                 XineramaSetCursorPosition(pDev, pSprite->hotPhys.x,
                                           pSprite->hotPhys.y, FALSE);
             }
@@ -3374,7 +3369,7 @@ InitializeSprite(DeviceIntPtr pDev, WindowPtr pWin)
         dixScreenRaiseDisplayCursor(pScreen, pDev, pSprite->current);
     }
 #ifdef XINERAMA
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         ScreenPtr masterScreen = dixGetMasterScreen();
         pSprite->hotLimits.x1 = -masterScreen->x;
         pSprite->hotLimits.y1 = -masterScreen->y;
@@ -3453,7 +3448,7 @@ UpdateSpriteForScreen(DeviceIntPtr pDev, ScreenPtr pScreen)
     dixScreenRaiseDisplayCursor(pScreen, pDev, pSprite->current);
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         ScreenPtr masterScreen = dixGetMasterScreen();
         pSprite->hotLimits.x1 = -masterScreen->x;
         pSprite->hotLimits.y1 = -masterScreen->y;
@@ -3494,7 +3489,7 @@ NewCurrentScreen(DeviceIntPtr pDev, ScreenPtr newScreen, int x, int y)
     pSprite->hotPhys.x = x;
     pSprite->hotPhys.y = y;
 #ifdef XINERAMA
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         ScreenPtr masterScreen = dixGetMasterScreen();
         pSprite->hotPhys.x += newScreen->x - masterScreen->x;
         pSprite->hotPhys.y += newScreen->y - masterScreen->y;
@@ -3668,7 +3663,7 @@ ProcWarpPointer(ClientPtr client)
     pSprite = dev->spriteInfo->sprite;
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension)
+    if (PanoramiXIsEnabled())
         return XineramaWarpPointer(client);
 #endif /* XINERAMA */
 
@@ -3750,7 +3745,7 @@ BorderSizeNotEmpty(DeviceIntPtr pDev, WindowPtr pWin)
         return TRUE;
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension && XineramaSetWindowPntrs(pDev, pWin)) {
+    if (PanoramiXIsEnabled() && XineramaSetWindowPntrs(pDev, pWin)) {
         XINERAMA_FOR_EACH_SCREEN_FORWARD_SKIP0({
             if (RegionNotEmpty
                 (&pDev->spriteInfo->sprite->windows[walkScreenIdx]->borderSize))
@@ -5390,7 +5385,7 @@ ProcQueryPointer(ClientPtr client)
     }
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         ScreenPtr masterScreen = dixGetMasterScreen();
         reply.rootX += masterScreen->x;
         reply.rootY += masterScreen->y;
@@ -5963,7 +5958,7 @@ CheckCursorConfinement(WindowPtr pWin)
     WindowPtr confineTo;
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension && pWin->drawable.pScreen->myNum)
+    if (PanoramiXIsEnabled() && pWin->drawable.pScreen->myNum)
         return;
 #endif /* XINERMA */
 
@@ -6023,7 +6018,7 @@ ProcRecolorCursor(ClientPtr client)
 
     DIX_FOR_EACH_SCREEN({
 #ifdef XINERAMA
-        if (!noPanoramiXExtension)
+        if (PanoramiXIsEnabled())
             displayed = (walkScreen == pSprite->screen);
         else
 #endif /* XINERAMA */
@@ -6069,7 +6064,7 @@ WriteEventsToClient(ClientPtr pClient, int count, xEvent *events)
 
 #ifdef XINERAMA
     ScreenPtr masterScreen = dixGetMasterScreen();
-    if (!noPanoramiXExtension && (masterScreen->x || masterScreen->y)) {
+    if (PanoramiXIsEnabled() && (masterScreen->x || masterScreen->y)) {
         switch (events->u.u.type) {
         case MotionNotify:
         case ButtonPress:

--- a/dix/getevents.c
+++ b/dix/getevents.c
@@ -50,6 +50,7 @@
 #include "os/probes_priv.h"
 #include "os/mathx_priv.h"
 #include "Xext/panoramiX/panoramiX.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
 
 #include "resource.h"
@@ -2120,7 +2121,7 @@ PostSyntheticMotion(DeviceIntPtr pDev,
     /* Translate back to the sprite screen since processInputProc
        will translate from sprite screen to screen 0 upon reentry
        to the DIX layer. */
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         ScreenPtr masterScreen = dixGetMasterScreen();
         x += masterScreen->x - screenInfo.screens[screen]->x;
         y += masterScreen->y - screenInfo.screens[screen]->y;

--- a/dix/main.c
+++ b/dix/main.c
@@ -77,6 +77,7 @@ Equipment Corporation.
 #include <version-config.h>
 
 #include <pixman.h>
+#include <stdbool.h>
 #include <X11/X.h>
 #include <X11/Xos.h>            /* for unistd.h  */
 #include <X11/Xproto.h>
@@ -106,6 +107,7 @@ Equipment Corporation.
 #include "os/screensaver.h"
 #include "os/serverlock.h"
 #include "Xext/dpms/dpms_priv.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
 
 #include "scrnintstr.h"
@@ -241,8 +243,9 @@ dix_main(int argc, char *argv[], char *envp[])
     /*
      * Consolidate window and colourmap information for each screen
      */
-    if (!noPanoramiXExtension)
+    if (PanoramiXIsEnabled()) {
         PanoramiXConsolidate();
+    }
 #endif /* XINERAMA */
 
     DIX_FOR_EACH_SCREEN({
@@ -264,7 +267,7 @@ dix_main(int argc, char *argv[], char *envp[])
     dixCloseRegistry();
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         if (!PanoramiXCreateConnectionBlock()) {
             FatalError("could not create connection block info");
         }
@@ -295,11 +298,11 @@ dix_main(int argc, char *argv[], char *envp[])
 
 #ifdef XINERAMA
     {
-        Bool remember_it = noPanoramiXExtension;
+        bool remember_it = PanoramiXIsDisabled();
 
         noPanoramiXExtension = TRUE;
         FreeAllResources();
-        noPanoramiXExtension = remember_it;
+        noPanoramiXExtension = (!!remember_it);
     }
 #else
     FreeAllResources();

--- a/dix/property.c
+++ b/dix/property.c
@@ -57,6 +57,7 @@ SOFTWARE.
 #include "include/extinit.h"
 #include "os/mathx_priv.h"
 #include "Xext/panoramiX/panoramiX.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
 
 #include "windowstr.h"
@@ -131,7 +132,7 @@ notifyVRRMode(ClientPtr pClient, WindowPtr pWindow, int state, PropertyPtr pProp
     WindowVRRMode mode = (WindowVRRMode)(state == PropertyNewValue ? (*((uint32_t*)pProp->data)) : 0);
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         PanoramiXRes *win;
         int rc;
 

--- a/dix/resource.c
+++ b/dix/resource.c
@@ -132,6 +132,7 @@ Equipment Corporation.
 #include "os/osdep.h"
 #include "os/probes_priv.h"
 #include "Xext/panoramiX/panoramiX.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
 
 #include "os.h"
@@ -1212,7 +1213,7 @@ LegalNewID(XID id, ClientPtr client)
 #ifdef XINERAMA
     XID minid, maxid;
 
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         minid = client->clientAsMask | (client->index ?
                                         SERVER_BIT : SERVER_MINID);
         maxid = (clientTable[client->index].fakeID | RESOURCE_ID_MASK) + 1;

--- a/dix/screenint_priv.h
+++ b/dix/screenint_priv.h
@@ -1,7 +1,6 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3+
  *
- * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
- * Copyright © 1987, 1998 The Open Group
+ * Copyright © 2026 Enrico Weigelt, metux IT consult <info@metux.net>
  */
 #ifndef _XSERVER_DIX_SCREENINT_PRIV_H
 #define _XSERVER_DIX_SCREENINT_PRIV_H
@@ -12,6 +11,8 @@
 #include "include/callback.h"
 #include "include/screenint.h"
 #include "include/scrnintstr.h" /* for screenInfo */
+
+#include "Xext/panoramiX/panoramiX_priv.h"
 
 typedef Bool (*ScreenInitProcPtr)(ScreenPtr pScreen, int argc, char **argv);
 
@@ -82,8 +83,7 @@ static inline bool dixScreenExists(unsigned int idx) {
 #define DIX_FOR_EACH_SCREEN_XINERAMA(__LAMBDA__) \
     do { \
         unsigned int __num_screens = screenInfo.numScreens; \
-        if (!noPanoramiXExtension) \
-            __num_screens = 1; \
+        if (PanoramiXIsEnabled()) { __num_screens = 1; } \
         for (unsigned walkScreenIdx = 0; walkScreenIdx < __num_screens; walkScreenIdx++) { \
             ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx]; \
             (void)walkScreen; \

--- a/dix/window.c
+++ b/dix/window.c
@@ -124,6 +124,7 @@ Equipment Corporation.
 #include "os/screensaver.h"
 #include "Xext/composite/compint.h"
 #include "Xext/panoramiX/panoramiX.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
 
 #include "scrnintstr.h"
@@ -2273,7 +2274,7 @@ ConfigureWindow(WindowPtr pWin, Mask mask, XID *vlist, ClientPtr client)
         event.u.u.type = ConfigureRequest;
         event.u.u.detail = (mask & CWStackMode) ? smode : Above;
 #ifdef XINERAMA
-        if (!noPanoramiXExtension && (!pParent || !pParent->parent)) {
+        if (PanoramiXIsEnabled() && (!pParent || !pParent->parent)) {
             ScreenPtr masterScreen = dixGetMasterScreen();
             event.u.configureRequest.x += masterScreen->x;
             event.u.configureRequest.y += masterScreen->y;
@@ -2357,7 +2358,7 @@ ConfigureWindow(WindowPtr pWin, Mask mask, XID *vlist, ClientPtr client)
         };
         event.u.u.type = ConfigureNotify;
 #ifdef XINERAMA
-        if (!noPanoramiXExtension && (!pParent || !pParent->parent)) {
+        if (PanoramiXIsEnabled() && (!pParent || !pParent->parent)) {
             ScreenPtr masterScreen = dixGetMasterScreen();
             event.u.configureNotify.x += masterScreen->x;
             event.u.configureNotify.y += masterScreen->y;
@@ -2503,7 +2504,7 @@ ReparentWindow(WindowPtr pWin, WindowPtr pParent,
     };
     event.u.u.type = ReparentNotify;
 #ifdef XINERAMA
-    if (!noPanoramiXExtension && !pParent->parent) {
+    if (PanoramiXIsEnabled() && !pParent->parent) {
         ScreenPtr masterScreen = dixGetMasterScreen();
         event.u.reparent.x += masterScreen->x;
         event.u.reparent.y += masterScreen->y;
@@ -2765,7 +2766,7 @@ UnrealizeTree(WindowPtr pWin, Bool fromConfigure)
         if (pChild->realized) {
             pChild->visibility = VisibilityNotViewable;
 #ifdef XINERAMA
-            if (!noPanoramiXExtension && !pChild->drawable.pScreen->myNum) {
+            if (PanoramiXIsEnabled() && !pChild->drawable.pScreen->myNum) {
                 PanoramiXRes *win;
                 int rc = dixLookupResourceByType((void **) &win,
                                                  pChild->drawable.id,
@@ -2993,7 +2994,7 @@ SendVisibilityNotify(WindowPtr pWin)
 
 #ifdef XINERAMA
     /* This is not quite correct yet, but it's close */
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         PanoramiXRes *win;
         WindowPtr pWin2;
         int rc, Scrnum;

--- a/hw/xfree86/common/xf86Config.c
+++ b/hw/xfree86/common/xf86Config.c
@@ -54,6 +54,7 @@
 #include "include/extinit.h"
 #include "os/log_priv.h"
 #include "os/osdep.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/xkeyboard/xkbsrv_priv.h"
 #ifdef DPMSExtension
 #include "Xext/dpms/dpms_priv.h"
@@ -960,14 +961,15 @@ configServerFlags(XF86ConfFlagsPtr flagsconf, XF86OptionPtr layoutopts)
 
 #ifdef XINERAMA
     from = X_DEFAULT;
-    if (!noPanoramiXExtension)
+    if (PanoramiXIsEnabled())
         from = X_CMDLINE;
     else if (xf86GetOptValBool(FlagOptions, FLAG_XINERAMA, &value)) {
         noPanoramiXExtension = !value;
         from = X_CONFIG;
     }
-    if (!noPanoramiXExtension)
+    if (PanoramiXIsEnabled()) {
         LogMessageVerb(from, 1, "Xinerama: enabled\n");
+    }
 #endif /* XINERAMA */
 
 #ifdef DRI2

--- a/hw/xfree86/common/xf86DGA.c
+++ b/hw/xfree86/common/xf86DGA.c
@@ -53,6 +53,7 @@
 #include "include/extinit.h"
 #include "include/misc.h"
 #include "mi/mi_priv.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 
 #include "xf86.h"
 #include "xf86str.h"
@@ -171,9 +172,10 @@ DGAInit(ScreenPtr pScreen, DGAFunctionPtr funcs, DGAModePtr modes, int num)
         modes[i].num = i + 1;
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension)
+    if (PanoramiXIsEnabled()) {
         for (i = 0; i < num; i++)
             modes[i].flags &= ~DGA_PIXMAP_AVAILABLE;
+    }
 #endif /* XINERAMA */
 
     return TRUE;
@@ -220,9 +222,10 @@ DGAReInitModes(ScreenPtr pScreen, DGAModePtr modes, int num)
         modes[i].num = i + 1;
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension)
+    if (PanoramiXIsEnabled()) {
         for (i = 0; i < num; i++)
             modes[i].flags &= ~DGA_PIXMAP_AVAILABLE;
+    }
 #endif /* XINERAMA */
 
     return TRUE;

--- a/hw/xfree86/common/xf86Mode.c
+++ b/hw/xfree86/common/xf86Mode.c
@@ -87,6 +87,7 @@
 #include "include/extinit.h"
 #include "os/log_priv.h"
 #include "os/mathx_priv.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 
 #include "xf86Modes.h"
 #include "xf86Crtc.h"
@@ -1630,8 +1631,9 @@ xf86ValidateModes(ScrnInfoPtr scrp, DisplayModePtr availModes,
 
     /* Lookup each mode */
 #ifdef XINERAMA
-    if (noPanoramiXExtension)
+    if (!PanoramiXIsEnabled()) {
         validateAllDefaultModes = TRUE;
+    }
 #endif /* XINERAMA */
 
     for (p = scrp->modes;; p = p->next) {

--- a/hw/xfree86/common/xf86RandR.c
+++ b/hw/xfree86/common/xf86RandR.c
@@ -28,6 +28,7 @@
 #include "dix/screen_hooks_priv.h"
 #include "include/extinit.h"
 #include "include/xf86DDC.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 
 #include "os.h"
 #include "globals.h"
@@ -363,11 +364,10 @@ xf86RandRInit(ScreenPtr pScreen)
     rrScrPrivPtr rp;
     ScrnInfoPtr scrp = xf86ScreenToScrn(pScreen);
 
-#ifdef XINERAMA
     /* XXX disable RandR when using Xinerama */
-    if (!noPanoramiXExtension)
+    if (PanoramiXIsEnabled()) {
         return TRUE;
-#endif /* XINERAMA */
+    }
 
     xf86RandRKey = &xf86RandRKeyRec;
 

--- a/hw/xfree86/dri/dri.c
+++ b/hw/xfree86/dri/dri.c
@@ -52,6 +52,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "include/extinit.h"
 #include "include/misc.h"
 #include "include/sarea.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 
 #include "xf86.h"
 #include "xf86drm.h"
@@ -390,17 +391,16 @@ DRIScreenInit(ScreenPtr pScreen, DRIInfoPtr pDRIInfo, int *pDRMFD)
         return FALSE;
     }
 
-#ifdef XINERAMA
     /*
      * If Xinerama is on, don't allow DRI to initialise.  It won't be usable
      * anyway.
      */
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         DRIDrvMsg(pScreen->myNum, X_WARNING,
                   "Direct rendering is not supported when Xinerama is enabled\n");
         return FALSE;
     }
-#endif /* XINERAMA */
+
     if (drm_server_inited == FALSE) {
         drmSetServerInfo(&DRIDRMServerInfo);
         drm_server_inited = TRUE;

--- a/hw/xfree86/modes/xf86RandR12.c
+++ b/hw/xfree86/modes/xf86RandR12.c
@@ -29,6 +29,7 @@
 #include "include/extinit.h"
 #include "include/xf86DDC.h"
 #include "os/mathx_priv.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/randr/randrstr_priv.h"
 
 #include "xf86.h"
@@ -759,11 +760,9 @@ xf86RandR12CreateScreenResources(ScreenPtr pScreen)
     int width, height;
     int mmWidth, mmHeight;
 
-#ifdef XINERAMA
     /* XXX disable RandR when using Xinerama */
-    if (!noPanoramiXExtension)
+    if (PanoramiXIsEnabled())
         return TRUE;
-#endif /* XINERAMA */
 
     config = XF86_CRTC_CONFIG_PTR(pScrn);
     randrp = XF86RANDRINFO(pScreen);
@@ -850,7 +849,7 @@ xf86RandR12Init(ScreenPtr pScreen)
 
 #ifdef XINERAMA
     /* XXX disable RandR when using Xinerama */
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         if (xf86NumScreens == 1)
             noPanoramiXExtension = TRUE;
         else

--- a/hw/xwin/InitOutput.c
+++ b/hw/xwin/InitOutput.c
@@ -42,6 +42,7 @@ from The Open Group.
 #ifdef DPMSExtension
 #include "Xext/dpms/dpms_priv.h"
 #endif
+#include "Xext/panoramiX/panoramiX_priv.h"
 #include "Xext/pseudoramiX/pseudoramiX.h"
 
 #include "winmsg.h"
@@ -933,7 +934,7 @@ InitOutput(int argc, char *argv[])
   /*
      Unless full xinerama has been explicitly enabled, register all native screens with pseudoramiX
   */
-  if (!noPanoramiXExtension)
+  if (PanoramiXIsEnabled())
       noPseudoramiXExtension = TRUE;
 
   if ((g_ScreenInfo[0].fMultipleMonitors) && !noPseudoramiXExtension)

--- a/hw/xwin/winscrinit.c
+++ b/hw/xwin/winscrinit.c
@@ -35,6 +35,7 @@
 
 #include "include/extinit.h"
 #include "mi/mi_priv.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 
 #include "win.h"
 #include "winmsg.h"
@@ -186,7 +187,7 @@ winScreenInit(ScreenPtr pScreen, int argc, char **argv)
     else
         winErrorFVerb(2, "winScreenInit - Using software cursor\n");
 
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         /*
            Note the screen origin in a normalized coordinate space where (0,0) is at the top left
            of the native virtual desktop area

--- a/mi/miexpose.c
+++ b/mi/miexpose.c
@@ -86,6 +86,7 @@ Equipment Corporation.
 #include "mi/mi_priv.h"
 #include "Xext/panoramiX/panoramiX.h"
 #include "Xext/panoramiX/panoramiXsrv.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 
 #include "regionstr.h"
 #include "scrnintstr.h"
@@ -322,7 +323,7 @@ miSendExposures(WindowPtr pWin, RegionPtr pRgn, int dx, int dy)
     }
 
 #ifdef XINERAMA
-    if (!noPanoramiXExtension) {
+    if (PanoramiXIsEnabled()) {
         int scrnum = pWin->drawable.pScreen->myNum;
         int x = 0, y = 0;
         XID realWin = 0;

--- a/mi/mipointer.c
+++ b/mi/mipointer.c
@@ -61,6 +61,7 @@ in this Software without prior written authorization from The Open Group.
 #include "include/misc.h"
 #include "mi/mi_priv.h"
 #include "mi/mipointer_priv.h"
+#include "Xext/panoramiX/panoramiX_priv.h"
 
 #include   "windowstr.h"
 #include   "pixmapstr.h"
@@ -407,11 +408,7 @@ miPointerWarpCursor(DeviceIntPtr pDev, ScreenPtr pScreen, int x, int y)
     /* Don't call USFS if we use Xinerama, otherwise the root window is
      * updated to the second screen, and we never receive any events.
      * (FDO bug #18668) */
-    if (changedScreen
-#ifdef XINERAMA
-        && noPanoramiXExtension
-#endif /* XINERAMA */
-        ) {
+    if (changedScreen && PanoramiXIsDisabled()) {
             DeviceIntPtr master = GetMaster(pDev, MASTER_POINTER);
             /* Hack for CVE-2023-5380: if we're moving
              * screens PointerWindows[] keeps referring to the


### PR DESCRIPTION
These helpers are always defined, even when compiling w/o PanoramiX
at all (symbol XINERAMA not defined), so we need fewer ifdef's.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
