### PR TITLE
(master) xext: xfixes: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/Xext/xfixes/cursor.c
+++ b/Xext/xfixes/cursor.c
@@ -44,6 +44,8 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "dix/cursor_priv.h"
 #include "dix/dix_priv.h"
 #include "dix/input_priv.h"
@@ -146,7 +148,7 @@ static Bool
 CursorDisplayCursor(DeviceIntPtr pDev, ScreenPtr pScreen, CursorPtr pCursor)
 {
     CursorPtr pOldCursor = CursorForDevice(pDev);
-    Bool ret;
+    bool ret;
     DisplayCursorProcPtr backupProc;
 
     Unwrap(&(pScreen->xfixes), pScreen, DisplayCursor, backupProc);

--- a/Xext/xfixes/region.c
+++ b/Xext/xfixes/region.c
@@ -22,6 +22,8 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
 #include "dix/rpcbuf_priv.h"
@@ -143,7 +145,7 @@ ProcXFixesCreateRegionFromWindow(ClientPtr client)
     }
 
     RegionPtr pRegion;
-    Bool copy = TRUE;
+    bool copy = TRUE;
     switch (stuff->kind) {
     case WindowRegionBounding:
         pRegion = wBoundingShape(pWin);


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
