### PR TITLE
(master) license: add X11 OR MIT OR AGPL-3.0-or-later to Enrico Weigelt's source files

### DIFF
--- a/Xext/composite/compositeext_intern.h
+++ b/Xext/composite/compositeext_intern.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3+
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2026 Enrico Weigelt, metux IT consult <info@metux.net>
  *

--- a/Xext/damage/damageext_priv.h
+++ b/Xext/damage/damageext_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * @copyright Enrico Weigelt, metux IT consult <info@metux.net>
  *

--- a/Xext/doublebuffer/doublebuffer_intern.h
+++ b/Xext/doublebuffer/doublebuffer_intern.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3+
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2026 Enrico Weigelt, metux IT consult <info@metux.net>
  *

--- a/Xext/dpms/dpms_priv.h
+++ b/Xext/dpms/dpms_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11 OR AGPL-3.0-or-later
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * DPMS (Display Power Management Signaling) — interface between the
  * DPMS extension and other parts (DIX, DDX, OS).

--- a/Xext/dri2/dri2_intern.h
+++ b/Xext/dri2/dri2_intern.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3+
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2026 Enrico Weigelt, metux IT consult <info@metux.net>
  *

--- a/Xext/dri2/pci_ids/pci_id_util.h
+++ b/Xext/dri2/pci_ids/pci_id_util.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #ifndef _PCI_ID_UTIL_H_
 #define _PCI_ID_UTIL_H_
 

--- a/Xext/namespace/config.c
+++ b/Xext/namespace/config.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #include <dix-config.h>
 
 #include <stdlib.h>

--- a/Xext/namespace/hook-client.c
+++ b/Xext/namespace/hook-client.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #define HOOK_NAME "client"
 
 #include <dix-config.h>

--- a/Xext/namespace/hook-clientstate.c
+++ b/Xext/namespace/hook-clientstate.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #define HOOK_NAME "clienstate"
 
 #include <dix-config.h>

--- a/Xext/namespace/hook-device.c
+++ b/Xext/namespace/hook-device.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #define HOOK_NAME "device"
 
 #include <dix-config.h>

--- a/Xext/namespace/hook-ext-access.c
+++ b/Xext/namespace/hook-ext-access.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #define HOOK_NAME "ext-access"
 
 #include <dix-config.h>

--- a/Xext/namespace/hook-ext-dispatch.c
+++ b/Xext/namespace/hook-ext-dispatch.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #define HOOK_NAME "ext-dispatch"
 
 #include <dix-config.h>

--- a/Xext/namespace/hook-init-rootwindow.c
+++ b/Xext/namespace/hook-init-rootwindow.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #define HOOK_NAME "initroot"
 
 #include <dix-config.h>

--- a/Xext/namespace/hook-property.c
+++ b/Xext/namespace/hook-property.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #define HOOK_NAME "property"
 
 #include <dix-config.h>

--- a/Xext/namespace/hook-receive.c
+++ b/Xext/namespace/hook-receive.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #define HOOK_NAME "recieve"
 
 #include <dix-config.h>

--- a/Xext/namespace/hook-resource.c
+++ b/Xext/namespace/hook-resource.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #define HOOK_NAME "resource"
 
 #include <dix-config.h>

--- a/Xext/namespace/hook-selection.c
+++ b/Xext/namespace/hook-selection.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #define HOOK_NAME "selection"
 
 #include <dix-config.h>

--- a/Xext/namespace/hook-send.c
+++ b/Xext/namespace/hook-send.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #define HOOK_NAME "send"
 
 #include <dix-config.h>

--- a/Xext/namespace/hook-server.c
+++ b/Xext/namespace/hook-server.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #define HOOK_NAME "server"
 
 #include <dix-config.h>

--- a/Xext/namespace/hook-windowproperty.c
+++ b/Xext/namespace/hook-windowproperty.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #define HOOK_NAME "windowproperty"
 
 #include <dix-config.h>

--- a/Xext/namespace/hooks.h
+++ b/Xext/namespace/hooks.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #ifndef __XSERVER_NAMESPACE_HOOKS_H
 #define __XSERVER_NAMESPACE_HOOKS_H
 

