### PR TITLE
modesetting: VT switch can freeze the desktop (lost Present completion)

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/vblank.c
+++ b/hw/xfree86/drivers/video/modesetting/vblank.c
@@ -305,9 +305,10 @@ ms_queue_coalesce(xf86CrtcPtr crtc, uint32_t seq, uint64_t msc)
     return TRUE;
 }
 
-Bool
-ms_queue_vblank(xf86CrtcPtr crtc, ms_queue_flag flags,
-                uint64_t msc, uint64_t *msc_queued, uint32_t seq)
+static Bool
+ms_queue_vblank_internal(xf86CrtcPtr crtc, ms_queue_flag flags,
+                         uint64_t msc, uint64_t *msc_queued, uint32_t seq,
+                         Bool abort_on_fail)
 {
     ScreenPtr screen = crtc->randr_crtc->pScreen;
     ScrnInfoPtr scrn = xf86ScreenToScrn(screen);
@@ -369,11 +370,19 @@ ms_queue_vblank(xf86CrtcPtr crtc, ms_queue_flag flags,
         }
     check:
         if (errno != EBUSY) {
-            ms_drm_abort_seq(scrn, seq);
+            if (abort_on_fail)
+                ms_drm_abort_seq(scrn, seq);
             return FALSE;
         }
         ms_flush_drm_events(screen);
     }
+}
+
+Bool
+ms_queue_vblank(xf86CrtcPtr crtc, ms_queue_flag flags,
+                uint64_t msc, uint64_t *msc_queued, uint32_t seq)
+{
+    return ms_queue_vblank_internal(crtc, flags, msc, msc_queued, seq, TRUE);
 }
 
 /**
@@ -616,12 +625,27 @@ ms_drm_sequence_handler(int fd, uint64_t frame, uint64_t ns, Bool is64bit, uint6
     /* Queue an event if the next queued MSC isn't soon enough */
     drmmode_crtc = crtc->driver_private;
     drmmode_crtc->next_msc = next_msc;
-    if (msc < next_msc && !ms_queue_vblank(crtc, MS_QUEUE_ABSOLUTE, msc, NULL, seq)) {
-        xf86DrvMsg(crtc->scrn->scrnIndex, X_WARNING,
-                   "failed to queue next vblank event, aborting lost events\n");
+    if (msc < next_msc &&
+        !ms_queue_vblank_internal(crtc, MS_QUEUE_ABSOLUTE, msc, NULL, seq, FALSE)) {
+        struct xorg_list expired;
+
+        /* Couldn't re-arm: the CRTC was just disabled (VT switch, DPMS off),
+         * so it has no vblank and the queue ioctl returns EINVAL. We asked it
+         * NOT to abort, so the stranded waits are still queued; complete them
+         * rather than drop them, at the earliest pending target msc. Detach
+         * first, then notify -- present_event_notify() re-enters ms_drm_queue. */
+        xorg_list_init(&expired);
         xorg_list_for_each_entry_safe(q, tmp, &ms_drm_queue, list) {
-            if (q->crtc == crtc && q->msc < next_msc)
-                ms_drm_abort_one(q);
+            if (q->crtc == crtc && !q->kernel_queued && q->msc < next_msc) {
+                xorg_list_del(&q->list);
+                xorg_list_append(&q->list, &expired);
+            }
+        }
+        xorg_list_for_each_entry_safe(q, tmp, &expired, list) {
+            xorg_list_del(&q->list);
+            if (!q->aborted)
+                q->handler(msc, ns / 1000, q->data);
+            free(q);
         }
     }
 }


### PR DESCRIPTION
=== BEGIN maintainer notice: PR was NOT merged 

this one had been *accidentially* merged, so master had to be reset immediately. 
thus the PR needs to be resubmitted. 

== END maintainer notice

I switch VTs quite often, and hit this issue maybe once a day before the fix.
I managed (with the help of Opus 5) to reliably reproduce it on the current
master (5f2e1b8d7).

## What happens

After switching to another VT and back, or after a DPMS off/on cycle, the
screen stays frozen on the last frame. The pointer still moves and changes
shape, and sound and background tasks keep running, but nothing repaints
and input has no visible effect. Another VT switch doesn't help; restarting the
compositor does. The log shows this at the first switch:

    (WW) modeset(0): failed to queue next vblank event, aborting lost events

## Root cause

With a client presenting through DRI3/Present in copy mode, each frame
waits for its present to complete before the next is drawn. When the CRTC
is disabled — a VT switch, DPMS off — the kernel force-completes any
parked vblank event one frame early and the CRTC has no vblank left, so
ms_queue_vblank() returns EINVAL. The re-arm in
ms_drm_sequence_handler() (hw/xfree86/drivers/video/modesetting/vblank.c)
then aborts the pending coalesced vblank events via ms_drm_abort_one(),
freeing them without present_event_notify(). Present never learns those
frames completed, so that client stays blocked in xcb_wait_for_special_event()
(under loader_dri3_swap_buffers_msc) indefinitely. When it's the compositor,
the whole desktop appears frozen; the server is otherwise idle, which is why
the cursor still moves.

## Reproducing

A tight DPMS cycle hits it reliably — no VT switching, single head, stock
config, one X server. Three trials here hit after 15, 8 and 20 cycles.

    #!/bin/sh
    LOG=${LOG:-/var/log/Xorg.0.log}   # rootless: ~/.local/state/xorg/Xorg.0.log
    [ -r "$LOG" ] || { echo "set LOG= to your Xorg log"; exit 1; }

    glxgears >/dev/null 2>&1 &        # vsync-throttled; do NOT set vblank_mode=0
    sleep 3

    BASE=$(wc -l < "$LOG")            # ignore anything already in the log
    i=0
    while :; do
        i=$((i+1))
        xset dpms force off
        xset dpms force on            # no gap between off and on
        tail -n +$((BASE+1)) "$LOG" | grep -q 'aborting lost events' \
            && { echo "hit after $i cycles"; exit 0; }
        sleep 0.5
    done

`aborting lost events` marks the moment. Whoever holds a coalesced wait at that
instant is stranded — sometimes just the GL client, sometimes the compositor
too, in which case the desktop freezes.

## Fix

When the re-arm can't queue the next vblank, complete the waiting
events (delivering their Present completions) instead of aborting them,
so clients aren't left waiting.
