### PR TITLE
(master) include: optionstr.h: drop unnecessary include of "list.h"

### DIFF
--- a/include/optionstr.h
+++ b/include/optionstr.h
@@ -1,6 +1,5 @@
 #ifndef OPTIONSTR_H_
 #define OPTIONSTR_H_
-#include "list.h"
 
 struct _InputOption {
     GenericListRec list;


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
