### PR TITLE
(master) dix: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -97,6 +97,8 @@ Equipment Corporation.
  */
 
 #include <dix-config.h>
+
+#include <stdbool.h>
 #include <version-config.h>
 
 #include <assert.h>
@@ -4123,7 +4125,7 @@ AddScreen(Bool (*pfnInit) (ScreenPtr /*pScreen */ ,
 
     int i;
     ScreenPtr pScreen;
-    Bool ret;
+    bool ret;
 
     i = screenInfo.numScreens;
     if (i == MAXSCREENS)
@@ -4170,7 +4172,7 @@ AddGPUScreen(Bool (*pfnInit) (ScreenPtr /*pScreen */ ,
 {
     int i;
     ScreenPtr pScreen;
-    Bool ret;
+    bool ret;
 
     i = screenInfo.numGPUScreens;
     if (i == MAXGPUSCREENS)

--- a/dix/dixfonts.c
+++ b/dix/dixfonts.c
@@ -23,6 +23,7 @@ SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <X11/X.h>
 #include <X11/Xmd.h>
@@ -62,7 +63,7 @@ struct list_font_state {
     int patlen;
     int current_fpe;
     int max_names;
-    Bool list_started;
+    bool list_started;
     void *private;
 };
 
@@ -91,7 +92,7 @@ struct list_fonts_with_info_closure {
     struct list_font_state current;
     struct list_font_state saved;
     int savedNumFonts;
-    Bool haveSaved;
+    bool haveSaved;
     char *savedName;
 };
 
@@ -102,7 +103,7 @@ struct list_fonts_closure {
     FontNamesPtr names;
     struct list_font_state current;
     struct list_font_state saved;
-    Bool haveSaved;
+    bool haveSaved;
     char *savedName;
     int savedNameLen;
 };

--- a/dix/dixutils.c
+++ b/dix/dixutils.c
@@ -82,6 +82,7 @@ Author:  Adobe Systems Incorporated
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 #include <X11/Xmd.h>
 
@@ -309,7 +310,7 @@ typedef struct _BlockHandler {
     ServerBlockHandlerProcPtr BlockHandler;
     ServerWakeupHandlerProcPtr WakeupHandler;
     void *blockData;
-    Bool deleted;
+    bool deleted;
 } BlockHandlerRec, *BlockHandlerPtr;
 
 static BlockHandlerPtr handlers;

--- a/dix/events.c
+++ b/dix/events.c
@@ -103,6 +103,7 @@ Equipment Corporation.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <assert.h>
 #include <X11/X.h>
 #include <X11/extensions/ge.h>
@@ -274,7 +275,7 @@ InputInfo inputInfo;
 EventSyncInfoRec syncEvents;
 
 static struct DeviceEventTime {
-    Bool reset;
+    bool reset;
     TimeStamp time;
 } lastDeviceEventTime[MAXDEVICES];
 
@@ -1617,7 +1618,7 @@ ActivatePointerGrab(DeviceIntPtr mouse, GrabPtr grab,
     GrabPtr oldgrab = grabinfo->grab;
     WindowPtr oldWin = (grabinfo->grab) ?
         grabinfo->grab->window : mouse->spriteInfo->sprite->win;
-    Bool isPassive = autoGrab & ~ImplicitGrabMask;
+    bool isPassive = !!(autoGrab & ~ImplicitGrabMask);
 
     /* slave devices need to float for the duration of the grab. */
     if (grab->grabtype == XI2 &&
@@ -1659,7 +1660,7 @@ void
 DeactivatePointerGrab(DeviceIntPtr mouse)
 {
     GrabPtr grab = mouse->deviceGrab.grab;
-    Bool wasPassive = mouse->deviceGrab.fromPassiveGrab;
+    bool wasPassive = !!mouse->deviceGrab.fromPassiveGrab;
     Bool wasImplicit = (mouse->deviceGrab.fromPassiveGrab &&
                         mouse->deviceGrab.implicitGrab);
     XID grab_resource = grab->resource;
@@ -1820,7 +1821,7 @@ DeactivateKeyboardGrab(DeviceIntPtr keybd)
 void
 AllowSome(ClientPtr client, TimeStamp time, DeviceIntPtr thisDev, int newState)
 {
-    Bool thisGrabbed, otherGrabbed, othersFrozen, thisSynced;
+    bool thisGrabbed, otherGrabbed, othersFrozen, thisSynced;
     TimeStamp grabTime;
     GrabInfoPtr devgrabinfo, grabinfo = &thisDev->deviceGrab;
 
@@ -1992,7 +1993,7 @@ ProcAllowEvents(ClientPtr client)
 void
 ReleaseActiveGrabs(ClientPtr client)
 {
-    Bool done;
+    bool done;
 
     /* XXX CloseDownClient should remove passive grabs before
      * releasing active grabs.
@@ -2271,7 +2272,7 @@ DeliverEventToInputClients(DeviceIntPtr dev, InputClients * inputclients,
 {
     int attempt;
     enum EventDeliveryState rc = EVENT_NOT_DELIVERED;
-    Bool have_device_button_grab_class_client = FALSE;
+    bool have_device_button_grab_class_client = FALSE;
 
     for (; inputclients; inputclients = inputclients->next) {
         Mask mask;
@@ -4129,7 +4130,7 @@ CheckDeviceGrabs(DeviceIntPtr device, InternalEvent *ievent, WindowPtr ancestor)
     FocusClassPtr focus =
         IsPointerEvent(ievent) ? NULL : device->focus;
     BOOL sendCore = (InputDevIsMaster(device) && device->coreEvents);
-    Bool ret = FALSE;
+    bool ret = FALSE;
     DeviceEvent *event = &ievent->device_event;
 
     if (event->type != ET_ButtonPress && event->type != ET_KeyPress)
@@ -5995,7 +5996,7 @@ ProcRecolorCursor(ClientPtr client)
 {
     CursorPtr pCursor;
     int rc;
-    Bool displayed;
+    bool displayed;
     SpritePtr pSprite = PickPointer(client)->spriteInfo->sprite;
 
     REQUEST(xRecolorCursorReq);

--- a/dix/gestures.c
+++ b/dix/gestures.c
@@ -25,6 +25,8 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "dix/dix_priv.h"
 #include "dix/dixgrabs_priv.h"
 #include "dix/eventconvert.h"
@@ -214,8 +216,8 @@ GestureAddGrabListener(DeviceIntPtr dev, GestureInfoPtr gi, GrabPtr grab)
 static void
 GestureAddPassiveGrabListener(DeviceIntPtr dev, GestureInfoPtr gi, WindowPtr win, InternalEvent *ev)
 {
-    Bool activate = FALSE;
-    Bool check_core = FALSE;
+    bool activate = FALSE;
+    bool check_core = FALSE;
 
     GrabPtr grab = CheckPassiveGrabsOnWindow(win, dev, ev, check_core,
                                              activate);

--- a/dix/getevents.c
+++ b/dix/getevents.c
@@ -29,6 +29,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <math.h>
 #include <limits.h>
 #include <pixman.h>
@@ -107,7 +108,7 @@ set_button_up(DeviceIntPtr pDev, int button, int type)
 Bool
 button_is_down(DeviceIntPtr pDev, int button, int type)
 {
-    Bool ret = FALSE;
+    bool ret = FALSE;
 
     if (type & BUTTON_PROCESSED)
         ret = ret || BitIsOn(pDev->button->down, button);
@@ -138,7 +139,7 @@ set_key_up(DeviceIntPtr pDev, int key_code, int type)
 Bool
 key_is_down(DeviceIntPtr pDev, int key_code, int type)
 {
-    Bool ret = FALSE;
+    bool ret = FALSE;
 
     if (type & KEY_PROCESSED)
         ret = ret || BitIsOn(pDev->key->down, key_code);
@@ -1925,7 +1926,7 @@ GetTouchEvents(InternalEvent *events, DeviceIntPtr dev, uint32_t ddx_touchid,
     RawDeviceEvent *raw;
     DDXTouchPointInfoPtr ti;
     int need_rawevent = TRUE;
-    Bool emulate_pointer = FALSE;
+    bool emulate_pointer = FALSE;
     int client_id = 0;
 
 #ifdef XSERVER_DTRACE

--- a/dix/grabs.c
+++ b/dix/grabs.c
@@ -47,6 +47,7 @@ SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>
 #include <X11/extensions/XI2.h>
@@ -85,7 +86,7 @@ PrintDeviceGrabInfo(DeviceIntPtr dev)
     LocalClientCredRec *lcc;
     GrabInfoPtr devGrab = &dev->deviceGrab;
     GrabPtr grab = devGrab->grab;
-    Bool clientIdPrinted = FALSE;
+    bool clientIdPrinted = FALSE;
 
     ErrorF("Active grab 0x%lx (%s) on device '%s' (%d):\n",
            (unsigned long) grab->resource,
@@ -576,7 +577,7 @@ DeletePassiveGrabFromList(GrabPtr pMinuendGrab)
     GrabPtr *deletes, *adds;
     Mask ***updates, **details;
     int i, ndels, nadds, nups;
-    Bool ok;
+    bool ok;
     unsigned int any_modifier;
     unsigned int any_key;
 

--- a/dix/ptrveloc.c
+++ b/dix/ptrveloc.c
@@ -24,6 +24,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <math.h>
 
 #include "dix/exevents_priv.h"
@@ -1086,7 +1087,7 @@ acceleratePointerPredictable(DeviceIntPtr dev, ValuatorMask *val, CARD32 evtime)
 {
     double dx = 0, dy = 0;
     DeviceVelocityPtr velocitydata = GetDevicePredictableAccelData(dev);
-    Bool soften = TRUE;
+    bool soften = TRUE;
 
     if (valuator_mask_num_valuators(val) == 0 || !velocitydata)
         return;

--- a/dix/region.c
+++ b/dix/region.c
@@ -77,6 +77,7 @@ Equipment Corporation.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/Xprotostr.h>
 #include <X11/Xfuncproto.h>
 #include <pixman.h>
@@ -579,7 +580,7 @@ RegionOp(RegionPtr newReg,      /* Place to store result         */
          RegionPtr reg2,        /* 2d region in operation        */
          OverlapProcPtr overlapFunc,    /* Function to call for over-
                                          * lapping bands                 */
-         Bool appendNon1,       /* Append non-overlapping bands  */
+         bool appendNon1,       /* Append non-overlapping bands  */
          /* in region 1 ? */
          Bool appendNon2,       /* Append non-overlapping bands  */
          /* in region 2 ? */
@@ -974,7 +975,7 @@ RegionAppend(RegionPtr dstrgn, RegionPtr rgn)
 {
     int numRects, dnumRects, size;
     BoxPtr new, old;
-    Bool prepend;
+    bool prepend;
 
     if (RegionNar(rgn))
         return RegionBreak(dstrgn);
@@ -1157,7 +1158,7 @@ RegionValidate(RegionPtr badreg, Bool *pOverlap)
     BoxPtr box;                 /* Current box in rects                 */
     BoxPtr riBox;               /* Last box in ri[j].reg                */
     RegionPtr hreg;             /* ri[j_half].reg                        */
-    Bool ret = TRUE;
+    bool ret = TRUE;
 
     *pOverlap = FALSE;
     if (!badreg->data) {

--- a/dix/selection.c
+++ b/dix/selection.c
@@ -46,6 +46,8 @@ SOFTWARE.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "dix/dix_priv.h"
 #include "dix/request_priv.h"
 #include "dix/selection_priv.h"
@@ -289,7 +291,7 @@ out:
 int
 ProcConvertSelection(ClientPtr client)
 {
-    Bool paramsOkay;
+    bool paramsOkay;
     xEvent event;
     WindowPtr pWin;
     Selection *pSel;

--- a/dix/touch.c
+++ b/dix/touch.c
@@ -26,6 +26,8 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "dix/dix_priv.h"
 #include "dix/dixgrabs_priv.h"
 #include "dix/eventconvert.h"
@@ -140,7 +142,7 @@ TouchBeginDDXTouch(DeviceIntPtr dev, uint32_t ddx_id)
     static int next_client_id = 1;
     TouchClassPtr t = dev->touch;
     DDXTouchPointInfoPtr ti = NULL;
-    Bool emulate_pointer;
+    bool emulate_pointer;
 
     if (!t)
         return NULL;
@@ -854,7 +856,7 @@ TouchSetupListeners(DeviceIntPtr dev, TouchPointInfoPtr ti, InternalEvent *ev)
     /* Find the first client with an applicable event selection,
      * going from deepest child window back up to the root window. */
     for (int i = sprite->spriteTraceGood - 1; i >= 0; i--) {
-        Bool delivered;
+        bool delivered;
 
         win = sprite->spriteTrace[i];
         delivered = TouchAddRegularListener(dev, ti, win, ev);

--- a/dix/window.c
+++ b/dix/window.c
@@ -98,6 +98,8 @@ Equipment Corporation.
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "dix/colormap_priv.h"
 #include "dix/cursor_priv.h"
 #include "dix/dispatch.h"
@@ -746,7 +748,7 @@ dixCreateWindow(Window wid, WindowPtr pParent, int x, int y, unsigned w,
     WindowPtr pWin;
     WindowPtr pHead;
     ScreenPtr pScreen;
-    Bool fOK;
+    bool fOK;
     DepthPtr pDepth;
     PixmapFormatRec *format;
     WindowOptPtr ancwopt;
@@ -1952,7 +1954,7 @@ static Bool
 ShapeOverlap(WindowPtr pWin, BoxPtr pWinBox, WindowPtr pSib, BoxPtr pSibBox)
 {
     RegionPtr pWinRgn, pSibRgn;
-    Bool ret;
+    bool ret;
 
     if (!IS_SHAPED(pWin) && !IS_SHAPED(pSib))
         return TRUE;
@@ -2126,7 +2128,7 @@ ReflectStackChange(WindowPtr pWin, WindowPtr pSib, VTKind kind)
 /* Note that pSib might be NULL */
 
     Bool WasViewable = (Bool) pWin->viewable;
-    Bool anyMarked;
+    bool anyMarked;
     WindowPtr pFirstChange;
     WindowPtr pLayerWin;
     ScreenPtr pScreen = pWin->drawable.pScreen;
@@ -2647,7 +2649,7 @@ MapWindow(WindowPtr pWin, ClientPtr client)
 
     pScreen = pWin->drawable.pScreen;
     if ((pParent = pWin->parent)) {
-        Bool anyMarked;
+        bool anyMarked;
 
         if ((!pWin->overrideRedirect) && (RedirectSend(pParent)))
             if (MaybeDeliverMapRequest(pWin, pParent, client))
@@ -2707,7 +2709,7 @@ MapSubwindows(WindowPtr pParent, ClientPtr client)
     ScreenPtr pScreen;
     Mask parentRedirect;
     Mask parentNotify;
-    Bool anyMarked;
+    bool anyMarked;
     WindowPtr pLayerWin;
 
     pScreen = pParent->drawable.pScreen;
@@ -2861,7 +2863,7 @@ UnmapSubwindows(WindowPtr pWin)
     WindowPtr pHead;
     Bool wasRealized = (Bool) pWin->realized;
     Bool wasViewable = (Bool) pWin->viewable;
-    Bool anyMarked = FALSE;
+    bool anyMarked = FALSE;
     Mask parentNotify;
     WindowPtr pLayerWin = NULL;
     ScreenPtr pScreen = pWin->drawable.pScreen;
@@ -3597,8 +3599,8 @@ void
 SetRootClip(ScreenPtr pScreen, int enable)
 {
     WindowPtr pWin = pScreen->root;
-    Bool WasViewable;
-    Bool anyMarked = FALSE;
+    bool WasViewable;
+    bool anyMarked = FALSE;
     WindowPtr pLayerWin;
     BoxRec box;
     enum RootClipMode mode = enable;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
