### PR TITLE
(master) Xext: panoramix: add PanoramiXIsMasterScreen() / PanoramiXIsSlaveScreen()

### DIFF
--- a/Xext/panoramiX/panoramiX_priv.h
+++ b/Xext/panoramiX/panoramiX_priv.h
@@ -8,6 +8,8 @@
 #include <stdbool.h>
 
 #include "include/extinit.h"
+#include "include/screenint.h"
+#include "include/scrnintstr.h"
 
 /*
  * @brief return TRUE if panoramiX / xinerama extension is enabled
@@ -25,6 +27,29 @@ static inline bool PanoramiXIsEnabled(void) {
  */
 static inline bool PanoramiXIsDisabled(void) {
     return !PanoramiXIsEnabled();
+}
+
+/*
+ * @brief return TRUE if panoramix enabled and screen is the master or
+ * panoramix is disabled
+ *
+ * this function is usually called in order to check whether the given
+ * screen behaves normally (eg. sending events, etc) and is NOT a
+ * panoramix slave screen.
+ */
+static inline bool PanoramiXIsMasterScreen(ScreenPtr pScreen) {
+    return PanoramiXIsDisabled() || (pScreen->myNum == 0);
+}
+
+/*
+ * @brief return TRUE if panoramix enabled AND screen is a slave.
+ *
+ * this function is usually called in order to check whether the given
+ * screen is a panoramix slave screen (thus shall not be visible to
+ * clients, eg. sending events, etc)
+ */
+static inline bool PanoramiXIsSlaveScreen(ScreenPtr pScreen) {
+    return PanoramiXIsEnabled() && (pScreen->myNum != 0);
 }
 
 #endif /* _XSERVER_PANORAMIX_PRIV_H_ */

--- a/Xext/saver/saver.c
+++ b/Xext/saver/saver.c
@@ -612,12 +612,11 @@ ScreenSaverHandle(ScreenPtr pScreen, int xstate, Bool force)
             ret = TRUE;
 
     }
-#ifdef XINERAMA
-    if (PanoramiXIsDisabled() || !pScreen->myNum)
-#endif /* XINERAMA */
-    {
+
+    if (PanoramiXIsMasterScreen(pScreen)) {
         SendScreenSaverNotify(pScreen, state, force);
     }
+
     return ret;
 }
 

--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -470,10 +470,11 @@ TellNoMap(WindowPtr pwin, Colormap * pmid)
             .u.colormap.state = ColormapUninstalled
         };
         xE.u.u.type = ColormapNotify;
