### PR TITLE
(master) meson_options: disable XvMC build by default

### DIFF
--- a/Xext/xv/meson.build
+++ b/Xext/xv/meson.build
@@ -1,8 +1,11 @@
 srcs_xv = [
     'xvmain.c',
     'xvdisp.c',
-    'xvmc.c',
 ]
+
+if build_xvmc
+    srcs_xv += 'xvmc.c'
+endif
 
 libxserver_xv = []
 if build_xv

--- a/Xext/xv/xvdix_priv.h
+++ b/Xext/xv/xvdix_priv.h
@@ -80,6 +80,8 @@ int XvdiMatchPort(XvPortPtr pPort, DrawablePtr pDraw);
 int XvdiGrabPort(ClientPtr client, XvPortPtr pPort, Time ctime, int *p_result);
 int XvdiUngrabPort(ClientPtr client, XvPortPtr pPort, Time ctime);
 
+#ifdef XvMCExtension
 XvImagePtr XvMCFindXvImage(XvPortPtr pPort, CARD32 id);
+#endif
 
 #endif /* _XORG_XVDIX_PRIV_H */

--- a/hw/xfree86/common/xf86xvmc.c
+++ b/hw/xfree86/common/xf86xvmc.c
@@ -43,6 +43,7 @@
 #include "xf86xvpriv.h"
 #include "xf86xvmc.h"
 
+#ifdef XvMCExtension
 typedef struct {
     int num_adaptors;
     XF86MCAdaptorPtr *adaptors;
@@ -206,6 +207,16 @@ xf86XvMCScreenInit(ScreenPtr pScreen,
 
     return TRUE;
 }
+#else /* !XvMCExtension */
+Bool
+xf86XvMCScreenInit(ScreenPtr pScreen, int num_adaptors, XF86MCAdaptorPtr *adaptors)
+{
+    (void) pScreen;
+    (void) num_adaptors;
+    (void) adaptors;
+    return FALSE;
+}
+#endif /* XvMCExtension */
 
 XF86MCAdaptorPtr
 xf86XvMCCreateAdaptorRec(void)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -107,7 +107,7 @@ option('xcsecurity', type: 'boolean', value: false,
        description: 'Security extension')
 option('xv', type: 'boolean', value: true,
        description: 'Xv extension')
-option('xvmc', type: 'boolean', value: true,
+option('xvmc', type: 'boolean', value: false,
        description: 'XvMC extension')
 option('dga', type: 'combo', choices: ['true', 'false', 'auto'], value: 'auto',
        description: 'DGA extension')

--- a/mi/miinitext.c
+++ b/mi/miinitext.c
@@ -154,7 +154,9 @@ static const ExtensionModule staticExtensions[] = {
 #endif
 #ifdef XV
     {XvExtensionInit, "XVideo", &noXvExtension},
+#ifdef XvMCExtension
     {XvMCExtensionInit, "XVideo-MotionCompensation", &noXvExtension},
+#endif
 #endif
 #ifdef XSELINUX
     {SELinuxExtensionInit, "SELinux", &noSELinuxExtension},

--- a/miext/extinit_priv.h
+++ b/miext/extinit_priv.h
@@ -62,7 +62,9 @@ void XkbExtensionInit(void);
 void SELinuxExtensionInit(void);
 void XTestExtensionInit(void);
 void XvExtensionInit(void);
+#ifdef XvMCExtension
 void XvMCExtensionInit(void);
+#endif
 void dri3_extension_init(void);
 void PseudoramiXExtensionInit(void);
 void present_extension_init(void);


### PR DESCRIPTION
XvMC is only helpful for old MPEG2 decoding (and here only some specific
part, the motion compensation). It's only supported by few cards, and needs
special client-side drivers, which need to have direct and pretty low-level
(non-DRI) GPU access (usually involving root access).

Since it's local-only anyways, modern clients can use generic GPU shaders
for various video formats (via standard DRI/mesa) and send whole frames.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
