### PR TITLE
(master) xfree86: remove $XORGCONFIG environment variable

### DIFF
--- a/hw/xfree86/common/xf86Config.c
+++ b/hw/xfree86/common/xf86Config.c
@@ -84,8 +84,6 @@
 #ifndef ALL_CONFIGPATH
 #define ALL_CONFIGPATH	"%A," "%R," \
 			"/etc/X11/%R," "%P/etc/X11/%R," \
-			"%E," "%F," \
-			"/etc/X11/%F," "%P/etc/X11/%F," \
 			"/etc/X11/%X," "/etc/%X," \
 			"%P/etc/X11/%X.%H," \
 			"%P/etc/X11/%X," \
@@ -94,7 +92,6 @@
 #endif
 #ifndef RESTRICTED_CONFIGPATH
 #define RESTRICTED_CONFIGPATH	"/etc/X11/%S," "%P/etc/X11/%S," \
-			"/etc/X11/%G," "%P/etc/X11/%G," \
 			"/etc/X11/%X," "/etc/%X," \
 			"%P/etc/X11/%X.%H," \
 			"%P/etc/X11/%X," \

--- a/hw/xfree86/man/xorg.conf.man
+++ b/hw/xfree86/man/xorg.conf.man
@@ -40,8 +40,6 @@ server is started as a normal user:
 .nf
 .IR /etc/X11/ <cmdline>
 .IR @projectroot@/etc/X11/ <cmdline>
-.IB /etc/X11/ $XORGCONFIG
-.IB @projectroot@/etc/X11/ $XORGCONFIG
 .I /etc/X11/xorg.conf
 .I /etc/xorg.conf
 .IR @projectroot@/etc/X11/xorg.conf. <hostname>
@@ -56,9 +54,6 @@ where
 is a relative path (with no \(lq..\&\(rq components) specified with the
 .B \-config
 command line option,
-.B $XORGCONFIG
-is the relative path (with no \(lq..\&\(rq components) specified by that
-environment variable, and
 .I <hostname>
 is the machine's hostname as reported by
 .BR gethostname (@libmansuffix@).
@@ -71,9 +66,6 @@ search locations are as follows:
 <cmdline>
 .IR /etc/X11/ <cmdline>
 .IR @projectroot@/etc/X11/ <cmdline>
-.B $XORGCONFIG
-.IB /etc/X11/ $XORGCONFIG
-.IB @projectroot@/etc/X11/ $XORGCONFIG
 .I /etc/X11/xorg.conf
 .I /etc/xorg.conf
 .IR @projectroot@/etc/X11/xorg.conf. <hostname>
@@ -88,9 +80,6 @@ where
 is the path specified with the
 .B \-config
 command line option (which may be absolute or relative),
-.B $XORGCONFIG
-is the path specified by that
-environment variable (absolute or relative),
 .B $HOME
 is the path specified by that environment variable (usually the home
 directory), and

--- a/hw/xfree86/parser/scan.c
+++ b/hw/xfree86/parser/scan.c
@@ -527,9 +527,6 @@ xf86pathIsSafe(const char *path)
  *    %S    cmdline argument as a "safe" path (relative, and no ".." elements)
  *    %X    default config file name ("xorg.conf")
  *    %H    hostname
- *    %E    config file environment ($XORGCONFIG) as an absolute path
- *    %F    config file environment ($XORGCONFIG) as a relative path
- *    %G    config file environment ($XORGCONFIG) as a safe path
  *    %P    projroot
  *    %C    sysconfdir
  *    %D    datadir
@@ -537,7 +534,6 @@ xf86pathIsSafe(const char *path)
  */
 
 #define XCONFIGSUFFIX	".conf"
-#define XCONFENV	"XORGCONFIG"
 
 #define BAIL_OUT		do {									\
 							free(result);				\
@@ -564,7 +560,6 @@ DoSubstitution(const char *template, const char *cmdline, const char *projroot,
                int *cmdlineUsed, int *envUsed, const char *XConfigFile)
 {
     int i, l;
-    static const char *env = NULL;
     static char *hostname = NULL;
 
     if (!template)
@@ -625,39 +620,6 @@ DoSubstitution(const char *template, const char *cmdline, const char *projroot,
                 }
                 if (hostname)
                     APPEND_STR(hostname);
-                break;
-            case 'E':
-                if (!env)
-                    env = getenv(XCONFENV);
-                if (env && xf86pathIsAbsolute(env)) {
-                    APPEND_STR(env);
-                    if (envUsed)
-                        *envUsed = 1;
-                }
-                else
-                    BAIL_OUT;
-                break;
-            case 'F':
-                if (!env)
-                    env = getenv(XCONFENV);
-                if (env && !xf86pathIsAbsolute(env)) {
-                    APPEND_STR(env);
-                    if (envUsed)
-                        *envUsed = 1;
-                }
-                else
-                    BAIL_OUT;
-                break;
-            case 'G':
-                if (!env)
-                    env = getenv(XCONFENV);
-                if (env && xf86pathIsSafe(env)) {
-                    APPEND_STR(env);
-                    if (envUsed)
-                        *envUsed = 1;
-                }
-                else
-                    BAIL_OUT;
                 break;
             case 'P':
                 if (projroot && xf86pathIsAbsolute(projroot))
@@ -871,8 +833,6 @@ xf86initConfigFiles(void)
 #ifndef DEFAULT_CONF_PATH
 #define DEFAULT_CONF_PATH	"/etc/X11/%S," \
 							"%P/etc/X11/%S," \
-							"/etc/X11/%G," \
-							"%P/etc/X11/%G," \
 							"/etc/X11/%X-%M," \
 							"/etc/X11/%X," \
 							"/etc/%X," \


### PR DESCRIPTION
It's just an ancient relic from previous century, that's ever been helpful
in a few corner cases - and can be easily replaced by -config / -configdir
cmdline options.

OTOH, it's a potential security risk for Xservers running with suid root
(eg. if it somehow fails to detect/switch to the restricted mode)

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
