### PR TITLE
(master) xext: xkeyboard: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/Xext/xkeyboard/XKBGAlloc.c
+++ b/Xext/xkeyboard/XKBGAlloc.c
@@ -26,6 +26,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>
@@ -784,7 +785,7 @@ XkbAddGeomOverlayKey(XkbOverlayPtr overlay,
     XkbOverlayKeyPtr key;
     XkbSectionPtr section;
     XkbRowPtr row_under;
-    Bool found;
+    bool found;
 
     if ((!overlay) || (!row) || (!over) || (!under))
         return NULL;

--- a/Xext/xkeyboard/XKBMisc.c
+++ b/Xext/xkeyboard/XKBMisc.c
@@ -26,6 +26,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>
@@ -179,7 +180,7 @@ XkbKeyTypesForCoreSymbols(XkbDescPtr xkb,
             }
         }
         if (syms[0] == NoSymbol) {
-            Bool found = FALSE;
+            bool found = FALSE;
 
             for (int n = 1; (!found) && (n < nSyms[i]); n++) {
                 found = (syms[n] != NoSymbol);
@@ -238,7 +239,7 @@ XkbKeyTypesForCoreSymbols(XkbDescPtr xkb,
         if (((sameType) || canonical) &&
             (!(protected &
                (XkbExplicitKeyTypesMask & ~XkbExplicitKeyType1Mask)))) {
-            Bool identical = TRUE;
+            bool identical = TRUE;
 
             for (int i = 1; identical && (i < nGroups); i++) {
                 KeySym *syms;

--- a/Xext/xkeyboard/ddxLoad.c
+++ b/Xext/xkeyboard/ddxLoad.c
@@ -26,6 +26,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <xkb-config.h>
 
 #include <stdio.h>
@@ -246,7 +247,7 @@ XkbDDXCompileKeymapByNames(XkbDescPtr xkb,
                            unsigned need, char *nameRtrn, int nameRtrnLen)
 {
     char *keymap;
-    Bool rc = FALSE;
+    bool rc = FALSE;
     XkbKeymapNamesCtx ctx = {
         .xkb = xkb,
         .names = names,
@@ -412,7 +413,7 @@ XkbDDXNamesFromRules(DeviceIntPtr keybd,
 {
     char buf[PATH_MAX] = { 0 };
     FILE *file;
-    Bool complete;
+    bool complete;
     XkbRF_RulesPtr rules;
 
     if (!rules_name)

--- a/Xext/xkeyboard/maprules.c
+++ b/Xext/xkeyboard/maprules.c
@@ -26,6 +26,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <ctype.h>
 #include <stdlib.h>
@@ -116,7 +117,7 @@ static Bool
 GetInputLine(FILE * file, InputLine * line, Bool checkbang)
 {
     int ch;
-    Bool endOfFile, spacePending, slashPending, inComment;
+    bool endOfFile, spacePending, slashPending, inComment;
 
     endOfFile = FALSE;
     while ((!endOfFile) && (line->num_line == 0)) {
@@ -275,7 +276,7 @@ SetUpRemap(InputLine * line, RemapSpec * remap)
     memset((char *) remap, 0, sizeof(RemapSpec));
     remap->number = len;
     while ((tok = _XStrtok(str, " ", strtok_buf)) != NULL) {
-        Bool found = FALSE;
+        bool found = FALSE;
         str = NULL;
         if (strcmp(tok, "=") == 0)
             continue;
@@ -425,7 +426,7 @@ CheckLine(InputLine * line,
     int nread;
     _Xstrtokparams strtok_buf;
     char *tok;
-    Bool append = FALSE;
+    bool append = FALSE;
 
     for (nread = 0; (tok = _XStrtok(str, " ", strtok_buf)) != NULL; nread++) {
         str = NULL;
@@ -628,7 +629,7 @@ XkbRF_CheckApplyRule(XkbRF_RulePtr rule,
                      XkbRF_MultiDefsPtr mdefs,
                      XkbComponentNamesPtr names, XkbRF_RulesPtr rules)
 {
-    Bool pending = FALSE;
+    bool pending = FALSE;
 
     if (rule->model != NULL) {
         if (mdefs->model == NULL)

--- a/Xext/xkeyboard/xkb.c
+++ b/Xext/xkeyboard/xkb.c
@@ -26,6 +26,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>
@@ -2647,7 +2648,7 @@ _XkbSetMap(ClientPtr client, DeviceIntPtr dev, xkbSetMapReq * req, char *values)
 {
     XkbEventCauseRec cause = { 0 };
     XkbChangesRec change = { 0 };
-    Bool sentNKN;
+    bool sentNKN;
     XkbSrvInfoPtr xkbi;
     XkbDescPtr xkb;
 
@@ -4299,7 +4300,7 @@ _XkbSetNames(ClientPtr client, DeviceIntPtr dev, xkbSetNamesReq * stuff)
         nn.nRadioGroups = names->num_rg;
     }
     if (nn.changed) {
-        Bool needExtEvent;
+        bool needExtEvent;
 
         needExtEvent = (nn.changed & XkbIndicatorNamesMask) != 0;
         XkbSendNamesNotify(dev, &nn);
@@ -5434,7 +5435,7 @@ static int
 _XkbSetGeometry(ClientPtr client, DeviceIntPtr dev, xkbSetGeometryReq * stuff)
 {
     XkbDescPtr xkb;
-    Bool new_name;
+    bool new_name;
     XkbGeometryPtr geom, old;
     int status;
 
@@ -5559,7 +5560,7 @@ ProcXkbPerClientFlags(ClientPtr client)
         client->xkbClientFlags |= stuff->value;
     }
     if (stuff->change & XkbPCF_AutoResetControlsMask) {
-        Bool want;
+        bool want;
 
         want = stuff->value & XkbPCF_AutoResetControlsMask;
         if (interest && !want) {
@@ -5773,7 +5774,7 @@ ProcXkbGetKbdByName(ClientPtr client)
     unsigned len;
     unsigned fwant, fneed;
     int status;
-    Bool geom_changed;
+    bool geom_changed;
     XkbSrvLedInfoPtr old_sli;
     XkbSrvLedInfoPtr sli;
     Mask access_mode = DixGetAttrAccess | DixManageAccess;
@@ -5862,7 +5863,7 @@ ProcXkbGetKbdByName(ClientPtr client)
     if (new == NULL)
         reported = 0;
 
-    Bool loaded = 0;
+    bool loaded = 0;
 
     stuff->want |= stuff->need;
 
@@ -6196,7 +6197,7 @@ CheckDeviceLedFBs(DeviceIntPtr dev,
 {
     int nFBs = 0;
     int length = 0;
-    Bool classOk = FALSE;
+    bool classOk = FALSE;
 
     if (class == XkbDfltXIClass) {
         if (dev->kbdfeed)

--- a/Xext/xkeyboard/xkbAccessX.c
+++ b/Xext/xkeyboard/xkbAccessX.c
@@ -26,6 +26,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #if !defined(WIN32)
 #include <sys/time.h>
 #endif
@@ -465,7 +466,7 @@ AccessXFilterPressEvent(DeviceEvent *event, DeviceIntPtr keybd)
 {
     XkbSrvInfoPtr xkbi = keybd->key->xkbInfo;
     XkbControlsPtr ctrls = xkbi->desc->ctrls;
-    Bool ignoreKeyEvent = FALSE;
+    bool ignoreKeyEvent = FALSE;
     KeyCode key = event->detail.key;
     KeySym *sym = XkbKeySymsPtr(xkbi->desc, key);
 
@@ -604,7 +605,7 @@ AccessXFilterReleaseEvent(DeviceEvent *event, DeviceIntPtr keybd)
     XkbSrvInfoPtr xkbi = keybd->key->xkbInfo;
     XkbControlsPtr ctrls = xkbi->desc->ctrls;
     KeyCode key = event->detail.key;
-    Bool ignoreKeyEvent = FALSE;
+    bool ignoreKeyEvent = FALSE;
 
     /* Don't transmit the KeyRelease if BounceKeys is on and
      * this is the release of a key that was ignored due to

--- a/Xext/xkeyboard/xkbActions.c
+++ b/Xext/xkeyboard/xkbActions.c
@@ -26,6 +26,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <ctype.h>
 #include <stdio.h>
 #include <math.h>
@@ -528,7 +529,7 @@ _XkbFilterPointerMove(XkbSrvInfoPtr xkbi,
                       XkbFilterPtr filter, unsigned keycode, XkbAction *pAction)
 {
     int x, y;
-    Bool accel;
+    bool accel;
 
     if (filter->keycode == 0) { /* initial press */
         filter->keycode = keycode;
@@ -1194,7 +1195,7 @@ _XkbApplyFilters(XkbSrvInfoPtr xkbi, unsigned kc, XkbAction *pAction)
 static int
 _XkbEnsureStateChange(XkbSrvInfoPtr xkbi)
 {
-    Bool genStateNotify = FALSE;
+    bool genStateNotify = FALSE;
 
     /* The state may change, so if we're not in the middle of sending a state
      * notify, prepare for it */
@@ -1240,7 +1241,7 @@ void
 XkbPushLockedStateToSlaves(DeviceIntPtr master, int evtype, int key)
 {
     DeviceIntPtr dev;
-    Bool genStateNotify;
+    bool genStateNotify;
 
     nt_list_for_each_entry(dev, inputInfo.devices, next) {
         if (!dev->key || GetMaster(dev, MASTER_KEYBOARD) != master)
@@ -1381,10 +1382,10 @@ XkbHandleActions(DeviceIntPtr dev, DeviceIntPtr kbd, DeviceEvent *event)
     XkbSrvInfoPtr xkbi;
     KeyClassPtr keyc;
     int sendEvent;
-    Bool genStateNotify;
+    bool genStateNotify;
     XkbAction act = { 0 };
-    Bool keyEvent;
-    Bool pressEvent;
+    bool keyEvent;
+    bool pressEvent;
     ProcessInputProc backupproc;
 
     xkbDeviceInfoPtr xkbPrivPtr = XKBDEVICEINFO(dev);
@@ -1595,7 +1596,7 @@ InjectPointerKeyEvents(DeviceIntPtr dev, int type, int button, int flags,
     InternalEvent *events;
     int nevents, i;
     DeviceIntPtr ptr, mpointer, lastSlave = NULL;
-    Bool saveWait;
+    bool saveWait;
 
     if (InputDevIsMaster(dev)) {
         mpointer = GetMaster(dev, MASTER_POINTER);

--- a/Xext/xkeyboard/xkbEvents.c
+++ b/Xext/xkeyboard/xkbEvents.c
@@ -26,6 +26,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>
@@ -1013,7 +1014,7 @@ XkbRemoveResourceClient(DevicePtr inDev, XID id)
     XkbSrvInfoPtr xkbi;
     DeviceIntPtr dev = (DeviceIntPtr) inDev;
     XkbInterestPtr interest;
-    Bool found;
+    bool found;
     unsigned long autoCtrls, autoValues;
     ClientPtr client = NULL;
 

--- a/Xext/xkeyboard/xkbLEDs.c
+++ b/Xext/xkeyboard/xkbLEDs.c
@@ -26,6 +26,7 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <ctype.h>
 #include <math.h>
@@ -94,7 +95,7 @@ XkbApplyLEDChangeToKeyboard(XkbSrvInfoPtr xkbi,
                             XkbIndicatorMapPtr map,
                             Bool on, XkbChangesPtr change)
 {
-    Bool ctrlChange, stateChange;
+    bool ctrlChange, stateChange;
     XkbStatePtr state;
 
     if ((map->flags & XkbIM_NoExplicit) ||
@@ -188,7 +189,7 @@ static Bool
 ComputeAutoState(XkbIndicatorMapPtr map,
                  XkbStatePtr state, XkbControlsPtr ctrls)
 {
-    Bool on;
+    bool on;
     CARD8 mods, group;
 
     on = FALSE;
@@ -562,8 +563,8 @@ XkbAllocSrvLedInfo(DeviceIntPtr dev,
                    KbdFeedbackPtr kf, LedFeedbackPtr lf, unsigned needed_parts)
 {
     XkbSrvLedInfoPtr sli;
-    Bool checkAccel;
-    Bool checkNames;
+    bool checkAccel;
+    bool checkNames;
 
     sli = NULL;
     checkAccel = checkNames = FALSE;
@@ -965,7 +966,7 @@ XkbApplyLedStateChanges(DeviceIntPtr dev,
     register unsigned i, bit, affected;
     XkbIndicatorMapPtr map;
     unsigned oldState;
-    Bool kb_changed;
+    bool kb_changed;
 
     if (changed_leds == 0)
         return;

--- a/Xext/xkeyboard/xkbUtils.c
+++ b/Xext/xkeyboard/xkbUtils.c
@@ -50,6 +50,7 @@ DEALINGS IN THE SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <ctype.h>
 #include <math.h>
@@ -2021,7 +2022,7 @@ XkbCopyKeymap(XkbDescPtr dst, XkbDescPtr src)
 Bool
 XkbDeviceApplyKeymap(DeviceIntPtr dst, XkbDescPtr desc)
 {
-    Bool ret;
+    bool ret;
 
     if (!dst->key || !desc)
         return FALSE;

--- a/Xext/xkeyboard/xkbout.c
+++ b/Xext/xkeyboard/xkbout.c
@@ -26,6 +26,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <ctype.h>
 #include <stdlib.h>
@@ -356,7 +357,7 @@ XkbWriteXKBSymbols(FILE * file,
     register unsigned i, tmp;
     XkbClientMapPtr map;
     XkbServerMapPtr srv;
-    Bool showActions;
+    bool showActions;
 
     if (!xkb) {
         _XkbLibError(_XkbErrMissingSymbols, "XkbWriteXKBSymbols", 0);
@@ -388,7 +389,7 @@ XkbWriteXKBSymbols(FILE * file,
         fprintf(file, "\n");
     srv = xkb->server;
     for (i = xkb->min_key_code; i <= xkb->max_key_code; i++) {
-        Bool simple;
+        bool simple;
 
         if ((int) XkbKeyNumSyms(xkb, i) < 1)
             continue;
@@ -401,7 +402,7 @@ XkbWriteXKBSymbols(FILE * file,
             if (((srv->explicit[i] & XkbExplicitKeyTypesMask) != 0) ||
                 (showImplicit)) {
                 int typeNdx, g;
-                Bool multi;
+                bool multi;
                 const char *comment = "  ";
 
                 if ((srv->explicit[i] & XkbExplicitKeyTypesMask) == 0)

--- a/Xext/xkeyboard/xkbtext.c
+++ b/Xext/xkeyboard/xkbtext.c
@@ -26,6 +26,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <ctype.h>
 #include <stdlib.h>
@@ -561,7 +562,7 @@ XkbStringText(char *str, unsigned format)
     char *buf;
     register char *in, *out;
     int len;
-    Bool ok;
+    bool ok;
 
     if (str == NULL) {
         buf = tbGetBuffer(2);


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
