### PR TITLE
(master) xfree86: remove xf86allocateConfig function

### DIFF
--- a/hw/xfree86/common/xf86AutoConfig.c
+++ b/hw/xfree86/common/xf86AutoConfig.c
@@ -54,38 +54,38 @@
 /* Sections for the default built-in configuration. */
 
 #define BUILTIN_DEVICE_NAME \
-	"\"Builtin Default %s Device %d\""
+    "\"Builtin Default %s Device %d\""
 
 #define BUILTIN_DEVICE_SECTION_PRE \
-	"Section \"Device\"\n" \
-	"\tIdentifier\t" BUILTIN_DEVICE_NAME "\n" \
-	"\tDriver\t\"%s\"\n"
+    "Section \"Device\"\n" \
+    "\tIdentifier\t" BUILTIN_DEVICE_NAME "\n" \
+    "\tDriver\t\"%s\"\n"
 
 #define BUILTIN_DEVICE_SECTION_POST \
-	"EndSection\n\n"
+    "EndSection\n\n"
 
 #define BUILTIN_DEVICE_SECTION \
-	BUILTIN_DEVICE_SECTION_PRE \
-	BUILTIN_DEVICE_SECTION_POST
+    BUILTIN_DEVICE_SECTION_PRE \
+    BUILTIN_DEVICE_SECTION_POST
 
 #define BUILTIN_SCREEN_NAME \
-	"\"Builtin Default %s Screen %d\""
+    "\"Builtin Default %s Screen %d\""
 
 #define BUILTIN_SCREEN_SECTION \
-	"Section \"Screen\"\n" \
-	"\tIdentifier\t" BUILTIN_SCREEN_NAME "\n" \
-	"\tDevice\t" BUILTIN_DEVICE_NAME "\n" \
-	"EndSection\n\n"
+    "Section \"Screen\"\n" \
+    "\tIdentifier\t" BUILTIN_SCREEN_NAME "\n" \
+    "\tDevice\t" BUILTIN_DEVICE_NAME "\n" \
+    "EndSection\n\n"
 
 #define BUILTIN_LAYOUT_SECTION_PRE \
-	"Section \"ServerLayout\"\n" \
-	"\tIdentifier\t\"Builtin Default Layout\"\n"
+    "Section \"ServerLayout\"\n" \
+    "\tIdentifier\t\"Builtin Default Layout\"\n"
 
 #define BUILTIN_LAYOUT_SCREEN_LINE \
-	"\tScreen\t" BUILTIN_SCREEN_NAME "\n"
+    "\tScreen\t" BUILTIN_SCREEN_NAME "\n"
 
 #define BUILTIN_LAYOUT_SECTION_POST \
-	"EndSection\n\n"
+    "EndSection\n\n"
 
 static const char **builtinConfig = NULL;
 static int builtinLines = 0;
@@ -173,11 +173,14 @@ xf86AutoConfig(void)
     ConfigStatus ret;
 
     /* Make sure config rec is there */
-    XF86ConfigPtr xf86configptr = calloc(1, sizeof(XF86ConfigRec));
     if(!xf86configptr)
     {
-        LogMessageVerb(X_ERROR, 1, "Couldn't allocate Config record.\n");
-        return FALSE;
+        xf86configptr = calloc(1, sizeof(XF86ConfigRec));
+        if(!xf86configptr)
+        {
+            LogMessageVerb(X_ERROR, 1, "Couldn't allocate Config record.\n");
+            return FALSE;
+        }
     }
 
     ret = CONFIG_OK;

--- a/hw/xfree86/common/xf86AutoConfig.c
+++ b/hw/xfree86/common/xf86AutoConfig.c
@@ -173,13 +173,14 @@ xf86AutoConfig(void)
     ConfigStatus ret;
 
     /* Make sure config rec is there */
-    if (xf86allocateConfig() != NULL) {
-        ret = CONFIG_OK;    /* OK so far */
-    }
-    else {
+    XF86ConfigPtr xf86configptr = calloc(1, sizeof(XF86ConfigRec));
+    if(!xf86configptr)
+    {
         LogMessageVerb(X_ERROR, 1, "Couldn't allocate Config record.\n");
         return FALSE;
     }
+
+    ret = CONFIG_OK;
 
     listPossibleVideoDrivers(&md);
 

--- a/hw/xfree86/parser/read.c
+++ b/hw/xfree86/parser/read.c
@@ -52,12 +52,10 @@
  * authorization from the copyright holder(s) and author(s).
  */
 #include <xorg-config.h>
-
 #include "xf86Config.h"
 #include "xf86Parser_priv.h"
 #include "xf86tokens.h"
 #include "Configint.h"
-
 
 static const xf86ConfigSymTabRec TopLevelTab[] = {
     {SECTION, "section"},
@@ -87,9 +85,11 @@ XF86ConfigPtr
 xf86readConfigFile(void)
 {
     int token;
-    XF86ConfigPtr ptr = NULL;
+    XF86ConfigPtr ptr = calloc(1, sizeof(XF86ConfigRec));
 
-    if ((ptr = xf86allocateConfig()) == NULL) {
+	// Return if config allocation failed
+    if(!ptr)
+    {
         return NULL;
     }
 
@@ -268,19 +268,6 @@ xf86itemNotSublist(GenericListPtr list_1, GenericListPtr list_2)
     }
 
     return (!(last_1 == last_2));
-}
-
-/*
- * Conditionally allocate config struct, but only allocate it
- * if it's not already there.  In either event, return the pointer
- * to the global config struct.
- */
-XF86ConfigPtr xf86allocateConfig(void)
-{
-    if (!xf86configptr) {
-        xf86configptr = calloc(1, sizeof(XF86ConfigRec));
-    }
-    return xf86configptr;
 }
 
 void

--- a/hw/xfree86/parser/read.c
+++ b/hw/xfree86/parser/read.c
@@ -85,12 +85,19 @@ XF86ConfigPtr
 xf86readConfigFile(void)
 {
     int token;
-    XF86ConfigPtr ptr = calloc(1, sizeof(XF86ConfigRec));
+    XF86ConfigPtr ptr = xf86configptr;
 
-	// Return if config allocation failed
+    // Allocate config if it is not
     if(!ptr)
     {
-        return NULL;
+        ptr = calloc(1, sizeof(XF86ConfigRec));
+
+        if(!ptr)
+        {
+            return NULL;
+        }
+
+        xf86configptr = ptr;
     }
 
     while ((token = xf86getToken(TopLevelTab)) != EOF_TOKEN) {

--- a/hw/xfree86/parser/xf86Parser_priv.h
+++ b/hw/xfree86/parser/xf86Parser_priv.h
@@ -20,7 +20,6 @@ char *xf86openConfigDirFiles(const char *path,
 void xf86setBuiltinConfig(const char *config[]);
 XF86ConfigPtr xf86readConfigFile(void);
 void xf86closeConfigFile(void);
-XF86ConfigPtr xf86allocateConfig(void);
 void xf86freeConfig(XF86ConfigPtr p);
 int xf86writeConfigFile(const char *filename, XF86ConfigPtr cptr);
 int xf86layoutAddInputDevices(XF86ConfigPtr config, XF86ConfLayoutPtr layout);


### PR DESCRIPTION
this is a very thin wrapper function than can be removed for better readability and clarity.

Signed by: RotaryBoot58, petersoncraft20@proton.me