### PR TITLE
(master) miext: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/miext/damage/damage.c
+++ b/miext/damage/damage.c
@@ -22,6 +22,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdlib.h>
 
 #include "dix/screen_hooks_priv.h"
@@ -341,7 +342,7 @@ damageCreateGC(GCPtr pGC)
 
     damageScrPriv(pScreen);
     damageGCPriv(pGC);
-    Bool ret;
+    bool ret;
 
     unwrap(pScrPriv, pScreen, CreateGC);
     if ((ret = (*pScreen->CreateGC) (pGC))) {
@@ -1312,7 +1313,7 @@ damageText(DrawablePtr pDrawable,
     CharInfoPtr *charinfo;
     unsigned long i;
     unsigned int n;
-    Bool imageblt;
+    bool imageblt;
 
     imageblt = (textType == TT_IMAGE8) || (textType == TT_IMAGE16);
 
@@ -1921,7 +1922,7 @@ DamageReportDamage(DamagePtr pDamage, RegionPtr pDamageRegion)
 {
     BoxRec tmpBox;
     RegionRec tmpRegion;
-    Bool was_empty;
+    bool was_empty;
 
     switch (pDamage->damageLevel) {
     case DamageReportRawRegion:

--- a/miext/rootless/rootlessGC.c
+++ b/miext/rootless/rootlessGC.c
@@ -31,6 +31,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stddef.h>             /* For NULL */
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -272,7 +273,7 @@ RootlessCreateGC(GCPtr pGC)
 {
     RootlessGCRec *gcrec;
     RootlessScreenRec *s;
-    Bool result;
+    bool result;
 
     SCREEN_UNWRAP(pGC->pScreen, CreateGC);
     s = SCREENREC(pGC->pScreen);

--- a/miext/rootless/rootlessScreen.c
+++ b/miext/rootless/rootlessScreen.c
@@ -31,6 +31,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -540,7 +541,7 @@ RootlessMarkOverlappedWindows(WindowPtr pWin, WindowPtr pFirst,
                               WindowPtr *ppLayerWin)
 {
     RegionRec saveRoot;
-    Bool result;
+    bool result;
     ScreenPtr pScreen = pWin->drawable.pScreen;
 
     SCREEN_UNWRAP(pScreen, MarkOverlappedWindows);
@@ -561,7 +562,7 @@ RootlessMarkOverlappedWindows(WindowPtr pWin, WindowPtr pFirst,
         // This code copied from miMarkOverlappedWindows()
 
         register WindowPtr pChild;
-        Bool anyMarked = FALSE;
+        bool anyMarked = FALSE;
         MarkWindowProcPtr MarkWindow = pScreen->MarkWindow;
 
         RL_DEBUG_MSG("is top level! ");

--- a/miext/rootless/rootlessWindow.c
+++ b/miext/rootless/rootlessWindow.c
@@ -31,6 +31,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stddef.h>             /* For NULL */
 #include <limits.h>             /* For CHAR_BIT */
 #include <assert.h>
@@ -146,7 +147,7 @@ RootlessNativeWindowMoved(WindowPtr pWin)
 Bool
 RootlessCreateWindow(WindowPtr pWin)
 {
-    Bool result;
+    bool result;
     RegionRec saveRoot;
 
     SETWINREC(pWin, NULL);
@@ -278,7 +279,7 @@ RootlessSetShape(WindowPtr pWin, int kind)
 Bool
 RootlessChangeWindowAttributes(WindowPtr pWin, unsigned long vmask)
 {
-    Bool result;
+    bool result;
     ScreenPtr pScreen = pWin->drawable.pScreen;
 
     RL_DEBUG_MSG("change window attributes start ");
@@ -419,7 +420,7 @@ RootlessEnsureFrame(WindowPtr pWin)
 Bool
 RootlessRealizeWindow(WindowPtr pWin)
 {
-    Bool result;
+    bool result;
     RegionRec saveRoot;
     ScreenPtr pScreen = pWin->drawable.pScreen;
 
@@ -493,7 +494,7 @@ RootlessUnrealizeWindow(WindowPtr pWin)
 {
     ScreenPtr pScreen = pWin->drawable.pScreen;
     RootlessWindowRec *winRec = WINREC(pWin);
-    Bool result;
+    bool result;
 
     RL_DEBUG_MSG("unrealizewindow start ");
 

--- a/miext/sync/misync.c
+++ b/miext/sync/misync.c
@@ -23,6 +23,8 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "scrnintstr.h"
 #include "misync_priv.h"
 #include "misyncstr.h"
@@ -134,7 +136,7 @@ void
 miSyncTriggerFence(SyncFence * pFence)
 {
     SyncTriggerList *ptl;
-    Bool triggered;
+    bool triggered;
 
     pFence->funcs.SetTriggered(pFence);
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
