### PR TITLE
xfree86: close seatd input devices after DisableDevice(), not before

### DIFF
--- a/hw/xfree86/common/xf86Events.c
+++ b/hw/xfree86/common/xf86Events.c
@@ -313,8 +313,9 @@ static void xf86DisableInputDeviceForVTSwitch(InputInfoPtr pInfo)
 
     xf86ReleaseKeys(pInfo->dev);
     ProcessInputEvents();
-    seatd_libseat_close_device(pInfo);
+    /* DEVICE_OFF reads pInfo->fd, disable before releasing the seatd fd */
     DisableDevice(pInfo->dev, TRUE);
+    seatd_libseat_close_device(pInfo);
 }
 
 void


### PR DESCRIPTION
I managed (with the help of Opus 5) to isolate another issue with broken session
after a VT switch. Note that the seatd version of the server is required to hit this,
systemd-logind doesn't have this issue. It should be simple to reproduce, and was
easy to fix and confirm that it works (at least in my own setup).

### Description

On a seatd-managed session, input can die permanently after a VT switch. The
server keeps rendering and serving clients normally, seatd logs a clean
enable/disable cycle on every switch, all input devices are reopened and re-enabled,
but nothing works. Mouse, keyboard, and devices hot-plugged afterwards are all
dead. Switching out and back never recovers it, only restarting the server does.

### Cause

`xf86DisableInputDeviceForVTSwitch()` releases the seatd fd before disabling the
device:

```c
seatd_libseat_close_device(pInfo); // clears pInfo->fd and the "fd" option
DisableDevice(pInfo->dev, TRUE);   // -> driver DEVICE_OFF
```

`DisableDevice()` invokes the driver's `DEVICE_OFF`, and `xf86libinput_off()`
needs both values intact: it unregisters libinput's epoll fd from the input thread
with `xf86RemoveEnabledDevice(pInfo)`, then restores pInfo->fd to the real device
fd through `use_server_fd()` / `xf86SetIntOption()`. With pInfo->fd already -1,
`use_server_fd()` is false and the unregister is issued for fd -1.

### Why it is fatal

The missed unregister leaves a stale `device_state_running` entry naming
libinput's epoll fd. When every libinput device is removed while the session is
switched away, the removals apply immediately while the additions are deferred
to `xf86InputEnableVTProbe()`. The per-device libinput refcount hits zero,
`libinput_unref()` destroys the context, and closing its epoll fd makes the kernel
silently drop it from the input thread's interest list. The replacement context takes
the same descriptor number, and `InputThreadRegisterDev()` matches on fd
number: it finds the stale entry, updates the callback pointers, and never calls
`ospoll_add()`. Nothing polls the new epoll, permanently.

This PR does not touch `InputThreadRegisterDev()`. I provided this just to explain
why a single missed unregister isn't recoverable.

### How to reproduce

```sh
# switch away from the seatd session, then run
udevadm trigger --subsystem-match=input --action=change
# switch back, input should be dead
```

### Further evidence

The input thread's poll set before and after the trigger, unpatched:

```
before: tfd: 19 ...    <- hotplug pipe
        tfd: 23 ...    <- libinput's epoll fd
after:  tfd: 19 ...    <- libinput's epoll fd is gone and never returns
```

while libinput's own epoll is fully repopulated with all evdev fds, every entry carrying
a fresh data pointer (a new context, unpolled).

The ordering itself is visible in the log. After the patch is applied, every close is
preceded by the option lookup from `xf86libinput_off()`:

```
(**) Option "fd" "22"
(II) seatd_libseat try close /dev/input/event5 (2:22)
```

Without the patch, the Option "fd" line is absent (`use_server_fd()` returned false
because pInfo->fd was already -1).

---

### Backport dashboard

| Target branch | Backport PR | Status |
|---|---|---|
| `release/25.2` | [#3444](https://github.com/X11Libre/xserver/pull/3444) | 🔄 Open |
| `release/25.1` | [#3445](https://github.com/X11Libre/xserver/pull/3445) | 🔄 Open |
| `release/25.0` | — | ✅ Already contained (seatd code not present) |
