### PR TITLE
(master) glamor: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/glamor/glamor.c
+++ b/glamor/glamor.c
@@ -32,6 +32,7 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <assert.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -459,7 +460,7 @@ glamor_add_format(ScreenPtr screen, int depth, CARD32 render_format,
 {
     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
     struct glamor_format *f = &glamor_priv->formats[depth];
-    Bool texture_only = FALSE;
+    bool texture_only = FALSE;
 
     /* If we're trying to run on GLES, make sure that we get the read
      * formats that we're expecting, since glamor_transfer relies on

--- a/glamor/glamor_compositerects.c
+++ b/glamor/glamor_compositerects.c
@@ -28,6 +28,8 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "include/mipict.h"
 
 #include "glamor_priv.h"
@@ -111,7 +113,7 @@ glamor_composite_rectangles(CARD8 op,
     pixman_box16_t *boxes;
     int num_boxes;
     PicturePtr source = NULL;
-    Bool need_free_region = FALSE;
+    bool need_free_region = FALSE;
 
     DEBUGF("%s(op=%d, %08x x %d [(%d, %d)x(%d, %d) ...])\n",
            __func__, op,

--- a/glamor/glamor_copy.c
+++ b/glamor/glamor_copy.c
@@ -21,6 +21,8 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "os/bug_priv.h"
 #include "os/mathx_priv.h"
 
@@ -374,7 +376,7 @@ glamor_copy_fbo_fbo_draw(DrawablePtr src,
     glamor_program *prog;
     const glamor_facet *copy_facet;
     int n;
-    Bool ret = FALSE;
+    bool ret = FALSE;
     BoxRec bounds = glamor_no_rendering_bounds();
 
     glamor_make_current(glamor_priv);

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -28,6 +28,7 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <assert.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -492,7 +493,7 @@ glamor_egl_image_from_gbm_bo(ScreenPtr screen, struct gbm_bo *bo)
     glamor_egl_priv_t *glamor_egl =
         glamor_egl_get_screen_private(screen);
 
-    Bool tried_fast_import = FALSE;
+    bool tried_fast_import = FALSE;
 
     if (glamor_egl->fast_gbm_import) {
         EGLImageKHR image;
@@ -610,7 +611,7 @@ glamor_egl_create_textured_pixmap_from_dma_bufs(PixmapPtr pixmap,
                                                 uint32_t format, uint64_t modifier)
 {
     ScreenPtr screen = pixmap->drawable.pScreen;
-    Bool used_modifiers = modifier != DRM_FORMAT_MOD_INVALID;
+    bool used_modifiers = modifier != DRM_FORMAT_MOD_INVALID;
 
     EGLImageKHR image = glamor_egl_image_from_dma_bufs(screen,
                                                        num_fds, fds,
@@ -664,7 +665,7 @@ glamor_make_pixmap_exportable(PixmapPtr pixmap, Bool modifiers_ok)
     unsigned height = pixmap->drawable.height;
     uint32_t format;
     struct gbm_bo *bo = NULL;
-    Bool used_modifiers = FALSE;
+    bool used_modifiers = FALSE;
     PixmapPtr exported;
     GCPtr scratch_gc;
 
@@ -1215,7 +1216,7 @@ glamor_pixmap_from_fds(ScreenPtr screen,
 #ifdef WITH_LIBDRM
     PixmapPtr pixmap;
     glamor_egl_priv_t *glamor_egl;
-    Bool ret = FALSE;
+    bool ret = FALSE;
 
     glamor_egl = glamor_egl_get_screen_private(screen);
 
@@ -1285,7 +1286,7 @@ glamor_pixmap_from_fd(ScreenPtr screen,
                       CARD16 stride, CARD8 depth, CARD8 bpp)
 {
     PixmapPtr pixmap;
-    Bool ret;
+    bool ret;
 
     pixmap = screen->CreatePixmap(screen, 0, 0, depth, 0);
 
@@ -1483,7 +1484,7 @@ void
 glamor_egl_exchange_buffers(PixmapPtr front, PixmapPtr back)
 {
     EGLImageKHR temp_img;
-    Bool temp_mod;
+    bool temp_mod;
     struct glamor_pixmap_private *front_priv =
         glamor_get_pixmap_private(front);
     struct glamor_pixmap_private *back_priv =
@@ -2443,7 +2444,7 @@ glamor_egl_can_texture_gbm_bo(glamor_egl_priv_t *glamor_egl, int is_nvidia)
     /* Check if at least one combination of format + modifier is supported */
     CARD32 *formats = NULL;
     CARD32 num_formats = 0;
-    Bool found = FALSE;
+    bool found = FALSE;
 
     int linear_only;
 

--- a/glamor/glamor_glyphblt.c
+++ b/glamor/glamor_glyphblt.c
@@ -27,6 +27,8 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "os/bug_priv.h"
 
 #include "glamor_priv.h"
@@ -53,7 +55,7 @@ glamor_poly_glyph_blt_gl(DrawablePtr drawable, GCPtr gc,
     glamor_program *prog;
     RegionPtr clip = gc->pCompositeClip;
     int box_index;
-    Bool ret = FALSE;
+    bool ret = FALSE;
 
     pixmap_priv = glamor_get_pixmap_private(pixmap);
     if (!GLAMOR_PIXMAP_PRIV_HAS_FBO(pixmap_priv))
@@ -187,7 +189,7 @@ glamor_push_pixels_gl(GCPtr gc, PixmapPtr bitmap,
     int num_points;
     INT16 *points = NULL;
     char *vbo_offset;
-    Bool ret = FALSE;
+    bool ret = FALSE;
 
     if (w * h > MAXINT / (2 * sizeof(float)))
         goto bail;

--- a/glamor/glamor_lines.c
+++ b/glamor/glamor_lines.c
@@ -21,6 +21,8 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "os/bug_priv.h"
 
 #include "glamor_priv.h"
@@ -49,7 +51,7 @@ glamor_poly_lines_solid_gl(DrawablePtr drawable, GCPtr gc,
     char *vbo_offset;
     int box_index;
     int add_last;
-    Bool ret = FALSE;
+    bool ret = FALSE;
 
     pixmap_priv = glamor_get_pixmap_private(pixmap);
     if (!GLAMOR_PIXMAP_PRIV_HAS_FBO(pixmap_priv))

--- a/glamor/glamor_picture.c
+++ b/glamor/glamor_picture.c
@@ -37,6 +37,7 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <assert.h>
 #include <stdlib.h>
 
@@ -76,7 +77,7 @@ glamor_get_tex_format_type_from_pictformat(ScreenPtr pScreen,
                                            GLenum *swizzle)
 {
     glamor_screen_private *glamor_priv = glamor_get_screen_private(pScreen);
-    Bool is_little_endian = IMAGE_BYTE_ORDER == LSBFirst;
+    bool is_little_endian = IMAGE_BYTE_ORDER == LSBFirst;
 
     *temp_format = format;
     swizzle[0] = GL_RED;
@@ -283,8 +284,8 @@ glamor_upload_picture_to_texture(PicturePtr picture)
     GLenum format, type;
     GLenum swizzle[4];
     GLenum iformat;
-    Bool ret = TRUE;
-    Bool needs_swizzle;
+    bool ret = TRUE;
+    bool needs_swizzle;
     pixman_image_t *converted_image = NULL;
     const struct glamor_format *f = glamor_format_for_pixmap(pixmap);
 

--- a/glamor/glamor_points.c
+++ b/glamor/glamor_points.c
@@ -27,6 +27,8 @@
  */
 #include <dix-config.h>
 
+
+#include <stdbool.h>
 #include "os/bug_priv.h"
 
 #include "glamor_priv.h"
@@ -51,7 +53,7 @@ glamor_poly_point_gl(DrawablePtr drawable, GCPtr gc, int mode, int npt, DDXPoint
     GLshort *vbo_ppt;
     char *vbo_offset;
     int box_index;
-    Bool ret = FALSE;
+    bool ret = FALSE;
 
     pixmap_priv = glamor_get_pixmap_private(pixmap);
     if (!GLAMOR_PIXMAP_PRIV_HAS_FBO(pixmap_priv))

--- a/glamor/glamor_program.c
+++ b/glamor/glamor_program.c
@@ -21,6 +21,8 @@
  */
 #include <dix-config.h>
 
+
+#include <stdbool.h>
 #include "glamor_priv.h"
 #include "glamor_transform.h"
 #include "glamor_program.h"
@@ -272,7 +274,7 @@ glamor_build_program(ScreenPtr          screen,
     char                        *fs_prog_string = NULL;
 
     GLint                       fs_prog, vs_prog;
-    Bool                        gpu_shader4 = FALSE;
+    bool                        gpu_shader4 = FALSE;
 
     if (!fill)
         fill = &facet_null_fill;

--- a/glamor/glamor_rects.c
+++ b/glamor/glamor_rects.c
@@ -21,6 +21,8 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "os/bug_priv.h"
 #include "os/mathx_priv.h"
 
@@ -58,7 +60,7 @@ glamor_poly_fill_rect_gl(DrawablePtr drawable,
     GLshort *v;
     char *vbo_offset;
     int box_index;
-    Bool ret = FALSE;
+    bool ret = FALSE;
     BoxRec bounds = glamor_no_rendering_bounds();
 
     pixmap_priv = glamor_get_pixmap_private(pixmap);

--- a/glamor/glamor_render.c
+++ b/glamor/glamor_render.c
@@ -33,6 +33,7 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <assert.h>
 
 #include "include/mipict.h"
@@ -407,7 +408,7 @@ glamor_create_composite_shader(ScreenPtr screen, struct shader_key *key,
     GLuint vs, fs, prog;
     GLint source_sampler_uniform_location, mask_sampler_uniform_location;
     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
-    Bool enable_rel_sampler = TRUE;
+    bool enable_rel_sampler = TRUE;
 
     glamor_make_current(glamor_priv);
     vs = glamor_create_composite_vs(glamor_priv, key);
@@ -908,13 +909,13 @@ glamor_composite_choose_shader(CARD8 op,
 {
     ScreenPtr screen = dest->pDrawable->pScreen;
     glamor_screen_private *glamor_priv = glamor_get_screen_private(screen);
-    Bool source_needs_upload = FALSE;
-    Bool mask_needs_upload = FALSE;
+    bool source_needs_upload = FALSE;
+    bool mask_needs_upload = FALSE;
     pixman_format_code_t saved_source_format = 0;
     struct shader_key key;
     GLfloat source_solid_color[4];
     GLfloat mask_solid_color[4];
-    Bool ret = FALSE;
+    bool ret = FALSE;
 
     if (!GLAMOR_PIXMAP_PRIV_HAS_FBO(dest_pixmap_priv)) {
         glamor_fallback("dest has no fbo.\n");
@@ -1236,10 +1237,10 @@ glamor_composite_with_shader(CARD8 op,
     float src_matrix[9], mask_matrix[9];
     float *psrc_matrix = NULL, *pmask_matrix = NULL;
     int nrect_max;
-    Bool ret = FALSE;
+    bool ret = FALSE;
     glamor_composite_shader *shader = NULL, *shader_ca = NULL;
     struct blendinfo op_info, op_info_ca;
-    Bool restore_colormask = FALSE;
+    bool restore_colormask = FALSE;
 
     if (!glamor_composite_choose_shader(op, source, mask, dest,
                                         source_pixmap, mask_pixmap, dest_pixmap,

--- a/glamor/glamor_segs.c
+++ b/glamor/glamor_segs.c
@@ -21,6 +21,8 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "glamor_priv.h"
 #include "glamor_program.h"
 #include "glamor_transform.h"
@@ -47,7 +49,7 @@ glamor_poly_segment_solid_gl(DrawablePtr drawable, GCPtr gc,
     char *vbo_offset;
     int box_index;
     int add_last;
-    Bool ret = FALSE;
+    bool ret = FALSE;
 
     pixmap_priv = glamor_get_pixmap_private(pixmap);
     if (!GLAMOR_PIXMAP_PRIV_HAS_FBO(pixmap_priv))

--- a/glamor/glamor_spans.c
+++ b/glamor/glamor_spans.c
@@ -21,6 +21,8 @@
  */
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "glamor_priv.h"
 #include "glamor_transform.h"
 #include "glamor_transfer.h"
@@ -57,7 +59,7 @@ glamor_fill_spans_gl(DrawablePtr drawable,
     char *vbo_offset;
     int c;
     int box_index;
-    Bool ret = FALSE;
+    bool ret = FALSE;
 
     pixmap_priv = glamor_get_pixmap_private(pixmap);
     if (!GLAMOR_PIXMAP_PRIV_HAS_FBO(pixmap_priv))


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
