### PR TITLE
Xext/randr: Set the legacy RandR size range to include rotations

### DIFF
--- a/Xext/randr/rrinfo.c
+++ b/Xext/randr/rrinfo.c
@@ -80,8 +80,8 @@ RRScanOldConfig(ScreenPtr pScreen, Rotation rotations)
     RRCrtcPtr crtc;
     RRModePtr mode, newMode = NULL;
     int i;
-    CARD16 minWidth = MAXSHORT, minHeight = MAXSHORT;
-    CARD16 maxWidth = 0, maxHeight = 0;
+    CARD16 minSize = MAXSHORT;
+    CARD16 maxSize = 0;
     CARD16 width, height;
 
     /*
@@ -148,17 +148,22 @@ RRScanOldConfig(ScreenPtr pScreen, Rotation rotations)
         width = mode->mode.width;
         height = mode->mode.height;
 
-        if (width < minWidth)
-            minWidth = width;
-        if (width > maxWidth)
-            maxWidth = width;
-        if (height < minHeight)
-            minHeight = height;
-        if (height > maxHeight)
-            maxHeight = height;
+        if (width < minSize)
+            minSize = width;
+        if (width > maxSize)
+            maxSize = width;
+        if (height < minSize)
+            minSize = height;
+        if (height > maxSize)
+            maxSize = height;
     }
 
-    RRScreenSetSizeRange(pScreen, minWidth, minHeight, maxWidth, maxHeight);
+    /**
+     * We pass the minimum/maximum sizes like this to allow rotations.
+     * For example, on a 1920x1080 screen, when we rotate the entire screen,
+     * randr thinks we're going to end up with a 1080x1920 mode, outside the supported range.
+     */
+    RRScreenSetSizeRange(pScreen, minSize, minSize, maxSize, maxSize);
 
     /* notice current mode */
     if (newMode)


### PR DESCRIPTION
Currently, the legacy RandR `GetInfo` path for X servers and drivers that call `RRRegisterSize` goes through the size list, finds the min/max witth and height, and sets that as the allowed size range.

The problem is that, for example on a 1400x1050 screen (Xephyr size), trying to rotate the screen to the right fails.

```
$ xrandr --output default --mode 1400x1050
xrandr: Failed to get size of gamma for output default
$ xrandr --output default --rotate right
xrandr: screen cannot be larger than 1600x1200 (desired size 1050x1400)
```

With this patch, the rotation is properly applied as expected.

Having the X server/driver call `RRScreenSetSizeRange` doesn't help, since `RRScanOldConfig` undoes it.

We could probably instead add the rotated sizes, but that seems ugly, since those rotated sizes can't actually be set,
and would be just there to work around RandR.

This affects Xephyr, Xfbdev, and any X server/driver that calls `RRRegisterSize`. I didn't test all the in-tree X servers, but from looking at them, they should be able to gracefully handle a request to set an unsupported mode, and some might even gain the ability to rotate.

I didn't test any xf86 drivers to see if they benefit from this. modesetting doesn't, since it doesn't call `RRRegisterSize`.

If there are any X servers/drivers that don't handle rotations gracefully, we really should fix them.

## Backport dashboard

| Branch | PR | Status |
|--------|----|--------|
| `release/25.2` | [#3563](https://github.com/X11Libre/xserver/pull/3563) | 🔄 Open |
| `release/25.1` | [#3582](https://github.com/X11Libre/xserver/pull/3582) | 🔄 Open |
| `release/25.0` | [#3597](https://github.com/X11Libre/xserver/pull/3597) | 🔄 Open |
