### PR TITLE
(master) treewide: rename OsVendorFatalError() and OsVendorInit()

### DIFF
--- a/hw/kdrive/ephyr/ephyrinit.c
+++ b/hw/kdrive/ephyr/ephyrinit.c
@@ -383,8 +383,7 @@ KdOsFuncs EphyrOsFuncs = {
     .Init = EphyrInit,
 };
 
-void
-OsVendorInit(void)
+void ddxInit(void)
 {
     EPHYR_DBG("mark");
 

--- a/hw/kdrive/linux/linux.c
+++ b/hw/kdrive/linux/linux.c
@@ -372,8 +372,7 @@ KdOsFuncs LinuxFuncs = {
     .Bell = LinuxBell,
 };
 
-void
-OsVendorInit(void)
+void ddxInit(void)
 {
     LinuxLogInit();
     KdOsInit(&LinuxFuncs);

--- a/hw/kdrive/src/kdrive.c
+++ b/hw/kdrive/src/kdrive.c
@@ -1162,8 +1162,7 @@ KdInitOutput(int argc, char **argv)
 #endif
 }
 
-void
-OsVendorFatalError(const char *f, va_list args)
+void ddxFatalError(const char *f, va_list args)
 {
 }
 

--- a/hw/vfb/InitOutput.c
+++ b/hw/vfb/InitOutput.c
@@ -277,13 +277,11 @@ ddxGiveUp(enum ExitCode error)
     }
 }
 
-void
-OsVendorInit(void)
+void ddxInit(void)
 {
 }
 
-void
-OsVendorFatalError(const char *f, va_list args)
+void ddxFatalError(const char *f, va_list args)
 {
 }
 

--- a/hw/xfree86/common/xf86Init.c
+++ b/hw/xfree86/common/xf86Init.c
@@ -754,14 +754,7 @@ CloseInput(void)
     LoaderClose();
 }
 
-/*
- * OsVendorInit --
- *      OS/Vendor-specific initialisations.  Called from OsInit(), which
- *      is called by dix before establishing the well known sockets.
- */
-
-void
-OsVendorInit(void)
+void ddxInit(void)
 {
     static Bool beenHere = FALSE;
 
@@ -860,7 +853,7 @@ ddxGiveUp(enum ExitCode error)
 }
 
 void
-OsVendorFatalError(const char *f, va_list args)
+ddxFatalError(const char *f, va_list args)
 {
     ErrorF("\nPlease consult the XLibre support: https://www.xlibre.net/\n");
     if (xf86LogFile && xf86LogFileWasOpened)

--- a/hw/xnest/Init.c
+++ b/hw/xnest/Init.c
@@ -152,16 +152,12 @@ ddxGiveUp(enum ExitCode error)
     xnestCloseDisplay();
 }
 
-void
-OsVendorInit(void)
+void ddxInit(void)
 {
-    return;
 }
 
-void
-OsVendorFatalError(const char *f, va_list args)
+void ddxFatalError(const char *f, va_list args)
 {
-    return;
 }
 
 #if INPUTTHREAD

--- a/hw/xquartz/darwin.c
+++ b/hw/xquartz/darwin.c
@@ -658,20 +658,11 @@ InitOutput(int argc, char **argv)
     DarwinAdjustScreenOrigins();
 }
 
-/*
- * OsVendorFatalError
- */
-void
-OsVendorFatalError(const char *f, va_list args)
+void ddxFatalError(const char *f, va_list args)
 {
 }
 
-/*
- * OsVendorInit
- *  Initialization of Darwin OS support.
- */
-void
-OsVendorInit(void)
+void ddxInit(void)
 {
         char *lf;
         char *home = getenv("HOME");

--- a/hw/xwin/InitOutput.c
+++ b/hw/xwin/InitOutput.c
@@ -607,8 +607,7 @@ winFixupPaths(void)
 #endif                          /* RELOCATE_PROJECTROOT */
 }
 
-void
-OsVendorInit(void)
+void ddxInit(void)
 {
     /* Re-initialize global variables on server reset */
     winInitializeGlobals();
@@ -636,7 +635,7 @@ OsVendorInit(void)
 
     /* Add a default screen if no screens were specified */
     if (g_iNumScreens == 0) {
-        winDebug("OsVendorInit - Creating default screen 0\n");
+        winDebug("ddxInit - Creating default screen 0\n");
 
         /*
          * We need to initialize the default screen 0 if no -screen

--- a/hw/xwin/winerror.c
+++ b/hw/xwin/winerror.c
@@ -39,13 +39,12 @@
 #include "dix/input_priv.h"
 
 /*
- * os/log.c:FatalError () calls our vendor ErrorF, so the message
+ * os/log.c:FatalError () calls our ddx ErrorF, so the message
  * from a FatalError will be logged.
  *
  * Attempt to do last-ditch, safe, important cleanup here.
  */
-void
-OsVendorFatalError(const char *f, va_list args)
+void ddxFatalError(const char *f, va_list args)
 {
     char errormsg[1024] = "";
 

--- a/hw/xwin/winprocarg.c
+++ b/hw/xwin/winprocarg.c
@@ -243,7 +243,7 @@ ddxProcessArgument(int argc, char *argv[], int i)
 
             /*
              * Initialize default screen settings.  We have to do this before
-             * OsVendorInit () gets called, otherwise we will overwrite
+             * ddxInit() gets called, otherwise we will overwrite
              * settings changed by parameters such as -fullscreen, etc.
              */
             winErrorFVerb(3, "ddxProcessArgument - Initializing default "

--- a/os/ddx_priv.h
+++ b/os/ddx_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3+
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */
@@ -25,7 +25,7 @@ void ddxGiveUp(enum ExitCode error);
 
 void ddxInputThreadInit(void);
 
-void OsVendorFatalError(const char *f, va_list args) _X_ATTRIBUTE_PRINTF(1, 0);
-void OsVendorInit(void);
+void ddxFatalError(const char *f, va_list args) _X_ATTRIBUTE_PRINTF(1, 0);
+void ddxInit(void);
 
 #endif /* _XSERVER_OS_DDX_PRIV_H */

--- a/os/log.c
+++ b/os/log.c
@@ -958,7 +958,7 @@ FatalError(const char *f, ...)
 
     va_start(args, f);
 
-    /* Make a copy for OsVendorFatalError */
+    /* Make a copy for ddxFatalError */
     va_copy(args2, args);
 
 #ifdef __APPLE__
@@ -975,7 +975,7 @@ FatalError(const char *f, ...)
     va_end(args);
     ErrorF("\n");
     if (!beenhere)
-        OsVendorFatalError(f, args2);
+        ddxFatalError(f, args2);
     va_end(args2);
     if (!beenhere) {
         beenhere = TRUE;

--- a/os/osinit.c
+++ b/os/osinit.c
@@ -218,10 +218,10 @@ OsInit(void)
         been_here = TRUE;
     }
     TimerInit();
-    OsVendorInit();
+    ddxInit();
     OsResetSignals();
     /*
-     * No log file by default.  OsVendorInit() should call LogInit() with the
+     * No log file by default.  ddxInit() should call LogInit() with the
      * log file name if logging to a file is desired.
      */
     LogInit(NULL, NULL);


### PR DESCRIPTION
There isn't any "vendor" since ancient xfree86 4.x times anymore,
but there're different DDX'es having their own init and fatal error
logic, so "ddx" is the correct prefix.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
