### PR TITLE
(master) compiler.h: replace legacy __inline__/__inline with standard C99 inline

### DIFF
--- a/hw/xfree86/int10/generic.c
+++ b/hw/xfree86/int10/generic.c
@@ -22,7 +22,7 @@
 
 #include <string.h>             /* needed for memmove */
 
-static __inline__ uint32_t
+static inline uint32_t
 ldl_u(uint32_t * p)
 {
     uint32_t ret;
@@ -31,7 +31,7 @@ ldl_u(uint32_t * p)
     return ret;
 }
 
-static __inline__ uint16_t
+static inline uint16_t
 ldw_u(uint16_t * p)
 {
     uint16_t ret;
@@ -40,7 +40,7 @@ ldw_u(uint16_t * p)
     return ret;
 }
 
-static __inline__ void
+static inline void
 stl_u(uint32_t val, uint32_t * p)
 {
     uint32_t tmp = val;
@@ -48,7 +48,7 @@ stl_u(uint32_t val, uint32_t * p)
     memmove(p, &tmp, sizeof(*p));
 }
 
-static __inline__ void
+static inline void
 stw_u(uint16_t val, uint16_t * p)
 {
     uint16_t tmp = val;

--- a/hw/xfree86/x86emu/sys.c
+++ b/hw/xfree86/x86emu/sys.c
@@ -65,7 +65,7 @@ struct __una_u16 {
 
 /* Elemental unaligned loads */
 
-static __inline__ u32
+static inline u32
 ldl_u(u32 * p)
 {
     const struct __una_u32 *ptr = (const struct __una_u32 *) p;
@@ -73,7 +73,7 @@ ldl_u(u32 * p)
     return ptr->x;
 }
 
-static __inline__ u16
+static inline u16
 ldw_u(u16 * p)
 {
     const struct __una_u16 *ptr = (const struct __una_u16 *) p;
@@ -83,7 +83,7 @@ ldw_u(u16 * p)
 
 /* Elemental unaligned stores */
 
-static __inline__ void
+static inline void
 stl_u(u32 val, u32 * p)
 {
     struct __una_u32 *ptr = (struct __una_u32 *) p;
@@ -91,7 +91,7 @@ stl_u(u32 val, u32 * p)
     ptr->x = val;
 }
 
-static __inline__ void
+static inline void
 stw_u(u16 val, u16 * p)
 {
     struct __una_u16 *ptr = (struct __una_u16 *) p;
@@ -100,7 +100,7 @@ stw_u(u16 val, u16 * p)
 }
 #else                           /* !__GNUC__ */
 
-static __inline__ u32
+static inline u32
 ldl_u(u32 * p)
 {
     u32 ret;
@@ -109,7 +109,7 @@ ldl_u(u32 * p)
     return ret;
 }
 
-static __inline__ u16
+static inline u16
 ldw_u(u16 * p)
 {
     u16 ret;
@@ -118,7 +118,7 @@ ldw_u(u16 * p)
     return ret;
 }
 
-static __inline__ void
+static inline void
 stl_u(u32 val, u32 * p)
 {
     u32 tmp = val;
@@ -126,7 +126,7 @@ stl_u(u32 val, u32 * p)
     memmove(p, &tmp, sizeof(*p));
 }
 
-static __inline__ void
+static inline void
 stw_u(u16 val, u16 * p)
 {
     u16 tmp = val;

--- a/hw/xquartz/xpr/x-hash.h
+++ b/hw/xquartz/xpr/x-hash.h
@@ -64,18 +64,18 @@ X_EXTERN void X_PFX(hash_table_foreach) (x_hash_table * h,
 /* Conversion between unsigned int (e.g. xp_resource_id) and void pointer */
 
 /* Forward declarations */
-static __inline__ void *
+static inline void *
 X_PFX(cvt_uint_to_vptr) (unsigned int val) __attribute__((always_inline));
-static __inline__ unsigned int
+static inline unsigned int
 X_PFX(cvt_vptr_to_uint) (void * val) __attribute__((always_inline));
 
 /* Implementations */
-static __inline__ void *
+static inline void *
 X_PFX(cvt_uint_to_vptr) (unsigned int val) {
     return (void *)((unsigned long)(val));
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 X_PFX(cvt_vptr_to_uint) (void * val) {
     size_t sv = (size_t)val;
     unsigned int uv = (unsigned int)sv;

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -59,22 +59,6 @@
 
 /* NOLINTBEGIN(hicpp-no-assembler) */
 
-/* Allow drivers to use the GCC-supported __inline__ and/or __inline. */
-#ifndef __inline__
-#if defined(__GNUC__)
-    /* gcc has __inline__ */
-#else
-#define __inline__ /**/
-#endif
-#endif                          /* __inline__ */
-#ifndef __inline
-#if defined(__GNUC__)
-    /* gcc has __inline */
-#else
-#define __inline /**/
-#endif
-#endif                          /* __inline */
-
 #ifdef __GNUC__
 #ifdef __i386__
 
@@ -168,37 +152,37 @@ extern _X_EXPORT unsigned int _inb(unsigned long port);
 extern _X_EXPORT unsigned int _inw(unsigned long port);
 extern _X_EXPORT unsigned int _inl(unsigned long port);
 
-static __inline__ void
+static inline void
 outb(unsigned long port, unsigned char val)
 {
     _outb(val, port);
 }
 
-static __inline__ void
+static inline void
 outw(unsigned long port, unsigned short val)
 {
     _outw(val, port);
 }
 
-static __inline__ void
+static inline void
 outl(unsigned long port, unsigned int val)
 {
     _outl(val, port);
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inb(unsigned long port)
 {
     return _inb(port);
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inw(unsigned long port)
 {
     return _inw(port);
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inl(unsigned long port)
 {
     return _inl(port);
@@ -230,25 +214,25 @@ extern _X_EXPORT unsigned int inl(unsigned int port);
 
 #include <inttypes.h>
 
-static __inline__ void
+static inline void
 outb(unsigned short port, unsigned char val)
 {
     __asm__ __volatile__("outb %0,%1"::"a"(val), "d"(port));
 }
 
-static __inline__ void
+static inline void
 outw(unsigned short port, unsigned short val)
 {
     __asm__ __volatile__("outw %0,%1"::"a"(val), "d"(port));
 }
 
-static __inline__ void
+static inline void
 outl(unsigned short port, unsigned int val)
 {
     __asm__ __volatile__("outl %0,%1"::"a"(val), "d"(port));
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inb(unsigned short port)
 {
     unsigned char ret;
@@ -257,7 +241,7 @@ inb(unsigned short port)
     return ret;
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inw(unsigned short port)
 {
     unsigned short ret;
@@ -266,7 +250,7 @@ inw(unsigned short port)
     return ret;
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inl(unsigned short port)
 {
     unsigned int ret;
@@ -281,7 +265,7 @@ inl(unsigned short port)
 #define ASI_PL 0x88
 #endif
 
-static __inline__ void
+static inline void
 outb(unsigned long port, unsigned char val)
 {
     __asm__ __volatile__("stba %0, [%1] %2":    /* No outputs */
@@ -290,7 +274,7 @@ outb(unsigned long port, unsigned char val)
     barrier();
 }
 
-static __inline__ void
+static inline void
 outw(unsigned long port, unsigned short val)
 {
     __asm__ __volatile__("stha %0, [%1] %2":    /* No outputs */
@@ -299,7 +283,7 @@ outw(unsigned long port, unsigned short val)
     barrier();
 }
 
-static __inline__ void
+static inline void
 outl(unsigned long port, unsigned int val)
 {
     __asm__ __volatile__("sta %0, [%1] %2":     /* No outputs */
@@ -308,7 +292,7 @@ outl(unsigned long port, unsigned int val)
     barrier();
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inb(unsigned long port)
 {
     unsigned int ret;
@@ -318,7 +302,7 @@ inb(unsigned long port)
     return ret;
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inw(unsigned long port)
 {
     unsigned int ret;
@@ -328,7 +312,7 @@ inw(unsigned long port)
     return ret;
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inl(unsigned long port)
 {
     unsigned int ret;
@@ -338,7 +322,7 @@ inl(unsigned long port)
     return ret;
 }
 
-static __inline__ unsigned char
+static inline unsigned char
 xf86ReadMmio8(__volatile__ void *base, const unsigned long offset)
 {
     unsigned long addr = ((unsigned long) base) + offset;
@@ -350,7 +334,7 @@ xf86ReadMmio8(__volatile__ void *base, const unsigned long offset)
     return ret;
 }
 
-static __inline__ unsigned short
+static inline unsigned short
 xf86ReadMmio16Be(__volatile__ void *base, const unsigned long offset)
 {
     unsigned long addr = ((unsigned long) base) + offset;
@@ -362,7 +346,7 @@ xf86ReadMmio16Be(__volatile__ void *base, const unsigned long offset)
     return ret;
 }
 
-static __inline__ unsigned short
+static inline unsigned short
 xf86ReadMmio16Le(__volatile__ void *base, const unsigned long offset)
 {
     unsigned long addr = ((unsigned long) base) + offset;
@@ -374,7 +358,7 @@ xf86ReadMmio16Le(__volatile__ void *base, const unsigned long offset)
     return ret;
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 xf86ReadMmio32Be(__volatile__ void *base, const unsigned long offset)
 {
     unsigned long addr = ((unsigned long) base) + offset;
@@ -386,7 +370,7 @@ xf86ReadMmio32Be(__volatile__ void *base, const unsigned long offset)
     return ret;
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 xf86ReadMmio32Le(__volatile__ void *base, const unsigned long offset)
 {
     unsigned long addr = ((unsigned long) base) + offset;
@@ -398,7 +382,7 @@ xf86ReadMmio32Le(__volatile__ void *base, const unsigned long offset)
     return ret;
 }
 
-static __inline__ void
+static inline void
 xf86WriteMmio8(__volatile__ void *base, const unsigned long offset,
                const unsigned int val)
 {
@@ -410,7 +394,7 @@ xf86WriteMmio8(__volatile__ void *base, const unsigned long offset,
     barrier();
 }
 
-static __inline__ void
+static inline void
 xf86WriteMmio16Be(__volatile__ void *base, const unsigned long offset,
                   const unsigned int val)
 {
@@ -422,7 +406,7 @@ xf86WriteMmio16Be(__volatile__ void *base, const unsigned long offset,
     barrier();
 }
 
-static __inline__ void
+static inline void
 xf86WriteMmio16Le(__volatile__ void *base, const unsigned long offset,
                   const unsigned int val)
 {
@@ -434,7 +418,7 @@ xf86WriteMmio16Le(__volatile__ void *base, const unsigned long offset,
     barrier();
 }
 
-static __inline__ void
+static inline void
 xf86WriteMmio32Be(__volatile__ void *base, const unsigned long offset,
                   const unsigned int val)
 {
@@ -446,7 +430,7 @@ xf86WriteMmio32Be(__volatile__ void *base, const unsigned long offset,
     barrier();
 }
 
-static __inline__ void
+static inline void
 xf86WriteMmio32Le(__volatile__ void *base, const unsigned long offset,
                   const unsigned int val)
 {
@@ -463,42 +447,42 @@ xf86WriteMmio32Le(__volatile__ void *base, const unsigned long offset,
 
 extern _X_EXPORT unsigned int IOPortBase;      /* Memory mapped I/O port area */
 
-static __inline__ void
+static inline void
 outb(unsigned PORT_SIZE port, unsigned char val)
 {
     *(volatile unsigned char *) (((unsigned PORT_SIZE) (port)) + IOPortBase) =
         val;
 }
 
-static __inline__ void
+static inline void
 outw(unsigned PORT_SIZE port, unsigned short val)
 {
     *(volatile unsigned short *) (((unsigned PORT_SIZE) (port)) + IOPortBase) =
         val;
 }
 
-static __inline__ void
+static inline void
 outl(unsigned PORT_SIZE port, unsigned int val)
 {
     *(volatile unsigned int *) (((unsigned PORT_SIZE) (port)) + IOPortBase) =
         val;
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inb(unsigned PORT_SIZE port)
 {
     return *(volatile unsigned char *) (((unsigned PORT_SIZE) (port)) +
                                         IOPortBase);
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inw(unsigned PORT_SIZE port)
 {
     return *(volatile unsigned short *) (((unsigned PORT_SIZE) (port)) +
                                          IOPortBase);
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inl(unsigned PORT_SIZE port)
 {
     return *(volatile unsigned int *) (((unsigned PORT_SIZE) (port)) +
@@ -508,7 +492,7 @@ inl(unsigned PORT_SIZE port)
 #if defined(__mips__)
 #ifdef __linux__                    /* don't mess with other OSs */
 #if X_BYTE_ORDER == X_BIG_ENDIAN
-static __inline__ unsigned int
+static inline unsigned int
 xf86ReadMmio32Be(__volatile__ void *base, const unsigned long offset)
 {
     unsigned long addr = ((unsigned long) base) + offset;
@@ -520,7 +504,7 @@ xf86ReadMmio32Be(__volatile__ void *base, const unsigned long offset)
     return ret;
 }
 
-static __inline__ void
+static inline void
 xf86WriteMmio32Be(__volatile__ void *base, const unsigned long offset,
                   const unsigned int val)
 {
@@ -541,7 +525,7 @@ xf86WriteMmio32Be(__volatile__ void *base, const unsigned long offset,
 
 extern _X_EXPORT volatile unsigned char *ioBase;
 
-static __inline__ unsigned char
+static inline unsigned char
 xf86ReadMmio8(__volatile__ void *base, const unsigned long offset)
 {
     register unsigned char val;
@@ -551,7 +535,7 @@ xf86ReadMmio8(__volatile__ void *base, const unsigned long offset)
     return val;
 }
 
-static __inline__ unsigned short
+static inline unsigned short
 xf86ReadMmio16Be(__volatile__ void *base, const unsigned long offset)
 {
     register unsigned short val;
@@ -561,7 +545,7 @@ xf86ReadMmio16Be(__volatile__ void *base, const unsigned long offset)
     return val;
 }
 
-static __inline__ unsigned short
+static inline unsigned short
 xf86ReadMmio16Le(__volatile__ void *base, const unsigned long offset)
 {
     register unsigned short val;
@@ -571,7 +555,7 @@ xf86ReadMmio16Le(__volatile__ void *base, const unsigned long offset)
     return val;
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 xf86ReadMmio32Be(__volatile__ void *base, const unsigned long offset)
 {
     register unsigned int val;
@@ -581,7 +565,7 @@ xf86ReadMmio32Be(__volatile__ void *base, const unsigned long offset)
     return val;
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 xf86ReadMmio32Le(__volatile__ void *base, const unsigned long offset)
 {
     register unsigned int val;
@@ -591,7 +575,7 @@ xf86ReadMmio32Le(__volatile__ void *base, const unsigned long offset)
     return val;
 }
 
-static __inline__ void
+static inline void
 xf86WriteMmio8(__volatile__ void *base, const unsigned long offset,
                const unsigned char val)
 {
@@ -602,7 +586,7 @@ xf86WriteMmio8(__volatile__ void *base, const unsigned long offset,
     eieio();
 }
 
-static __inline__ void
+static inline void
 xf86WriteMmio16Le(__volatile__ void *base, const unsigned long offset,
                   const unsigned short val)
 {
@@ -613,7 +597,7 @@ xf86WriteMmio16Le(__volatile__ void *base, const unsigned long offset,
     eieio();
 }
 
-static __inline__ void
+static inline void
 xf86WriteMmio16Be(__volatile__ void *base, const unsigned long offset,
                   const unsigned short val)
 {
@@ -624,7 +608,7 @@ xf86WriteMmio16Be(__volatile__ void *base, const unsigned long offset,
     eieio();
 }
 
-static __inline__ void
+static inline void
 xf86WriteMmio32Le(__volatile__ void *base, const unsigned long offset,
                   const unsigned int val)
 {
@@ -635,7 +619,7 @@ xf86WriteMmio32Le(__volatile__ void *base, const unsigned long offset,
     eieio();
 }
 
-static __inline__ void
+static inline void
 xf86WriteMmio32Be(__volatile__ void *base, const unsigned long offset,
                   const unsigned int val)
 {
@@ -646,7 +630,7 @@ xf86WriteMmio32Be(__volatile__ void *base, const unsigned long offset,
     eieio();
 }
 
-static __inline__ void
+static inline void
 outb(unsigned short port, unsigned char value)
 {
     if (ioBase == MAP_FAILED)
@@ -654,7 +638,7 @@ outb(unsigned short port, unsigned char value)
     xf86WriteMmio8((void *) ioBase, port, value);
 }
 
-static __inline__ void
+static inline void
 outw(unsigned short port, unsigned short value)
 {
     if (ioBase == MAP_FAILED)
@@ -662,7 +646,7 @@ outw(unsigned short port, unsigned short value)
     xf86WriteMmio16Le((void *) ioBase, port, value);
 }
 
-static __inline__ void
+static inline void
 outl(unsigned short port, unsigned int value)
 {
     if (ioBase == MAP_FAILED)
@@ -670,7 +654,7 @@ outl(unsigned short port, unsigned int value)
     xf86WriteMmio32Le((void *) ioBase, port, value);
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inb(unsigned short port)
 {
     if (ioBase == MAP_FAILED)
@@ -678,7 +662,7 @@ inb(unsigned short port)
     return xf86ReadMmio8((void *) ioBase, port);
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inw(unsigned short port)
 {
     if (ioBase == MAP_FAILED)
@@ -686,7 +670,7 @@ inw(unsigned short port)
     return xf86ReadMmio16Le((void *) ioBase, port);
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inl(unsigned short port)
 {
     if (ioBase == MAP_FAILED)
@@ -703,13 +687,13 @@ inl(unsigned short port)
 
 #define PORT_SIZE long
 
-static __inline__ unsigned char
+static inline unsigned char
 xf86ReadMmio8(__volatile__ void *base, const unsigned long offset)
 {
     return *(volatile unsigned char *) ((unsigned char *) base + offset);
 }
 
-static __inline__ void
+static inline void
 xf86WriteMmio8(__volatile__ void *base, const unsigned long offset,
                const unsigned int val)
 {
@@ -717,7 +701,7 @@ xf86WriteMmio8(__volatile__ void *base, const unsigned long offset,
     barrier();
 }
 
-static __inline__ unsigned short
+static inline unsigned short
 xf86ReadMmio16Swap(__volatile__ void *base, const unsigned long offset)
 {
     unsigned long addr = ((unsigned long) base) + offset;
@@ -729,13 +713,13 @@ xf86ReadMmio16Swap(__volatile__ void *base, const unsigned long offset)
     return ret;
 }
 
-static __inline__ unsigned short
+static inline unsigned short
 xf86ReadMmio16(__volatile__ void *base, const unsigned long offset)
 {
     return *(volatile unsigned short *) ((char *) base + offset);
 }
 
-static __inline__ void
+static inline void
 xf86WriteMmio16Swap(__volatile__ void *base, const unsigned long offset,
                     const unsigned int val)
 {
@@ -747,7 +731,7 @@ xf86WriteMmio16Swap(__volatile__ void *base, const unsigned long offset,
     barrier();
 }
 
-static __inline__ void
+static inline void
 xf86WriteMmio16(__volatile__ void *base, const unsigned long offset,
                 const unsigned int val)
 {
@@ -755,7 +739,7 @@ xf86WriteMmio16(__volatile__ void *base, const unsigned long offset,
     barrier();
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 xf86ReadMmio32Swap(__volatile__ void *base, const unsigned long offset)
 {
     unsigned long addr = ((unsigned long) base) + offset;
@@ -768,13 +752,13 @@ xf86ReadMmio32Swap(__volatile__ void *base, const unsigned long offset)
     return ret;
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 xf86ReadMmio32(__volatile__ void *base, const unsigned long offset)
 {
     return *(volatile unsigned int *) ((unsigned char *) base + offset);
 }
 
-static __inline__ void
+static inline void
 xf86WriteMmio32Swap(__volatile__ void *base, const unsigned long offset,
                     const unsigned int val)
 {
@@ -786,7 +770,7 @@ xf86WriteMmio32Swap(__volatile__ void *base, const unsigned long offset,
     barrier();
 }
 
-static __inline__ void
+static inline void
 xf86WriteMmio32(__volatile__ void *base, const unsigned long offset,
                 const unsigned int val)
 {
@@ -795,77 +779,77 @@ xf86WriteMmio32(__volatile__ void *base, const unsigned long offset,
 }
 
 #if defined(NDS32_MMIO_SWAP)
-static __inline__ void
+static inline void
 outb(unsigned PORT_SIZE port, unsigned char val)
 {
     xf86WriteMmio8(IOPortBase, port, val);
 }
 
-static __inline__ void
+static inline void
 outw(unsigned PORT_SIZE port, unsigned short val)
 {
     xf86WriteMmio16Swap(IOPortBase, port, val);
 }
 
-static __inline__ void
+static inline void
 outl(unsigned PORT_SIZE port, unsigned int val)
 {
     xf86WriteMmio32Swap(IOPortBase, port, val);
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inb(unsigned PORT_SIZE port)
 {
     return xf86ReadMmio8(IOPortBase, port);
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inw(unsigned PORT_SIZE port)
 {
     return xf86ReadMmio16Swap(IOPortBase, port);
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inl(unsigned PORT_SIZE port)
 {
     return xf86ReadMmio32Swap(IOPortBase, port);
 }
 
 #else                           /* !NDS32_MMIO_SWAP */
-static __inline__ void
+static inline void
 outb(unsigned PORT_SIZE port, unsigned char val)
 {
     *(volatile unsigned char *) (((unsigned PORT_SIZE) (port))) = val;
     barrier();
 }
 
-static __inline__ void
+static inline void
 outw(unsigned PORT_SIZE port, unsigned short val)
 {
     *(volatile unsigned short *) (((unsigned PORT_SIZE) (port))) = val;
     barrier();
 }
 
-static __inline__ void
+static inline void
 outl(unsigned PORT_SIZE port, unsigned int val)
 {
     *(volatile unsigned int *) (((unsigned PORT_SIZE) (port))) = val;
     barrier();
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inb(unsigned PORT_SIZE port)
 {
     return *(volatile unsigned char *) (((unsigned PORT_SIZE) (port)));
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inw(unsigned PORT_SIZE port)
 {
     return *(volatile unsigned short *) (((unsigned PORT_SIZE) (port)));
 }
 
-static __inline__ unsigned int
+static inline unsigned int
 inl(unsigned PORT_SIZE port)
 {
     return *(volatile unsigned int *) (((unsigned PORT_SIZE) (port)));


### PR DESCRIPTION
__inline__ and __inline are GCC legacy keywords. The X server already
requires C99 (inline is a standard keyword). Every supported compiler
(GCC, Clang) defines __GNUC__ which guarantees built-in support for
inline, so the fallback blocks in compiler.h are redundant.

Replace all uses of static __inline__ with static inline in:
  - include/compiler.h (80+ occurrences in arch port I/O/MMIO)
  - hw/xfree86/int10/generic.c
  - hw/xfree86/x86emu/sys.c
  - hw/xquartz/xpr/x-hash.h

Remove the #ifndef __inline__ / __inline fallback blocks entirely.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
