### PR TITLE
(master) xext: xinput: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/Xext/xinput/exevents.c
+++ b/Xext/xinput/exevents.c
@@ -80,6 +80,7 @@ SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>
 #include <X11/extensions/geproto.h>
@@ -1778,8 +1779,8 @@ ProcessGestureEvent(InternalEvent *ev, DeviceIntPtr dev)
 {
     GestureInfoPtr gi;
     DeviceIntPtr kbd;
-    Bool deactivateGestureGrab = FALSE;
-    Bool delivered = FALSE;
+    bool deactivateGestureGrab = FALSE;
+    bool delivered = FALSE;
 
     if (!dev->gesture)
         return;
@@ -1829,7 +1830,7 @@ static void
 ProcessDeviceEvent(InternalEvent *ev, DeviceIntPtr device)
 {
     GrabPtr grab;
-    Bool deactivateDeviceGrab = FALSE;
+    bool deactivateDeviceGrab = FALSE;
     int key = 0, rootX, rootY;
     ButtonClassPtr b;
     int ret = 0;
@@ -2026,7 +2027,7 @@ DeliverTouchBeginEvent(DeviceIntPtr dev, TouchPointInfoPtr ti,
 {
     enum TouchListenerState state;
     int rc = Success;
-    Bool has_ownershipmask;
+    bool has_ownershipmask;
 
     if (listener->type == TOUCH_LISTENER_POINTER_REGULAR ||
         listener->type == TOUCH_LISTENER_POINTER_GRAB) {
@@ -2138,7 +2139,7 @@ DeliverTouchEvent(DeviceIntPtr dev, TouchPointInfoPtr ti, InternalEvent *ev,
                   TouchListener * listener, ClientPtr client,
                   WindowPtr win, GrabPtr grab, XI2Mask *xi2mask)
 {
-    Bool has_ownershipmask = FALSE;
+    bool has_ownershipmask = FALSE;
     int rc = Success;
 
     if (xi2mask)

--- a/Xext/xinput/listdev.c
+++ b/Xext/xinput/listdev.c
@@ -52,6 +52,7 @@ SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>              /* for inputstr.h    */
 #include <X11/Xproto.h>         /* Request macro     */
 #include <X11/extensions/XI.h>

--- a/Xext/xinput/xiallowev.c
+++ b/Xext/xinput/xiallowev.c
@@ -31,6 +31,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/extensions/XI2.h>
 #include <X11/extensions/XI2proto.h>
 
@@ -50,7 +51,7 @@
 int
 ProcXIAllowEvents(ClientPtr client)
 {
-    Bool have_xi22 = FALSE;
+    bool have_xi22 = FALSE;
     CARD32 clientTime;
     int deviceId;
     int mode;

--- a/Xext/xinput/xibarriers.c
+++ b/Xext/xinput/xibarriers.c
@@ -43,6 +43,8 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
@@ -79,8 +81,8 @@ struct PointerBarrierDevice {
     Time last_timestamp;
     int barrier_event_id;
     int release_event_id;
-    Bool hit;
-    Bool seen;
+    bool hit;
+    bool seen;
 };
 
 struct PointerBarrierClient {

--- a/Xext/xinput/xiproperty.c
+++ b/Xext/xinput/xiproperty.c
@@ -27,6 +27,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/Xatom.h>
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XIproto.h>
@@ -665,7 +666,7 @@ XIChangeDeviceProperty(DeviceIntPtr dev, Atom property, Atom type,
     unsigned long total_len;
     XIPropertyValuePtr prop_value;
     XIPropertyValueRec new_value;
-    Bool add = FALSE;
+    bool add = FALSE;
     int rc;
 
     size_in_bytes = format >> 3;

--- a/Xext/xinput/xiquerydevice.c
+++ b/Xext/xinput/xiquerydevice.c
@@ -30,6 +30,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 #include <X11/Xatom.h>
 #include <X11/extensions/XI2proto.h>

--- a/Xext/xinput/xiquerypointer.c
+++ b/Xext/xinput/xiquerypointer.c
@@ -31,6 +31,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>              /* for inputstr.h    */
 #include <X11/Xproto.h>         /* Request macro     */
 #include <X11/extensions/XI.h>
@@ -75,7 +76,7 @@ ProcXIQueryPointer(ClientPtr client)
     WindowPtr pWin, t;
     SpritePtr pSprite;
     XkbStatePtr state;
-    Bool have_xi22 = FALSE;
+    bool have_xi22 = FALSE;
 
     /* Check if client is compliant with XInput 2.2 or later. Earlier clients
      * do not know about touches, so we must report emulated button presses. 2.2


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
