### PR TITLE
(master) xext: pseudoramix: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/Xext/pseudoramiX/pseudoramiX.c
+++ b/Xext/pseudoramiX/pseudoramiX.c
@@ -35,6 +35,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/Xfuncproto.h>
 
 #include "dix/dix_priv.h"
@@ -116,7 +117,7 @@ PseudoramiXAddScreen(int x, int y, int w, int h)
 void
 PseudoramiXExtensionInit(void)
 {
-    Bool success = FALSE;
+    bool success = FALSE;
     ExtensionEntry      *extEntry;
 
     if (noPseudoramiXExtension) return;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
