### PR TITLE
(master) drop ifdef's on RANDR_12_INTERFACE

### DIFF
--- a/Xext/randr/rrcrtc.c
+++ b/Xext/randr/rrcrtc.c
@@ -807,13 +807,11 @@ RRCrtcSet(RRCrtcPtr crtc,
                                            numOutputs, outputs);
             }
         }
-#if RANDR_12_INTERFACE
         if (pScrPriv->rrCrtcSet) {
             ret = (*pScrPriv->rrCrtcSet) (pScreen, crtc, mode, x, y,
                                           rotation, numOutputs, outputs);
         }
         else
-#endif
         {
             if (pScrPriv->rrSetConfig) {
                 RRScreenSize size;
@@ -940,20 +938,18 @@ RRCrtcGammaSet(RRCrtcPtr crtc, CARD16 *red, CARD16 *green, CARD16 *blue)
 {
     Bool ret = TRUE;
 
-#if RANDR_12_INTERFACE
     ScreenPtr pScreen = crtc->pScreen;
-#endif
 
     memcpy(crtc->gammaRed, red, crtc->gammaSize * sizeof(CARD16));
     memcpy(crtc->gammaGreen, green, crtc->gammaSize * sizeof(CARD16));
     memcpy(crtc->gammaBlue, blue, crtc->gammaSize * sizeof(CARD16));
-#if RANDR_12_INTERFACE
+
     if (pScreen) {
         rrScrPriv(pScreen);
         if (pScrPriv->rrCrtcSetGamma)
             ret = (*pScrPriv->rrCrtcSetGamma) (pScreen, crtc);
     }
-#endif
+
     return ret;
 }
 
@@ -966,17 +962,14 @@ RRCrtcGammaGet(RRCrtcPtr crtc)
 {
     Bool ret = TRUE;
 
-#if RANDR_12_INTERFACE
     ScreenPtr pScreen = crtc->pScreen;
-#endif
 
-#if RANDR_12_INTERFACE
     if (pScreen) {
         rrScrPriv(pScreen);
         if (pScrPriv->rrCrtcGetGamma)
             ret = (*pScrPriv->rrCrtcGetGamma) (pScreen, crtc);
     }
-#endif
+
     return ret;
 }
 
@@ -1390,7 +1383,6 @@ ProcRRSetCrtcConfig(ClientPtr client)
             return BadMatch;
         }
 
-#ifdef RANDR_12_INTERFACE
         /*
          * Check screen size bounds if the DDX provides a 1.2 interface
          * for setting screen size. Else, assume the CrtcSet sets
@@ -1434,7 +1426,6 @@ ProcRRSetCrtcConfig(ClientPtr client)
                 return BadValue;
             }
         }
-#endif
     }
 
     if (!RRCrtcSet(crtc, mode, stuff->x, stuff->y,

--- a/Xext/randr/rrscreen.c
+++ b/Xext/randr/rrscreen.c
@@ -172,12 +172,10 @@ RRScreenSizeSet(ScreenPtr pScreen,
 {
     rrScrPriv(pScreen);
 
-#if RANDR_12_INTERFACE
     if (pScrPriv->rrScreenSetSize) {
         return (*pScrPriv->rrScreenSetSize) (pScreen,
                                              width, height, mmWidth, mmHeight);
     }
-#endif
     if (pScrPriv->rrSetConfig) {
         return TRUE;            /* can't set size separately */
     }

--- a/Xext/randr/rrtransform.c
+++ b/Xext/randr/rrtransform.c
@@ -255,7 +255,6 @@ RRTransformCompute(int x,
                                      f_scale_dy);
     }
 
