### PR TITLE
licensing: add SPDX AGPL-3.0-or-later headers to .github/ files authored by Enrico Weigelt

### DIFF
--- a/.github/actions/libvirt-cleanup/action.yml
+++ b/.github/actions/libvirt-cleanup/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 name: 'libvirt VM cleanup'
 description: >
   Tear down a leftover libvirt domain and any orphaned qemu process from a

--- a/.github/actions/ubuntu-fetch-pkg/action.yml
+++ b/.github/actions/ubuntu-fetch-pkg/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 name: ubuntu fetch packages
 runs:
     using: "composite"

--- a/.github/actions/ubuntu-install-pkg/action.yml
+++ b/.github/actions/ubuntu-install-pkg/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 name: ubuntu package install
 description: install required packages and cache apt downloads
 runs:

--- a/.github/actions/ubuntu-pkg-cache/action.yml
+++ b/.github/actions/ubuntu-pkg-cache/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 name: deploy ubuntu package cache
 runs:
     using: "composite"

--- a/.github/arch/PKGBUILD
+++ b/.github/arch/PKGBUILD
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 # based on artist's Xlibre PKGBUILD for Artix
 

--- a/.github/arch/xlibre-xserver-bootstrap.install
+++ b/.github/arch/xlibre-xserver-bootstrap.install
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 post_install() {
   cat <<MSG
 >>> xlibre-xserver-bootstrap is a bootstrap package and is not intended for use in an X session.

--- a/.github/arch/xlibre-xserver.install
+++ b/.github/arch/xlibre-xserver.install
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 post_upgrade() {
   if (( $(vercmp $2 1.16.0-3) < 0 )); then
     post_install

--- a/.github/docker/gentoo/Dockerfile
+++ b/.github/docker/gentoo/Dockerfile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 # Prebuilt Gentoo image with all X-server build dependencies baked in.
 #
 # Why: the official Gentoo binhost is built with the default-profile USE flags

--- a/.github/docker/sdk/Dockerfile
+++ b/.github/docker/sdk/Dockerfile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 # Per-commit X-server + SDK image, built on top of the prebuilt deps base image.
 #
 # Step 2 of the driver-pipeline rework: builds the xserver with -Dxorg-sdk=true

--- a/.github/docker/ubuntu/Dockerfile
+++ b/.github/docker/ubuntu/Dockerfile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 # Base image for the ubuntu xserver / SDK / driver builds.
 #
 # Bakes in everything those jobs install before building the xserver itself:

--- a/.github/scripts/DragonFlyBSD/install-pkg.sh
+++ b/.github/scripts/DragonFlyBSD/install-pkg.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/DragonFlyBSD/run-xserver-build.sh
+++ b/.github/scripts/DragonFlyBSD/run-xserver-build.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/alpine/install-pkg.sh
+++ b/.github/scripts/alpine/install-pkg.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/alpine/run-xserver-build.sh
+++ b/.github/scripts/alpine/run-xserver-build.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/conf.sh
+++ b/.github/scripts/conf.sh
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 export X11_OS=`uname -s`
 
 export X11_PREFIX="${X11_PREFIX:-$HOME/x11}"

--- a/.github/scripts/freebsd/install-pkg.sh
+++ b/.github/scripts/freebsd/install-pkg.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/freebsd/run-xserver-build.sh
+++ b/.github/scripts/freebsd/run-xserver-build.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/gentoo/run-xserver-build.sh
+++ b/.github/scripts/gentoo/run-xserver-build.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/gh-purge-pipelines.sh
+++ b/.github/scripts/gh-purge-pipelines.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 set -euo pipefail
 
 usage() {

--- a/.github/scripts/gh-retry-transient-failed
+++ b/.github/scripts/gh-retry-transient-failed
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 # gh-retry-transient-failed — restart CI jobs that likely failed from infrastructure issues.
 #
 # Reads [make-pr] from .git/config to determine the GitHub remote, then

--- a/.github/scripts/git-smart-checkout.sh
+++ b/.github/scripts/git-smart-checkout.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 # git-smart-checkout: clone/reuse a repo and force-checkout a given ref (branch/tag/commit),
 #                     with mirror URLs, minimal transfer, and automatic retries.
 

--- a/.github/scripts/github/gh-purge-deleted-branch-workflows.sh
+++ b/.github/scripts/github/gh-purge-deleted-branch-workflows.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 set -euo pipefail
 
 usage() {

--- a/.github/scripts/github/make-release
+++ b/.github/scripts/github/make-release
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 err() {
     echo "$0: $*"

--- a/.github/scripts/hurd/run-vm-build.sh
+++ b/.github/scripts/hurd/run-vm-build.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 #
 # Host-side orchestration for the GNU/Hurd build (runs on the ubuntu runner).
 # There is no vmactions/hurd-vm, so this hand-rolls the VM: fetch Debian's

--- a/.github/scripts/hurd/run-xserver-build.sh
+++ b/.github/scripts/hurd/run-xserver-build.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 #
 # Runs INSIDE the Debian GNU/Hurd VM (over ssh) — see the xserver-build-hurd job
 # in .github/workflows/build-xserver.yml. Builds, as the job's FATAL pass/fail

--- a/.github/scripts/macos/install-prereq.sh
+++ b/.github/scripts/macos/install-prereq.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/netbsd/install-pkg.sh
+++ b/.github/scripts/netbsd/install-pkg.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -ex
 

--- a/.github/scripts/netbsd/run-xserver-build.sh
+++ b/.github/scripts/netbsd/run-xserver-build.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/openbsd/install-pkg.sh
+++ b/.github/scripts/openbsd/install-pkg.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/openbsd/run-xserver-build.sh
+++ b/.github/scripts/openbsd/run-xserver-build.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/rhel/install-pkg.sh
+++ b/.github/scripts/rhel/install-pkg.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/rhel/run-xserver-build.sh
+++ b/.github/scripts/rhel/run-xserver-build.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/solaris/install-pkg.sh
+++ b/.github/scripts/solaris/install-pkg.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 #
 # Install xserver build dependencies on OpenIndiana (illumos), via IPS (`pkg`).
 #

--- a/.github/scripts/solaris/run-xserver-build.sh
+++ b/.github/scripts/solaris/run-xserver-build.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 #
 # Build the X server inside an OpenIndiana (illumos) VM. Mirrors the BSD
 # run-xserver-build.sh scripts: install deps, then meson setup/compile/install.

--- a/.github/scripts/ubuntu/compile-driver-single.sh
+++ b/.github/scripts/ubuntu/compile-driver-single.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/ubuntu/fetch-pkg.sh
+++ b/.github/scripts/ubuntu/fetch-pkg.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 # NOTE: don't forget to update both fetch-pkg and install-pkg and change cache name
 

--- a/.github/scripts/ubuntu/install-pkg.sh
+++ b/.github/scripts/ubuntu/install-pkg.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/ubuntu/install-prereq-drivers.sh
+++ b/.github/scripts/ubuntu/install-prereq-drivers.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/ubuntu/install-prereq.sh
+++ b/.github/scripts/ubuntu/install-prereq.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/ubuntu/remove-unused-pkg.sh
+++ b/.github/scripts/ubuntu/remove-unused-pkg.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 apt-mark auto \
     7zip \

--- a/.github/scripts/ubuntu/run-xserver-build-and-test.sh
+++ b/.github/scripts/ubuntu/run-xserver-build-and-test.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 set -e
 

--- a/.github/scripts/util.sh
+++ b/.github/scripts/util.sh
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 
 . .github/scripts/conf.sh
 

--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 name: Build X servers
 
 permissions:

--- a/.github/workflows/conflict-notify.yml
+++ b/.github/workflows/conflict-notify.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 name: check PRs for merge conflicts
 
 on:

--- a/.github/workflows/prune-sdk-images.yml
+++ b/.github/workflows/prune-sdk-images.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 name: Prune old SDK images
 
 # Step 5 of the driver-pipeline rework: build-sdk-image pushes a per-commit

--- a/.github/workflows/retry-transient-ci.yml
+++ b/.github/workflows/retry-transient-ci.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 name: retry transient CI failures
 on:
     schedule:

--- a/.github/workflows/tidy-up-auto.yml
+++ b/.github/workflows/tidy-up-auto.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net>
 name: delete old workflow runs
 on:
     schedule:


### PR DESCRIPTION
Add SPDX-License-Identifier: AGPL-3.0-or-later and Copyright headers to 47 CI/helper/config files under .github/ that were originally authored by Enrico Weigelt and do not end up in the final X server binary.

Per project licensing policy: new files that are NOT part of the final delivery (CI scripts, workflows, dev tooling, build orchestration) are AGPL-3.0-or-later only.

Affected groups:
- actions/ (4) — libvirt-cleanup, ubuntu-fetch/install/pkg-cache
- arch/ (3) — PKGBUILD, .install scripts
- docker/ (3) — gentoo, sdk, ubuntu Dockerfiles
- scripts/ (32) — all per-platform CI scripts
- workflows/ (5) — build-xserver, conflict-notify, prune-sdk, retry-transient, tidy-up

One file (.github/scripts/ubuntu/run-pyxtest-valgrind.sh) already had the header and is unchanged.