### PR TITLE
(release/25.2) xfree86: close seatd input devices after DisableDevice(), not before

### DIFF
--- a/hw/xfree86/common/xf86Events.c
+++ b/hw/xfree86/common/xf86Events.c
@@ -313,8 +313,9 @@ static void xf86DisableInputDeviceForVTSwitch(InputInfoPtr pInfo)
 
     xf86ReleaseKeys(pInfo->dev);
     ProcessInputEvents();
-    seatd_libseat_close_device(pInfo);
+    /* DEVICE_OFF reads pInfo->fd, disable before releasing the seatd fd */
     DisableDevice(pInfo->dev, TRUE);
+    seatd_libseat_close_device(pInfo);
 }
 
 void


### PR DESCRIPTION
Backport of [#3440](https://github.com/X11Libre/xserver/pull/3440) (master)

before DisableDevice(), but DisableDevice() is what runs the driver's
DEVICE_OFF. The close has already cleared pInfo->fd and the "fd" option,
so xf86libinput_off() takes its use_server_fd() == false path and
unregisters libinput's epoll fd as -1 -- libinput's fd is never removed
from the input thread.

The stale entry left behind is unrecoverable: a later libinput context
reuses the same fd number and is adopted into it without being re-armed,
so the server ends up with every device enabled but nothing polling
libinput, and all input dies until a restart.

Close the seatd fd after DisableDevice() so pInfo->fd and the "fd"
option are still valid when DEVICE_OFF runs. Upstream releases no fds in
this function at all; the inversion is specific to the seatd integration.

Assisted-by: Claude:claude-opus-5
Signed-off-by: galternat <galternat.twins223@simplelogin.com>
(cherry picked from commit 2e9520df2f02fe1e8def4e5cf49e6aabf6b709e9)
