### PR TITLE
(master) xext: glx: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/Xext/glx/glx_dri/glxdri2.c
+++ b/Xext/glx/glx_dri/glxdri2.c
@@ -23,6 +23,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -281,7 +282,7 @@ __glXDRIcontextWait(__GLXcontext * baseContext,
                     __GLXclientState * cl, int *error)
 {
     __GLXcontext *cx = lastGLContext;
-    Bool ret;
+    bool ret;
 
     ret = DRI2WaitSwap(cl->client, baseContext->drawPriv->pDraw);
     if (cx != lastGLContext) {
@@ -591,7 +592,7 @@ __glXDRIscreenCreateDrawable(ClientPtr client,
     __GLXDRIconfig *config = (__GLXDRIconfig *) glxConfig;
     __GLXDRIdrawable *private;
     __GLXcontext *cx = lastGLContext;
-    Bool ret;
+    bool ret;
 
     private = calloc(1, sizeof *private);
     if (private == NULL)
@@ -775,7 +776,7 @@ static const __DRIextension *loader_extensions[] = {
 static Bool
 glxDRIEnterVT(ScrnInfoPtr scrn)
 {
-    Bool ret;
+    bool ret;
     __GLXDRIscreen *screen = (__GLXDRIscreen *)
         glxGetScreen(xf86ScrnToScreen(scrn));
 

--- a/Xext/glx/glxcmds.c
+++ b/Xext/glx/glxcmds.c
@@ -30,6 +30,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <string.h>
 #include <assert.h>
 #include <GL/glxtokens.h>
@@ -640,7 +641,7 @@ xorgGlxMakeCurrent(ClientPtr client, GLXContextTag tag, XID drawId, XID readId,
 
     if (prevglxc) {
         /* Flush the previous context if needed. */
-        Bool need_flush = !prevglxc->isDirect;
+        bool need_flush = !prevglxc->isDirect;
 #ifdef GLX_CONTEXT_RELEASE_BEHAVIOR_ARB
         if (prevglxc->releaseBehavior == GLX_CONTEXT_RELEASE_BEHAVIOR_NONE_ARB)
             need_flush = GL_FALSE;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
