### PR TITLE
meson.build: Use a `disabler` for the gbm dependency

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -105,7 +105,7 @@ conf_data.set('GLAMOR_HAS_GBM', build_gbm ? '1' : false)
 conf_data.set('GBM_BO_WITH_MODIFIERS',
               build_glamor and build_gbm and gbm_dep.version().version_compare('>= 17.1') ? '1' : false)
 conf_data.set('GBM_BO_FD',
-              build_glamor and gbm_dep.found() and cc.has_header_symbol('gbm.h', 'gbm_bo_get_fd', dependencies : gbm_dep )  ? '1' : false)
+              build_glamor and build_gbm and cc.has_header_symbol('gbm.h', 'gbm_bo_get_fd', dependencies : gbm_dep )  ? '1' : false)
 conf_data.set('GBM_BO_FD_FOR_PLANE',
               build_glamor and build_gbm and gbm_dep.version().version_compare('>= 21.1') ? '1' : false)
 conf_data.set('GBM_BO_WITH_MODIFIERS2',

--- a/meson.build
+++ b/meson.build
@@ -399,7 +399,7 @@ endif
 
 # Don't even link to libgbm
 if not build_gbm
-    gbm_dep = dependency('', required: false)
+    gbm_dep = disabler()
 endif
 
 # Lots of sha1 options, because Linux is about choice :)


### PR DESCRIPTION
Fix an instance of `gbm_dep.found()` being used instead of `build_gbm`