-#ifdef XINERAMA
-        if (PanoramiXIsDisabled() || !pwin->drawable.pScreen->myNum)
-#endif /* XINERAMA */
+
+        if (PanoramiXIsMasterScreen(pwin->drawable.pScreen)) {
             DeliverEvents(pwin, &xE, 1, (WindowPtr) NULL);
+        }
+
         if (pwin->optional) {
             pwin->optional->colormap = None;
             CheckWindowOptionalNeed(pwin);
@@ -489,7 +490,7 @@ TellLostMap(WindowPtr pwin, void *value)
 {
     Colormap *pmid = (Colormap *) value;
 
-    if (PanoramiXIsEnabled() && pwin->drawable.pScreen->myNum) {
+    if (PanoramiXIsSlaveScreen(pwin->drawable.pScreen)) {
         return WT_STOPWALKING;
     }
 
@@ -514,11 +515,9 @@ TellGainedMap(WindowPtr pwin, void *value)
 {
     Colormap *pmid = (Colormap *) value;
 
-#ifdef XINERAMA
-    if (PanoramiXIsEnabled() && pwin->drawable.pScreen->myNum) {
+    if (PanoramiXIsSlaveScreen(pwin->drawable.pScreen)) {
         return WT_STOPWALKING;
     }
-#endif
 
     if (wColormap(pwin) == *pmid) {
         /* This should be call to DeliverEvent */

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -2777,13 +2777,11 @@ ProcAllocNamedColor(ClientPtr client)
     }
 
     /* if PanoramiX is active, and this isn't the master screen, keep radio silence */
-#ifdef XINERAMA
-    if (PanoramiXIsDisabled() || !pcmp->pScreen->myNum)
-        return X_SEND_REPLY_SIMPLE(client, reply);
-    return Success;
-#else
+    if (PanoramiXIsSlaveScreen(pcmp->pScreen)) {
+        return Success;
+    }
+
     return X_SEND_REPLY_SIMPLE(client, reply);
-#endif /* XINERAMA */
 }
 
 int
@@ -2826,9 +2824,8 @@ ProcAllocColorCells(ClientPtr client)
             x_rpcbuf_clear(&rpcbuf);
             return rc;
         }
-#ifdef XINERAMA
-        if (PanoramiXIsDisabled() || !pcmp->pScreen->myNum)
-#endif /* XINERAMA */
+
+        if (PanoramiXIsMasterScreen(pcmp->pScreen))
         {
             xAllocColorCellsReply reply = {
                 .nPixels = npixels,
@@ -2902,12 +2899,10 @@ ProcAllocColorPlanes(ClientPtr client)
             swapl(&reply.blueMask);
         }
 
-#ifdef XINERAMA
-        if (PanoramiXIsDisabled() || !pcmp->pScreen->myNum)
-#endif /* XINERAMA */
-        {
+        if (PanoramiXIsMasterScreen(pcmp->pScreen)) {
             return X_SEND_REPLY_WITH_RPCBUF(client, reply, rpcbuf);
         }
+
         x_rpcbuf_clear(&rpcbuf);
         return Success;
     }
@@ -3838,7 +3833,6 @@ static int
 SendConnSetup(ClientPtr client, const char *reason)
 {
     xWindowRoot *root;
-    int numScreens;
     char *lConnectionInfo;
     xConnSetupPrefix *lconnSetupPrefix;
 
@@ -3858,7 +3852,6 @@ SendConnSetup(ClientPtr client, const char *reason)
         return client->noClientException = -1;
     }
 
-    numScreens = screenInfo.numScreens;
     lConnectionInfo = ConnectionInfo;
     lconnSetupPrefix = &connSetupPrefix;
 
@@ -3879,12 +3872,11 @@ SendConnSetup(ClientPtr client, const char *reason)
 #endif
     /* fill in the "currentInputMask" */
     root = (xWindowRoot *) (lConnectionInfo + connBlockScreenStart);
-#ifdef XINERAMA
-    if (PanoramiXIsDisabled())
-        numScreens = screenInfo.numScreens;
-    else
+
+    int numScreens = screenInfo.numScreens;
+    if (PanoramiXIsEnabled()) {
         numScreens = ((xConnSetup *) ConnectionInfo)->numRoots;
-#endif /* XINERAMA */
+    }
 
     for (unsigned int walkScreenIdx = 0; walkScreenIdx < numScreens; walkScreenIdx++) {
         ScreenPtr walkScreen = screenInfo.screens[walkScreenIdx];

--- a/dix/events.c
+++ b/dix/events.c
@@ -2554,9 +2554,10 @@ Bool MaybeDeliverEventToClient(WindowPtr pWin, xEvent *pEvents,
         if (dixClientForWindow(pWin) == dontClient)
             return FALSE;
 #ifdef XINERAMA
-        if (PanoramiXIsEnabled() && pWin->drawable.pScreen->myNum)
+        if (PanoramiXIsSlaveScreen(pWin->drawable.pScreen)) {
             return XineramaTryClientEventsResult(dixClientForWindow(pWin), NullGrab,
                                                  pWin->eventMask, filter);
+        }
 #endif /* XINERAMA */
         if (XaceHookReceiveAccess(dixClientForWindow(pWin), pWin, pEvents, 1))
             return TRUE;           /* don't send, but pretend we did */
@@ -2568,9 +2569,10 @@ Bool MaybeDeliverEventToClient(WindowPtr pWin, xEvent *pEvents,
             if (SameClient(other, dontClient))
                 return FALSE;
 #ifdef XINERAMA
-            if (PanoramiXIsEnabled() && pWin->drawable.pScreen->myNum)
+            if (PanoramiXIsSlaveScreen(pWin->drawable.pScreen)) {
                 return XineramaTryClientEventsResult(dixClientForOtherClients(other), NullGrab,
                                                      other->mask, filter);
+            }
 #endif /* XINERAMA */
             if (XaceHookReceiveAccess(dixClientForOtherClients(other), pWin, pEvents, 1))
                 return TRUE;       /* don't send, but pretend we did */
@@ -2949,10 +2951,9 @@ DeliverEvents(WindowPtr pWin, xEvent *xE, size_t count, WindowPtr otherParent)
     DeviceIntRec dummy;
     int deliveries;
 
-#ifdef XINERAMA
-    if (PanoramiXIsEnabled() && pWin->drawable.pScreen->myNum)
+    if (PanoramiXIsSlaveScreen(pWin->drawable.pScreen)) {
         return count;
-#endif /* XINERAMA */
+    }
 
     if (!count)
         return 0;
@@ -5957,10 +5958,9 @@ CheckCursorConfinement(WindowPtr pWin)
     GrabPtr grab;
     WindowPtr confineTo;
 
-#ifdef XINERAMA
-    if (PanoramiXIsEnabled() && pWin->drawable.pScreen->myNum)
+    if (PanoramiXIsSlaveScreen(pWin->drawable.pScreen)) {
         return;
-#endif /* XINERMA */
+    }
 
     for (DeviceIntPtr pDev = inputInfo.devices; pDev; pDev = pDev->next) {
         if (DevHasCursor(pDev)) {

--- a/dix/window.c
+++ b/dix/window.c
@@ -2766,7 +2766,7 @@ UnrealizeTree(WindowPtr pWin, Bool fromConfigure)
         if (pChild->realized) {
             pChild->visibility = VisibilityNotViewable;
 #ifdef XINERAMA
-            if (PanoramiXIsEnabled() && !pChild->drawable.pScreen->myNum) {
+            if (PanoramiXIsMasterScreen(pChild->drawable.pScreen)) {
                 PanoramiXRes *win;
                 int rc = dixLookupResourceByType((void **) &win,
                                                  pChild->drawable.id,


### PR DESCRIPTION
Adding inline helper functions for detection of whether a given Screen
is a master or slave screen.

With PanoramiX enabled, the first one (->myNum == 0) is considered the
master, while the others are slaves. When disabled, all screens are
considered master.

That's allowing us to move some more implementation detail logic out of
DDX/DIX into the extension code and get rid of some ifdef's.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
