### PR TITLE
(master) exa: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/exa/exa.c
+++ b/exa/exa.c
@@ -30,6 +30,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <assert.h>
 #include <stdlib.h>
 
@@ -272,7 +273,7 @@ ExaDoPrepareAccess(PixmapPtr pPixmap, int index)
 
     ExaScreenPriv(pScreen);
     ExaPixmapPriv(pPixmap);
-    Bool has_gpu_copy, ret;
+    bool has_gpu_copy, ret;
     int i;
 
     if (!(pExaScr->info->flags & EXA_OFFSCREEN_PIXMAPS))
@@ -585,7 +586,7 @@ exaCreateGC(GCPtr pGC)
 
     ExaScreenPriv(pScreen);
     ExaGCPriv(pGC);
-    Bool ret;
+    bool ret;
 
     swap(pExaScr, pScreen, CreateGC);
     if ((ret = (*pScreen->CreateGC) (pGC))) {
@@ -600,7 +601,7 @@ exaCreateGC(GCPtr pGC)
 static Bool
 exaChangeWindowAttributes(WindowPtr pWin, unsigned long mask)
 {
-    Bool ret;
+    bool ret;
     ScreenPtr pScreen = pWin->drawable.pScreen;
 
     ExaScreenPriv(pScreen);

--- a/exa/exa_accel.c
+++ b/exa/exa_accel.c
@@ -29,6 +29,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <X11/fonts/fontstruct.h>
 
 #include "os/mathx_priv.h"
@@ -149,7 +150,7 @@ exaDoPutImage(DrawablePtr pDrawable, GCPtr pGC, int depth, int x, int y,
     int nbox;
     int xoff, yoff;
     int bpp = pDrawable->bitsPerPixel;
-    Bool ret = TRUE;
+    bool ret = TRUE;
 
     if (pExaScr->fallback_counter || pExaPixmap->accel_blocked ||
         !pExaScr->info->UploadToScreen)
@@ -197,7 +198,7 @@ exaDoPutImage(DrawablePtr pDrawable, GCPtr pGC, int depth, int x, int y,
         int x2 = x + w;
         int y2 = y + h;
         char *src;
-        Bool ok;
+        bool ok;
 
         if (x1 < pbox->x1)
             x1 = pbox->x1;
@@ -375,7 +376,7 @@ exaHWCopyNtoN(DrawablePtr pSrcDrawable,
     int src_off_x, src_off_y;
     int dst_off_x, dst_off_y;
     RegionPtr srcregion = NULL, dstregion = NULL;
-    Bool ret = TRUE;
+    bool ret = TRUE;
 
     /* avoid doing copy operations if no boxes */
     if (nbox == 0)
@@ -999,7 +1000,7 @@ exaFillRegionSolid(DrawablePtr pDrawable, RegionPtr pRegion, Pixel pixel,
 
     ExaPixmapPriv(pPixmap);
     int xoff, yoff;
-    Bool ret = FALSE;
+    bool ret = FALSE;
 
     exaGetDrawableDeltas(pDrawable, pPixmap, &xoff, &yoff);
     RegionTranslate(pRegion, xoff, yoff);
@@ -1085,7 +1086,7 @@ exaFillRegionTiled(DrawablePtr pDrawable, RegionPtr pRegion, PixmapPtr pTile,
     int tileWidth, tileHeight;
     int nbox = RegionNumRects(pRegion);
     BoxPtr pBox = RegionRects(pRegion);
-    Bool ret = FALSE;
+    bool ret = FALSE;
     int i;
 
     tileWidth = pTile->drawable.width;
@@ -1187,7 +1188,7 @@ exaFillRegionTiled(DrawablePtr pDrawable, RegionPtr pRegion, PixmapPtr pTile,
         if (alu != GXcopy)
             ret = TRUE;
         else {
-            Bool more_copy = FALSE;
+            bool more_copy = FALSE;
 
             for (i = 0; i < nbox; i++) {
                 int dstX = pBox[i].x1 + tileWidth;
@@ -1262,7 +1263,7 @@ exaGetImage(DrawablePtr pDrawable, int x, int y, int w, int h,
 
     ExaPixmapPriv(pPix);
     int xoff, yoff;
-    Bool ok;
+    bool ok;
 
     if (pExaScr->fallback_counter || pExaScr->swappedOut)
         goto fallback;

--- a/exa/exa_classic.c
+++ b/exa/exa_classic.c
@@ -24,6 +24,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <string.h>
 
 #include "exa_priv.h"
@@ -150,7 +151,7 @@ exaModifyPixmapHeader_classic(PixmapPtr pPixmap, int width, int height,
     ScreenPtr pScreen;
     ExaScreenPrivPtr pExaScr;
     ExaPixmapPrivPtr pExaPixmap;
-    Bool ret;
+    bool ret;
 
     if (!pPixmap)
         return FALSE;
@@ -235,7 +236,7 @@ exaPixmapHasGpuCopy_classic(PixmapPtr pPixmap)
 
     ExaScreenPriv(pScreen);
     ExaPixmapPriv(pPixmap);
-    Bool ret;
+    bool ret;
 
     if (pExaScr->info->PixmapIsOffscreen) {
         void *old_ptr = pPixmap->devPrivate.ptr;

--- a/exa/exa_driver.c
+++ b/exa/exa_driver.c
@@ -24,6 +24,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <string.h>
 
 #include "exa_priv.h"
@@ -133,7 +134,7 @@ exaModifyPixmapHeader_driver(PixmapPtr pPixmap, int width, int height,
     ScreenPtr pScreen;
     ExaScreenPrivPtr pExaScr;
     ExaPixmapPrivPtr pExaPixmap;
-    Bool ret;
+    bool ret;
 
     if (!pPixmap)
         return FALSE;
@@ -207,7 +208,7 @@ exaPixmapHasGpuCopy_driver(PixmapPtr pPixmap)
 
     ExaScreenPriv(pScreen);
     void *saved_ptr;
-    Bool ret;
+    bool ret;
 
     saved_ptr = pPixmap->devPrivate.ptr;
     pPixmap->devPrivate.ptr = ExaGetPixmapAddress(pPixmap);

--- a/exa/exa_migration_classic.c
+++ b/exa/exa_migration_classic.c
@@ -28,6 +28,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <string.h>
 
 #include "os/mathx_priv.h"
@@ -115,12 +116,12 @@ exaCopyDirty(ExaMigrationPtr migrate, RegionPtr pValidDst, RegionPtr pValidSrc,
     ExaPixmapPriv(pPixmap);
     RegionPtr damage = DamageRegion(pExaPixmap->pDamage);
     RegionRec CopyReg;
-    Bool save_use_gpu_copy;
+    bool save_use_gpu_copy;
     int save_pitch;
     BoxPtr pBox;
     int nbox;
-    Bool access_prepared = FALSE;
-    Bool need_sync = FALSE;
+    bool access_prepared = FALSE;
+    bool need_sync = FALSE;
 
     /* Damaged bits are valid in current copy but invalid in other one */
     if (pExaPixmap->use_gpu_copy) {
@@ -540,7 +541,7 @@ exaAssertNotDirty(PixmapPtr pPixmap)
     RegionRec ValidReg;
     int dst_pitch, src_pitch, cpp, y, nbox, save_pitch;
     BoxPtr pBox;
-    Bool ret = TRUE, save_use_gpu_copy;
+    bool ret = TRUE, save_use_gpu_copy;
 
     if (exaPixmapIsPinned(pPixmap) || pExaPixmap->area == NULL)
         return ret;

--- a/exa/exa_migration_mixed.c
+++ b/exa/exa_migration_mixed.c
@@ -24,6 +24,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <string.h>
 
 #include "exa_priv.h"
@@ -170,7 +171,7 @@ exaPrepareAccessReg_mixed(PixmapPtr pPixmap, int index, RegionPtr pReg)
 {
     ExaPixmapPriv(pPixmap);
     Bool has_gpu_copy = exaPixmapHasGpuCopy(pPixmap);
-    Bool success;
+    bool success;
 
     success = ExaDoPrepareAccess(pPixmap, index);
 
@@ -223,7 +224,7 @@ exaPrepareAccessReg_mixed(PixmapPtr pPixmap, int index, RegionPtr pReg)
 
         if (!pExaPixmap->pDamage &&
             (has_gpu_copy || !exaPixmapIsPinned(pPixmap))) {
-            Bool as_dst = pixmaps[0].as_dst;
+            bool as_dst = pixmaps[0].as_dst;
 
             /* Set up damage tracking */
             pExaPixmap->pDamage = DamageCreate(exaDamageReport_mixed, NULL,

--- a/exa/exa_mixed.c
+++ b/exa/exa_mixed.c
@@ -24,6 +24,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <string.h>
 
 #include "exa_priv.h"
@@ -128,7 +129,7 @@ exaModifyPixmapHeader_mixed(PixmapPtr pPixmap, int width, int height, int depth,
     ScreenPtr pScreen;
     ExaScreenPrivPtr pExaScr;
     ExaPixmapPrivPtr pExaPixmap;
-    Bool ret, has_gpu_copy;
+    bool ret, has_gpu_copy;
 
     if (!pPixmap)
         return FALSE;
@@ -271,7 +272,7 @@ exaPixmapHasGpuCopy_mixed(PixmapPtr pPixmap)
     ExaScreenPriv(pScreen);
     ExaPixmapPriv(pPixmap);
     void *saved_ptr;
-    Bool ret;
+    bool ret;
 
     if (!pExaPixmap->driverPriv)
         return FALSE;
@@ -289,7 +290,7 @@ exaSharePixmapBacking_mixed(PixmapPtr pPixmap, ScreenPtr secondary, void **handl
 {
     ScreenPtr pScreen = pPixmap->drawable.pScreen;
     ExaScreenPriv(pScreen);
-    Bool ret = FALSE;
+    bool ret = FALSE;
 
     exaMoveInPixmap(pPixmap);
     /* get the driver to give us a handle */
@@ -304,7 +305,7 @@ exaSetSharedPixmapBacking_mixed(PixmapPtr pPixmap, void *handle)
 {
     ScreenPtr pScreen = pPixmap->drawable.pScreen;
     ExaScreenPriv(pScreen);
-    Bool ret = FALSE;
+    bool ret = FALSE;
 
     if (pExaScr->info->SetSharedPixmapBacking)
         ret = pExaScr->info->SetSharedPixmapBacking(pPixmap, handle);

--- a/exa/exa_offscreen.c
+++ b/exa/exa_offscreen.c
@@ -27,11 +27,12 @@
  */
 #include <dix-config.h>
 
-#include "exa_priv.h"
-
+#include <stdbool.h>
 #include <limits.h>
 #include <assert.h>
 #include <stdlib.h>
+
+#include "exa_priv.h"
 
 #if DEBUG_OFFSCREEN
 #define DBG_OFFSCREEN(a) ErrorF a
@@ -495,7 +496,7 @@ ExaOffscreenDefragment(ScreenPtr pScreen)
         ExaOffscreenArea *prev = area->prev;
         PixmapPtr pSrcPix;
         ExaPixmapPrivPtr pExaSrcPix;
-        Bool save_use_gpu_copy;
+        bool save_use_gpu_copy;
         int save_pitch;
 
         if (area->state != ExaOffscreenAvail ||

--- a/exa/exa_render.c
+++ b/exa/exa_render.c
@@ -23,6 +23,7 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <assert.h>
 #include <stdlib.h>
 
@@ -875,8 +876,8 @@ exaComposite(CARD8 op,
 {
     ExaScreenPriv(pDst->pDrawable->pScreen);
     int ret = -1;
-    Bool saveSrcRepeat = pSrc->repeat;
-    Bool saveMaskRepeat = pMask ? pMask->repeat : 0;
+    bool saveSrcRepeat = pSrc->repeat;
+    bool saveMaskRepeat = pMask ? pMask->repeat : 0;
     RegionRec region;
 
     if (pExaScr->swappedOut)
@@ -916,7 +917,7 @@ exaComposite(CARD8 op,
             if (!pSrc->repeat && xSrc >= 0 && ySrc >= 0 &&
                 (xSrc + width <= pSrc->pDrawable->width) &&
                 (ySrc + height <= pSrc->pDrawable->height)) {
-                Bool suc;
+                bool suc;
 
                 xDst += pDst->pDrawable->x;
                 yDst += pDst->pDrawable->y;
@@ -1002,7 +1003,7 @@ exaComposite(CARD8 op,
 
     if (pExaScr->info->PrepareComposite &&
         !pSrc->alphaMap && (!pMask || !pMask->alphaMap) && !pDst->alphaMap) {
-        Bool isSrcSolid;
+        bool isSrcSolid;
 
         ret = exaTryDriverComposite(op, pSrc, pMask, pDst, xSrc, ySrc, xMask,
                                     yMask, xDst, yDst, width, height);

--- a/exa/exa_unaccel.c
+++ b/exa/exa_unaccel.c
@@ -22,6 +22,8 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "include/mipict.h"
 
 #include "exa_priv.h"
@@ -486,7 +488,7 @@ ExaPrepareCompositeReg(ScreenPtr pScreen,
     PixmapPtr pDstPix;
 
     ExaScreenPriv(pScreen);
-    Bool ret;
+    bool ret;
 
     RegionNull(&region);
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
