### PR TITLE
xquartz/GL: sanitize QuickDraw WindowPtr in capabilities.c

### DIFF
--- a/hw/xquartz/GL/capabilities.c
+++ b/hw/xquartz/GL/capabilities.c
@@ -26,8 +26,13 @@
 #include <stdlib.h>
 #include <assert.h>
 
-#define Cursor Mac_Cursor
-#define BOOL   Mac_BOOL
+/* QuickDraw in ApplicationServices conflicts with the basic X server headers
+ * (e.g. WindowPtr, now pulled in transitively via os.h -> xlibre_ptrtypes.h).
+ * Rename the QuickDraw symbols out of the way, matching sanitizedCarbon.h. */
+#define Cursor    Mac_Cursor
+#define BOOL      Mac_BOOL
+#define WindowPtr QD_WindowPtr
+#define Picture   QD_Picture
 #include <OpenGL/OpenGL.h>
 #include <OpenGL/gl.h>
 #include <OpenGL/glu.h>
@@ -35,6 +40,8 @@
 #include <ApplicationServices/ApplicationServices.h>
 #undef Cursor
 #undef BOOL
+#undef WindowPtr
+#undef Picture
 
 #include "capabilities.h"
 


### PR DESCRIPTION
capabilities.c includes <ApplicationServices/ApplicationServices.h>, which pulls in QuickDraw's WindowPtr, and then includes "os.h".  Since commit 976e6cd ("include: new header for fundamental pointer types") os.h pulls in xlibre_ptrtypes.h, which defines the X server's own WindowPtr, so the two now conflict:

    error: conflicting types for 'WindowPtr'; have 'struct _Window *'

The file already renames Cursor and BOOL out of the way around the Apple headers; do the same for WindowPtr and Picture, matching the pattern in sanitizedCarbon.h.

Fixes: https://github.com/X11Libre/xserver/issues/3461