### PR TITLE
(master) os: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/os/WaitFor.c
+++ b/os/WaitFor.c
@@ -54,6 +54,7 @@ SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <errno.h>
 #include <stdio.h>
 #ifdef WIN32
@@ -171,9 +172,7 @@ WaitForSomething(Bool are_ready)
     int timeout;
     int pollerr;
     static Bool were_ready;
-    Bool timer_is_running;
-
-    timer_is_running = were_ready;
+    bool timer_is_running = !!were_ready;
 
     if (were_ready && !are_ready) {
         timer_is_running = FALSE;

--- a/os/access.c
+++ b/os/access.c
@@ -78,6 +78,7 @@ SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #ifdef WIN32
 #include <X11/Xwinsock.h>
 #endif
@@ -1063,22 +1064,20 @@ ComputeLocalClient(ClientPtr client)
         if (!cmd)
             return FALSE;
 
-        Bool ret;
-
         /* Cut off any colon and whatever comes after it, see
          * https://lists.freedesktop.org/archives/xorg-devel/2015-December/048164.html
          */
         char *tok = strtok(cmd, ":");
 
 #if !defined(WIN32) || defined(__CYGWIN__)
-        ret = strcmp(basename(tok), "ssh") != 0;
+        bool ret = strcmp(basename(tok), "ssh") != 0;
 #else
-        ret = strcmp(tok, "ssh") != 0;
+        bool ret = strcmp(tok, "ssh") != 0;
 #endif
 
         free(cmd);
 
-        return ret;
+        return !!ret;
     }
 
     return TRUE;
@@ -1641,7 +1640,7 @@ siTypeAdd(const char *typeName, siAddrMatchFunc addrMatch,
 static Bool
 siAddrMatch(int family, void *addr, int len, HOST * host, ClientPtr client)
 {
-    Bool matches = FALSE;
+    bool matches = FALSE;
     struct siType *s;
     const char *valueString;
     int addrlen;
@@ -1744,7 +1743,7 @@ siHostnameAddrMatch(int family, void *addr, int len,
                     const char *siAddr, int siAddrLen, ClientPtr client,
                     void *typePriv)
 {
-    Bool res = FALSE;
+    bool res = FALSE;
 
 /* Currently only supports checking against IPv4 & IPv6 connections, but
  * support for other address families, such as DECnet, could be added if
@@ -1832,8 +1831,8 @@ siHostnameCheckAddr(const char *valueString, int length, void *typePriv)
      */
     int len = length;
     int i;
-    Bool dotAllowed = FALSE;
-    Bool dashAllowed = FALSE;
+    bool dotAllowed = FALSE;
+    bool dashAllowed = FALSE;
 
     if ((length <= 0) || (length >= SI_HOSTNAME_MAXLEN)) {
         len = -1;
@@ -1975,7 +1974,7 @@ static siLocalCredPrivRec siLocalGroupPriv = { LOCAL_GROUP };
 static Bool
 siLocalCredGetId(const char *addr, int len, siLocalCredPrivPtr lcPriv, int *id)
 {
-    Bool parsedOK = FALSE;
+    bool parsedOK = FALSE;
     char *addrbuf = calloc(1, len + 1);
 
     if (addrbuf == NULL) {

--- a/os/busfault.c
+++ b/os/busfault.c
@@ -22,6 +22,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -41,7 +42,7 @@ struct busfault {
     void                *addr;
     size_t              size;
 
-    Bool                valid;
+    bool                valid;
 
     busfault_notify_ptr notify;
     void                *context;

--- a/os/connection.c
+++ b/os/connection.c
@@ -62,6 +62,7 @@ SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #ifdef WIN32
 #include <X11/Xwinsock.h>
 #endif
@@ -257,10 +258,10 @@ CreateWellKnownSockets(void)
                 FatalError ("Failed to establish all listening sockets");
     }
     else { /* -displayfd and no explicit display number */
-        Bool found = 0;
+        bool found = FALSE;
         for (i = 0; i < 65536 - X_TCP_PORT; i++) {
             if (TryCreateSocket(i, &partial) && !partial) {
-                found = 1;
+                found = TRUE;
                 break;
             }
             else

--- a/os/inputthread.c
+++ b/os/inputthread.c
@@ -27,6 +27,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <errno.h>
 #include <stdlib.h>
@@ -75,8 +76,8 @@ typedef struct {
     struct ospoll *fds;
     int readPipe;
     int writePipe;
-    Bool changed;
-    Bool running;
+    bool changed;
+    bool running;
 } InputThreadInfo;
 
 static InputThreadInfo *inputThreadInfo;
@@ -255,7 +256,7 @@ int
 InputThreadUnregisterDev(int fd)
 {
     InputThreadDevice *dev;
-    Bool found_device = FALSE;
+    bool found_device = FALSE;
 
     /* return silently if input thread is already finished (e.g., at
      * DisableDevice time, evdev tries to call this function again through

--- a/os/io.c
+++ b/os/io.c
@@ -248,9 +248,7 @@ ReadRequestFromClient(ClientPtr client)
     ConnectionInputPtr oci = oc->input;
     unsigned int gotnow, needed;
     int result;
-    register xReq *request;
-    Bool need_header;
-    Bool move_header;
+    xReq *request;
 
     NextAvailableInput(oc);
 
@@ -279,8 +277,8 @@ ReadRequestFromClient(ClientPtr client)
 
     oci->bufptr += oci->lenLastReq;
 
-    need_header = FALSE;
-    move_header = FALSE;
+    bool need_header = FALSE;
+    bool move_header = FALSE;
     gotnow = oci->bufcnt + oci->buffer - oci->bufptr;
 
     if (oci->ignoreBytes > 0) {
@@ -628,7 +626,7 @@ FlushAllOutput(void)
 {
     OsCommPtr oc;
     register ClientPtr client, tmp;
-    Bool newoutput = NewOutputPending;
+    bool newoutput = !!NewOutputPending;
 
     if (!newoutput)
         return;
@@ -796,7 +794,7 @@ dixWriteToClient(ClientPtr who, int count, const void *__buf)
                        "******** %s called from input thread *********\n", __func__);
 
 #ifdef DEBUG_COMMUNICATION
-    Bool multicount = FALSE;
+    bool multicount = FALSE;
 #endif
     if (!count || !who || who == serverClient || who->clientGone)
         return 0;

--- a/os/xdmauth.c
+++ b/os/xdmauth.c
@@ -35,6 +35,7 @@ from The Open Group.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <X11/X.h>
 
@@ -105,12 +106,10 @@ static Bool
 XdmAuthenticationAddAuth(int name_len, const char *name,
                          int data_len, char *data)
 {
-    Bool ret;
-
     XdmcpUnwrap((unsigned char *) data, (unsigned char *) &privateKey,
                 (unsigned char *) data, data_len);
     authFromXDMCP = TRUE;
-    ret = AddAuthorization(name_len, name, data_len, data);
+    bool ret = !!AddAuthorization(name_len, name, data_len, data);
     authFromXDMCP = FALSE;
     return ret;
 }

--- a/os/xdmcp.c
+++ b/os/xdmcp.c
@@ -15,6 +15,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #ifdef WIN32
 #include <X11/Xwinsock.h>
 #include "os/Xtrans.h"
@@ -928,10 +929,10 @@ static void
 send_query_msg(void)
 {
     XdmcpHeader header;
-    Bool broadcast = FALSE;
+    bool broadcast = FALSE;
 
 #if defined(IPv6)
-    Bool multicast = FALSE;
+    bool multicast = FALSE;
 #endif
     int i;
     int socketfd = xdmcpSocket;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