--- a/Xext/namespace/namespace.c
+++ b/Xext/namespace/namespace.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #include <dix-config.h>
 
 #include <stdio.h>

--- a/Xext/namespace/namespace.h
+++ b/Xext/namespace/namespace.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #ifndef __XSERVER_NAMESPACE_H
 #define __XSERVER_NAMESPACE_H
 

--- a/Xext/panoramiX/panoramiX_priv.h
+++ b/Xext/panoramiX/panoramiX_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3+
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2026 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/config/config-hal.h
+++ b/config/config-hal.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #ifndef _XSERVER_CONFIG_HAL_H
 #define _XSERVER_CONFIG_HAL_H
 

--- a/config/config-udev.h
+++ b/config/config-udev.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #ifndef _XSERVER_CONFIG_UDEV_H
 #define _XSERVER_CONFIG_UDEV_H
 

--- a/config/config-wscons.h
+++ b/config/config-wscons.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #ifndef _XSERVER_CONFIG_WSCONS_H
 #define _XSERVER_CONFIG_WSCONS_H
 

--- a/config/hotplug_priv.h
+++ b/config/hotplug_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/atom_priv.h
+++ b/dix/atom_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/callback_priv.h
+++ b/dix/callback_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/client.c
+++ b/dix/client.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/client_priv.h
+++ b/dix/client_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/colormap_priv.h
+++ b/dix/colormap_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/cursor_priv.h
+++ b/dix/cursor_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/devices_priv.h
+++ b/dix/devices_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/display.c
+++ b/dix/display.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/dix_priv.h
+++ b/dix/dix_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/dixgrabs_priv.h
+++ b/dix/dixgrabs_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/dixstruct_priv.h
+++ b/dix/dixstruct_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright 1987 by Digital Equipment Corporation, Maynard, Massachusetts.
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>

--- a/dix/exevents_priv.h
+++ b/dix/exevents_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 1996 Thomas E. Dickey <dickey@clark.net>
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>

--- a/dix/extension_priv.h
+++ b/dix/extension_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X112
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/gc_priv.h
+++ b/dix/gc_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  * Copyright © 1987 by Digital Equipment Corporation, Maynard, Massachusetts.

--- a/dix/input_priv.h
+++ b/dix/input_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  + Copyright © 1987, 1998  The Open Group
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>

--- a/dix/lookup.c
+++ b/dix/lookup.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  *

--- a/dix/property_priv.h
+++ b/dix/property_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 1987, 1998  The Open Group
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>

--- a/dix/ptrveloc_priv.h
+++ b/dix/ptrveloc_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  * Copyright © 2006-2011 Simon Thum             simon dot thum at gmx dot de

--- a/dix/registry_priv.h
+++ b/dix/registry_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/reqhandlers_priv.h
+++ b/dix/reqhandlers_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/request_priv.h
+++ b/dix/request_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/resource_priv.h
+++ b/dix/resource_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/rpcbuf.c
+++ b/dix/rpcbuf.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/rpcbuf_priv.h
+++ b/dix/rpcbuf_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/saveset_priv.h
+++ b/dix/saveset_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/screen.c
+++ b/dix/screen.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/screen_hooks.c
+++ b/dix/screen_hooks.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/screen_hooks_priv.h
+++ b/dix/screen_hooks_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  *

--- a/dix/screenint_priv.h
+++ b/dix/screenint_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3+
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2026 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/screensaver_priv.h
+++ b/dix/screensaver_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/selection_priv.h
+++ b/dix/selection_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/server_priv.h
+++ b/dix/server_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/settings.c
+++ b/dix/settings.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  *

--- a/dix/settings_priv.h
+++ b/dix/settings_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/dix/window_priv.h
+++ b/dix/window_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2025 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/fb/fb_priv.h
+++ b/fb/fb_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/fb/fbpict_priv.h
+++ b/fb/fbpict_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/stubs/ddxBeforeReset.c
+++ b/hw/stubs/ddxBeforeReset.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xfree86/common/action_priv.h
+++ b/hw/xfree86/common/action_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xfree86/common/console.c
+++ b/hw/xfree86/common/console.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * @copyright Enrico Weigelt, metux IT consult <info@metux.net>
  * @brief console driver interface