-#ifdef RANDR_12_INTERFACE
     if (rr_transform) {
         if (!pixman_transform_multiply
             (transform, &rr_transform->transform, transform))
@@ -265,7 +264,7 @@ RRTransformCompute(int x,
         pixman_f_transform_multiply(f_inverse, f_inverse,
                                     &rr_transform->f_inverse);
     }
-#endif
+
     /*
      * Compute the class of the resulting transform
      */

--- a/hw/vfb/InitOutput.c
+++ b/hw/vfb/InitOutput.c
@@ -961,7 +961,6 @@ vfbRandRInit(ScreenPtr pScreen)
 {
     rrScrPrivPtr pScrPriv;
 
-#if RANDR_12_INTERFACE
     RRModePtr mode;
     RRCrtcPtr crtc;
     RROutputPtr output;
@@ -969,14 +968,12 @@ vfbRandRInit(ScreenPtr pScreen)
     char name[64];
     int i;
     vfbScreenInfoPtr pvfb = &vfbScreens[pScreen->myNum];
-#endif
     int mmWidth, mmHeight;
 
     if (!RRScreenInit(pScreen))
         return FALSE;
     pScrPriv = rrGetScrPriv(pScreen);
     pScrPriv->rrGetInfo = vfbRRGetInfo;
-#if RANDR_12_INTERFACE
     pScrPriv->rrCrtcSet = vfbRRCrtcSet;
     pScrPriv->rrScreenSetSize = vfbRRScreenSetSize;
     pScrPriv->rrOutputSetProperty = NULL;
@@ -1033,7 +1030,6 @@ vfbRandRInit(ScreenPtr pScreen)
                 return FALSE;
         }
     }
-#endif
     return TRUE;
 }
 

--- a/hw/xfree86/doc/README.modes
+++ b/hw/xfree86/doc/README.modes
@@ -442,7 +442,6 @@ driver writer.
 	 * Holds driver-private information
 	 */
 	void            *driver_private;
-    #ifdef RANDR_12_INTERFACE
 	/**
 	 * RandR crtc
 	 *
@@ -450,9 +449,6 @@ driver writer.
 	 * points at the associated crtc object
 	 */
 	RRCrtcPtr       randr_crtc;
-    #else
-	void            *randr_crtc;
-    #endif
     };
 
     

--- a/hw/xfree86/modes/xf86Crtc.c
+++ b/hw/xfree86/modes/xf86Crtc.c
@@ -99,9 +99,7 @@ xf86CrtcCreate(ScrnInfoPtr scrn, const xf86CrtcFuncsRec * funcs)
     crtc->version = XF86_CRTC_VERSION;
     crtc->scrn = scrn;
     crtc->funcs = funcs;
-#ifdef RANDR_12_INTERFACE
     crtc->randr_crtc = NULL;
-#endif
     crtc->rotation = RR_Rotate_0;
     crtc->desiredRotation = RR_Rotate_0;
     pixman_transform_init_identity(&crtc->crtc_to_framebuffer);
@@ -657,9 +655,7 @@ xf86OutputCreate(ScrnInfoPtr scrn,
      * Use the old per-screen monitor section for the first output
      */
     output->use_screen_monitor = (xf86_config->num_output == 0);
-#ifdef RANDR_12_INTERFACE
     output->randr_output = NULL;
-#endif
     if (name) {
         xf86OutputSetMonitor(output);
         if (xf86OutputIgnored(output)) {
@@ -2997,9 +2993,7 @@ xf86SetSingleMode(ScrnInfoPtr pScrn, DisplayModePtr desired, Rotation rotation)
         }
     }
     xf86DisableUnusedFunctions(pScrn);
-#ifdef RANDR_12_INTERFACE
     xf86RandR12TellChanged(pScrn->pScreen);
-#endif
     return ok;
 }
 
@@ -3101,8 +3095,6 @@ xf86DisableUnusedFunctions(ScrnInfoPtr pScrn)
     }
 }
 
