### PR TITLE
(master) fb: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/fb/fbblt.c
+++ b/fb/fbblt.c
@@ -22,6 +22,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <string.h>
 #include "fb.h"
 
@@ -79,7 +80,7 @@ fbBlt(FbBits * srcLine,
     FbBits startmask, endmask;
     FbBits bits, bits1;
     int n, nmiddle;
-    Bool destInvarient;
+    bool destInvarient;
     int startbyte, endbyte;
 
     FbDeclareMergeRop();

--- a/fb/fbbltone.c
+++ b/fb/fbbltone.c
@@ -22,6 +22,8 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "fb.h"
 
 /*
@@ -179,10 +181,10 @@ fbBltOne(FbStip * src, FbStride srcStride,      /* FbStip units per scanline */
     int w;
     int n, nmiddle;
     int dstS;                   /* stipple-relative dst X coordinate */
-    Bool copy;                  /* accelerate dest-invariant */
-    Bool transparent;           /* accelerate 0 nop */
+    bool copy;                  /* accelerate dest-invariant */
+    bool transparent;           /* accelerate 0 nop */
     int srcinc;                 /* source units consumed */
-    Bool endNeedsLoad = FALSE;  /* need load for endmask */
+    bool endNeedsLoad = FALSE;  /* need load for endmask */
     int startbyte, endbyte;
 
     /*

--- a/fb/fbglyph.c
+++ b/fb/fbglyph.c
@@ -23,6 +23,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/fonts/fontstruct.h>
 
 #include "fb/fb_priv.h"
@@ -130,7 +131,7 @@ fbImageGlyphBlt(DrawablePtr pDrawable,
     unsigned char *pglyph;      /* pointer bits in glyph */
     int gWidth, gHeight;        /* width and height of glyph */
     FbStride gStride;           /* stride of glyph */
-    Bool opaque;
+    bool opaque;
     int n;
     int gx, gy;
     void (*glyph) (FbBits *, FbStride, int, FbStip *, FbBits, int, int);

--- a/fb/fbline.c
+++ b/fb/fbline.c
@@ -22,6 +22,8 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "fb.h"
 
 static void
@@ -57,7 +59,7 @@ fbZeroSegment(DrawablePtr pDrawable, GCPtr pGC, int nseg, xSegment * pSegs)
 {
     int dashOffset;
     int x, y;
-    Bool drawLast = pGC->capStyle != CapNotLast;
+    bool drawLast = pGC->capStyle != CapNotLast;
 
     x = pDrawable->x;
     y = pDrawable->y;

--- a/fb/fbpixmap.c
+++ b/fb/fbpixmap.c
@@ -22,6 +22,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdlib.h>
 
 #include "fb/fb_priv.h"
@@ -131,7 +132,7 @@ fbPixmapToRegion(PixmapPtr pPix)
     int irectPrevStart, irectLineStart;
     register BoxPtr prectO, prectN;
     BoxPtr FirstRect, rects, prectLineStart;
-    Bool fInBox, fSame;
+    bool fInBox, fSame;
     register FbBits mask0 = FB_ALLONES & ~FbScrRight(FB_ALLONES, 1);
     FbBits *pwLine;
     int nWidth;
@@ -314,7 +315,7 @@ fbValidateDrawable(DrawablePtr pDrawable)
     int stride, bpp;
     int xoff, yoff;
     int height;
-    Bool failed;
+    bool failed;
 
     if (pDrawable->type != DRAWABLE_PIXMAP)
         pDrawable = (DrawablePtr) fbGetWindowPixmap(pDrawable);

--- a/fb/fbseg.c
+++ b/fb/fbseg.c
@@ -22,6 +22,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdlib.h>
 
 #include "fb/fb_priv.h"
@@ -125,8 +126,8 @@ fbBresDash(DrawablePtr pDrawable,
 
     FbDashDeclare;
     int dashlen;
-    Bool even;
-    Bool doOdd;
+    bool even;
+    bool doOdd;
 
     fbGetStipDrawable(pDrawable, dst, dstStride, dstBpp, dstXoff, dstYoff);
     doOdd = pGC->lineStyle == LineDoubleDash;
@@ -230,9 +231,9 @@ fbBresFillDash(DrawablePtr pDrawable,
 
     FbDashDeclare;
     int dashlen;
-    Bool even;
-    Bool doOdd;
-    Bool doBg;
+    bool even;
+    bool doOdd;
+    bool doBg;
     Pixel fg, bg;
 
     fg = pGC->fgPixel;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
