### PR TITLE
(master) xquartz: use stdbool's 'bool' instead of 'Bool' for local variables

### DIFF
--- a/hw/xquartz/darwin.c
+++ b/hw/xquartz/darwin.c
@@ -30,6 +30,7 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <assert.h>
 #include <sys/stat.h>
 #include <X11/X.h>
@@ -188,7 +189,7 @@ DarwinScreenInit(ScreenPtr pScreen, int argc, char **argv)
 {
     int dpi;
     static int foundIndex = 0;
-    Bool ret;
+    bool ret;
 
     if (!dixRegisterPrivateKey(&darwinScreenKeyRec, PRIVATE_SCREEN, 0))
         return FALSE;

--- a/hw/xquartz/mach-startup/bundle-main.c
+++ b/hw/xquartz/mach-startup/bundle-main.c
@@ -660,7 +660,7 @@ setup_env(void)
 int
 main(int argc, char **argv, char **envp)
 {
-    Bool listenOnly = FALSE;
+    bool listenOnly = FALSE;
     int i;
     mach_msg_size_t mxmsgsz = sizeof(union MaxMsgSize) + MAX_TRAILER_SIZE;
     mach_port_t mp;

--- a/hw/xquartz/quartzKeyboard.c
+++ b/hw/xquartz/quartzKeyboard.c
@@ -35,6 +35,8 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #define HACK_MISSING   1
 #define HACK_KEYPAD    1
 #define HACK_BLACKLIST 1
@@ -876,7 +878,7 @@ QuartzReadSystemKeymap(darwinKeyboardInfo *info)
 Bool
 QuartsResyncKeymap(Bool sendDDXEvent)
 {
-    Bool retval;
+    bool retval;
     /* Update keyInfo */
     pthread_mutex_lock(&keyInfo_mutex);
     memset(keyInfo.keyMap, 0, sizeof(keyInfo.keyMap));

--- a/hw/xquartz/quartzRandR.c
+++ b/hw/xquartz/quartzRandR.c
@@ -33,6 +33,8 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "dix/screenint_priv.h"
 
 #include "quartzRandR.h"
@@ -135,7 +137,7 @@ QuartzRandREnumerateModes(ScreenPtr pScreen,
                           QuartzModeCallback callback,
                           void *data)
 {
-    Bool retval = FALSE;
+    bool retval = FALSE;
     QuartzScreenPtr pQuartzScreen = QUARTZ_PRIV(pScreen);
 
     /* Just an 800x600 fallback if we have no attached heads */
@@ -255,7 +257,7 @@ QuartzRandREnumerateModes(ScreenPtr pScreen,
                           QuartzModeCallback callback,
                           void *data)
 {
-    Bool retval = FALSE;
+    bool retval = FALSE;
     QuartzScreenPtr pQuartzScreen = QUARTZ_PRIV(pScreen);
 
     /* Just an 800x600 fallback if we have no attached heads */

--- a/hw/xquartz/xpr/driWrap.c
+++ b/hw/xquartz/xpr/driWrap.c
@@ -29,7 +29,9 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <stddef.h>
+
 #include "mi.h"
 #include "scrnintstr.h"
 #include "gcstruct.h"
@@ -51,7 +53,7 @@ typedef struct {
 } DRIWrapScreenRec;
 
 typedef struct {
-    Bool didSave;
+    bool didSave;
     int devKind;
     DevUnion devPrivate;
 } DRISavedDrawableState;
@@ -525,7 +527,7 @@ DRICreateGC(GCPtr pGC)
     ScreenPtr pScreen = pGC->pScreen;
     DRIWrapScreenRec *pScreenPriv;
     DRIGCRec *pGCPriv;
-    Bool ret;
+    bool ret;
 
     pScreenPriv = dixLookupPrivate(&pScreen->devPrivates, driWrapScreenKey);
 

--- a/hw/xquartz/xpr/xprCursor.c
+++ b/hw/xquartz/xpr/xprCursor.c
@@ -33,6 +33,8 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
+
 #include "quartz.h"
 #include "xpr.h"
 #include "darwinEvents.h"
@@ -67,7 +69,7 @@ static Bool
 load_cursor(CursorPtr src, int screen)
 {
     uint32_t *data;
-    Bool free_data = FALSE;
+    bool free_data = FALSE;
     uint32_t rowbytes;
     int width, height;
     int hot_x, hot_y;

--- a/hw/xquartz/xpr/xprFrame.c
+++ b/hw/xquartz/xpr/xprFrame.c
@@ -29,7 +29,9 @@
 
 #include <dix-config.h>
 
+#include <stdbool.h>
 #include <assert.h>
+
 #include "dix/dix_priv.h"
 #include "dix/property_priv.h"
 #include "dix/screenint_priv.h"
@@ -593,7 +595,7 @@ xprGetXWindow(xp_window_id wid)
 Bool
 xprIsX11Window(int windowNumber)
 {
-    Bool ret;
+    bool ret;
     xp_window_id wid;
 
     if (xp_lookup_native_window(windowNumber, &wid))


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