-#ifdef RANDR_12_INTERFACE
-
 #define EDID_ATOM_NAME		"EDID"
 
 /**
@@ -3146,8 +3138,6 @@ xf86OutputSetTileProperty(xf86OutputPtr output)
         RRDeleteOutputProperty(output->randr_output, tile_atom);
     }
 }
-
-#endif
 
 /* Pull out a physical size from a detailed timing if available. */
 struct det_phySize_parameter {
@@ -3219,9 +3209,7 @@ xf86OutputSetTile(xf86OutputPtr output, struct xf86CrtcTileInfo *tile_info)
         output->tile_info = *tile_info;
     else
         memset(&output->tile_info, 0, sizeof(output->tile_info));
-#ifdef RANDR_12_INTERFACE
     xf86OutputSetTileProperty(output);
-#endif
 }
 
 /**
@@ -3234,9 +3222,7 @@ xf86OutputSetEDID(xf86OutputPtr output, xf86MonPtr edid_mon)
     xf86CrtcConfigPtr config = XF86_CRTC_CONFIG_PTR(scrn);
     Bool debug_modes = config->debug_modes || xf86Initialising;
 
-#ifdef RANDR_12_INTERFACE
     int size;
-#endif
 
     free(output->MonInfo);
 
@@ -3255,7 +3241,6 @@ xf86OutputSetEDID(xf86OutputPtr output, xf86MonPtr edid_mon)
     if (output == xf86CompatOutput(scrn) && !scrn->is_gpu)
         xf86SetDDCproperties(scrn, edid_mon);
 
-#ifdef RANDR_12_INTERFACE
     /* Set the RandR output properties */
     size = 0;
     if (edid_mon) {
@@ -3269,7 +3254,6 @@ xf86OutputSetEDID(xf86OutputPtr output, xf86MonPtr edid_mon)
     }
     xf86OutputSetEDIDProperty(output, edid_mon ? edid_mon->rawData : NULL,
                               size);
-#endif
 
     if (edid_mon) {
 
@@ -3516,9 +3500,7 @@ xf86ProviderSetup(ScrnInfoPtr scrn,
 
     xf86_config->name = strdup(name);
     xf86_config->provider_funcs = funcs;
-#ifdef RANDR_12_INTERFACE
     xf86_config->randr_provider = NULL;
-#endif
 }
 
 void

--- a/hw/xfree86/modes/xf86RandR12.c
+++ b/hw/xfree86/modes/xf86RandR12.c
@@ -75,10 +75,8 @@ typedef struct _xf86RandR12Info {
     ConstrainCursorHarderProcPtr orig_ConstrainCursorHarder;
 } XF86RandRInfoRec, *XF86RandRInfoPtr;
 
-#ifdef RANDR_12_INTERFACE
 static Bool xf86RandR12Init12(ScreenPtr pScreen);
 static Bool xf86RandR12CreateScreenResources12(ScreenPtr pScreen);
-#endif
 
 static x_server_generation_t xf86RandR12Generation;
 
@@ -735,10 +733,8 @@ xf86RandR12ScreenSetSize(ScreenPtr pScreen,
 
     if (pRoot && pScrn->vtSema)
         (*pScrn->EnableDisableFBAccess) (pScrn, TRUE);
-#if RANDR_12_INTERFACE
     if (pScreen->root && ret)
         RRScreenSizeNotify(pScreen);
-#endif
     return ret;
 }
 
@@ -835,10 +831,8 @@ xf86RandR12CreateScreenResources(ScreenPtr pScreen)
         randrp->virtualY = pScrn->virtualY;
     }
     xf86CrtcSetScreenSubpixelOrder(pScreen);
-#if RANDR_12_INTERFACE
     if (xf86RandR12CreateScreenResources12(pScreen))
         return TRUE;
-#endif
     return TRUE;
 }
 
@@ -891,10 +885,8 @@ xf86RandR12Init(ScreenPtr pScreen)
 
     dixSetPrivate(&pScreen->devPrivates, &xf86RandR12KeyRec, randrp);
 