--- a/hw/xfree86/common/dgaproc_priv.h
+++ b/hw/xfree86/common/dgaproc_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xfree86/common/xf86Module_priv.h
+++ b/hw/xfree86/common/xf86Module_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xfree86/common/xf86Opt_priv.h
+++ b/hw/xfree86/common/xf86Opt_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xfree86/common/xf86VGAarbiter_priv.h
+++ b/hw/xfree86/common/xf86VGAarbiter_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xfree86/common/xf86Xinput_priv.h
+++ b/hw/xfree86/common/xf86Xinput_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xfree86/common/xf86_console_priv.h
+++ b/hw/xfree86/common/xf86_console_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * @copyright Enrico Weigelt, metux IT consult <info@metux.net>
  * @brief definitions for XF86 console driver interface

--- a/hw/xfree86/common/xf86_pci_priv.h
+++ b/hw/xfree86/common/xf86_pci_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xfree86/common/xf86_priv.h
+++ b/hw/xfree86/common/xf86_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xfree86/common/xf86platformBus_priv.h
+++ b/hw/xfree86/common/xf86platformBus_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xfree86/common/xf86sbusBus_priv.h
+++ b/hw/xfree86/common/xf86sbusBus_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  * Copyright © 2000 Jakub Jelinek (jakub@redhat.com)

--- a/hw/xfree86/compat/clientexception.c
+++ b/hw/xfree86/compat/clientexception.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #include <dix-config.h>
 
 #include <X11/Xfuncproto.h>

--- a/hw/xfree86/compat/geeventinit.c
+++ b/hw/xfree86/compat/geeventinit.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #include <dix-config.h>
 
 #include <X11/Xfuncproto.h>

--- a/hw/xfree86/compat/log.c
+++ b/hw/xfree86/compat/log.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #include <dix-config.h>
 
 #include <X11/Xfuncproto.h>

--- a/hw/xfree86/compat/nvidiabug.c
+++ b/hw/xfree86/compat/nvidiabug.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xfree86/compat/timercheck.c
+++ b/hw/xfree86/compat/timercheck.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #include <dix-config.h>
 
 #include <X11/Xfuncproto.h>

--- a/hw/xfree86/compat/xf86_compat.h
+++ b/hw/xfree86/compat/xf86_compat.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xfree86/ddc/xf86DDC_priv.h
+++ b/hw/xfree86/ddc/xf86DDC_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  * Copyright © 1998 by Egbert Eich <Egbert.Eich@Physik.TU-Darmstadt.DE>

--- a/hw/xfree86/dri/dri_priv.h
+++ b/hw/xfree86/dri/dri_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xfree86/drivers/input/null/null.c
+++ b/hw/xfree86/drivers/input/null/null.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #include <xorg-config.h>
 
 #include <exevents.h>

--- a/hw/xfree86/int10/xf86int10_priv.h
+++ b/hw/xfree86/int10/xf86int10_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  * Copyright © 1999 Egbert Eich

--- a/hw/xfree86/modes/xf86RandR12_priv.h
+++ b/hw/xfree86/modes/xf86RandR12_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xfree86/os-support/bsd/console.c
+++ b/hw/xfree86/os-support/bsd/console.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xfree86/os-support/bsd/console_pcvt.c
+++ b/hw/xfree86/os-support/bsd/console_pcvt.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #include <xorg-config.h>
 
 #if defined(PCVT_SUPPORT)

--- a/hw/xfree86/os-support/bsd/console_syscons.c
+++ b/hw/xfree86/os-support/bsd/console_syscons.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #include <xorg-config.h>
 
 #if defined(SYSCONS_SUPPORT)

--- a/hw/xfree86/os-support/bsd/console_wscons.c
+++ b/hw/xfree86/os-support/bsd/console_wscons.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #include <xorg-config.h>
 
 #if defined(WSCONS_SUPPORT)

