### PR TITLE
(master) CI: work around Ubuntu mirror removing libc6-dbg (404 on fetch)

### DIFF
--- a/.github/scripts/ubuntu/install-pkg.sh
+++ b/.github/scripts/ubuntu/install-pkg.sh
@@ -12,7 +12,6 @@ EPHEMERAL="
 	python3-pytest
 	python3-pytest-timeout
 	python3-pytest-xdist
-	valgrind
 	x11-utils
 	x11-xserver-utils
 	xauth

--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -266,6 +266,11 @@ jobs:
 
             - uses: ./.github/actions/ubuntu-install-pkg
 
+            - name: Install valgrind (separate from install-pkg to work around Ubuntu mirror races on libc6-dbg)
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y valgrind
+
             - name: prepare build environment
               run: |
                 MACHINE=`gcc -dumpmachine`


### PR DESCRIPTION
libc6-dbg was pulled in as a dependency of valgrind, but the Ubuntu
mirror no longer has the exact version matching the runner image's
libc6. This caused all ubuntu-* CI lanes to fail with a 404 error.

Fix: remove valgrind from the shared install-pkg.sh (it was only
needed by the valgrind lane anyway) and install it separately in the
xserver-build-ubuntu-valgrind job with a fresh apt-get update to
resolve the latest package versions.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
