### PR TITLE
(master) xfree86: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/hw/xfree86/common/xf86Bus.c
+++ b/hw/xfree86/common/xf86Bus.c
@@ -32,6 +32,7 @@
 
 #include <assert.h>
 #include <ctype.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <X11/X.h>
@@ -77,7 +78,7 @@ BusRec primaryBus = { BUS_NONE, {0} };
 Bool
 xf86CallDriverProbe(DriverPtr drv, Bool detect_only)
 {
-    Bool foundScreen = FALSE;
+    bool foundScreen = FALSE;
 
 #ifdef XSERVER_PLATFORM_BUS
     /* xf86platformBus.c does not support Xorg -configure */

--- a/hw/xfree86/common/xf86Config.c
+++ b/hw/xfree86/common/xf86Config.c
@@ -43,6 +43,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <grp.h>
@@ -266,7 +267,7 @@ xf86ModulelistFromConfig(void ***optlist)
     };
     void **optarray;
     XF86LoadPtr modp;
-    Bool found;
+    bool found;
 
     /*
      * make sure the config file has been parsed and that we have a
@@ -532,7 +533,7 @@ static void
 configFiles(XF86ConfFilesPtr fileconf)
 {
     MessageType pathFrom;
-    Bool must_copy;
+    bool must_copy;
     int size, countDirs;
     char *temp_path, *log_buf, *start, *end;
 
@@ -1055,7 +1056,7 @@ static Bool
 checkCoreInputDevices(serverLayoutPtr servlayoutp, Bool implicitLayout)
 {
     InputInfoPtr corePointer = NULL, coreKeyboard = NULL;
-    Bool foundPointer = FALSE, foundKeyboard = FALSE;
+    bool foundPointer = FALSE, foundKeyboard = FALSE;
     const char *pointerMsg = NULL, *keyboardMsg = NULL;
     InputInfoPtr *devs,         /* iterator */
      indp;