--- a/hw/xfree86/os-support/bsd/xf86_bsd_priv.h
+++ b/hw/xfree86/os-support/bsd/xf86_bsd_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xfree86/os-support/xf86_os_support.h
+++ b/hw/xfree86/os-support/xf86_os_support.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xfree86/parser/xf86Parser_priv.h
+++ b/hw/xfree86/parser/xf86Parser_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  * Copyright © 1997 Metro Link Incorporated

--- a/hw/xnest/xcb.c
+++ b/hw/xnest/xcb.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xnest/xkb.c
+++ b/hw/xnest/xkb.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>

--- a/hw/xnest/xnest-xcb.h
+++ b/hw/xnest/xnest-xcb.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xnest/xnest-xkb.h
+++ b/hw/xnest/xnest-xkb.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/hw/xwin/os-compat.h
+++ b/hw/xwin/os-compat.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #ifndef __XWIN_OS_COMPAT_H
 #define __XWIN_OS_COMPAT_H
 

--- a/include/fd_notify.h
+++ b/include/fd_notify.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  *

--- a/include/xlibre_ptrtypes.h
+++ b/include/xlibre_ptrtypes.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  *

--- a/mi/mi_priv.h
+++ b/mi/mi_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/mi/mipointer_priv.h
+++ b/mi/mipointer_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/miext/sync/misync_priv.h
+++ b/miext/sync/misync_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  * Copyright © 2010 NVIDIA Corporation

--- a/os/alloc.c
+++ b/os/alloc.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 1987, 1998  The Open Group
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>

--- a/os/auth.h
+++ b/os/auth.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #ifndef _XSERVER_OS_AUTH_H
 #define _XSERVER_OS_AUTH_H
 

--- a/os/bug_priv.h
+++ b/os/bug_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/os/client_priv.h
+++ b/os/client_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  * Copyright © 2010 Nokia Corporation and/or its subsidiary(-ies).

--- a/os/cmdline.c
+++ b/os/cmdline.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  *

--- a/os/cmdline.h
+++ b/os/cmdline.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/os/ddx_priv.h
+++ b/os/ddx_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11 OR AGPLv3+
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/os/fmt.c
+++ b/os/fmt.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  * Copyright © 1987, 1998  The Open Group

--- a/os/fmt.h
+++ b/os/fmt.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/os/io_priv.h
+++ b/os/io_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/os/log_priv.h
+++ b/os/log_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/os/mathx_priv.h
+++ b/os/mathx_priv.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/os/mitauth.h
+++ b/os/mitauth.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #ifndef _XSERVER_OS_MITAUTH_H
 #define _XSERVER_OS_MITAUTH_H
 

--- a/os/ossock.c
+++ b/os/ossock.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/os/ossock.h
+++ b/os/ossock.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/os/screensaver.h
+++ b/os/screensaver.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/os/serverlock.c
+++ b/os/serverlock.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/os/serverlock.h
+++ b/os/serverlock.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/os/string.c
+++ b/os/string.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 1987, 1998  The Open Group
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>

--- a/os/xdmauth.h
+++ b/os/xdmauth.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #ifndef _XSERVER_OS_XDMAUTH_H
 #define _XSERVER_OS_XDMAUTH_H
 

--- a/os/xdmcp.h
+++ b/os/xdmcp.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later */
+/* Copyright (C) 2026 Enrico Weigelt, metux IT consult <info@metux.net> */
 #ifndef _XSERVER_OS_XDMCP_H
 #define _XSERVER_OS_XDMCP_H
 

--- a/os/xhostname.c
+++ b/os/xhostname.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/os/xhostname.h
+++ b/os/xhostname.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2024 Enrico Weigelt, metux IT consult <info@metux.net>
  */

--- a/test/list_zeroinit.c
+++ b/test/list_zeroinit.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: MIT OR X11
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
  *
  * Copyright © 2026 Enrico Weigelt, metux IT consult <info@metux.net>
  *


### PR DESCRIPTION
Update SPDX-License-Identifier from MIT OR X11 (or MIT OR X11 OR AGPLv3+ variants)
to the canonical X11 OR MIT OR AGPL-3.0-or-later on 95 existing source files.
Add the triple-license header to 33 newly-identified files authored by Enrico
Weigelt that were missing SPDX headers entirely.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