-#if RANDR_12_INTERFACE
     if (!xf86RandR12Init12(pScreen))
         return FALSE;
-#endif
     return TRUE;
 }
 
@@ -907,10 +899,8 @@ xf86RandR12CloseScreen(ScreenPtr pScreen)
         return;
 
     randrp = XF86RANDRINFO(pScreen);
-#if RANDR_12_INTERFACE
     xf86ScreenToScrn(pScreen)->EnterVT = randrp->orig_EnterVT;
     pScreen->ConstrainCursorHarder = randrp->orig_ConstrainCursorHarder;
-#endif
 
     free(randrp->palette);
     free(randrp);
@@ -921,23 +911,19 @@ xf86RandR12SetRotations(ScreenPtr pScreen, Rotation rotations)
 {
     XF86RandRInfoPtr randrp;
 
-#if RANDR_12_INTERFACE
     ScrnInfoPtr pScrn = xf86ScreenToScrn(pScreen);
     int c;
     xf86CrtcConfigPtr config = XF86_CRTC_CONFIG_PTR(pScrn);
-#endif
 
     if (!dixPrivateKeyRegistered(&xf86RandR12KeyRec))
         return;
 
     randrp = XF86RANDRINFO(pScreen);
-#if RANDR_12_INTERFACE
     for (c = 0; c < config->num_crtc; c++) {
         xf86CrtcPtr crtc = config->crtc[c];
 
         RRCrtcSetRotations(crtc->randr_crtc, rotations);
     }
-#endif
     randrp->supported_rotations = rotations;
 }
 
@@ -977,8 +963,6 @@ xf86RandR12GetOriginalVirtualSize(ScrnInfoPtr pScrn, int *x, int *y)
         *y = randrp->virtualY;
     }
 }
-
-#if RANDR_12_INTERFACE
 
 #define FLAG_BITS (RR_HSyncPositive | \
 		   RR_HSyncNegative | \
@@ -2411,8 +2395,6 @@ xf86RandR12Init12(ScreenPtr pScreen)
 
     return TRUE;
 }
-
-#endif
 
 Bool
 xf86RandR12PreInit(ScrnInfoPtr pScrn)

--- a/hw/xfree86/modes/xf86Rotate.c
+++ b/hw/xfree86/modes/xf86Rotate.c
@@ -451,7 +451,6 @@ xf86CrtcRotate(xf86CrtcPtr crtc)
                 return FALSE;
             }
         }
-#ifdef RANDR_12_INTERFACE
         if (transform) {
             if (transform->nparams) {
                 new_params = calloc(transform->nparams, sizeof(xFixed));
@@ -469,7 +468,6 @@ xf86CrtcRotate(xf86CrtcPtr crtc)
                 new_height = new_filter->height;
             }
         }
-#endif
         crtc->transform_in_use = TRUE;
     }
     crtc->crtc_to_framebuffer = crtc_to_fb;

--- a/include/randrstr.h
+++ b/include/randrstr.h
@@ -196,7 +196,6 @@ struct _rrLease {
     RROutputPtr *outputs;
 };
 