@@ -1710,7 +1711,7 @@ configScreen(confScreenPtr screenp, XF86ConfScreenPtr conf_screen, int scrnum,
     int count = 0;
     XF86ConfDisplayPtr dispptr;
     XF86ConfAdaptorLinkPtr conf_adaptor;
-    Bool defaultMonitor = FALSE;
+    bool defaultMonitor = FALSE;
     XF86ConfScreenRec local_conf_screen;
     int i;
 
@@ -2187,7 +2188,7 @@ configExtensions(XF86ConfExtensionsPtr conf_ext)
             char *name = xf86OptionName(o);
             char *val = xf86OptionValue(o);
             char *n;
-            Bool enable = TRUE;
+            bool enable = TRUE;
 
             /* Handle "No<ExtensionName>" */
             n = xf86NormalizeName(name);
@@ -2332,7 +2333,7 @@ xf86HandleConfigFile(Bool autoconfig)
     const char *scanptr;
     Bool singlecard = 0;
 #endif
-    Bool implicit_layout = FALSE;
+    bool implicit_layout = FALSE;
     XF86ConfLayoutPtr layout;
 
     if (!autoconfig) {

--- a/hw/xfree86/common/xf86Configure.c
+++ b/hw/xfree86/common/xf86Configure.c
@@ -26,6 +26,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <stdbool.h>
 
 #include "include/misc.h"
 #include "os/ddx_priv.h"
@@ -642,7 +643,7 @@ DoConfigure(void)
 
     /* Call all of the probe functions, reporting the results. */
     for (CurrentDriver = 0; CurrentDriver < xf86NumDrivers; CurrentDriver++) {
-        Bool found_screen;
+        bool found_screen;
         DriverRec *const drv = xf86DriverList[CurrentDriver];
 
         found_screen = xf86CallDriverProbe(drv, TRUE);
@@ -742,7 +743,7 @@ DoConfigure(void)
             k = screennum > 0 ? screennum : 1;
             for (l = oldNumScreens; l < xf86NumScreens; l++) {
                 /* is screen primary? */
-                Bool primary = FALSE;
+                bool primary = FALSE;
 
                 for (n = 0; n < xf86Screens[l]->numEntities; n++) {
                     if (xf86IsEntityPrimary(xf86Screens[l]->entityList[n])) {

--- a/hw/xfree86/common/xf86Cursor.c
+++ b/hw/xfree86/common/xf86Cursor.c
@@ -26,6 +26,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 #include <X11/Xmd.h>
 #include <X11/extensions/XIproto.h>
@@ -135,7 +136,7 @@ xf86SetViewport(ScreenPtr pScreen, int x, int y)
 static void
 xf86PointerMoved(ScrnInfoPtr pScr, int x, int y)
 {
-    Bool frameChanged = FALSE;
+    bool frameChanged = FALSE;
 
     /*
      * check whether (x,y) belongs to the visual part of the screen
@@ -192,7 +193,7 @@ xf86SwitchMode(ScreenPtr pScreen, DisplayModePtr mode)
 {
     ScrnInfoPtr pScr = xf86ScreenToScrn(pScreen);
     ScreenPtr pCursorScreen;
-    Bool Switched;
+    bool Switched;
     int px, py;
     DeviceIntPtr dev, it;
 
@@ -569,7 +570,7 @@ xf86InitOrigins(void)
     int x1, x2, y1, y2, left, right, top, bottom;
     int i, j, ref, minX, minY, min, max;
     xf86ScreenLayoutPtr pLayout;
-    Bool OldStyleConfig = FALSE;
+    bool OldStyleConfig = FALSE;
 
     memset(xf86ScreenLayout, 0, MAXSCREENS * sizeof(xf86ScreenLayoutRec));
 

--- a/hw/xfree86/common/xf86DGA.c
+++ b/hw/xfree86/common/xf86DGA.c
@@ -38,6 +38,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <assert.h>
 #include <string.h>
 #include <X11/X.h>
@@ -99,7 +100,7 @@ static int DGAEventBase;
     dixLookupPrivate(&(pScreen)->devPrivates, &DGAScreenKeyRec))
 
 typedef struct _FakedVisualList {
-    Bool free;
+    bool free;
     VisualPtr pVisual;
     struct _FakedVisualList *next;
 } FakedVisualList;
@@ -119,8 +120,8 @@ typedef struct {
     FakedVisualList *fakedVisuals;
     ColormapPtr dgaColormap;
     ColormapPtr savedColormap;
-    Bool grabMouse;
-    Bool grabKeyboard;
+    bool grabMouse;
+    bool grabKeyboard;
 } DGAScreenRec, *DGAScreenPtr;
 
 Bool
@@ -402,7 +403,7 @@ xf86SetDGAMode(ScrnInfoPtr pScrn, int num, DGADevicePtr devRet)
         return BadAlloc;
 
     if (!pScreenPriv->current) {
-        Bool oldVTSema = pScrn->vtSema;
+        bool oldVTSema = !!pScrn->vtSema;
 
         pScrn->vtSema = FALSE;  /* kludge until we rewrite VT switching */
         (*pScrn->EnableDisableFBAccess) (pScrn, FALSE);

--- a/hw/xfree86/common/xf86DPMS.c
+++ b/hw/xfree86/common/xf86DPMS.c
@@ -29,7 +29,9 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
+
 #include "os.h"
 #include "globals.h"
 #include "windowstr.h"
@@ -67,7 +69,7 @@ xf86DPMSInit(ScreenPtr pScreen, DPMSSetProcPtr set, int flags)
     ScrnInfoPtr pScrn = xf86ScreenToScrn(pScreen);
     void *DPMSOpt;
     MessageType enabled_from = X_DEFAULT;
-    Bool enabled = TRUE;
+    bool enabled = TRUE;
 
     DPMSOpt = xf86FindOption(pScrn->options, "dpms");
     if (DPMSDisabledSwitch) {

--- a/hw/xfree86/common/xf86Events.c
+++ b/hw/xfree86/common/xf86Events.c
@@ -50,6 +50,7 @@
 /* [JCH-96/01/21] Extended std reverse map to four buttons. */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <assert.h>
 #include <errno.h>
 #include <X11/X.h>
@@ -105,8 +106,8 @@ typedef struct x_IHRec {
     int fd;
     InputHandlerProc ihproc;
     void *data;
-    Bool enabled;
-    Bool is_input;
+    bool enabled;
+    bool is_input;
     struct x_IHRec *next;
 } IHRec, *IHPtr;
 

--- a/hw/xfree86/common/xf86Helper.c
+++ b/hw/xfree86/common/xf86Helper.c
@@ -35,6 +35,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <assert.h>
 #include <sys/stat.h>
 #include <X11/X.h>
@@ -205,7 +206,7 @@ xf86DeleteScreen(ScrnInfoPtr pScrn)
 {
     int i;
     int scrnIndex;
-    Bool is_gpu = FALSE;
+    bool is_gpu = FALSE;
 
     if (!pScrn)
         return;
@@ -393,7 +394,7 @@ xf86SetDepthBpp(ScrnInfoPtr scrp, int depth, int dummy, int fbbpp,
              * Device sections.
              */
             GDevPtr device;
-            Bool found = FALSE;
+            bool found = FALSE;
 
             for (i = 0; i < scrp->numEntities; i++) {
                 device = xf86GetDevFromEntity(scrp->entityList[i],

--- a/hw/xfree86/common/xf86Init.c
+++ b/hw/xfree86/common/xf86Init.c
@@ -31,6 +31,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <sys/stat.h>
@@ -284,9 +285,9 @@ InitOutput(int argc, char **argv)
     int i, j, k, scr_index;
     const char **modulelist;
     void **optionlist;
-    Bool autoconfig = FALSE;
-    Bool sigio_blocked = FALSE;
-    Bool want_hw_access = FALSE;
+    bool autoconfig = FALSE;
+    bool sigio_blocked = FALSE;
+    bool want_hw_access = FALSE;
     GDevPtr configured_device;
 
     xf86Initialising = TRUE;
@@ -1260,7 +1261,7 @@ xf86LoadModules(const char **list, void **optlist)
     void *opt;
     int i;
     char *name;
-    Bool failed = FALSE;
+    bool failed = FALSE;
 
     if (!list)
         return TRUE;

--- a/hw/xfree86/common/xf86Mode.c
+++ b/hw/xfree86/common/xf86Mode.c
@@ -81,6 +81,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 
 #include "include/edid.h"
@@ -464,7 +465,7 @@ xf86LookupMode(ScrnInfoPtr scrp, DisplayModePtr modep,
     ClockRangePtr cp;
     int i, k, gap, minimumGap = CLOCK_TOLERANCE + 1;
     double refresh, bestRefresh = 0.0;
-    Bool found = FALSE;
+    bool found = FALSE;
     int extraFlags = 0;
     int clockIndex = -1;
     int MulFactor = 1;
@@ -1354,12 +1355,12 @@ xf86ValidateModes(ScrnInfoPtr scrp, DisplayModePtr availModes,
     int linePitch = -1, virtX = 0, virtY = 0;
     int newLinePitch, newVirtX, newVirtY;
     int modeSize;               /* in pixels */
-    Bool validateAllDefaultModes = FALSE;
-    Bool userModes = FALSE;
+    bool validateAllDefaultModes = FALSE;
+    bool userModes = FALSE;
     int saveType;
     PixmapFormatRec *BankFormat;
     ClockRangePtr cp;
-    Bool inferred_virtual = FALSE;
+    bool inferred_virtual = FALSE;
 
     DebugF
         ("xf86ValidateModes(%p, %p, %p, %p,\n\t\t  %p, %d, %d, %d, %d, %d, %d, %d, %d, 0x%x)\n",
@@ -1395,7 +1396,7 @@ xf86ValidateModes(ScrnInfoPtr scrp, DisplayModePtr availModes,
     }
     else {
         const char *type = "";
-        Bool specified = FALSE;
+        bool specified = FALSE;
 
         if (scrp->monitor->nHsync <= 0) {
             scrp->monitor->hsync[0].lo = 31.5;
@@ -1637,7 +1638,7 @@ xf86ValidateModes(ScrnInfoPtr scrp, DisplayModePtr availModes,
 #endif /* XINERAMA */
 
     for (p = scrp->modes;; p = p->next) {
-        Bool repeat;
+        bool repeat;
 
         /*
          * If the supplied mode names don't produce a valid mode, scan through

--- a/hw/xfree86/common/xf86Option.c
+++ b/hw/xfree86/common/xf86Option.c
@@ -32,6 +32,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <X11/X.h>
@@ -440,7 +441,7 @@ ParseOptionValue(int scrnIndex, XF86OptionPtr options, OptionInfoPtr p,
 {
     const char *s;
     char *end;
-    Bool wasUsed = FALSE;
+    bool wasUsed = FALSE;
 
     if ((s = xf86findOptionValue(options, p->name)) != NULL) {
         if (markUsed) {

--- a/hw/xfree86/common/xf86PM.c
+++ b/hw/xfree86/common/xf86PM.c
@@ -26,6 +26,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 
 #include "xf86_priv.h"
@@ -195,7 +196,7 @@ xf86HandlePMEvents(int fd, void *data)
 {
     pmEvent events[MAX_NO_EVENTS];
     int i, n;
-    Bool wait = FALSE;
+    bool wait = FALSE;
 
     if (!xf86PMGetEventFromOs)
         return;

--- a/hw/xfree86/common/xf86RandR.c
+++ b/hw/xfree86/common/xf86RandR.c
@@ -22,6 +22,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 
 #include "dix/input_priv.h"
@@ -157,7 +158,7 @@ xf86RandRSetMode(ScreenPtr pScreen,
     int oldVirtualX = scrp->virtualX;
     int oldVirtualY = scrp->virtualY;
     WindowPtr pRoot = pScreen->root;
-    Bool ret = TRUE;
+    bool ret = TRUE;
 
     if (pRoot && scrp->vtSema)
         (*scrp->EnableDisableFBAccess) (scrp, FALSE);
@@ -235,10 +236,10 @@ xf86RandRSetConfig(ScreenPtr pScreen,
     XF86RandRInfoPtr randrp = XF86RANDRINFO(pScreen);
     DisplayModePtr mode;
     int pos[MAXDEVICES][2];
-    Bool useVirtual = FALSE;
+    bool useVirtual = FALSE;
     Rotation oldRotation = randrp->rotation;
     DeviceIntPtr dev;
-    Bool view_adjusted = FALSE;
+    bool view_adjusted = FALSE;
 
     for (dev = inputInfo.devices; dev; dev = dev->next) {
         if (!InputDevIsMaster(dev) && !InputDevIsFloating(dev))

--- a/hw/xfree86/common/xf86VGAarbiter.c
+++ b/hw/xfree86/common/xf86VGAarbiter.c
@@ -30,6 +30,8 @@
 
 #include "xorg-config.h"
 
+#include <stdbool.h>
+
 #include "dix/colormap_priv.h"
 
 #include "xf86VGAarbiter_priv.h"
@@ -213,7 +215,7 @@ xf86VGAarbiterWrapFunctions(void)
 static Bool
 VGAarbiterCloseScreen(ScreenPtr pScreen)
 {
-    Bool val;
+    bool val;
     ScrnInfoPtr pScrn = xf86ScreenToScrn(pScreen);
     VGAarbiterScreenPtr pScreenPriv =
         (VGAarbiterScreenPtr) dixLookupPrivate(&pScreen->devPrivates,
@@ -360,7 +362,7 @@ VGAarbiterCreatePixmap(ScreenPtr pScreen, int w, int h, int depth,
 static Bool
 VGAarbiterSaveScreen(ScreenPtr pScreen, Bool unblank)
 {
-    Bool val;
+    bool val;
 
     SCREEN_PROLOG(SaveScreen);
     VGAGet(pScreen);
@@ -397,7 +399,7 @@ VGAarbiterRecolorCursor(DeviceIntPtr pDev,
 static Bool
 VGAarbiterRealizeCursor(DeviceIntPtr pDev, ScreenPtr pScreen, CursorPtr pCursor)
 {
-    Bool val;
+    bool val;
 
     SCREEN_PROLOG(RealizeCursor);
     VGAGet(pScreen);
@@ -411,7 +413,7 @@ static Bool
 VGAarbiterUnrealizeCursor(DeviceIntPtr pDev,
                           ScreenPtr pScreen, CursorPtr pCursor)
 {
-    Bool val;
+    bool val;
 
     SCREEN_PROLOG(UnrealizeCursor);
     VGAGet(pScreen);
@@ -424,7 +426,7 @@ VGAarbiterUnrealizeCursor(DeviceIntPtr pDev,
 static Bool
 VGAarbiterDisplayCursor(DeviceIntPtr pDev, ScreenPtr pScreen, CursorPtr pCursor)
 {
-    Bool val;
+    bool val;
 
     SCREEN_PROLOG(DisplayCursor);
     VGAGet(pScreen);
@@ -438,7 +440,7 @@ static Bool
 VGAarbiterSetCursorPosition(DeviceIntPtr pDev,
                             ScreenPtr pScreen, int x, int y, Bool generateEvent)
 {
-    Bool val;
+    bool val;
 
     SCREEN_PROLOG(SetCursorPosition);
     VGAGet(pScreen);
@@ -464,7 +466,7 @@ VGAarbiterAdjustFrame(ScrnInfoPtr pScrn, int x, int y)
 static Bool
 VGAarbiterSwitchMode(ScrnInfoPtr pScrn, DisplayModePtr mode)
 {
-    Bool val;
+    bool val;
     ScreenPtr pScreen = xf86ScrnToScreen(pScrn);
     VGAarbiterScreenPtr pScreenPriv =
         (VGAarbiterScreenPtr) dixLookupPrivate(&pScreen->devPrivates,
@@ -479,7 +481,7 @@ VGAarbiterSwitchMode(ScrnInfoPtr pScrn, DisplayModePtr mode)
 static Bool
 VGAarbiterEnterVT(ScrnInfoPtr pScrn)
 {
-    Bool val;
+    bool val;
     ScreenPtr pScreen = xf86ScrnToScreen(pScrn);
     VGAarbiterScreenPtr pScreenPriv =
         (VGAarbiterScreenPtr) dixLookupPrivate(&pScreen->devPrivates,
@@ -529,7 +531,7 @@ VGAarbiterCreateGC(GCPtr pGC)
     ScreenPtr pScreen = pGC->pScreen;
     VGAarbiterGCPtr pGCPriv =
         (VGAarbiterGCPtr) dixLookupPrivate(&pGC->devPrivates, &VGAarbiterGCKeyRec);
-    Bool ret;
+    bool ret;
 
     SCREEN_PROLOG(CreateGC);
     ret = (*pScreen->CreateGC) (pGC);
@@ -895,7 +897,7 @@ static Bool
 VGAarbiterSpriteRealizeCursor(DeviceIntPtr pDev, ScreenPtr pScreen,
                               CursorPtr pCur)
 {
-    Bool val;
+    bool val;
 
     SPRITE_PROLOG;
     VGAGet(pScreen);
@@ -909,7 +911,7 @@ static Bool
 VGAarbiterSpriteUnrealizeCursor(DeviceIntPtr pDev, ScreenPtr pScreen,
                                 CursorPtr pCur)
 {
-    Bool val;
+    bool val;
 
     SPRITE_PROLOG;
     VGAGet(pScreen);
@@ -943,7 +945,7 @@ VGAarbiterSpriteMoveCursor(DeviceIntPtr pDev, ScreenPtr pScreen, int x, int y)
 static Bool
 VGAarbiterDeviceCursorInitialize(DeviceIntPtr pDev, ScreenPtr pScreen)
 {
-    Bool val;
+    bool val;
 
     SPRITE_PROLOG;
     VGAGet(pScreen);

--- a/hw/xfree86/common/xf86VidMode.c
+++ b/hw/xfree86/common/xf86VidMode.c
@@ -35,6 +35,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 
 #include "dix/screenint_priv.h"
@@ -248,7 +249,7 @@ xf86VidModeSwitchMode(ScreenPtr pScreen, DisplayModePtr mode)
 {
     ScrnInfoPtr pScrn;
     DisplayModePtr pTmpMode;
-    Bool retval;
+    bool retval;
 
     pScrn = xf86ScreenToScrn(pScreen);
     /* save in case we fail */
@@ -441,7 +442,7 @@ xf86VidModeInit(ScreenPtr pScreen)
 void
 XFree86VidModeExtensionInit(void)
 {
-    Bool enabled = FALSE;
+    bool enabled = FALSE;
 
     DebugF("XFree86VidModeExtensionInit");
 

--- a/hw/xfree86/common/xf86Xinput.c
+++ b/hw/xfree86/common/xf86Xinput.c
@@ -47,6 +47,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <string.h>             /* InputClassMatches */
 #include <X11/Xfuncproto.h>
 #include <X11/Xmd.h>
@@ -627,7 +628,7 @@ MatchAttrToken(const char *attr, struct xorg_list *groups)
      * a separate Match line.
      */
     xorg_list_for_each_entry(group, groups, entry) {
-        Bool match = FALSE;
+        bool match = FALSE;
 
         xorg_list_for_each_entry(pattern, &group->patterns, entry) {
             /* It is enough to find one pattern matched by the attribute */
@@ -688,7 +689,7 @@ InputClassMatches(const XF86ConfInputClassPtr iclass, const InputInfoPtr idev,
      */
     if (!xorg_list_is_empty(&iclass->match_tag)) {
         char *const *tag;
-        Bool match;
+        bool match;
 
         if (!attrs->tags)
             return FALSE;
@@ -785,7 +786,7 @@ static Bool
 IgnoreInputClass(const InputInfoPtr idev, const InputAttributes * attrs)
 {
     XF86ConfInputClassPtr cl;
-    Bool ignore = FALSE;
+    bool ignore = FALSE;
     const char *ignore_class;
 
     for (cl = xf86configptr->conf_inputclass_lst; cl; cl = cl->list.next) {

--- a/hw/xfree86/common/xf86cmap.c
+++ b/hw/xfree86/common/xf86cmap.c
@@ -26,6 +26,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <math.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>
@@ -84,13 +85,13 @@ typedef struct {
     int *PreAllocIndices;
     CMapLinkPtr maps;
     unsigned int flags;
-    Bool isDGAmode;
+    bool isDGAmode;
 } CMapScreenRec, *CMapScreenPtr;
 
 typedef struct {
     int numColors;
     LOCO *colors;
-    Bool recalculate;
+    bool recalculate;
     int overscan;
 } CMapColormapRec, *CMapColormapPtr;
 
@@ -288,7 +289,7 @@ CMapCreateColormap(ColormapPtr pmap)
     ScreenPtr pScreen = pmap->pScreen;
     CMapScreenPtr pScreenPriv =
         (CMapScreenPtr) dixLookupPrivate(&pScreen->devPrivates, CMapScreenKey);
-    Bool ret = FALSE;
+    bool ret = FALSE;
 
     pScreen->CreateColormap = pScreenPriv->CreateColormap;
     if ((*pScreen->CreateColormap) (pmap)) {
@@ -449,7 +450,7 @@ static Bool
 CMapEnterVT(ScrnInfoPtr pScrn)
 {
     ScreenPtr pScreen = xf86ScrnToScreen(pScrn);
-    Bool ret;
+    bool ret;
     CMapScreenPtr pScreenPriv =
         (CMapScreenPtr) dixLookupPrivate(&pScreen->devPrivates, CMapScreenKey);
 
@@ -679,7 +680,7 @@ CMapSetOverscan(ColormapPtr pmap, int defs, int *indices)
     int i;
     LOCO *colors;
     int index;
-    Bool newOverscan = FALSE;
+    bool newOverscan = FALSE;
     int overscan, tmpOverscan;
 
     colors = pColPriv->colors;

--- a/hw/xfree86/common/xf86fbman.c
+++ b/hw/xfree86/common/xf86fbman.c
@@ -27,12 +27,11 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
+
 #include <X11/X.h>
 
 #include "dix/screen_hooks_priv.h"
-
-#include <X11/X.h>
-
 #include "include/misc.h"
 #include "os/log_priv.h"
 
@@ -624,7 +623,7 @@ localQueryLargestOffscreenArea(ScreenPtr pScreen,
         area = w * h;
 
         if (w > 0) {
-            Bool gotIt = FALSE;
+            bool gotIt = FALSE;
 
             switch (preferences) {
             case FAVOR_AREA_THEN_WIDTH:
@@ -1127,7 +1126,7 @@ xf86InitFBManager(ScreenPtr pScreen, BoxPtr FullBox)
     RegionRec ScreenRegion;
     RegionRec FullRegion;
     BoxRec ScreenBox;
-    Bool ret;
+    bool ret;
 
     ScreenBox.x1 = 0;
     ScreenBox.y1 = 0;

--- a/hw/xfree86/common/xf86pciBus.c
+++ b/hw/xfree86/common/xf86pciBus.c
@@ -29,6 +29,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <ctype.h>
 #include <dirent.h>
 #include <stdlib.h>
@@ -159,7 +160,7 @@ xf86PciProbe(void)
     /* Print a summary of the video devices found */
     for (k = 0; k < num; k++) {
         const char *prim = " ";
-        Bool memdone = FALSE, iodone = FALSE;
+        bool memdone = FALSE, iodone = FALSE;
 
         info = xf86PciVideoInfo[k];
 
@@ -479,7 +480,7 @@ xf86PciProbeDev(DriverPtr drvp)
 {
     int i, j;
     struct pci_device *pPci;
-    Bool foundScreen = FALSE;
+    bool foundScreen = FALSE;
     const struct pci_id_match *const devices = drvp->supported_devices;
     GDevPtr *devList;
     const unsigned numDevs = xf86MatchDevice(drvp->driverName, &devList);
@@ -607,8 +608,8 @@ pciDeviceHasBars(struct pci_device *pci)
 struct Inst {
     struct pci_device *pci;
     GDevPtr dev;
-    Bool foundHW;               /* PCIid in list of supported chipsets */
-    Bool claimed;               /* BusID matches with a device section */
+    bool foundHW;               /* PCIid in list of supported chipsets */
+    bool claimed;               /* BusID matches with a device section */
     int chip;
     int screen;
 };
@@ -685,7 +686,7 @@ xf86MatchPciInstances(const char *driverName, int vendorID,
     iter = pci_slot_match_iterator_create(NULL);
     while ((pPci = pci_device_next(iter)) != NULL) {
         unsigned device_class = pPci->device_class;
-        Bool foundVendor = FALSE;
+        bool foundVendor = FALSE;
 
         /* Convert the pre-PCI 2.0 device class for a VGA adapter to the
          * 2.0 version of the same class.

--- a/hw/xfree86/common/xf86platformBus.c
+++ b/hw/xfree86/common/xf86platformBus.c
@@ -28,6 +28,8 @@
 #include <xorg-config.h>
 
 #ifdef XSERVER_PLATFORM_BUS
+
+#include <stdbool.h>
 #include <assert.h>
 #include <errno.h>
 
@@ -253,7 +255,7 @@ int
 xf86platformProbe(void)
 {
     int i;
-    Bool pci = TRUE;
+    bool pci = TRUE;
     XF86ConfOutputClassPtr cl, cl_head = (xf86configptr) ?
             xf86configptr->conf_outputclass_lst : NULL;
 
@@ -516,7 +518,7 @@ xf86UnclaimPlatformSlot(struct xf86_platform_device *d, GDevPtr dev)
 static Bool doPlatformProbe(struct xf86_platform_device *dev, DriverPtr drvp,
                             GDevPtr gdev, int flags, intptr_t match_data)
 {
-    Bool foundScreen = FALSE;
+    bool foundScreen = FALSE;
     int entity;
 
     entity = xf86ClaimPlatformSlot(dev, drvp, 0,
@@ -562,7 +564,7 @@ static Bool
 probeSingleDevice(struct xf86_platform_device *dev, DriverPtr drvp, GDevPtr gdev, int flags)
 {
     int k;
-    Bool foundScreen = FALSE;
+    bool foundScreen = FALSE;
     struct pci_device *pPci;
     const struct pci_id_match *const devices = drvp->supported_devices;
 
@@ -603,7 +605,7 @@ isGPUDevice(GDevPtr gdev)
 int
 xf86platformProbeDev(DriverPtr drvp)
 {
-    Bool foundScreen = FALSE;
+    bool foundScreen = FALSE;
     GDevPtr *devList;
     const unsigned numDevs = xf86MatchDevice(drvp->driverName, &devList);
     int i, j;
@@ -672,7 +674,7 @@ xf86platformProbeDev(DriverPtr drvp)
 int
 xf86platformAddGPUDevices(DriverPtr drvp)
 {
-    Bool foundScreen = FALSE;
+    bool foundScreen = FALSE;
     GDevPtr *devList;
     int j;
 
@@ -817,7 +819,7 @@ xf86platformRemoveDevice(int index)
 {
     EntityPtr entity;
     int ent_num, i, j, scrnum;
-    Bool found;
+    bool found;
 
     for (ent_num = 0; ent_num < xf86NumEntities; ent_num++) {
         entity = xf86Entities[ent_num];

--- a/hw/xfree86/common/xf86sbusBus.c
+++ b/hw/xfree86/common/xf86sbusBus.c
@@ -22,18 +22,18 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <ctype.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <X11/X.h>
+
 #include "os.h"
 #include "xf86_priv.h"
 #include "xf86Priv.h"
 #include "xf86_OSlib.h"
 #include "xf86cmap.h"
-
 #include "xf86Bus.h"
-
 #include "xf86sbusBus_priv.h"
 #include "xf86Sbus_priv.h"
 
@@ -385,7 +385,7 @@ xf86MatchSbusInstances(const char *driverName, int sbusDevId,
     struct Inst {
         sbusDevicePtr sbus;
         GDevPtr dev;
-        Bool claimed;           /* BusID matches with a device section */
+        bool claimed;           /* BusID matches with a device section */
     } *instances = NULL;
 
     *foundEntities = NULL;
@@ -596,7 +596,7 @@ static DevPrivateKeyRec sbusPaletteKeyRec;
 
 typedef struct _sbusCmap {
     sbusDevicePtr psdp;
-    Bool origCmapValid;
+    bool origCmapValid;
     unsigned char origRed[16];
     unsigned char origGreen[16];
     unsigned char origBlue[16];

--- a/hw/xfree86/common/xf86xv.c
+++ b/hw/xfree86/common/xf86xv.c
@@ -29,6 +29,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>
 #include <X11/extensions/Xv.h>
@@ -552,7 +553,7 @@ xf86XVUpdateCompositeClip(XvPortRecPrivatePtr portPriv)
 {
     RegionPtr pregWin, pCompositeClip;
     WindowPtr pWin;
-    Bool freeCompClip = FALSE;
+    bool freeCompClip = FALSE;
 
     if (portPriv->pCompositeClip)
         return;
@@ -641,7 +642,7 @@ xf86XVRegetVideo(XvPortRecPrivatePtr portPriv)
     RegionRec ClipRegion;
     BoxRec WinBox;
     int ret = Success;
-    Bool clippedAway = FALSE;
+    bool clippedAway = FALSE;
 
     xf86XVUpdateCompositeClip(portPriv);
 
@@ -698,7 +699,7 @@ xf86XVReputVideo(XvPortRecPrivatePtr portPriv)
     RegionRec ClipRegion;
     BoxRec WinBox;
     int ret = Success;
-    Bool clippedAway = FALSE;
+    bool clippedAway = FALSE;
 
     xf86XVUpdateCompositeClip(portPriv);
 
@@ -771,7 +772,7 @@ xf86XVReputImage(XvPortRecPrivatePtr portPriv)
     RegionRec ClipRegion;
     BoxRec WinBox;
     int ret = Success;
-    Bool clippedAway = FALSE;
+    bool clippedAway = FALSE;
 
     xf86XVUpdateCompositeClip(portPriv);
 
@@ -958,7 +959,7 @@ xf86XVReputOrStopAllPorts(ScrnInfoPtr pScrn, Bool onlyChanged)
             XvPortRecPrivatePtr pPriv =
                 (XvPortRecPrivatePtr) pPort->devPriv.ptr;
             WindowPtr pWin = (WindowPtr) pPriv->pDraw;
-            Bool visible;
+            bool visible;
 
             if (pPriv->isOn == XV_OFF || !pWin)
                 continue;
@@ -1039,7 +1040,7 @@ xf86XVWindowExposures(WindowPtr pWin, RegionPtr reg1)
     XF86XVScreenPtr ScreenPriv = GET_XF86XV_SCREEN(pScreen);
     XF86XVWindowPtr WinPriv = GET_XF86XV_WINDOW(pWin);
     XvPortRecPrivatePtr pPriv;
-    Bool AreasExposed;
+    bool AreasExposed;
 
     AreasExposed = (WinPriv && reg1 && RegionNotEmpty(reg1));
 
@@ -1052,7 +1053,7 @@ xf86XVWindowExposures(WindowPtr pWin, RegionPtr reg1)
         return;
 
     while (WinPriv) {
-        Bool visible = TRUE;
+        bool visible = TRUE;
 
         pPriv = WinPriv->PortRec;
 
@@ -1160,7 +1161,7 @@ xf86XVEnterVT(ScrnInfoPtr pScrn)
 {
     ScreenPtr pScreen = xf86ScrnToScreen(pScrn);
     XF86XVScreenPtr ScreenPriv = GET_XF86XV_SCREEN(pScreen);
-    Bool ret;
+    bool ret;
 
     pScrn->EnterVT = ScreenPriv->EnterVT;
     ret = (*ScreenPriv->EnterVT) (pScrn);
@@ -1314,7 +1315,7 @@ xf86XVPutStill(DrawablePtr pDraw,
     RegionRec ClipRegion;
     BoxRec WinBox;
     int ret = Success;
-    Bool clippedAway = FALSE;
+    bool clippedAway = FALSE;
 
     if (pDraw->type != DRAWABLE_WINDOW)
         return BadAlloc;
@@ -1461,7 +1462,7 @@ xf86XVGetStill(DrawablePtr pDraw,
     RegionRec ClipRegion;
     BoxRec WinBox;
     int ret = Success;
-    Bool clippedAway = FALSE;
+    bool clippedAway = FALSE;
 
     if (pDraw->type != DRAWABLE_WINDOW)
         return BadAlloc;
@@ -1584,7 +1585,7 @@ xf86XVPutImage(DrawablePtr pDraw,
     RegionRec ClipRegion;
     BoxRec WinBox;
     int ret = Success;
-    Bool clippedAway = FALSE;
+    bool clippedAway = FALSE;
 
     if (pDraw->type != DRAWABLE_WINDOW)
         return BadAlloc;

--- a/hw/xfree86/ddc/ddc.c
+++ b/hw/xfree86/ddc/ddc.c
@@ -11,6 +11,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <string.h>
 
 #include "include/misc.h"
@@ -367,7 +368,7 @@ DDC2Read(I2CDevPtr dev, int block, unsigned char *R_Buffer)
         /* Stop bits reset the segment pointer to 0, so be careful here. */
         segment = block >> 1;
         if (segment) {
-            Bool b;
+            bool b;
 
             if (!(seg = xf86I2CFindDev(dev->pI2CBus, 0x0060)))
                 return FALSE;

--- a/hw/xfree86/dri/dri.c
+++ b/hw/xfree86/dri/dri.c
@@ -33,6 +33,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <assert.h>
 #include <errno.h>
 #include <stdio.h>
@@ -167,7 +168,7 @@ DRIOpenDRMMaster(ScrnInfoPtr pScrn,
                  const char *busID, const char *drmDriverName)
 {
     drmSetVersion saveSv, sv;
-    Bool drmWasAvailable;
+    bool drmWasAvailable;
     DRIEntPrivPtr pDRIEntPriv;
     DRIEntPrivRec tmp;
     int count;
@@ -693,7 +694,7 @@ DRICloseScreen(ScreenPtr pScreen)
     int reserved_count;
     ScrnInfoPtr pScrn = xf86ScreenToScrn(pScreen);
     DRIEntPrivPtr pDRIEntPriv = DRI_ENT_PRIV(pScrn);
-    Bool closeMaster;
+    bool closeMaster;
 
     if (pDRIPriv) {
 

--- a/hw/xfree86/drivers/video/modesetting/dri2.c
+++ b/hw/xfree86/drivers/video/modesetting/dri2.c
@@ -34,6 +34,7 @@
 
 #include "dix-config.h"
 
+#include <stdbool.h>
 #include <errno.h>
 #include <time.h>
 
@@ -273,7 +274,7 @@ ms_dri2_copy_region2(ScreenPtr screen, DrawablePtr drawable, RegionPtr pRegion,
     DrawablePtr dst = (destBuffer->attachment == DRI2BufferFrontLeft)
         ? drawable : &dst_pixmap->drawable;
     int off_x = 0, off_y = 0;
-    Bool translate = FALSE;
+    bool translate = FALSE;
     RegionPtr pCopyClip;
     GCPtr gc;
 

--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -34,6 +34,7 @@
 
 #include "dix-config.h"
 
+#include <stdbool.h>
 #include <errno.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -523,7 +524,7 @@ Probe(DriverPtr drv, int flags)
 {
     int i, numDevSections;
     GDevPtr *devSections;
-    Bool foundScreen = FALSE;
+    bool foundScreen = FALSE;
 
     /* For now, just bail out for PROBE_DETECT. */
     if (flags & PROBE_DETECT)
@@ -1334,7 +1335,7 @@ PreInit(ScrnInfoPtr pScrn, int flags)
     try_enable_glamor(pScrn);
 
     if (!ms->drmmode.glamor_gbm) {
-        Bool prefer_shadow = TRUE;
+        bool prefer_shadow = TRUE;
 
         if (ms->drmmode.force_24_32) {
             prefer_shadow = TRUE;
@@ -1537,7 +1538,7 @@ msUpdatePacked(ScreenPtr pScreen, shadowBufPtr pBuf)
 {
     ScrnInfoPtr pScrn = xf86ScreenToScrn(pScreen);
     modesettingPtr ms = modesettingPTR(pScrn);
-    Bool use_3224 = ms->drmmode.force_24_32 && pScrn->bitsPerPixel == 32;
+    bool use_3224 = ms->drmmode.force_24_32 && pScrn->bitsPerPixel == 32;
 
     if (ms->drmmode.shadow_enable2 && ms->drmmode.shadow_fb2) do {
         RegionPtr damage = DamageRegion(pBuf->pDamage), tiles;

--- a/hw/xfree86/drivers/video/modesetting/drmmode_bo.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_bo.c
@@ -4,6 +4,8 @@
  */
 
 #include <stddef.h>
+
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "dix-config.h"
@@ -24,7 +26,7 @@
 typedef struct {
     void* map_data; /* Opaque ptr for the mapped region */
     void* map_addr; /* Address of the map, what we actually want to use */
-    Bool used_modifiers;
+    bool used_modifiers;
 } bo_priv_t;
 
 #ifndef GBM_HAVE_BO_USE_LINEAR
@@ -141,7 +143,7 @@ gbm_bo_map_or_free(struct gbm_bo *bo, bo_priv_t *data)
 static inline struct gbm_bo*
 gbm_bo_create_and_map(struct gbm_device *gbm,
                       bo_priv_t *data,
-                      Bool do_map,
+                      bool do_map,
                       uint32_t width, uint32_t height,
                       uint32_t format,
                       const uint64_t *modifiers,
@@ -173,7 +175,7 @@ gbm_bo_create_and_map(struct gbm_device *gbm,
 static inline struct gbm_bo*
 gbm_bo_create_and_map_with_flag_list(struct gbm_device *gbm,
                                      bo_priv_t *data,
-                                     Bool do_map,
+                                     bool do_map,
                                      uint32_t width, uint32_t height,
                                      uint32_t format,
                                      const uint64_t *modifiers,

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -29,6 +29,7 @@
 
 #include "dix-config.h"
 
+#include <stdbool.h>
 #include <assert.h>
 #include <errno.h>
 #include <sys/ioctl.h>
@@ -143,7 +144,7 @@ drmmode_is_format_supported(ScrnInfoPtr scrn, uint32_t format,
     for (c = 0; c < xf86_config->num_crtc; c++) {
         xf86CrtcPtr crtc = xf86_config->crtc[c];
         drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
-        Bool found = FALSE;
+        bool found = FALSE;
 
         if (!crtc->enabled)
             continue;
@@ -209,7 +210,7 @@ get_modifiers_set(ScrnInfoPtr scrn, uint32_t format, uint64_t **modifiers,
                 continue;
 
             for (j = 0; j < iter->num_modifiers; j++) {
-                Bool found = FALSE;
+                bool found = FALSE;
 
                 /* Don't choose multi-plane formats for our screen pixmap.
                  * These will get used with frontbuffer rendering, which will
@@ -250,7 +251,7 @@ get_drawable_modifiers(DrawablePtr draw, uint32_t format,
 {
     ScrnInfoPtr scrn = xf86ScreenToScrn(draw->pScreen);
     modesettingPtr ms = modesettingPTR(scrn);
-    Bool async_flip;
+    bool async_flip;
 
     if (!present_can_window_flip((WindowPtr) draw) ||
         !ms->drmmode.pageflip || ms->drmmode.dri2_flipping || !scrn->vtSema) {
@@ -336,7 +337,7 @@ drmmode_prop_info_update(drmmode_ptr drmmode,
     assert(num_infos <= 32 && "update return type");
 
     for (i = 0; i < props->count_props; i++) {
-        Bool props_incomplete = FALSE;
+        bool props_incomplete = FALSE;
         unsigned int k;
 
         for (j = 0; j < num_infos; j++) {
@@ -580,7 +581,7 @@ crtc_add_dpms_props(drmModeAtomicReq *req, xf86CrtcPtr crtc,
 {
     xf86CrtcConfigPtr xf86_config = XF86_CRTC_CONFIG_PTR(crtc->scrn);
     drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
-    Bool crtc_active = FALSE;
+    bool crtc_active = FALSE;
     int i;
     int ret = 0;
 
@@ -1068,7 +1069,7 @@ struct vblank_event_args {
     PixmapPtr backTarget;
     xf86CrtcPtr crtc;
     drmmode_ptr drmmode;
-    Bool flip;
+    bool flip;
 };
 static void
 drmmode_SharedPixmapVBlankEventHandler(uint64_t frame, uint64_t usec,
@@ -1541,7 +1542,7 @@ drmmode_set_mode_major(xf86CrtcPtr crtc, DisplayModePtr mode,
     Rotation saved_rotation;
     DisplayModeRec saved_mode;
     Bool ret = TRUE;
-    Bool can_test;
+    bool can_test;
     int i;
 
     if (mode)
@@ -3625,7 +3626,7 @@ static Bool
 drmmode_connector_check_vrr_capable(uint32_t drm_fd, int connector_id)
 {
     uint32_t i;
-    Bool found = FALSE;
+    bool found = FALSE;
     uint64_t prop_value = 0;
     drmModeObjectPropertiesPtr props;
     const char* prop_name = "VRR_CAPABLE";
@@ -3668,7 +3669,7 @@ drmmode_output_init(ScrnInfoPtr pScrn, drmmode_ptr drmmode, drmModeResPtr mode_r
     drmmode_output_private_ptr drmmode_output;
     char name[32];
     int i;
-    Bool nonDesktop = FALSE;
+    bool nonDesktop = FALSE;
     drmModePropertyBlobPtr path_blob = NULL;
     const char *s;
     drmModeObjectPropertiesPtr props;
@@ -4229,7 +4230,7 @@ drmmode_set_desired_modes(ScrnInfoPtr pScrn, drmmode_ptr drmmode, Bool set_hw,
                           Bool ign_err)
 {
     xf86CrtcConfigPtr config = XF86_CRTC_CONFIG_PTR(pScrn);
-    Bool success = TRUE;
+    bool success = TRUE;
     int c;
 
     drmmmode_prepare_modeset(pScrn);
@@ -4447,8 +4448,8 @@ drmmode_update_kms_state(drmmode_ptr drmmode)
     drmModeResPtr mode_res;
     xf86CrtcConfigPtr  config = XF86_CRTC_CONFIG_PTR(scrn);
     int i, j;
-    Bool found = FALSE;
-    Bool changed = FALSE;
+    bool found = FALSE;
+    bool changed = FALSE;
 
     /* Try to re-set the mode on all the connectors with a BAD link-state:
      * This may happen if a link degrades and a new modeset is necessary, using
@@ -4579,7 +4580,7 @@ drmmode_handle_uevents(int fd, void *closure)
 {
     drmmode_ptr drmmode = closure;
     struct udev_device *dev;
-    Bool found = FALSE;
+    bool found = FALSE;
 
     while ((dev = udev_monitor_receive_device(drmmode->uevent_monitor))) {
         udev_device_unref(dev);
@@ -5006,7 +5007,7 @@ static void drmmode_sprite_do_set_cursor(msSpritePrivPtr sprite_priv,
 {
     modesettingPtr ms = modesettingPTR(scrn);
     CursorPtr cursor = sprite_priv->cursor;
-    Bool sprite_visible = sprite_priv->sprite_visible;
+    bool sprite_visible = !!sprite_priv->sprite_visible;
 
     if (cursor) {
         x -= cursor->bits->xhot;

--- a/hw/xfree86/drivers/video/modesetting/pageflip.c
+++ b/hw/xfree86/drivers/video/modesetting/pageflip.c
@@ -22,6 +22,7 @@
 
 #include "dix-config.h"
 
+#include <stdbool.h>
 #include <errno.h>
 
 #include "os/xserver_poll.h"
@@ -105,7 +106,7 @@ struct ms_flipdata {
  * one of them per crtc per flip.
  */
 struct ms_crtc_pageflip {
-    Bool on_reference_crtc;
+    bool on_reference_crtc;
     /* reference to the ms_flipdata */
     struct ms_flipdata *flipdata;
     struct xorg_list node;

--- a/hw/xfree86/drivers/video/modesetting/present.c
+++ b/hw/xfree86/drivers/video/modesetting/present.c
@@ -22,6 +22,7 @@
 
 #include "dix-config.h"
 
+#include <stdbool.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -51,7 +52,7 @@
 
 struct ms_present_vblank_event {
     uint64_t        event_id;
-    Bool            unflip;
+    bool            unflip;
 };
 
 static RRCrtcPtr
@@ -321,7 +322,7 @@ ms_present_check_flip(RRCrtcPtr crtc,
     ScreenPtr screen = window->drawable.pScreen;
     ScrnInfoPtr scrn = xf86ScreenToScrn(screen);
     modesettingPtr ms = modesettingPTR(scrn);
-    Bool async_flip = !sync_flip;
+    bool async_flip = !sync_flip;
 
     if (reason)
         *reason = PRESENT_FLIP_REASON_UNKNOWN;
@@ -405,7 +406,7 @@ ms_present_flip(RRCrtcPtr crtc,
     ScrnInfoPtr scrn = xf86ScreenToScrn(screen);
     modesettingPtr ms = modesettingPTR(scrn);
     xf86CrtcPtr xf86_crtc = crtc->devPrivate;
-    Bool ret;
+    bool ret;
     struct ms_present_vblank_event *event;
 
     /* A NULL pixmap means this is a fake flip to be routed through TearFree */

--- a/hw/xfree86/glamor_egl/glamor_xf86_egl.c
+++ b/hw/xfree86/glamor_egl/glamor_xf86_egl.c
@@ -5,6 +5,8 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #define GLAMOR_FOR_XORG
 #include <xf86.h>
 #include <xf86Priv.h>
@@ -60,7 +62,7 @@ _glamor_egl_init(ScrnInfoPtr scrn, int fd, int *caps)
     OptionInfoPtr options;
     const char *api = NULL;
     glamor_egl_conf_t glamor_egl_conf = {.fd = fd};
-    Bool ret;
+    bool ret;
 
     glamor_egl = calloc(1, sizeof(*glamor_egl));
     if (glamor_egl == NULL)

--- a/hw/xfree86/i2c/xf86i2c.c
+++ b/hw/xfree86/i2c/xf86i2c.c
@@ -7,6 +7,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <sys/time.h>
 #include <string.h>
 #include <X11/X.h>
@@ -171,7 +172,7 @@ I2CStop(I2CDevPtr d)
 static Bool
 I2CWriteBit(I2CBusPtr b, int sda, int timeout)
 {
-    Bool r;
+    bool r;
 
     b->I2CPutBits(b, 0, sda);
     b->I2CUDelay(b, b->RiseFallTime);
@@ -188,7 +189,7 @@ I2CWriteBit(I2CBusPtr b, int sda, int timeout)
 static Bool
 I2CReadBit(I2CBusPtr b, int *psda, int timeout)
 {
-    Bool r;
+    bool r;
     int scl;
 
     r = I2CRaiseSCL(b, 1, timeout);
@@ -221,7 +222,7 @@ I2CReadBit(I2CBusPtr b, int *psda, int timeout)
 static Bool
 I2CPutByte(I2CDevPtr d, I2CByte data)
 {
-    Bool r;
+    bool r;
     int i, scl, sda;
     I2CBusPtr b = d->pI2CBus;
 
@@ -409,7 +410,7 @@ static Bool
 I2CWriteRead(I2CDevPtr d,
              I2CByte * WriteBuffer, int nWrite, I2CByte * ReadBuffer, int nRead)
 {
-    Bool r = TRUE;
+    bool r = TRUE;
     I2CBusPtr b = d->pI2CBus;
     int s = 0;
 
@@ -495,7 +496,7 @@ Bool
 xf86I2CWriteVec(I2CDevPtr d, I2CByte * vec, int nValues)
 {
     I2CBusPtr b = d->pI2CBus;
-    Bool r = TRUE;
+    bool r = TRUE;
     int s = 0;
 
     if (nValues > 0) {

--- a/hw/xfree86/int10/generic.c
+++ b/hw/xfree86/int10/generic.c
@@ -5,6 +5,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <errno.h>
 #include <string.h>
 #include <unistd.h>
@@ -240,7 +241,7 @@ xf86ExtendedInitInt10(int entityIndex, int Flags)
      */
     {
         int bios_location = V_BIOS;
-        Bool done = FALSE;
+        bool done = FALSE;
 
         vbiosMem = (unsigned char *) base + bios_location;
 

--- a/hw/xfree86/int10/vbe.c
+++ b/hw/xfree86/int10/vbe.c
@@ -9,6 +9,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <assert.h>
 #include <string.h>
 #include <X11/extensions/dpmsconst.h>
@@ -51,7 +52,7 @@ VBEExtendedInit(xf86Int10InfoPtr pInt, int entityIndex, int Flags)
     void *page = NULL;
     ScrnInfoPtr pScrn = xf86FindScreenForEntity(entityIndex);
     vbeControllerInfoPtr vbe = NULL;
-    Bool init_int10 = FALSE;
+    bool init_int10 = FALSE;
     vbeInfoPtr vip = NULL;
     int screen;
 
@@ -820,7 +821,7 @@ void
 VBEVesaSaveRestore(vbeInfoPtr pVbe, vbeSaveRestorePtr vbe_sr,
                    vbeSaveRestoreFunction function)
 {
-    Bool SaveSucc = FALSE;
+    bool SaveSucc = FALSE;
 
     if (VBE_VERSION_MAJOR(pVbe->version) > 1
         && (function == MODE_SAVE || vbe_sr->pstate)) {

--- a/hw/xfree86/int10/vbeModes.c
+++ b/hw/xfree86/int10/vbeModes.c
@@ -30,6 +30,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -129,7 +130,7 @@ CheckMode(ScrnInfoPtr pScrn, vbeInfoPtr pVbe, VbeInfoBlock * vbe, int id,
     VbeModeInfoBlock *mode;
     DisplayModePtr pMode;
     VbeModeInfoData *data;
-    Bool modeOK = FALSE;
+    bool modeOK = FALSE;
 
     major = (unsigned) (vbe->VESAVersion >> 8);
 

--- a/hw/xfree86/modes/xf86Crtc.c
+++ b/hw/xfree86/modes/xf86Crtc.c
@@ -22,6 +22,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <assert.h>
 #include <stddef.h>
 #include <string.h>
@@ -209,7 +210,7 @@ void
 xf86CrtcSetScreenSubpixelOrder(ScreenPtr pScreen)
 {
     int subpixel_order = SubPixelUnknown;
-    Bool has_none = FALSE;
+    bool has_none = FALSE;
     ScrnInfoPtr scrn = xf86ScreenToScrn(pScreen);
     xf86CrtcConfigPtr xf86_config = XF86_CRTC_CONFIG_PTR(scrn);
     int icrtc, o;
@@ -276,14 +277,14 @@ xf86CrtcSetModeTransform(xf86CrtcPtr crtc, DisplayModePtr mode,
     ScrnInfoPtr scrn = crtc->scrn;
     xf86CrtcConfigPtr xf86_config = XF86_CRTC_CONFIG_PTR(scrn);
     int i;
-    Bool ret = FALSE;
-    Bool didLock = FALSE;
+    bool ret = FALSE;
+    bool didLock = FALSE;
     DisplayModePtr adjusted_mode;
     DisplayModeRec saved_mode;
     int saved_x, saved_y;
     Rotation saved_rotation;
     RRTransformRec saved_transform;
-    Bool saved_transform_present;
+    bool saved_transform_present;
 
     crtc->enabled = xf86CrtcInUse(crtc) && !xf86CrtcIsLeased(crtc);
 
@@ -1115,7 +1116,7 @@ xf86UserConfiguredOutputs(ScrnInfoPtr scrn, DisplayModePtr * modes)
 {
     xf86CrtcConfigPtr config = XF86_CRTC_CONFIG_PTR(scrn);
     int o;
-    Bool user_conf = FALSE;
+    bool user_conf = FALSE;
 
     for (o = 0; o < config->num_output; o++) {
         xf86OutputPtr output = config->output[o];
@@ -1177,8 +1178,8 @@ xf86InitialOutputPositions(ScrnInfoPtr scrn, DisplayModePtr * modes)
      * Loop until all outputs are set
      */
     for (;;) {
-        Bool any_set = FALSE;
-        Bool keep_going = FALSE;
+        bool any_set = FALSE;
+        bool keep_going = FALSE;
 
         for (o = 0; o < config->num_output; o++) {
             static const OutputOpts relations[] = {
@@ -1596,8 +1597,8 @@ enum det_monrec_source {
 struct det_monrec_parameter {
     MonRec *mon_rec;
     int *max_clock;
-    Bool set_hsync;
-    Bool set_vrefresh;
+    bool set_hsync;
+    bool set_vrefresh;
     enum det_monrec_source *sync_source;
 };
 
@@ -1659,7 +1660,7 @@ xf86ProbeOutputModes(ScrnInfoPtr scrn, int maxX, int maxY)
         int max_clock = 0;
         double clock;
         Bool add_default_modes;
-        Bool debug_modes = config->debug_modes || xf86Initialising;
+        bool debug_modes = !!(config->debug_modes || xf86Initialising);
         enum det_monrec_source sync_source = sync_default;
 
         while (output->probed_modes != NULL)
@@ -2044,7 +2045,7 @@ static Bool
 xf86CollectEnabledOutputs(ScrnInfoPtr scrn, xf86CrtcConfigPtr config,
                           Bool *enabled)
 {
-    Bool any_enabled = FALSE;
+    bool any_enabled = FALSE;
     int o;
 
     /*
@@ -2162,7 +2163,7 @@ xf86TargetRightOf(ScrnInfoPtr scrn, xf86CrtcConfigPtr config,
 {
     int o;
     int w = 0;
-    Bool has_tile = FALSE;
+    bool has_tile = FALSE;
     uint32_t configured_outputs;
 
     xf86GetOptValBool(config->options, OPTION_PREFER_CLONEMODE,
@@ -2267,7 +2268,7 @@ xf86TargetPreferred(ScrnInfoPtr scrn, xf86CrtcConfigPtr config,
     int o, p;
     int max_pref_width = 0, max_pref_height = 0;
     DisplayModePtr *preferred, *preferred_match;
-    Bool ret = FALSE;
+    bool ret = FALSE;
 
     preferred = XNFcallocarray(config->num_output, sizeof(DisplayModePtr));
     preferred_match = XNFcallocarray(config->num_output, sizeof(DisplayModePtr));
@@ -2281,10 +2282,10 @@ xf86TargetPreferred(ScrnInfoPtr scrn, xf86CrtcConfigPtr config,
                                                        width, height))) {
             int pref_width = xf86ModeWidth(preferred[p], r);
             int pref_height = xf86ModeHeight(preferred[p], r);
-            Bool all_match = TRUE;
+            bool all_match = TRUE;
 
             for (o = -1; nextEnabledOutput(config, enabled, &o);) {
-                Bool match = FALSE;
+                bool match = FALSE;
                 xf86OutputPtr output = config->output[o];
 
                 if (o == p)
@@ -2376,7 +2377,7 @@ xf86TargetAspect(ScrnInfoPtr scrn, xf86CrtcConfigPtr config,
     int o;
     float aspect = 0.0, *aspects;
     xf86OutputPtr output;
-    Bool ret = FALSE;
+    bool ret = FALSE;
     DisplayModePtr guess = NULL, aspect_guess = NULL, base_guess = NULL;
 
     aspects = XNFcallocarray(config->num_output, sizeof(float));
@@ -2531,9 +2532,9 @@ xf86InitialConfiguration(ScrnInfoPtr scrn, Bool canGrow)
     int width, height;
     int no_output_width, no_output_height;
     int i = scrn->scrnIndex;
-    Bool have_outputs = TRUE;
-    Bool ret;
-    Bool success = FALSE;
+    bool have_outputs = TRUE;
+    bool ret;
+    bool success = FALSE;
 
     /* Set up the device options */
     config->options = XNFalloc(sizeof(xf86DeviceOptions));
@@ -2944,7 +2945,7 @@ Bool
 xf86SetSingleMode(ScrnInfoPtr pScrn, DisplayModePtr desired, Rotation rotation)
 {
     xf86CrtcConfigPtr config = XF86_CRTC_CONFIG_PTR(pScrn);
-    Bool ok = TRUE;
+    bool ok = TRUE;
     xf86OutputPtr compat_output;
     DisplayModePtr compat_mode = NULL;
     int c;
@@ -3153,7 +3154,7 @@ xf86OutputSetTileProperty(xf86OutputPtr output)
 struct det_phySize_parameter {
     xf86OutputPtr output;
     ddc_quirk_t quirks;
-    Bool ret;
+    bool ret;
 };
 
 static void
@@ -3232,7 +3233,7 @@ xf86OutputSetEDID(xf86OutputPtr output, xf86MonPtr edid_mon)
 {
     ScrnInfoPtr scrn = output->scrn;
     xf86CrtcConfigPtr config = XF86_CRTC_CONFIG_PTR(scrn);
-    Bool debug_modes = config->debug_modes || xf86Initialising;
+    bool debug_modes = !!(config->debug_modes || xf86Initialising);
 
 #ifdef RANDR_12_INTERFACE
     int size;
@@ -3421,7 +3422,7 @@ xf86_crtc_clip_video_helper(ScrnInfoPtr pScrn,
                             INT32 *ya,
                             INT32 *yb, RegionPtr reg, INT32 width, INT32 height)
 {
-    Bool ret;
+    bool ret;
     RegionRec crtc_region_local;
     RegionPtr crtc_region = reg;
 

--- a/hw/xfree86/modes/xf86Cursors.c
+++ b/hw/xfree86/modes/xf86Cursors.c
@@ -24,8 +24,8 @@
 
 #include <stddef.h>
 #include <string.h>
+#include <stdbool.h>
 #include <stdio.h>
-
 #include <X11/Xarch.h>
 #include <X11/Xatom.h>
 #include <X11/extensions/render.h>
@@ -380,7 +380,7 @@ xf86_crtc_transform_cursor_position(xf86CrtcPtr crtc, int *x, int *y)
         (xf86CursorScreenPtr) dixLookupPrivate(&screen->devPrivates,
                                                &xf86CursorScreenKeyRec);
     int dx, dy, t;
-    Bool swap_reflection = FALSE;
+    bool swap_reflection = FALSE;
 
     *x = *x - crtc->x + ScreenPriv->HotX;
     *y = *y - crtc->y + ScreenPriv->HotY;

--- a/hw/xfree86/modes/xf86EdidModes.c
+++ b/hw/xfree86/modes/xf86EdidModes.c
@@ -29,6 +29,8 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
+
 #include "os/mathx_priv.h"
 
 #define _PARSE_EDID_
@@ -1007,8 +1009,8 @@ struct det_modes_parameter {
     xf86MonPtr DDC;
     ddc_quirk_t quirks;
     DisplayModePtr Modes;
-    Bool rb;
-    Bool preferred;
+    bool rb;
+    bool preferred;
     int timing_level;
 };
 
@@ -1053,7 +1055,7 @@ xf86DDCGetModes(int scrnIndex, xf86MonPtr DDC)
 {
     DisplayModePtr Modes = NULL, Mode;
     ddc_quirk_t quirks;
-    Bool preferred, rb;
+    bool preferred, rb;
     int timing_level;
     struct det_modes_parameter p;
 
@@ -1110,9 +1112,9 @@ xf86DDCGetModes(int scrnIndex, xf86MonPtr DDC)
 struct det_mon_parameter {
     MonPtr Monitor;
     ddc_quirk_t quirks;
-    Bool have_hsync;
-    Bool have_vrefresh;
-    Bool have_maxpixclock;
+    bool have_hsync;
+    bool have_vrefresh;
+    bool have_maxpixclock;
 };
 
 static void

--- a/hw/xfree86/modes/xf86Modes.c
+++ b/hw/xfree86/modes/xf86Modes.c
@@ -26,6 +26,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <libxcvt/libxcvt.h>
 
 #include "os/mathx_priv.h"
@@ -469,7 +470,7 @@ xf86ValidateModesSync(ScrnInfoPtr pScrn, DisplayModePtr modeList, MonPtr mon)
     DisplayModePtr mode;
 
     for (mode = modeList; mode != NULL; mode = mode->next) {
-        Bool bad;
+        bool bad;
         int i;
 
         bad = TRUE;
@@ -516,7 +517,7 @@ xf86ValidateModesClocks(ScrnInfoPtr pScrn, DisplayModePtr modeList,
     int i;
 
     for (mode = modeList; mode != NULL; mode = mode->next) {
-        Bool good = FALSE;
+        bool good = FALSE;
 
         for (i = 0; i < n_ranges; i++) {
             if (mode->Clock >= min[i] * (1 - SYNC_TOLERANCE) &&
@@ -552,7 +553,7 @@ xf86ValidateModesUserConfig(ScrnInfoPtr pScrn, DisplayModePtr modeList)
 
     for (mode = modeList; mode != NULL; mode = mode->next) {
         int i;
-        Bool good = FALSE;
+        bool good = FALSE;
 
         for (i = 0; pScrn->display->modes[i] != NULL; i++) {
             if (strncmp(pScrn->display->modes[i], mode->name,

--- a/hw/xfree86/modes/xf86RandR12.c
+++ b/hw/xfree86/modes/xf86RandR12.c
@@ -21,6 +21,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <X11/extensions/render.h>
 
 #include "dix/dix_priv.h"
@@ -71,7 +72,7 @@ typedef struct _xf86RandR12Info {
      */
     xf86EnterVTProc *orig_EnterVT;
 
-    Bool                         panning;
+    bool                         panning;
     ConstrainCursorHarderProcPtr orig_ConstrainCursorHarder;
 } XF86RandRInfoRec, *XF86RandRInfoPtr;
 
@@ -352,7 +353,7 @@ xf86RandR13Pan(xf86CrtcPtr crtc, int x, int y)
 {
     int newX, newY;
     int width, height;
-    Bool panned = FALSE;
+    bool panned = FALSE;
 
     if (crtc->version < 2)
         return;
@@ -521,7 +522,7 @@ xf86RandR12SetMode(ScreenPtr pScreen,
     int oldmmHeight = pScreen->mmHeight;
     WindowPtr pRoot = pScreen->root;
     DisplayModePtr currentMode = NULL;
-    Bool ret = TRUE;
+    bool ret = TRUE;
 
     if (pRoot)
         (*scrp->EnableDisableFBAccess) (scrp, FALSE);
@@ -589,11 +590,11 @@ xf86RandR12SetConfig(ScreenPtr pScreen,
     XF86RandRInfoPtr randrp = XF86RANDRINFO(pScreen);
     DisplayModePtr mode;
     int pos[MAXDEVICES][2];
-    Bool useVirtual = FALSE;
+    bool useVirtual = FALSE;
     int maxX = 0, maxY = 0;
     Rotation oldRotation = randrp->rotation;
     DeviceIntPtr dev;
-    Bool view_adjusted = FALSE;
+    bool view_adjusted = FALSE;
 
     randrp->rotation = rotation;
 
@@ -688,7 +689,7 @@ xf86RandR12ScreenSetSize(ScreenPtr pScreen,
     xf86CrtcConfigPtr config = XF86_CRTC_CONFIG_PTR(pScrn);
     WindowPtr pRoot = pScreen->root;
     PixmapPtr pScrnPix;
-    Bool ret = FALSE;
+    bool ret = FALSE;
     int c;
 
     if (randrp->virtualX == -1 || randrp->virtualY == -1) {
@@ -1057,7 +1058,7 @@ xf86RandR12CrtcNotify(RRCrtcPtr randr_crtc)
     xf86OutputPtr output;
     int i, j;
     DisplayModePtr mode = &crtc->mode;
-    Bool ret;
+    bool ret;
 
     randr_outputs = calloc(config->num_output, sizeof(RROutputPtr));
     if (!randr_outputs)
@@ -1143,10 +1144,10 @@ xf86RandR12CrtcSet(ScreenPtr pScreen,
     xf86CrtcConfigPtr config = XF86_CRTC_CONFIG_PTR(pScrn);
     xf86CrtcPtr crtc = randr_crtc->devPrivate;
     RRTransformPtr transform;
-    Bool changed = FALSE;
+    bool changed = FALSE;
     int o, ro;
     xf86CrtcPtr *save_crtcs;
-    Bool save_enabled = crtc->enabled;
+    bool save_enabled = !!crtc->enabled;
 
     if (!crtc->scrn->vtSema)
         return FALSE;
@@ -1589,7 +1590,7 @@ xf86RROutputSetModes(RROutputPtr randr_output, DisplayModePtr modes)
     RRModePtr *rrmodes = NULL;
     int nmode = 0;
     int npreferred = 0;
-    Bool ret = TRUE;
+    bool ret = TRUE;
     int pref;
 
     for (mode = modes; mode; mode = mode->next)
@@ -1924,7 +1925,7 @@ xf86RandR13SetPanning(ScreenPtr pScreen,
     BoxRec oldTotalArea;
     BoxRec oldTrackingArea;
     INT16 oldBorder[4];
-    Bool oldPanning = randrp->panning;
+    bool oldPanning = randrp->panning;
 
     if (crtc->version < 2)
         return FALSE;
@@ -2060,7 +2061,7 @@ xf86RandR12EnterVT(ScrnInfoPtr pScrn)
     ScreenPtr pScreen = xf86ScrnToScreen(pScrn);
     XF86RandRInfoPtr randrp = XF86RANDRINFO(pScreen);
     rrScrPrivPtr rp = rrGetScrPriv(pScreen);
-    Bool ret;
+    bool ret;
     int i;
 
     if (randrp->orig_EnterVT) {

--- a/hw/xfree86/modes/xf86Rotate.c
+++ b/hw/xfree86/modes/xf86Rotate.c
@@ -22,6 +22,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
 #include <stdio.h>
@@ -357,7 +358,7 @@ xf86CrtcRotate(xf86CrtcPtr crtc)
     int new_width = 0;
     int new_height = 0;
     RRTransformPtr transform = NULL;
-    Bool damage = FALSE;
+    bool damage = FALSE;
 
     if (pScreen->isGPU)
         return TRUE;

--- a/hw/xfree86/os-support/bus/Pci.c
+++ b/hw/xfree86/os-support/bus/Pci.c
@@ -121,13 +121,15 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
+
 #include "Pci.h"
 #include "../xf86_os_support.h"
 
 Bool
 xf86scanpci(void)
 {
-    Bool success = FALSE;
+    bool success = FALSE;
 
     success = (pci_system_init() == 0);
 

--- a/hw/xfree86/os-support/linux/int10/linux.c
+++ b/hw/xfree86/os-support/linux/int10/linux.c
@@ -4,6 +4,8 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
+
 #include "xf86.h"
 #include "xf86_OSproc.h"
 #include "xf86Pci.h"
@@ -84,7 +86,7 @@ xf86ExtendedInitInt10(int entityIndex, int Flags)
     int pagesize;
     memType cs;
     legacyVGARec vga;
-    Bool videoBiosMapped = FALSE;
+    bool videoBiosMapped = FALSE;
     ScrnInfoPtr pScrn;
     if (int10Generation != serverGeneration) {
         counter = 0;

--- a/hw/xfree86/os-support/linux/systemd-logind.c
+++ b/hw/xfree86/os-support/linux/systemd-logind.c
@@ -25,6 +25,7 @@
 #include <xorg-config.h>
 
 #include <dbus/dbus.h>
+#include <stdbool.h>
 #include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -46,8 +47,8 @@
 struct systemd_logind_info {
     DBusConnection *conn;
     char *session;
-    Bool active;
-    Bool vt_active;
+    bool active;
+    bool vt_active;
 };
 
 static struct systemd_logind_info logind_info;

--- a/hw/xfree86/os-support/shared/drm_platform.c
+++ b/hw/xfree86/os-support/shared/drm_platform.c
@@ -6,6 +6,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include "config/hotplug_priv.h"
@@ -127,7 +128,7 @@ xf86PlatformDeviceCheckBusID(struct xf86_platform_device *device, const char *bu
 void
 xf86PlatformReprobeDevice(int index, struct OdevAttributes *attribs)
 {
-    Bool ret;
+    bool ret;
     char *dpath = attribs->path;
 
     ret = get_drm_info(attribs, dpath, index);
@@ -145,7 +146,7 @@ xf86PlatformDeviceProbe(struct OdevAttributes *attribs)
 {
     int i;
     char *path = attribs->path;
-    Bool ret;
+    bool ret;
 
     if (!path)
         goto out_free;

--- a/hw/xfree86/os-support/shared/seatd-libseat.c
+++ b/hw/xfree86/os-support/shared/seatd-libseat.c
@@ -25,6 +25,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
@@ -52,8 +53,8 @@
 
 struct libseat_info {
     char *session;
-    Bool active;
-    Bool vt_active;
+    bool active;
+    bool vt_active;
     /*
      * This pointer gets initialised to the actual libseat client instance
      * provided by libseat_open_seat.

--- a/hw/xfree86/parser/InputClass.c
+++ b/hw/xfree86/parser/InputClass.c
@@ -24,6 +24,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <string.h>
 
 #include "os/fmt.h"
@@ -102,7 +103,7 @@ xf86parseInputClassSection(void)
 {
     int has_ident = FALSE;
     int token;
-    Bool negated;
+    bool negated;
     xf86MatchGroup *group;
 
     parsePrologue(XF86ConfInputClassPtr, XF86ConfInputClassRec)
@@ -350,7 +351,7 @@ xf86printInputClassSection (FILE * cf, XF86ConfInputClassPtr ptr)
 {
     const xf86MatchGroup *group;
     const xf86MatchPattern *pattern;
-    Bool not_first;
+    bool not_first;
 
     while (ptr) {
         fprintf(cf, "Section \"InputClass\"\n");

--- a/hw/xfree86/parser/OutputClass.c
+++ b/hw/xfree86/parser/OutputClass.c
@@ -24,6 +24,8 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
+
 #include "os/fmt.h"
 
 #include "os.h"
@@ -175,7 +177,7 @@ xf86printOutputClassSection(FILE * cf, XF86ConfOutputClassPtr ptr)
 {
     const xf86MatchGroup *group;
     const xf86MatchPattern *pattern;
-    Bool not_first;
+    bool not_first;
 
     while (ptr) {
         fprintf(cf, "Section \"OutputClass\"\n");

--- a/hw/xfree86/parser/patterns.c
+++ b/hw/xfree86/parser/patterns.c
@@ -5,6 +5,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -195,7 +196,7 @@ xf86printMatchPattern(FILE * cf, const xf86MatchPattern *pattern, Bool not_first
         fprintf(cf, "%c%s%c", REGEX_FLAG,
             pattern->str ? pattern->str : "(none)", REGEX_FLAG);
     else if (pattern->mode == MATCH_SUBSTRINGS_SEQUENCE) {
-        Bool after = FALSE;
+        bool after = FALSE;
         char *str = pattern->str;
         while (*str) {
             if (after)

--- a/hw/xfree86/parser/scan.c
+++ b/hw/xfree86/parser/scan.c
@@ -52,6 +52,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -755,8 +756,8 @@ static Bool
 AddConfigDirFiles(const char *dirpath, struct dirent **list, int num)
 {
     int i;
-    Bool openedFile = FALSE;
-    Bool warnOnce = FALSE;
+    bool openedFile = FALSE;
+    bool warnOnce = FALSE;
 
     for (i = 0; i < num; i++) {
         FILE *file;
@@ -796,7 +797,7 @@ OpenConfigDir(const char *path, const char *cmdline, const char *projroot,
 {
     char *dirpath = NULL, *pathcopy;
     const char *template;
-    Bool found = FALSE;
+    bool found = FALSE;
     int cmdlineUsed = 0;
 
     pathcopy = strdup(path);

--- a/hw/xfree86/ramdac/xf86CursorRD.c
+++ b/hw/xfree86/ramdac/xf86CursorRD.c
@@ -1,5 +1,7 @@
 #include <xorg-config.h>
 
+#include <stdbool.h>
+
 #include "dix/colormap_priv.h"
 #include "dix/cursor_priv.h"
 #include "dix/screen_hooks_priv.h"
@@ -246,7 +248,7 @@ xf86CursorEnableDisableFBAccess(ScrnInfoPtr pScrn, Bool enable)
 static Bool
 xf86CursorSwitchMode(ScrnInfoPtr pScrn, DisplayModePtr mode)
 {
-    Bool ret;
+    bool ret;
     ScreenPtr pScreen = xf86ScrnToScreen(pScrn);
     xf86CursorScreenPtr ScreenPriv =
         (xf86CursorScreenPtr) dixLookupPrivate(&pScreen->devPrivates,

--- a/hw/xfree86/ramdac/xf86HWCurs.c
+++ b/hw/xfree86/ramdac/xf86HWCurs.c
@@ -1,5 +1,6 @@
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <string.h>
 #include <X11/X.h>
 
@@ -137,7 +138,7 @@ Bool
 xf86CheckHWCursor(ScreenPtr pScreen, CursorPtr cursor, xf86CursorInfoPtr infoPtr)
 {
     ScreenPtr pSlave;
-    Bool use_hw_cursor = TRUE;
+    bool use_hw_cursor = TRUE;
 
     input_lock();
 
@@ -239,7 +240,7 @@ xf86SetCursor(ScreenPtr pScreen, CursorPtr pCurs, int x, int y)
         (xf86CursorScreenPtr) dixLookupPrivate(&pScreen->devPrivates,
                                                &xf86CursorScreenKeyRec);
     ScreenPtr pSlave;
-    Bool ret = FALSE;
+    bool ret = FALSE;
 
     input_lock();
 

--- a/hw/xfree86/shadowfb/shadowfb.c
+++ b/hw/xfree86/shadowfb/shadowfb.c
@@ -7,6 +7,7 @@
 */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>
 #include <X11/fonts/font.h>
@@ -117,7 +118,7 @@ shadowfbReportPost(DamagePtr damage, RegionPtr reg, void *closure)
 static Bool
 ShadowCreateRootWindow(WindowPtr pWin)
 {
-    Bool ret;
+    bool ret;
     ScreenPtr pScreen = pWin->drawable.pScreen;
     ShadowScreenPtr pPriv = shadowfbGetScreenPrivate(pScreen);
 

--- a/hw/xfree86/vgahw/vgaHW.c
+++ b/hw/xfree86/vgahw/vgaHW.c
@@ -9,6 +9,7 @@
  */
 #include <xorg-config.h>
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -631,7 +632,7 @@ Bool
 vgaHWSaveScreen(ScreenPtr pScreen, int mode)
 {
     ScrnInfoPtr pScrn = NULL;
-    Bool on;
+    bool on;
 
     if (pScreen != NULL)
         pScrn = xf86ScreenToScrn(pScreen);
@@ -718,7 +719,7 @@ vgaHWRestoreFonts(ScrnInfoPtr pScrnInfo, vgaRegPtr restore)
     vgaHWPtr hwp = VGAHWPTR(pScrnInfo);
     int savedIOBase;
     unsigned char miscOut, attr10, gr1, gr3, gr4, gr5, gr6, gr8, seq2, seq4;
-    Bool doMap = FALSE;
+    bool doMap = FALSE;
 
     /* If nothing to do, return now */
     if (!hwp->FontInfo1 && !hwp->FontInfo2 && !hwp->TextInfo)
@@ -900,7 +901,7 @@ vgaHWSaveFonts(ScrnInfoPtr pScrnInfo, vgaRegPtr save)
     vgaHWPtr hwp = VGAHWPTR(pScrnInfo);
     int savedIOBase;
     unsigned char miscOut, attr10, gr4, gr5, gr6, seq2, seq4;
-    Bool doMap = FALSE;
+    bool doMap = FALSE;
 
     if (hwp->Base == NULL) {
         doMap = TRUE;
@@ -1034,7 +1035,7 @@ static void
 vgaHWSaveColormap(ScrnInfoPtr pScrnInfo, vgaRegPtr save)
 {
     vgaHWPtr hwp = VGAHWPTR(pScrnInfo);
-    Bool readError = FALSE;
+    bool readError = FALSE;
     int i;
 
 #ifdef NEED_SAVED_CMAP

--- a/hw/xfree86/xext/vidmode.c
+++ b/hw/xfree86/xext/vidmode.c
@@ -33,6 +33,7 @@ from Kaleb S. KEITHLEY
 
 #ifdef XF86VIDMODE
 
+#include <stdbool.h>
 #include <X11/X.h>
 #include <X11/Xproto.h>
 #include <X11/extensions/xf86vmproto.h>
@@ -533,7 +534,7 @@ static int VidModeAddModeLine(ClientPtr client, xXF86VidModeAddModeLineReq* stuf
         return BadImplementation;
 
     if (stuff->after_htotal != 0 || stuff->after_vtotal != 0) {
-        Bool found = FALSE;
+        bool found = FALSE;
 
         if (pVidMode->GetFirstModeline(pScreen, &mode, &dotClock)) {
             do {


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
