### PR TITLE
(master) config: config-backends.h: drop obsolete includes

### DIFF
--- a/config/config-backends.h
+++ b/config/config-backends.h
@@ -26,9 +26,6 @@
 #ifndef XSERVER_CONFIG_BACKENDS_H
 #define XSERVER_CONFIG_BACKENDS_H
 
-#include "input.h"
-#include "list.h"
-
 void remove_devices(const char *backend, const char *config_info);
 BOOL device_is_duplicate(const char *config_info);
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