-#if RANDR_12_INTERFACE
 typedef Bool (*RRScreenSetSizeProcPtr) (ScreenPtr pScreen,
                                         CARD16 width,
                                         CARD16 height,
@@ -228,8 +227,6 @@ typedef Bool (*RROutputValidateModeProcPtr) (ScreenPtr pScreen,
                                              RRModePtr mode);
 
 typedef void (*RRModeDestroyProcPtr) (ScreenPtr pScreen, RRModePtr mode);
-
-#endif
 
 #if RANDR_13_INTERFACE
 typedef Bool (*RROutputGetPropertyProcPtr) (ScreenPtr pScreen,
@@ -326,7 +323,6 @@ typedef struct _rrScrPriv {
      */
     RRSetConfigProcPtr rrSetConfig;
     RRGetInfoProcPtr rrGetInfo;
-#if RANDR_12_INTERFACE
     RRScreenSetSizeProcPtr rrScreenSetSize;
     RRCrtcSetProcPtr rrCrtcSet;
     RRCrtcSetGammaProcPtr rrCrtcSetGamma;
@@ -334,7 +330,6 @@ typedef struct _rrScrPriv {
     RROutputSetPropertyProcPtr rrOutputSetProperty;
     RROutputValidateModeProcPtr rrOutputValidateMode;
     RRModeDestroyProcPtr rrModeDestroy;
-#endif
 #if RANDR_13_INTERFACE
     RROutputGetPropertyProcPtr rrOutputGetProperty;
     RRGetPanningProcPtr rrGetPanning;
@@ -410,9 +405,7 @@ typedef struct _rrScrPriv {
     RRRequestLeaseProcPtr rrRequestLease;
     RRGetLeaseProcPtr rrGetLease;
 
-#if RANDR_12_INTERFACE
     RRCrtcGetProcPtr rrCrtcGet;
-#endif
 } rrScrPrivRec, *rrScrPrivPtr;
 
 extern _X_EXPORT DevPrivateKeyRec rrPrivKeyRec;
@@ -452,7 +445,6 @@ typedef struct _RRClient {
 /*  RRTimesRec	times[0]; */
 } RRClientRec, *RRClientPtr;
 
-#ifdef RANDR_12_INTERFACE
 /*
  * Set the range of sizes for the screen
  */
@@ -461,7 +453,6 @@ extern _X_EXPORT void
 RRScreenSetSizeRange(ScreenPtr pScreen,
                      CARD16 minWidth,
                      CARD16 minHeight, CARD16 maxWidth, CARD16 maxHeight);
-#endif
 
 /* rrscreen.c */
 /*

--- a/include/xf86Crtc.h
+++ b/include/xf86Crtc.h
@@ -309,7 +309,6 @@ struct _xf86Crtc {
      */
     void *driver_private;
 
-#ifdef RANDR_12_INTERFACE
     /**
      * RandR crtc
      *
@@ -317,9 +316,6 @@ struct _xf86Crtc {
      * points at the associated crtc object
      */
     RRCrtcPtr randr_crtc;
-#else
-    void *randr_crtc;
-#endif
 
     /**
      * Current cursor is ARGB
@@ -503,14 +499,12 @@ typedef struct _xf86OutputFuncs {
      */
      DisplayModePtr(*get_modes) (xf86OutputPtr output);
 
-#ifdef RANDR_12_INTERFACE
     /**
      * Callback when an output's property has changed.
      */
     Bool
      (*set_property) (xf86OutputPtr output,
                       Atom property, RRPropertyValuePtr value);
-#endif
 #ifdef RANDR_13_INTERFACE
     /**
      * Callback to get an updated property value
@@ -633,7 +627,6 @@ struct _xf86Output {
      */
     Bool non_desktop;
 
-#ifdef RANDR_12_INTERFACE
     /**
      * RandR 1.2 output structure.
      *
@@ -641,9 +634,6 @@ struct _xf86Output {
      * RandR output structure and is created when this output is created
      */
     RROutputPtr randr_output;
-#else
-    void *randr_output;
-#endif
     /**
      * Desired initial panning
      * Added in ABI version 2
@@ -823,11 +813,7 @@ typedef struct _xf86CrtcConfig {
 
     char *name;
     const xf86ProviderFuncsRec *provider_funcs;
-#ifdef RANDR_12_INTERFACE
     RRProviderPtr randr_provider;
-#else
-    void *randr_provider;
-#endif
 } xf86CrtcConfigRec, *xf86CrtcConfigPtr;
 
 extern _X_EXPORT int xf86CrtcConfigPrivateIndex;


### PR DESCRIPTION
It's always defined by aeons, so no need for the extra ifdef's.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
