### PR TITLE
(master) xext: randr: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/Xext/randr/rrcrtc.c
+++ b/Xext/randr/rrcrtc.c
@@ -22,6 +22,7 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/Xatom.h>
 
 #include "dix/dix_priv.h"
@@ -350,7 +351,7 @@ static void
 RRComputeContiguity(ScreenPtr pScreen)
 {
     rrScrPriv(pScreen);
-    Bool discontiguous = TRUE;
+    bool discontiguous = TRUE;
     int i, n = pScrPriv->numCrtcs;
 
     int *reachable = calloc(n, sizeof(int));
@@ -755,9 +756,9 @@ RRCrtcSet(RRCrtcPtr crtc,
           int y, Rotation rotation, int numOutputs, RROutputPtr * outputs)
 {
     ScreenPtr pScreen = crtc->pScreen;
-    Bool ret = FALSE;
-    Bool recompute = TRUE;
-    Bool crtcChanged;
+    bool ret = FALSE;
+    bool recompute = TRUE;
+    bool crtcChanged;
     int  o;
 
     BUG_RETURN_VAL(numOutputs != 0 && outputs == NULL, FALSE);
@@ -938,7 +939,7 @@ RRCrtcDestroyResource(void *value, XID pid)
 Bool
 RRCrtcGammaSet(RRCrtcPtr crtc, CARD16 *red, CARD16 *green, CARD16 *blue)
 {
-    Bool ret = TRUE;
+    bool ret = TRUE;
 
 #if RANDR_12_INTERFACE
     ScreenPtr pScreen = crtc->pScreen;
@@ -964,7 +965,7 @@ RRCrtcGammaSet(RRCrtcPtr crtc, CARD16 *red, CARD16 *green, CARD16 *blue)
 static Bool
 RRCrtcGammaGet(RRCrtcPtr crtc)
 {
-    Bool ret = TRUE;
+    bool ret = TRUE;
 
 #if RANDR_12_INTERFACE
     ScreenPtr pScreen = crtc->pScreen;
@@ -1868,7 +1869,7 @@ RRConstrainCursorHarder(DeviceIntPtr pDev, ScreenPtr pScreen, int mode, int *x,
                         int *y)
 {
     rrScrPriv(pScreen);
-    Bool ret;
+    bool ret;
     ScreenPtr secondary;
 
     /* intentional dead space -> let it float */
@@ -1908,7 +1909,7 @@ Bool
 RRReplaceScanoutPixmap(DrawablePtr pDrawable, PixmapPtr pPixmap, Bool enable)
 {
     rrScrPriv(pDrawable->pScreen);
-    Bool ret = TRUE;
+    bool ret = TRUE;
     PixmapPtr *saved_scanout_pixmap;
     int i;
 
@@ -1918,7 +1919,7 @@ RRReplaceScanoutPixmap(DrawablePtr pDrawable, PixmapPtr pPixmap, Bool enable)
 
     for (i = 0; i < pScrPriv->numCrtcs; i++) {
         RRCrtcPtr crtc = pScrPriv->crtcs[i];
-        Bool size_fits;
+        bool size_fits;
 
         saved_scanout_pixmap[i] = crtc->scanout_pixmap;
 

--- a/Xext/randr/rrmonitor.c
+++ b/Xext/randr/rrmonitor.c
@@ -21,6 +21,8 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
 #include "os/mathx_priv.h"
@@ -132,7 +134,7 @@ RRMonitorGetGeometry(RRMonitorPtr monitor, RRMonitorGeometryPtr geometry)
         *geometry = first;
         for (o = 0; o < monitor->numOutputs; o++) {
             RRCrtcPtr   crtc = NULL;
-            Bool        in_use = FALSE;
+            bool        in_use = FALSE;
 
             for (c = 0; !in_use && c < pScrPriv->numCrtcs; c++) {
                 crtc = pScrPriv->crtcs[c];
@@ -318,7 +320,7 @@ RRMonitorMakeList(ScreenPtr screen, Bool get_active, RRMonitorPtr *monitors_ret,
     RRMonitorListRec    list;
     int                 m, c;
     RRMonitorPtr        mon, monitors;
-    Bool                has_primary = FALSE;
+    bool                has_primary = FALSE;
 
     if (!pScrPriv)
         return FALSE;
@@ -594,7 +596,7 @@ ProcRRGetMonitors(ClientPtr client)
     int                 r;
     RRMonitorPtr        monitors;
     int                 nmonitors;
-    Bool                get_active;
+    bool                get_active;
 
     r = dixLookupWindow(&window, stuff->window, client, DixGetAttrAccess);
     if (r != Success)

--- a/Xext/randr/rroutput.c
+++ b/Xext/randr/rroutput.c
@@ -22,6 +22,7 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/Xatom.h>
 
 #include "dix/dix_priv.h"
@@ -468,7 +469,7 @@ ProcRRGetOutputInfo(ClientPtr client)
     ScreenPtr pScreen;
     rrScrPrivPtr pScrPriv;
     int i;
-    Bool leased;
+    bool leased;
 
     VERIFY_RR_OUTPUT(stuff->output, output, DixReadAccess);
 

--- a/Xext/randr/rrproperty.c
+++ b/Xext/randr/rrproperty.c
@@ -21,6 +21,7 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/Xatom.h>
 
 #include "dix/dix_priv.h"
@@ -147,7 +148,7 @@ RRNoticePropertyChange(RROutputPtr output, Atom property, RRPropertyValuePtr val
     if (property == non_desktop_prop) {
         if (value->type == XA_INTEGER && value->format == 32 && value->size >= 1) {
             uint32_t     nonDesktopData;
-            Bool        nonDesktop;
+            bool        nonDesktop;
 
             memcpy(&nonDesktopData, value->data, sizeof (nonDesktopData));
             nonDesktop = nonDesktopData != 0;
@@ -172,7 +173,7 @@ RRChangeOutputProperty(RROutputPtr output, Atom property, Atom type,
     unsigned long total_len;
     RRPropertyValuePtr prop_value;
     RRPropertyValueRec new_value;
-    Bool add = FALSE;
+    bool add = FALSE;
 
     size_in_bytes = format >> 3;
 
@@ -287,7 +288,7 @@ RRPostPendingProperties(RROutputPtr output)
     RRPropertyValuePtr pending_value;
     RRPropertyValuePtr current_value;
     RRPropertyPtr property;
-    Bool ret = TRUE;
+    bool ret = TRUE;
 
     if (!output->pendingProperties)
         return TRUE;
@@ -359,7 +360,7 @@ RRConfigureOutputProperty(RROutputPtr output, Atom property,
                           int num_values, const INT32 *values)
 {
     RRPropertyPtr prop = RRQueryOutputProperty(output, property);
-    Bool add = FALSE;
+    bool add = FALSE;
 
     if (!prop) {
         prop = RRCreateOutputProperty(property);

--- a/Xext/randr/rrproviderproperty.c
+++ b/Xext/randr/rrproviderproperty.c
@@ -21,6 +21,8 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
 #include "os/mathx_priv.h"
@@ -139,7 +141,7 @@ RRChangeProviderProperty(RRProviderPtr provider, Atom property, Atom type,
     unsigned long total_len;
     RRPropertyValuePtr prop_value;
     RRPropertyValueRec new_value;
-    Bool add = FALSE;
+    bool add = FALSE;
 
     size_in_bytes = format >> 3;
 
@@ -285,7 +287,7 @@ RRConfigureProviderProperty(RRProviderPtr provider, Atom property,
                           int num_values, INT32 *values)
 {
     RRPropertyPtr prop = RRQueryProviderProperty(provider, property);
-    Bool add = FALSE;
+    bool add = FALSE;
 
     if (!prop) {
         prop = RRCreateProviderProperty(property);

--- a/Xext/randr/rrscreen.c
+++ b/Xext/randr/rrscreen.c
@@ -21,6 +21,8 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
 #include "dix/server_priv.h"

--- a/Xext/randr/rrtransform.c
+++ b/Xext/randr/rrtransform.c
@@ -21,6 +21,8 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "include/rrtransform.h"
 #include "Xext/randr/randrstr_priv.h"
 
@@ -144,7 +146,7 @@ RRTransformCompute(int x,
 {
     PictTransform t_transform, inverse;
     struct pixman_f_transform tf_transform, tf_inverse;
-    Bool overflow = FALSE;
+    bool overflow = FALSE;
 
     if (!transform)
         transform = &t_transform;

--- a/Xext/randr/rrxinerama.c
+++ b/Xext/randr/rrxinerama.c
@@ -69,6 +69,7 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/Xmd.h>
 #include <X11/extensions/panoramiXproto.h>
 
@@ -124,7 +125,7 @@ ProcRRXineramaGetState(ClientPtr client)
     register int rc;
     ScreenPtr pScreen;
     rrScrPrivPtr pScrPriv;
-    Bool active = FALSE;
+    bool active = FALSE;
 
     rc = dixLookupWindow(&pWin, stuff->window, client, DixGetAttrAccess);
     if (rc != Success)


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
