### PR TITLE
(master) kdrive: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/hw/kdrive/ephyr/ephyr.c
+++ b/hw/kdrive/ephyr/ephyr.c
@@ -26,6 +26,7 @@
 #include <kdrive-config.h>
 
 #include <assert.h>
+#include <stdbool.h>
 #include <xcb/xcb_keysyms.h>
 #include <X11/keysym.h>
 
@@ -58,7 +59,7 @@ static int mouseState = 0;
 static Rotation ephyrRandr = RR_Rotate_0;
 
 typedef struct _EphyrInputPrivate {
-    Bool enabled;
+    bool enabled;
 } EphyrKbdPrivate, EphyrPointerPrivate;
 
 Bool EphyrWantGrayScale = 0;
@@ -480,10 +481,10 @@ ephyrRandRSetConfig(ScreenPtr pScreen,
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     EphyrScrPriv *scrpriv = screen->driver;
-    Bool wasEnabled = pScreenPriv->enabled;
+    bool wasEnabled = pScreenPriv->enabled;
     EphyrScrPriv oldscr;
     int oldwidth, oldheight, oldmmwidth, oldmmheight;
-    Bool oldshadow;
+    bool oldshadow;
     int newwidth, newheight;
 
     if (screen->randr & (RR_Rotate_0 | RR_Rotate_180)) {
@@ -625,7 +626,7 @@ ephyrResizeScreen (ScreenPtr           pScreen,
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     RRScreenSize size = {0};
-    Bool ret;
+    bool ret;
     int t;
 
     if (screen->randr & (RR_Rotate_90|RR_Rotate_270)) {

--- a/hw/kdrive/ephyr/ephyr.c
+++ b/hw/kdrive/ephyr/ephyr.c
@@ -26,6 +26,7 @@
 #include <kdrive-config.h>
 
 #include <assert.h>
+#include <stdbool.h>
 #include <xcb/xcb_keysyms.h>
 #include <X11/keysym.h>
 
@@ -58,7 +59,7 @@ static int mouseState = 0;
 static Rotation ephyrRandr = RR_Rotate_0;
 
 typedef struct _EphyrInputPrivate {
-    Bool enabled;
+    bool enabled;
 } EphyrKbdPrivate, EphyrPointerPrivate;
 
 Bool EphyrWantGrayScale = 0;
@@ -480,10 +481,10 @@ ephyrRandRSetConfig(ScreenPtr pScreen,
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     EphyrScrPriv *scrpriv = screen->driver;
-    Bool wasEnabled = pScreenPriv->enabled;
+    bool wasEnabled = !!pScreenPriv->enabled;
     EphyrScrPriv oldscr;
     int oldwidth, oldheight, oldmmwidth, oldmmheight;
-    Bool oldshadow;
+    bool oldshadow;
     int newwidth, newheight;
 
     if (screen->randr & (RR_Rotate_0 | RR_Rotate_180)) {
@@ -625,7 +626,7 @@ ephyrResizeScreen (ScreenPtr           pScreen,
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     RRScreenSize size = {0};
-    Bool ret;
+    bool ret;
     int t;
 
     if (screen->randr & (RR_Rotate_90|RR_Rotate_270)) {

--- a/hw/kdrive/ephyr/ephyr_draw.c
+++ b/hw/kdrive/ephyr/ephyr_draw.c
@@ -28,6 +28,7 @@
 #include <kdrive-config.h>
 
 #include <assert.h>
+#include <stdbool.h>
 
 #include "ephyr.h"
 #include "exa_priv.h"
@@ -437,7 +438,7 @@ ephyrDrawInit(ScreenPtr pScreen)
     EphyrScrPriv *scrpriv = screen->driver;
     EphyrPriv *priv = screen->card->driver;
     EphyrFakexaPriv *fakexa;
-    Bool success;
+    bool success;
 
     fakexa = calloc(1, sizeof(*fakexa));
     if (fakexa == NULL)

--- a/hw/kdrive/ephyr/ephyrinit.c
+++ b/hw/kdrive/ephyr/ephyrinit.c
@@ -25,6 +25,8 @@
 
 #include <kdrive-config.h>
 
+#include <stdbool.h>
+
 #include "dix/dix_priv.h"
 #include "dix/settings_priv.h"
 #include "os/cmdline.h"
@@ -153,7 +155,7 @@ processScreenOrOutputArg(const char *screen_size, const char *output, char *pare
     if (card) {
         KdScreenInfo *screen;
         unsigned long p_id = 0;
-        Bool use_geometry;
+        bool use_geometry;
 
         screen = KdScreenInfoAdd(card);
         KdParseScreen(screen, screen_size);

--- a/hw/kdrive/ephyr/ephyrvideo.c
+++ b/hw/kdrive/ephyr/ephyrvideo.c
@@ -27,6 +27,8 @@
  */
 
 #include <kdrive-config.h>
+
+#include <stdbool.h>
 #include <string.h>
 #include <X11/extensions/Xv.h>
 #include <xcb/xcb.h>
@@ -93,7 +95,7 @@ static int ephyrGetPortAttribute(KdScreenInfo * a_screen_info,
                                  int *a_attr_value, void *a_port_priv);
 
 static void ephyrQueryBestSize(KdScreenInfo * a_info,
-                               Bool a_motion,
+                               bool a_motion,
                                short a_src_w,
                                short a_src_h,
                                short a_drw_w,
@@ -211,7 +213,7 @@ ephyrLocalAtomToHost(int a_local_atom, int *a_host_atom)
 Bool
 ephyrInitVideo(ScreenPtr pScreen)
 {
-    Bool is_ok = FALSE;
+    bool is_ok = FALSE;
 
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
@@ -444,7 +446,7 @@ ephyrXVPrivQueryHostAdaptors(EphyrXVPriv * a_this)
     xcb_connection_t *conn = hostx_get_xcbconn();
     xcb_screen_t *xscreen = xcb_aux_get_screen(conn, hostx_get_screen());
     int base_port_id = 0, i = 0, port_priv_offset = 0;
-    Bool is_ok = FALSE;
+    bool is_ok = FALSE;
     xcb_generic_error_t *e = NULL;
     xcb_xv_adaptor_info_iterator_t it;
 
@@ -615,7 +617,7 @@ ephyrXVPrivSetAdaptorsHooks(EphyrXVPriv * a_this)
 static Bool
 ephyrXVPrivRegisterAdaptors(EphyrXVPriv * a_this, ScreenPtr a_screen)
 {
-    Bool is_ok = FALSE;
+    bool is_ok = FALSE;
 
     EPHYR_RETURN_VAL_IF_FAIL(a_this && a_screen, FALSE);
 
@@ -675,7 +677,7 @@ ephyrXVPrivGetImageBufSize(int a_port_id,
     xcb_connection_t *conn = hostx_get_xcbconn();
     xcb_xv_query_image_attributes_cookie_t cookie;
     xcb_xv_query_image_attributes_reply_t *reply;
-    Bool is_ok = FALSE;
+    bool is_ok = FALSE;
 
     EPHYR_RETURN_VAL_IF_FAIL(a_size, FALSE);
 
@@ -703,7 +705,7 @@ ephyrXVPrivSaveImageToPortPriv(EphyrPortPriv * a_port_priv,
                                const unsigned char *a_image_buf,
                                int a_image_len)
 {
-    Bool is_ok = FALSE;
+    bool is_ok = FALSE;
 
     EPHYR_LOG("enter\n");
 
@@ -839,7 +841,7 @@ ephyrGetPortAttribute(KdScreenInfo * a_screen_info,
 
 static void
 ephyrQueryBestSize(KdScreenInfo * a_info,
-                   Bool a_motion,
+                   bool a_motion,
                    short a_src_w,
                    short a_src_h,
                    short a_drw_w,
@@ -894,7 +896,7 @@ ephyrHostXVPutImage(KdScreenInfo * a_info,
     EphyrScrPriv *scrpriv = a_info->driver;
     xcb_connection_t *conn = hostx_get_xcbconn();
     xcb_gcontext_t gc;
-    Bool is_ok = TRUE;
+    bool is_ok = TRUE;
     int data_len, width, height;
     xcb_xv_query_image_attributes_cookie_t image_attr_cookie;
     xcb_xv_query_image_attributes_reply_t *image_attr_reply;
@@ -978,7 +980,7 @@ ephyrPutImage(KdScreenInfo * a_info,
               Bool a_sync, RegionPtr a_clipping_region, void *a_port_priv)
 {
     EphyrPortPriv *port_priv = a_port_priv;
-    Bool is_ok = FALSE;
+    bool is_ok = FALSE;
     int result = BadImplementation, image_size = 0;
 
     EPHYR_RETURN_VAL_IF_FAIL(a_info && a_info->pScreen, BadValue);

--- a/hw/kdrive/ephyr/ephyrvideo.c
+++ b/hw/kdrive/ephyr/ephyrvideo.c
@@ -27,6 +27,8 @@
  */
 
 #include <kdrive-config.h>
+
+#include <stdbool.h>
 #include <string.h>
 #include <X11/extensions/Xv.h>
 #include <xcb/xcb.h>
@@ -211,7 +213,7 @@ ephyrLocalAtomToHost(int a_local_atom, int *a_host_atom)
 Bool
 ephyrInitVideo(ScreenPtr pScreen)
 {
-    Bool is_ok = FALSE;
+    bool is_ok = FALSE;
 
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
@@ -444,7 +446,7 @@ ephyrXVPrivQueryHostAdaptors(EphyrXVPriv * a_this)
     xcb_connection_t *conn = hostx_get_xcbconn();
     xcb_screen_t *xscreen = xcb_aux_get_screen(conn, hostx_get_screen());
     int base_port_id = 0, i = 0, port_priv_offset = 0;
-    Bool is_ok = FALSE;
+    bool is_ok = FALSE;
     xcb_generic_error_t *e = NULL;
     xcb_xv_adaptor_info_iterator_t it;
 
@@ -615,7 +617,7 @@ ephyrXVPrivSetAdaptorsHooks(EphyrXVPriv * a_this)
 static Bool
 ephyrXVPrivRegisterAdaptors(EphyrXVPriv * a_this, ScreenPtr a_screen)
 {
-    Bool is_ok = FALSE;
+    bool is_ok = FALSE;
 
     EPHYR_RETURN_VAL_IF_FAIL(a_this && a_screen, FALSE);
 
@@ -675,7 +677,7 @@ ephyrXVPrivGetImageBufSize(int a_port_id,
     xcb_connection_t *conn = hostx_get_xcbconn();
     xcb_xv_query_image_attributes_cookie_t cookie;
     xcb_xv_query_image_attributes_reply_t *reply;
-    Bool is_ok = FALSE;
+    bool is_ok = FALSE;
 
     EPHYR_RETURN_VAL_IF_FAIL(a_size, FALSE);
 
@@ -703,7 +705,7 @@ ephyrXVPrivSaveImageToPortPriv(EphyrPortPriv * a_port_priv,
                                const unsigned char *a_image_buf,
                                int a_image_len)
 {
-    Bool is_ok = FALSE;
+    bool is_ok = FALSE;
 
     EPHYR_LOG("enter\n");
 
@@ -894,7 +896,7 @@ ephyrHostXVPutImage(KdScreenInfo * a_info,
     EphyrScrPriv *scrpriv = a_info->driver;
     xcb_connection_t *conn = hostx_get_xcbconn();
     xcb_gcontext_t gc;
-    Bool is_ok = TRUE;
+    bool is_ok = TRUE;
     int data_len, width, height;
     xcb_xv_query_image_attributes_cookie_t image_attr_cookie;
     xcb_xv_query_image_attributes_reply_t *image_attr_reply;
@@ -978,7 +980,7 @@ ephyrPutImage(KdScreenInfo * a_info,
               Bool a_sync, RegionPtr a_clipping_region, void *a_port_priv)
 {
     EphyrPortPriv *port_priv = a_port_priv;
-    Bool is_ok = FALSE;
+    bool is_ok = FALSE;
     int result = BadImplementation, image_size = 0;
 
     EPHYR_RETURN_VAL_IF_FAIL(a_info && a_info->pScreen, BadValue);

--- a/hw/kdrive/ephyr/hostx.c
+++ b/hw/kdrive/ephyr/hostx.c
@@ -25,6 +25,7 @@
 
 #include <kdrive-config.h>
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -90,16 +91,16 @@ struct EphyrHostXVars {
     xcb_cursor_t empty_cursor;
     xcb_generic_event_t *saved_event;
     int depth;
-    Bool use_sw_cursor;
-    Bool use_fullscreen;
-    Bool have_shm;
-    Bool have_shm_fd_passing;
+    bool use_sw_cursor;
+    bool use_fullscreen;
+    bool have_shm;
+    bool have_shm_fd_passing;
 
     int n_screens;
     KdScreenInfo **screens;
 
     long damage_debug_msec;
-    Bool size_set_from_configure;
+    bool size_set_from_configure;
     char *glvnd_vendor;
 };
 
@@ -888,7 +889,7 @@ hostx_screen_init(KdScreenInfo *screen,
                   int *bytes_per_line, int *bits_per_pixel)
 {
     EphyrScrPriv *scrpriv = screen->driver;
-    Bool shm_success = FALSE;
+    bool shm_success = FALSE;
 
     if (!scrpriv) {
         fprintf(stderr, "%s: Error in accessing hostx data\n", __func__);
@@ -1388,7 +1389,7 @@ hostx_get_window_attributes(int a_window, EphyrHostWindowAttributes * a_attrs)
 int
 hostx_get_visuals_info(EphyrHostVisualInfo ** a_visuals, int *a_num_entries)
 {
-    Bool is_ok = FALSE;
+    bool is_ok = FALSE;
     EphyrHostVisualInfo *host_visuals = NULL;
     int nb_items = 0, i = 0, screen_num;
     xcb_screen_iterator_t screens;
@@ -1444,7 +1445,7 @@ hostx_create_window(int a_screen_number,
                     EphyrBox * a_geometry,
                     int a_visual_id, int *a_host_peer /*out parameter */ )
 {
-    Bool is_ok = FALSE;
+    bool is_ok = FALSE;
     xcb_window_t win;
     int winmask = 0;
     uint32_t attrs[2];
@@ -1540,7 +1541,7 @@ int
 hostx_set_window_bounding_rectangles(int a_window,
                                      EphyrRect * a_rects, int a_num_rects)
 {
-    Bool is_ok = FALSE;
+    bool is_ok = FALSE;
     int i = 0;
     xcb_rectangle_t *rects = NULL;
 

--- a/hw/kdrive/fbdev/fbdev.c
+++ b/hw/kdrive/fbdev/fbdev.c
@@ -22,6 +22,7 @@
 
 #include <kdrive-config.h>
 
+#include <stdbool.h>
 #include <sys/ioctl.h>
 #include <errno.h>
 
@@ -282,8 +283,8 @@ fbdevScreenInitialize(KdScreenInfo * screen, FbdevScrPriv * scrpriv)
     Pixel allbits;
     int depth;
     int rate;
-    Bool want_rate = FALSE;
-    Bool gray;
+    bool want_rate = FALSE;
+    bool gray;
     struct fb_var_screeninfo var;
     const KdMonitorTiming *t;
     int k;
@@ -741,7 +742,7 @@ fbdevRandRSetConfig(ScreenPtr pScreen,
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     FbdevScrPriv *scrpriv = screen->driver;
-    Bool wasEnabled = pScreenPriv->enabled;
+    bool wasEnabled = !!pScreenPriv->enabled;
     FbdevScrPriv oldscr;
     const KdMonitorTiming *t;
     int oldwidth;

--- a/hw/kdrive/fbdev/fbinit.c
+++ b/hw/kdrive/fbdev/fbinit.c
@@ -21,14 +21,16 @@
  */
 
 #include <kdrive-config.h>
+
+#include <stdbool.h>
+#include <string.h>
+
 #include "fbdev.h"
 
 #include "dix/dix_priv.h"
 #include "os/cmdline.h"
 #include "os/ddx_priv.h"
 #include "os/log_priv.h"
-
-#include <string.h>
 
 static FbScreenConf *fbCurrScreen = NULL;
 
@@ -202,7 +204,7 @@ ddxProcessArgument(int argc, char **argv, int i)
         || ((i >= 2) && ('0' <= argv[i - 1][0]) && (argv[i - 1][0] <= '9') && !strcmp(argv[i - 2], "-screen")) /* Last screen had explicit geometry */
         ) {
         /* Put each screen on a separate card */
-        Bool need_new_card = !fbCurrScreen;
+        bool need_new_card = !fbCurrScreen;
 
         /**
          * If this is either the first argument, or the

--- a/hw/kdrive/linux/linux.c
+++ b/hw/kdrive/linux/linux.c
@@ -21,6 +21,8 @@
  */
 
 #include <kdrive-config.h>
+
+#include <stdbool.h>
 #include "kdrive.h"
 #include <errno.h>
 #include <linux/vt.h>
@@ -170,7 +172,7 @@ static void
 LinuxApmNotify(int fd, int mask, void *blockData)
 {
     apm_event_t event;
-    Bool running = LinuxApmRunning;
+    bool running = !!LinuxApmRunning;
     int cmd = APM_IOC_SUSPEND;
 
     while (read(fd, &event, sizeof(event)) == sizeof(event)) {

--- a/hw/kdrive/linux/linux.c
+++ b/hw/kdrive/linux/linux.c
@@ -21,6 +21,8 @@
  */
 
 #include <kdrive-config.h>
+
+#include <stdbool.h>
 #include "kdrive.h"
 #include <errno.h>
 #include <linux/vt.h>
@@ -170,7 +172,7 @@ static void
 LinuxApmNotify(int fd, int mask, void *blockData)
 {
     apm_event_t event;
-    Bool running = LinuxApmRunning;
+    bool running = LinuxApmRunning;
     int cmd = APM_IOC_SUSPEND;
 
     while (read(fd, &event, sizeof(event)) == sizeof(event)) {

--- a/hw/kdrive/linux/mouse.c
+++ b/hw/kdrive/linux/mouse.c
@@ -21,6 +21,8 @@
  */
 
 #include <kdrive-config.h>
+
+#include <stdbool.h>
 #include <errno.h>
 #include <termios.h>
 #include <X11/X.h>
@@ -182,7 +184,7 @@ typedef struct _kmouseProt {
     Bool (*Init) (KdPointerInfo * pi);
     unsigned char headerMask, headerValid;
     unsigned char dataMask, dataValid;
-    Bool tty;
+    bool tty;
     unsigned int c_iflag;
     unsigned int c_oflag;
     unsigned int c_lflag;
@@ -201,7 +203,7 @@ typedef struct _kmouse {
     const KmouseProt *prot;
     int i_prot;
     KmouseStage stage;          /* protocol verification stage */
-    Bool tty;                   /* mouse device is a tty */
+    bool tty;                   /* mouse device is a tty */
     int valid;                  /* sequential valid events */
     int tested;                 /* bytes scanned during Testing phase */
     int invalid;                /* total invalid bytes for this protocol */
@@ -419,7 +421,7 @@ ps2SkipInit(KdPointerInfo * pi, int ninit, Bool ret_next)
 {
     Kmouse *km = pi->driverPrivate;
     int c = -1;
-    Bool waiting;
+    bool waiting;
 
     waiting = FALSE;
     while (ninit || ret_next) {

--- a/hw/kdrive/src/kd_glamor_xv.c
+++ b/hw/kdrive/src/kd_glamor_xv.c
@@ -23,6 +23,8 @@
 
 #include <kdrive-config.h>
 
+#include <stdbool.h>
+
 #include "kdrive.h"
 #include "kxv.h"
 #include "glamor_priv.h"
@@ -61,7 +63,7 @@ kd_glamor_xv_get_port_attribute(KdScreenInfo *screen,
 
 static void
 kd_glamor_xv_query_best_size(KdScreenInfo *screen,
-                             Bool motion,
+                             bool motion,
                              short vid_w, short vid_h,
                              short drw_w, short drw_h,
                              unsigned int *p_w, unsigned int *p_h,

--- a/hw/kdrive/src/kd_glamor_xv.c
+++ b/hw/kdrive/src/kd_glamor_xv.c
@@ -23,6 +23,8 @@
 
 #include <kdrive-config.h>
 
+#include <stdbool.h>
+
 #include "kdrive.h"
 #include "kxv.h"
 #include "glamor_priv.h"

--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -22,6 +22,7 @@
 
 #include <kdrive-config.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 
 #include "config/hotplug_priv.h"
@@ -678,7 +679,7 @@ Bool KdCloseScreen(ScreenPtr pScreen)
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     KdCardInfo *card = pScreenPriv->card;
-    Bool ret;
+    bool ret;
 
     if (card->cfuncs->closeScreen)
         (*card->cfuncs->closeScreen)(pScreen);

--- a/hw/kdrive/src/kinput.c
+++ b/hw/kdrive/src/kinput.c
@@ -22,6 +22,8 @@
  */
 
 #include <kdrive-config.h>
+
+#include <stdbool.h>
 #include <xkb-config.h>
 #include "kdrive.h"
 #include "inputstr.h"
@@ -673,7 +675,7 @@ KdKbdCtrl(DeviceIntPtr pDevice, KeybdCtrl * ctrl)
 static int
 KdKeyboardProc(DeviceIntPtr pDevice, int onoff)
 {
-    Bool ret;
+    bool ret;
     DevicePtr pDev = (DevicePtr) pDevice;
     KdKeyboardInfo *ki;
     Atom xiclass;
@@ -1881,7 +1883,7 @@ static void
 KdCheckLock(void)
 {
     KeyClassPtr keyc = NULL;
-    Bool isSet = FALSE, shouldBeSet = FALSE;
+    bool isSet = FALSE, shouldBeSet = FALSE;
     KdKeyboardInfo *tmp = NULL;
 
     for (tmp = kdKeyboards; tmp; tmp = tmp->next) {

--- a/hw/kdrive/src/kxv.c
+++ b/hw/kdrive/src/kxv.c
@@ -37,6 +37,7 @@ of the copyright holder.
 
 #include <kdrive-config.h>
 
+#include <stdbool.h>
 #include <X11/extensions/Xv.h>
 #include <X11/extensions/Xvproto.h>
 
@@ -437,7 +438,7 @@ KdXVUpdateCompositeClip(XvPortRecPrivatePtr portPriv)
 {
     RegionPtr pregWin, pCompositeClip;
     WindowPtr pWin;
-    Bool freeCompClip = FALSE;
+    bool freeCompClip = FALSE;
 
     if (portPriv->pCompositeClip)
         return;
@@ -509,7 +510,7 @@ KdXVRegetVideo(XvPortRecPrivatePtr portPriv)
     RegionRec ClipRegion;
     BoxRec WinBox;
     int ret = Success;
-    Bool clippedAway = FALSE;
+    bool clippedAway = FALSE;
 
     KdXVUpdateCompositeClip(portPriv);
 
@@ -570,7 +571,7 @@ KdXVReputVideo(XvPortRecPrivatePtr portPriv)
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     int ret = Success;
-    Bool clippedAway = FALSE;
+    bool clippedAway = FALSE;
 
     KdXVUpdateCompositeClip(portPriv);
 
@@ -646,7 +647,7 @@ KdXVReputImage(XvPortRecPrivatePtr portPriv)
     KdScreenPriv(pScreen);
     KdScreenInfo *screen = pScreenPriv->screen;
     int ret = Success;
-    Bool clippedAway = FALSE;
+    bool clippedAway = FALSE;
 
     KdXVUpdateCompositeClip(portPriv);
 
@@ -863,7 +864,7 @@ KdXVWindowExposures(WindowPtr pWin, RegionPtr reg1)
     KdXVWindowPtr WinPriv = GET_KDXV_WINDOW(pWin);
     KdXVWindowPtr pPrev;
     XvPortRecPrivatePtr pPriv;
-    Bool AreasExposed;
+    bool AreasExposed;
 
     AreasExposed = (WinPriv && reg1 && RegionNotEmpty(reg1));
 
@@ -1074,7 +1075,7 @@ KdXVPutStill(DrawablePtr pDraw,
     RegionRec ClipRegion;
     BoxRec WinBox;
     int ret = Success;
-    Bool clippedAway = FALSE;
+    bool clippedAway = FALSE;
 
     if (pDraw->type != DRAWABLE_WINDOW)
         return BadAlloc;
@@ -1218,7 +1219,7 @@ KdXVGetStill(DrawablePtr pDraw,
     RegionRec ClipRegion;
     BoxRec WinBox;
     int ret = Success;
-    Bool clippedAway = FALSE;
+    bool clippedAway = FALSE;
 
     if (pDraw->type != DRAWABLE_WINDOW)
         return BadAlloc;
@@ -1347,7 +1348,7 @@ KdXVPutImage(DrawablePtr pDraw,
     RegionRec ClipRegion;
     BoxRec WinBox;
     int ret = Success;
-    Bool clippedAway = FALSE;
+    bool clippedAway = FALSE;
 
     if (pDraw->type != DRAWABLE_WINDOW)
         return BadAlloc;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
