### PR TITLE
(master) mi: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/mi/miarc.c
+++ b/mi/miarc.c
@@ -48,6 +48,7 @@ SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <math.h>
 #include <X11/X.h>
 #include <X11/Xprotostr.h>
@@ -895,7 +896,7 @@ miWideArc(DrawablePtr pDraw, GCPtr pGC, int narcs, xArc * parcs)
     int pixmapWidth = 0, pixmapHeight = 0;
     int xOrg = 0, yOrg = 0;
     int width = pGC->lineWidth;
-    Bool fTricky;
+    bool fTricky;
     DrawablePtr pDrawTo;
     CARD32 fg, bg;
     GCPtr pGCTo;
@@ -2266,7 +2267,7 @@ angleToLength(int angle, dashMap * map)
     double len, excesslen, sidelen = map->map[DASH_MAP_SIZE - 1], totallen;
     int di;
     int excess;
-    Bool oddSide = FALSE;
+    bool oddSide = FALSE;
 
     totallen = 0;
     if (angle >= 0) {
@@ -2314,7 +2315,7 @@ lengthToAngle(double len, dashMap * map)
 {
     double sidelen = map->map[DASH_MAP_SIZE - 1];
     int angle, angleexcess;
-    Bool oddSide = FALSE;
+    bool oddSide = FALSE;
     int a0, a1, a;
 
     angle = 0;

--- a/mi/micopy.c
+++ b/mi/micopy.c
@@ -22,6 +22,8 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "mi.h"
 #include "scrnintstr.h"
 #include "gcstruct.h"
@@ -37,8 +39,8 @@ miCopyRegion(DrawablePtr pSrcDrawable,
              int dx, int dy, miCopyProc copyProc, Pixel bitPlane, void *closure)
 {
     int careful;
-    Bool reverse;
-    Bool upsidedown;
+    bool reverse;
+    bool upsidedown;
     BoxPtr pbox;
     int nbox;
     BoxPtr pboxNew1, pboxNew2, pboxBase, pboxNext, pboxTmp;
@@ -136,7 +138,7 @@ miDoCopy(DrawablePtr pSrcDrawable,
          int xOut, int yOut, miCopyProc copyProc, Pixel bitPlane, void *closure)
 {
     RegionPtr prgnSrcClip = NULL;       /* may be a new region, or just a copy */
-    Bool freeSrcClip = FALSE;
+    bool freeSrcClip = FALSE;
     RegionPtr prgnExposed = NULL;
     RegionRec rgnDst;
     int dx;
@@ -146,9 +148,9 @@ miDoCopy(DrawablePtr pSrcDrawable,
     int box_y1;
     int box_x2;
     int box_y2;
-    Bool fastSrc = FALSE;       /* for fast clipping with pixmap source */
-    Bool fastDst = FALSE;       /* for fast clipping with one rect dest */
-    Bool fastExpose = FALSE;    /* for fast exposures with pixmap source */
+    bool fastSrc = FALSE;       /* for fast clipping with pixmap source */
+    bool fastDst = FALSE;       /* for fast clipping with one rect dest */
+    bool fastExpose = FALSE;    /* for fast exposures with pixmap source */
 
     /* Short cut for unmapped windows */
 

--- a/mi/miexpose.c
+++ b/mi/miexpose.c
@@ -73,6 +73,7 @@ Equipment Corporation.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 #include <X11/Xmd.h>
 #include <X11/Xproto.h>
@@ -132,7 +133,7 @@ miHandleExposures(DrawablePtr pSrcDrawable, DrawablePtr pDstDrawable,
                                  */
     WindowPtr pSrcWin;
     BoxRec expBox = { 0, };
-    Bool extents;
+    bool extents;
 
     /* avoid work if we can */
     if (!pGC->graphicsExposures && pDstDrawable->type == DRAWABLE_PIXMAP)
@@ -417,7 +418,7 @@ miPaintWindow(WindowPtr pWin, RegionPtr prgn, int what)
      */
     int tile_x_off, tile_y_off;
     PixUnion fill;
-    Bool solid = TRUE;
+    bool solid = TRUE;
     DrawablePtr drawable = &pWin->drawable;
 
     if (what == PW_BACKGROUND) {

--- a/mi/mifillarc.c
+++ b/mi/mifillarc.c
@@ -28,9 +28,11 @@ Author:  Bob Scheifler, MIT X Consortium
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <math.h>
 #include <X11/X.h>
 #include <X11/Xprotostr.h>
+
 #include "regionstr.h"
 #include "gcstruct.h"
 #include "pixmapstr.h"
@@ -169,7 +171,7 @@ miEllipseAngleToSlope(int angle, int width, int height, int *dxp, int *dyp,
 {
     int dx, dy;
     double d_dx, d_dy, scale;
-    Bool negative_dx, negative_dy;
+    bool negative_dx, negative_dy;
 
     switch (angle) {
     case 0:
@@ -339,7 +341,7 @@ miFillArcSliceSetup(xArc * arc, miArcSliceRec * slice, GCPtr pGC)
     else {
         double w2, h2, x1, y1, x2, y2, dx, dy, scale;
         int signdx, signdy, y, k;
-        Bool isInt1 = TRUE, isInt2 = TRUE;
+        bool isInt1 = TRUE, isInt2 = TRUE;
 
         w2 = (double) arc->width / 2.0;
         h2 = (double) arc->height / 2.0;

--- a/mi/migc.c
+++ b/mi/migc.c
@@ -28,6 +28,8 @@ from The Open Group.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "scrnintstr.h"
 #include "gcstruct.h"
 #include "pixmapstr.h"
@@ -101,7 +103,7 @@ miComputeCompositeClip(GCPtr pGC, DrawablePtr pDrawable)
     if (pDrawable->type == DRAWABLE_WINDOW) {
         WindowPtr pWin = (WindowPtr) pDrawable;
         RegionPtr pregWin;
-        Bool freeTmpClip, freeCompClip;
+        bool freeTmpClip, freeCompClip;
 
         if (pGC->subWindowMode == IncludeInferiors) {
             pregWin = NotClippedByChildren(pWin);

--- a/mi/miinitext.c
+++ b/mi/miinitext.c
@@ -73,6 +73,8 @@ SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #ifdef HAVE_XORG_CONFIG_H
 #include <xorg-config.h>
 #include "xf86Extensions.h"
@@ -211,7 +213,7 @@ EnableDisableExtensionError(const char *name, Bool enable)
 {
     const ExtensionModule *ext;
     int i;
-    Bool found = FALSE;
+    bool found = FALSE;
 
     for (i = 0; i < ARRAY_SIZE(staticExtensions); i++) {
         ext = &staticExtensions[i];

--- a/mi/mipointer.c
+++ b/mi/mipointer.c
@@ -48,6 +48,7 @@ in this Software without prior written authorization from The Open Group.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 #include <X11/Xmd.h>
 #include <X11/Xproto.h>
@@ -78,10 +79,10 @@ typedef struct {
     CursorPtr pCursor;          /* current cursor */
     CursorPtr pSpriteCursor;    /* cursor on screen */
     BoxRec limits;              /* current constraints */
-    Bool confined;              /* pointer can't change screens */
+    bool confined;              /* pointer can't change screens */
     int x, y;                   /* hot spot location */
     int devx, devy;             /* sprite position */
-    Bool generateEvent;         /* generate an event during warping? */
+    bool generateEvent;         /* generate an event during warping? */
 } miPointerRec, *miPointerPtr;
 
 DevPrivateKeyRec miPointerScreenKeyRec;
@@ -567,7 +568,7 @@ Bool
 miPointerSetWaitForUpdate(ScreenPtr pScreen, Bool wait)
 {
     SetupScreen(pScreen);
-    Bool prevWait = pScreenPriv->waitForUpdate;
+    bool prevWait = !!pScreenPriv->waitForUpdate;
 
     pScreenPriv->waitForUpdate = wait;
     return prevWait;
@@ -631,8 +632,8 @@ miPointerSetPosition(DeviceIntPtr pDev, int mode, double *screenx,
     ScreenPtr pScreen;
     ScreenPtr newScreen;
     int x, y;
-    Bool switch_screen = FALSE;
-    Bool should_constrain_barriers = FALSE;
+    bool switch_screen = FALSE;
+    bool should_constrain_barriers = FALSE;
     int i;
 
     miPointerPtr pPointer;

--- a/mi/mipushpxl.c
+++ b/mi/mipushpxl.c
@@ -45,7 +45,9 @@ SOFTWARE.
 ******************************************************************/
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
+
 #include "gcstruct.h"
 #include "scrnintstr.h"
 #include "pixmapstr.h"
@@ -97,7 +99,7 @@ miPushPixels(GCPtr pGC, PixmapPtr pBitMap, DrawablePtr pDrawable,
     MiBits msk;
     int ib, w;
     int ipt;                    /* index into above arrays */
-    Bool fInBox;
+    bool fInBox;
     xPoint pt[NPT], ptThisLine;
     int width[NPT];
 

--- a/mi/misprite.c
+++ b/mi/misprite.c
@@ -31,6 +31,8 @@ in this Software without prior written authorization from The Open Group.
 
 #include <dix-config.h>
 
+
+#include <stdbool.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>
 #include <X11/fonts/font.h>
@@ -60,9 +62,9 @@ typedef struct {
     int x;                      /* cursor hotspot */
     int y;
     BoxRec saved;               /* saved area from the screen */
-    Bool isUp;                  /* cursor in frame buffer */
-    Bool shouldBeUp;            /* cursor should be displayed */
-    Bool checkPixels;           /* check colormap collision */
+    bool isUp;                  /* cursor in frame buffer */
+    bool shouldBeUp;            /* cursor should be displayed */
+    bool checkPixels;           /* check colormap collision */
     ScreenPtr pScreen;
 } miCursorInfoRec, *miCursorInfoPtr;
 
@@ -89,7 +91,7 @@ typedef struct {
     ColormapPtr pColormap;
     VisualPtr pVisual;
     DamagePtr pDamage;          /* damage tracking structure */
-    Bool damageRegistered;
+    bool damageRegistered;
     int numberOfCursors;
 } miSpriteScreenRec, *miSpriteScreenPtr;
 
@@ -424,7 +426,7 @@ miSpriteBlockHandler(ScreenPtr pScreen, void *timeout)
     miSpriteScreenPtr pPriv = GetSpriteScreen(pScreen);
     DeviceIntPtr pDev;
     miCursorInfoPtr pCursorInfo;
-    Bool WorkToDo = FALSE;
+    bool WorkToDo = FALSE;
 
     SCREEN_PROLOGUE(pPriv, pScreen, BlockHandler);
 

--- a/mi/mivaltree.c
+++ b/mi/mivaltree.c
@@ -90,7 +90,8 @@ Equipment Corporation.
   */
 #include <dix-config.h>
 
-#include    <X11/X.h>
+#include <stdbool.h>
+#include <X11/X.h>
 
 #include "dix/window_priv.h"
 #include "mi/mi_priv.h"
@@ -112,7 +113,7 @@ miShapedWindowIn(RegionPtr universe, RegionPtr bounding,
     BoxRec box;
     BoxPtr boundBox;
     int nbox;
-    Bool someIn, someOut;
+    bool someIn, someOut;
     int t, x1, y1, x2, y2;
 
     nbox = RegionNumRects(bounding);
@@ -555,7 +556,7 @@ miValidateTree(WindowPtr pParent,       /* Parent to validate */
     WindowPtr pWin;
     Bool overlap;
     int viewvals;
-    Bool forward;
+    bool forward;
 
     pScreen = pParent->drawable.pScreen;
     if (pChild == NullWindow)

--- a/mi/miwideline.c
+++ b/mi/miwideline.c
@@ -54,6 +54,7 @@ SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #ifdef _XOPEN_SOURCE
 #include <math.h>
@@ -1193,7 +1194,7 @@ miLineArcD(DrawablePtr pDraw,
     double radius, x0, y0, el, er, yk, xlk, xrk, k;
     int xbase, ybase, y, boty, xl, xr, xcl, xcr;
     int ymin, ymax;
-    Bool edge1IsMin, edge2IsMin;
+    bool edge1IsMin, edge2IsMin;
     int ymin1, ymin2;
 
     pts = points;
@@ -1893,12 +1894,12 @@ miWideLine(DrawablePtr pDrawable, GCPtr pGC,
     SpanDataRec spanDataRec;
     SpanDataPtr spanData;
     long pixel;
-    Bool projectLeft, projectRight;
+    bool projectLeft, projectRight;
     LineFaceRec leftFace = { 0 }, rightFace = { 0 }, prevRightFace;
     LineFaceRec firstFace;
     int first;
-    Bool somethingDrawn = FALSE;
-    Bool selfJoin;
+    bool somethingDrawn = FALSE;
+    bool selfJoin;
 
     spanData = miSetupSpanData(pGC, &spanDataRec, npt);
     pixel = pGC->fgPixel;
@@ -2037,7 +2038,7 @@ miWideDashSegment(DrawablePtr pDrawable,
     double rdx, rdy;
     double dashDx, dashDy;
     double saveK = 0.0;
-    Bool first = TRUE;
+    bool first = TRUE;
     double lcenterx, lcentery, rcenterx = 0.0, rcentery = 0.0;
     unsigned long fgPixel, bgPixel;
 
@@ -2331,7 +2332,7 @@ miWideDash(DrawablePtr pDrawable, GCPtr pGC,
 {
     int x1, y1, x2, y2;
     unsigned long pixel;
-    Bool projectLeft, projectRight;
+    bool projectLeft, projectRight;
     LineFaceRec leftFace, rightFace, prevRightFace;
     LineFaceRec firstFace;
     int first;
@@ -2339,10 +2340,10 @@ miWideDash(DrawablePtr pDrawable, GCPtr pGC,
     int prevDashIndex;
     SpanDataRec spanDataRec;
     SpanDataPtr spanData;
-    Bool somethingDrawn = FALSE;
-    Bool selfJoin;
-    Bool endIsFg = FALSE, startIsFg = FALSE;
-    Bool firstIsFg = FALSE, prevIsFg = FALSE;
+    bool somethingDrawn = FALSE;
+    bool selfJoin;
+    bool endIsFg = FALSE, startIsFg = FALSE;
+    bool firstIsFg = FALSE, prevIsFg = FALSE;
 
 #if 0
     /* XXX backward compatibility */

--- a/mi/miwindow.c
+++ b/mi/miwindow.c
@@ -46,6 +46,7 @@ SOFTWARE.
 ******************************************************************/
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 #include <X11/extensions/shapeconst.h>
 
@@ -141,7 +142,7 @@ miMarkOverlappedWindows(WindowPtr pWin, WindowPtr pFirst, WindowPtr *ppLayerWin)
 {
     BoxPtr box;
     WindowPtr pChild, pLast;
-    Bool anyMarked = FALSE;
+    bool anyMarked = FALSE;
     MarkWindowProcPtr MarkWindow = pWin->drawable.pScreen->MarkWindow;
 
     /* single layered systems are easy */
@@ -252,7 +253,7 @@ miMoveWindow(WindowPtr pWin, int x, int y, WindowPtr pNextSib, VTKind kind)
     short bw;
     RegionPtr oldRegion = NULL;
     xPoint oldpt;
-    Bool anyMarked = FALSE;
+    bool anyMarked = FALSE;
     ScreenPtr pScreen;
     WindowPtr windowToValidate;
     WindowPtr pLayerWin;
@@ -352,7 +353,7 @@ miResizeWindow(WindowPtr pWin, int x, int y, unsigned int w, unsigned int h,
     short dw, dh;
     xPoint oldpt;
     RegionPtr oldRegion = NULL;
-    Bool anyMarked = FALSE;
+    bool anyMarked = FALSE;
     ScreenPtr pScreen;
     WindowPtr pFirstChange;
     WindowPtr pChild;
@@ -364,8 +365,8 @@ miResizeWindow(WindowPtr pWin, int x, int y, unsigned int w, unsigned int h,
     RegionPtr destClip;         /* portions of destination already written */
     RegionPtr oldWinClip = NULL;        /* old clip list for window */
     RegionPtr borderVisible = NullRegion;       /* visible area of the border */
-    Bool shrunk = FALSE;        /* shrunk in an inner dimension */
-    Bool moved = FALSE;         /* window position changed */
+    bool shrunk = FALSE;        /* shrunk in an inner dimension */
+    bool moved = FALSE;         /* window position changed */
     WindowPtr pLayerWin;
 
     /* if this is a root window, can't be resized */
@@ -636,7 +637,7 @@ miSetShape(WindowPtr pWin, int kind)
 {
     Bool WasViewable = (Bool) (pWin->viewable);
     ScreenPtr pScreen = pWin->drawable.pScreen;
-    Bool anyMarked = FALSE;
+    bool anyMarked = FALSE;
     WindowPtr pLayerWin;
 
     if (kind != ShapeInput) {
@@ -685,10 +686,10 @@ void
 miChangeBorderWidth(WindowPtr pWin, unsigned int width)
 {
     int oldwidth;
-    Bool anyMarked = FALSE;
+    bool anyMarked = FALSE;
     ScreenPtr pScreen;
     Bool WasViewable = (Bool) (pWin->viewable);
-    Bool HadBorder;
+    bool HadBorder;
     WindowPtr pLayerWin;
 
     oldwidth = wBorderWidth(pWin);

--- a/mi/mizerarc.c
+++ b/mi/mizerarc.c
@@ -34,6 +34,7 @@ Author:  Bob Scheifler, MIT X Consortium
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <math.h>
 #include <X11/X.h>
 #include <X11/Xprotostr.h>
@@ -370,7 +371,7 @@ miZeroArcPts(xArc * arc, DDXPointPtr pts)
     miZeroArcRec info;
     int x, y, a, b, d, mask;
     int k1, k3, dx, dy;
-    Bool do360;
+    bool do360;
 
     do360 = miZeroArcSetup(arc, &info, TRUE);
     MIARCSETUP();
@@ -649,7 +650,7 @@ miZeroPolyArc(DrawablePtr pDraw, GCPtr pGC, int narcs, xArc * parcs)
     DDXPointPtr points, pts, oddPts = NULL;
     DDXPointPtr pt;
     int numPts;
-    Bool dospans;
+    bool dospans;
     int *widths = NULL;
     XID fgPixel = pGC->fgPixel;
     DashInfo dinfo;

--- a/mi/mizerline.c
+++ b/mi/mizerline.c
@@ -45,6 +45,7 @@ SOFTWARE.
 ******************************************************************/
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 
 #include "include/misc.h"
@@ -110,7 +111,7 @@ miZeroLine(DrawablePtr pDraw, GCPtr pGC, int mode,      /* Origin or Previous */
     int oc1, oc2;
     int result;
     int pt1_clipped, pt2_clipped = 0;
-    Bool new_span;
+    bool new_span;
     int signdx, signdy;
     int clipdx, clipdy;
     int width, height;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
