### PR TITLE
(master) xext: saver: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/Xext/saver/saver.c
+++ b/Xext/saver/saver.c
@@ -158,7 +158,7 @@ SendScreenSaverNotify(ScreenPtr pScreen,
 typedef struct _ScreenSaverScreenPrivate {
     ScreenSaverEventPtr events;
     ScreenSaverAttrPtr attr;
-    Bool hasWindow;
+    bool hasWindow;
     Colormap installedMap;
 } ScreenSaverScreenPrivateRec, *ScreenSaverScreenPrivatePtr;
 
@@ -593,7 +593,7 @@ static Bool
 ScreenSaverHandle(ScreenPtr pScreen, int xstate, Bool force)
 {
     int state = 0;
-    Bool ret = FALSE;
+    bool ret = FALSE;
     ScreenSaverScreenPrivatePtr pPriv;
 
     switch (xstate) {


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
