### PR TITLE
(release/25.1) hw/xfree86/glamor_egl: do not link staticaly glx library

### DIFF
--- a/glx/extension_string.h
+++ b/glx/extension_string.h
@@ -34,6 +34,8 @@
 #ifndef GLX_EXTENSION_STRING_H
 #define GLX_EXTENSION_STRING_H
 
+#include <X11/Xfuncproto.h>
+
 enum {
 /*   GLX_ARB_get_proc_address is implemented on the client. */
     ARB_context_flush_control_bit = 0,
@@ -74,9 +76,16 @@ enum {
 
 #define __GLX_EXT_BYTES ((__NUM_GLX_EXTS + 7) / 8)
 
+/* exported for glamor */
+_X_EXPORT
 extern int __glXGetExtensionString(const unsigned char *enable_bits,
                                    char *buffer);
+/* exported for glamor */
+_X_EXPORT
 extern void __glXEnableExtension(unsigned char *enable_bits, const char *ext);
+
+/* exported for glamor */
+_X_EXPORT
 extern void __glXInitExtensionEnableBits(unsigned char *enable_bits);
 
 #endif                          /* GLX_EXTENSION_STRING_H */

--- a/glx/glxscreens.h
+++ b/glx/glxscreens.h
@@ -145,7 +145,10 @@ struct __GLXscreen {
     unsigned char glx_enable_bits[__GLX_EXT_BYTES];
 };
 
-void __glXScreenInit(__GLXscreen * screen, ScreenPtr pScreen);
-void __glXScreenDestroy(__GLXscreen * screen);
+/* exported for glamor */
+_X_EXPORT void __glXScreenInit(__GLXscreen * screen, ScreenPtr pScreen);
+
+/* exported for glamor */
+_X_EXPORT void __glXScreenDestroy(__GLXscreen * screen);
 
 #endif                          /* !__GLX_screens_h__ */

--- a/glx/glxserver.h
+++ b/glx/glxserver.h
@@ -93,7 +93,9 @@ void glxResumeClients(void);
 
 typedef void (*glx_func_ptr)(void);
 typedef glx_func_ptr (*glx_gpa_proc)(const char *);
-void __glXsetGetProcAddress(glx_gpa_proc get_proc_address);
+
+/* exported for glamor */
+_X_EXPORT void __glXsetGetProcAddress(glx_gpa_proc get_proc_address);
 void *__glGetProcAddress(const char *);
 
 void

--- a/glx/glxutil.h
+++ b/glx/glxutil.h
@@ -1,6 +1,8 @@
 #ifndef _glxcmds_h_
 #define _glxcmds_h_
 
+#include <X11/Xfuncproto.h>
+
 /*
  * SGI FREE SOFTWARE LICENSE B (Version 2.0, Sept. 18, 2008)
  * Copyright (C) 1991-2000 Silicon Graphics, Inc. All Rights Reserved.
@@ -30,7 +32,9 @@
  * other dealings in this Software without prior written authorization from
  * Silicon Graphics, Inc.
  */
-
+ 
+/* exported for glamor */
+_X_EXPORT
 extern GLboolean __glXDrawableInit(__GLXdrawable * drawable,
                                    __GLXscreen * screen,
                                    DrawablePtr pDraw, int type, XID drawID,

--- a/hw/xfree86/glamor_egl/meson.build
+++ b/hw/xfree86/glamor_egl/meson.build
@@ -15,7 +15,7 @@ shared_module(
         dependency('libdrm', version: '>= 2.4.46'),
         gbm_dep,
     ],
-    link_with: [glamor, libxserver_glx],
+    link_with: [glamor ],
 
     install: true,
     install_dir: module_abi_dir,

--- a/include/glx_extinit.h
+++ b/include/glx_extinit.h
@@ -41,6 +41,8 @@ struct __GLXprovider {
 };
 extern __GLXprovider __glXDRISWRastProvider;
 
+/* exported for glamor */
+_X_EXPORT
 void GlxPushProvider(__GLXprovider * provider);
 Bool xorgGlxCreateVendor(void);
 #else


### PR DESCRIPTION
### Backport dashboard

Master: #3213 ✅ merged

| Branch | PR | Status |
|---|---|---|
| release/25.1 | #3472 | ⬜ open ← this PR |

<sub>Auto-generated backport dashboard — links the source master PR and sibling backports with their merge status.</sub>

---

**Backport of #3213** to `release/25.1`.

Backports **both** commits of master PR #3213 (merge `6c75731752`): the
meson `link_with` fix (drop `libxserver_glx`) and its prerequisite commit
`9b74a3a7f9a2` that `_X_EXPORT`s the GLX symbols glamor needs. Paths
auto-remapped for the `Xext/glx/` → `glx/` reorg (`glx/extension_string.h`,
`glxscreens.h`, `glxserver.h`, `glxutil.h`, `include/glx_extinit.h`);
`glx/glxutil.h` additionally gains an explicit `#include <X11/Xfuncproto.h>`
(it no longer pulls in `glxserver.h` on this branch).

---

Commit a987fc7c360fa1c59efa0dde61316d84c171801b linked glx library
statically, which leaded dublicated glx extension symbols in glx.so and
glamoregl.so libraries. This commit do not link glx directly.

Signed-off-by: Tautvis <gtautvis@gmail.com>
(cherry picked from commit 6c7573175290ac0a03016d822104b67e1e0bac70)
