### PR TITLE
(master) xfree86: config: drop useless extra definition of PROJECROOT (x11r6 relic)

### DIFF
--- a/hw/xfree86/common/xf86Config.c
+++ b/hw/xfree86/common/xf86Config.c
@@ -113,9 +113,6 @@
 #ifndef SYS_CONFIGDIRPATH
 #define SYS_CONFIGDIRPATH	"%D/X11/%X"
 #endif
-#ifndef PROJECTROOT
-#define PROJECTROOT	"/usr/X11R6"
-#endif
 
 static ModuleDefault ModuleDefaults[] = {
 #ifdef GLXEXT


### PR DESCRIPTION
if PROJECTROOT isn't defined by the build system, then it's a serious bug,
and just silently defining it to ancient (today non-existing) /usr/X11R6
directory and so expecting config files there is even worse.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
