### PR TITLE
xquartz/GL: include xpr_dri.h instead of dri.h

### DIFF
--- a/hw/xquartz/GL/indirect.c
+++ b/hw/xquartz/GL/indirect.c
@@ -48,7 +48,13 @@
 #include "x-hash.h"
 
 #include "visualConfigs.h"
-#include "dri.h"
+/* This is XQuartz's own DRI surface API (hw/xquartz/xpr/xpr_dri.h), not the
+ * generic xfree86 include/dri.h.  It was renamed from dri.h to xpr_dri.h in
+ * 9bd146a39 ("xfree86: dri: move over public SDK headers to include/"); before
+ * that, "dri.h" resolved to ../xpr/dri.h.  Include the new name explicitly so
+ * we don't fall through to include/dri.h, which pulls in Linux-only
+ * <pciaccess.h> and xf86dri.h. */
+#include "xpr_dri.h"
 
 #include "darwin.h"
 #define GLAQUA_DEBUG_MSG(msg, args ...) ASL_LOG(ASL_LEVEL_DEBUG, "GLXAqua", \

--- a/hw/xquartz/GL/visualConfigs.c
+++ b/hw/xquartz/GL/visualConfigs.c
@@ -31,7 +31,10 @@
 #include <dix-config.h>
 
 #include <assert.h>
-#include "dri.h"
+/* XQuartz's own DRI header (hw/xquartz/xpr/xpr_dri.h), renamed from dri.h in
+ * 9bd146a39; use the new name so we don't fall through to the generic
+ * include/dri.h, which pulls in Linux-only <pciaccess.h> and xf86dri.h. */
+#include "xpr_dri.h"
 
 #include <OpenGL/OpenGL.h>
 #include <OpenGL/gl.h>


### PR DESCRIPTION
indirect.c and visualConfigs.c #include "dri.h" to get XQuartz's own DRI surface API (DRICreateSurface, DRISurfaceNotifyArg, ...).  That header used to live at hw/xquartz/xpr/dri.h and was resolved via the ../xpr include path.  Commit 9bd146a39 ("xfree86: dri: move over public SDK headers to include/") renamed it to xpr_dri.h, so "dri.h" now falls through to the generic include/dri.h, which unconditionally includes the Linux-only <pciaccess.h> and xf86dri.h and breaks the macOS build:

    fatal error: pciaccess.h: No such file or directory
    fatal error: xf86dri.h: No such file or directory

Include the new name explicitly.

Fixes: https://github.com/X11Libre/xserver/issues/3462