### PR TITLE
(master) xext: render: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/Xext/render/animcur.c
+++ b/Xext/render/animcur.c
@@ -33,6 +33,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 #include <X11/Xmd.h>
 
@@ -164,7 +165,7 @@ static Bool
 AnimCurDisplayCursor(DeviceIntPtr pDev, ScreenPtr pScreen, CursorPtr pCursor)
 {
     AnimCurScreenPtr as = GetAnimCurScreen(pScreen);
-    Bool ret = TRUE;
+    bool ret = TRUE;
 
     if (InputDevIsFloating(pDev))
         return FALSE;
@@ -203,7 +204,7 @@ AnimCurSetCursorPosition(DeviceIntPtr pDev,
                          ScreenPtr pScreen, int x, int y, Bool generateEvent)
 {
     AnimCurScreenPtr as = GetAnimCurScreen(pScreen);
-    Bool ret;
+    bool ret;
 
     Unwrap(as, pScreen, SetCursorPosition);
     if (pDev->spriteInfo->anim.pCursor) {
@@ -218,7 +219,7 @@ static Bool
 AnimCurRealizeCursor(DeviceIntPtr pDev, ScreenPtr pScreen, CursorPtr pCursor)
 {
     AnimCurScreenPtr as = GetAnimCurScreen(pScreen);
-    Bool ret;
+    bool ret;
 
     Unwrap(as, pScreen, RealizeCursor);
     if (IsAnimCur(pCursor))
@@ -233,7 +234,7 @@ static Bool
 AnimCurUnrealizeCursor(DeviceIntPtr pDev, ScreenPtr pScreen, CursorPtr pCursor)
 {
     AnimCurScreenPtr as = GetAnimCurScreen(pScreen);
-    Bool ret;
+    bool ret;
 
     Unwrap(as, pScreen, UnrealizeCursor);
     if (IsAnimCur(pCursor)) {

--- a/Xext/render/miindex.c
+++ b/Xext/render/miindex.c
@@ -23,6 +23,8 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "dix/colormap_priv.h"
 #include "include/mipict.h"
 
@@ -42,7 +44,7 @@ miBuildRenderColormap(ColormapPtr pColormap, Pixel * pixels, int *nump)
     int r, g, b;
     unsigned short red, green, blue;
     Pixel pixel;
-    Bool used[MI_MAX_INDEXED];
+    bool used[MI_MAX_INDEXED];
     int needed;
     int policy;
     int cube, gray;

--- a/Xext/render/mipict.c
+++ b/Xext/render/mipict.c
@@ -23,6 +23,8 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "include/mipict.h"
 #include "os/osdep.h"
 
@@ -105,7 +107,7 @@ miValidatePicture(PicturePtr pPicture, Mask mask)
         if (pDrawable->type == DRAWABLE_WINDOW) {
             WindowPtr pWin = (WindowPtr) pDrawable;
             RegionPtr pregWin;
-            Bool freeTmpClip, freeCompClip;
+            bool freeTmpClip, freeCompClip;
 
             if (pPicture->subWindowMode == IncludeInferiors) {
                 pregWin = NotClippedByChildren(pWin);
@@ -265,7 +267,7 @@ static inline Bool
 miClipPictureSrc(RegionPtr pRegion, PicturePtr pPicture, int dx, int dy)
 {
     if (pPicture->clientClip) {
-        Bool result;
+        bool result;
 
         pixman_region_translate(pPicture->clientClip,
                                 pPicture->clipOrigin.x + dx,

--- a/Xext/render/picture.c
+++ b/Xext/render/picture.c
@@ -24,6 +24,8 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "dix/colormap_priv.h"
 #include "dix/screen_hooks_priv.h"
 #include "include/extinit.h"
@@ -1427,7 +1429,7 @@ static CARD8
 ReduceCompositeOp(CARD8 op, PicturePtr pSrc, PicturePtr pMask, PicturePtr pDst,
                   INT16 xSrc, INT16 ySrc, CARD16 width, CARD16 height)
 {
-    Bool no_src_alpha, no_dst_alpha;
+    bool no_src_alpha, no_dst_alpha;
 
     /* Sampling off the edge of a RepeatNone picture introduces alpha
      * even if the picture itself doesn't have alpha. We don't try to

--- a/Xext/render/render.c
+++ b/Xext/render/render.c
@@ -24,6 +24,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>
@@ -781,7 +782,7 @@ ProcRenderFreeGlyphSet(ClientPtr client)
 typedef struct _GlyphNew {
     Glyph id;
     GlyphPtr glyph;
-    Bool found;
+    bool found;
     unsigned char sha1[20];
 } GlyphNewRec, *GlyphNewPtr;
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
