### PR TITLE
(master) xwin: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/hw/xwin/glx/indirect.c
+++ b/hw/xwin/glx/indirect.c
@@ -75,6 +75,8 @@
 */
 #include <xwin-config.h>
 
+#include <stdbool.h>
+
 #include "glwindows.h"
 
 #include "Xext/glx/glxserver.h"
@@ -595,7 +597,7 @@ glxWinScreenProbe(ScreenPtr pScreen)
         {
             const char *wglext;
             const char *glxext;
-            Bool mandatory;
+            bool mandatory;
         } extensionMap[] = {
             { "WGL_ARB_make_current_read", "GLX_SGI_make_current_read", 1 },
             { "WGL_EXT_swap_control", "GLX_SGI_swap_control", 0 },

--- a/hw/xwin/winclipboardinit.c
+++ b/hw/xwin/winclipboardinit.c
@@ -29,6 +29,8 @@
  */
 #include <xwin-config.h>
 
+#include <stdbool.h>
+
 #include <unistd.h>
 #include <pthread.h>
 
@@ -58,7 +60,7 @@ winClipboardThreadProc(void *arg)
 
   while (1)
     {
-      Bool fShutdown;
+      bool fShutdown;
 
       ++clipboardRestarts;
 

--- a/hw/xwin/winconfig.c
+++ b/hw/xwin/winconfig.c
@@ -29,6 +29,8 @@
  */
 #include <xwin-config.h>
 
+#include <stdbool.h>
+
 #include "win.h"
 #include "winconfig.h"
 #include "winmsg.h"
@@ -123,7 +125,7 @@ winConfigKeyboard(DeviceIntPtr pDevice)
     keyboardType = GetKeyboardType(0);
     if (keyboardType > 0 && GetKeyboardLayoutName(layoutName)) {
         WinKBLayoutPtr pLayout;
-        Bool bfound = FALSE;
+        bool bfound = FALSE;
         int pass;
 
         layoutNum = strtoul(layoutName, (char **) NULL, 16);

--- a/hw/xwin/winengine.c
+++ b/hw/xwin/winengine.c
@@ -29,6 +29,8 @@
  */
 #include <xwin-config.h>
 
+#include <stdbool.h>
+
 #include "win.h"
 #include "winmsg.h"
 
@@ -206,7 +208,7 @@ winSetEngine(ScreenPtr pScreen)
 Bool
 winGetDDProcAddresses(void)
 {
-    Bool fReturn = TRUE;
+    bool fReturn = TRUE;
 
     /* Load the DirectDraw library */
     g_hmodDirectDraw = LoadLibraryEx("ddraw.dll", NULL, 0);

--- a/hw/xwin/winkeybd.c
+++ b/hw/xwin/winkeybd.c
@@ -32,6 +32,8 @@
  */
 #include <xwin-config.h>
 
+#include <stdbool.h>
+
 #include "dix/screenint_priv.h"
 #include "mi/mi_priv.h"
 
@@ -350,7 +352,7 @@ winIsFakeCtrl_L(UINT message, WPARAM wParam, LPARAM lParam)
 {
     MSG msgNext;
     LONG lTime;
-    Bool fReturn;
+    bool fReturn;
 
     static Bool lastWasControlL = FALSE;
     static LONG lastTime;

--- a/hw/xwin/winmultiwindowwm.c
+++ b/hw/xwin/winmultiwindowwm.c
@@ -118,7 +118,7 @@ typedef struct _WMInfo {
     xcb_atom_t atmNumberDesktops;
     xcb_atom_t atmDesktopNames;
     xcb_ewmh_connection_t ewmh;
-    Bool fCompositeWM;
+    bool fCompositeWM;
 } WMInfoRec, *WMInfoPtr;
 
 typedef struct _WMProcArgRec {
@@ -557,7 +557,7 @@ getHwnd(WMInfoPtr pWMInfo, xcb_window_t iWindow)
 static Bool
 IsOverrideRedirect(xcb_connection_t *conn, xcb_window_t iWin)
 {
-    Bool result = FALSE;
+    bool result = FALSE;
     xcb_get_window_attributes_reply_t *reply;
     xcb_get_window_attributes_cookie_t cookie;
 
@@ -908,7 +908,7 @@ winMultiWindowWMProc(void *pArg)
             */
             if (pNode->msg.iWindow)
             {
-              Bool neverFocus = FALSE;
+              bool neverFocus = FALSE;
               xcb_get_property_cookie_t cookie;
               xcb_icccm_wm_hints_t hints;
 
@@ -1203,7 +1203,7 @@ winMultiWindowXMsgProc(void *pArg)
     while (1) {
         xcb_generic_event_t *event;
         uint8_t type;
-        Bool send_event;
+        bool send_event;
 
         if (g_shutdown)
             break;
@@ -1653,7 +1653,7 @@ winSendMessageToWM(void *pWMInfo, winWMMessagePtr pMsg)
 static Bool
 CheckAnotherWindowManager(xcb_connection_t *conn, DWORD dwScreen)
 {
-    Bool redirectError = FALSE;
+    bool redirectError = FALSE;
 
     /* Get root window id */
     xcb_screen_t *root_screen = xcb_aux_get_screen(conn, dwScreen);

--- a/hw/xwin/winmultiwindowwndproc.c
+++ b/hw/xwin/winmultiwindowwndproc.c
@@ -33,6 +33,8 @@
  */
 #include <xwin-config.h>
 
+#include <stdbool.h>
+
 #include "win.h"
 
 #include "dix/dix_priv.h"
@@ -423,9 +425,9 @@ winTopLevelWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
     HWND hwndScreen = NULL;
     DrawablePtr pDraw = NULL;
     winWMMessageRec wmMsg;
-    Bool fWMMsgInitialized = FALSE;
+    bool fWMMsgInitialized = FALSE;
     static Bool s_fTracking = FALSE;
-    Bool needRestack = FALSE;
+    bool needRestack = FALSE;
     LRESULT ret;
     static Bool hasEnteredSizeMove = FALSE;
 

--- a/hw/xwin/winprefs.c
+++ b/hw/xwin/winprefs.c
@@ -31,6 +31,8 @@
  */
 #include <xwin-config.h>
 
+#include <stdbool.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #ifdef __CYGWIN__
@@ -542,7 +544,7 @@ LoadImageComma(char *fname, char *iconDirectory, int sx, int sy, int flags)
     else {
         char *file = calloc(1, PATH_MAX + NAME_MAX + 2);
 #ifdef  __CYGWIN__
-        Bool convert = FALSE;
+        bool convert = FALSE;
 #endif
 
         if (!file)

--- a/hw/xwin/winshadddnl.c
+++ b/hw/xwin/winshadddnl.c
@@ -32,6 +32,8 @@
  */
 #include <xwin-config.h>
 
+#include <stdbool.h>
+
 #include "win.h"
 
 #include "dix/colormap_priv.h"
@@ -650,7 +652,7 @@ winCloseScreenShadowDDNL(ScreenPtr pScreen)
 {
     winScreenPriv(pScreen);
     winScreenInfo *pScreenInfo = pScreenPriv->pScreenInfo;
-    Bool fReturn = TRUE;
+    bool fReturn = TRUE;
 
 #if ENABLE_DEBUG
     winDebug("winCloseScreenShadowDDNL - Freeing screen resources\n");
@@ -844,7 +846,7 @@ winBltExposedRegionsShadowDDNL(ScreenPtr pScreen)
     HDC hdcUpdate;
     PAINTSTRUCT ps;
     HRESULT ddrval = DD_OK;
-    Bool fReturn = TRUE;
+    bool fReturn = TRUE;
     int i;
 
     /* Quite common case. The primary surface was lost (maybe because of depth

--- a/hw/xwin/winshadgdi.c
+++ b/hw/xwin/winshadgdi.c
@@ -29,6 +29,8 @@
  */
 #include <xwin-config.h>
 
+#include <stdbool.h>
+
 #include <assert.h>
 
 #include "win.h"
@@ -151,7 +153,7 @@ static
 winQueryRGBBitsAndMasks(ScreenPtr pScreen)
 {
     winScreenPriv(pScreen);
-    Bool fReturn = TRUE;
+    bool fReturn = TRUE;
     LPDWORD pdw = NULL;
     DWORD dwRedBits, dwGreenBits, dwBlueBits;
 
@@ -321,7 +323,7 @@ winAllocateFBShadowGDI(ScreenPtr pScreen)
     winScreenPriv(pScreen);
     winScreenInfo *pScreenInfo = pScreenPriv->pScreenInfo;
     DIBSECTION dibsection;
-    Bool fReturn = TRUE;
+    bool fReturn = TRUE;
 
     /* Describe shadow bitmap to be created */
     pScreenPriv->pbmih->biWidth = pScreenInfo->dwWidth;
@@ -572,7 +574,7 @@ winCloseScreenShadowGDI(ScreenPtr pScreen)
 {
     winScreenPriv(pScreen);
     winScreenInfo *pScreenInfo = pScreenPriv->pScreenInfo;
-    Bool fReturn = TRUE;
+    bool fReturn = TRUE;
 
 #if ENABLE_DEBUG
     winDebug("winCloseScreenShadowGDI - Freeing screen resources\n");

--- a/hw/xwin/winwindow.c
+++ b/hw/xwin/winwindow.c
@@ -30,6 +30,8 @@
  */
 #include <xwin-config.h>
 
+#include <stdbool.h>
+
 #include "dix/window_priv.h"
 #include "mi/mi_priv.h"
 
@@ -57,7 +59,7 @@ static
 Bool
 winCreateWindowRootless(WindowPtr pWin)
 {
-    Bool fResult = FALSE;
+    bool fResult = FALSE;
 
     winWindowPriv(pWin);
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
