### PR TITLE
(master) CI/hurd: pin git/git-man to unreleased when sid toolchain is unresolvable

### DIFF
--- a/.github/scripts/hurd/run-xserver-build.sh
+++ b/.github/scripts/hurd/run-xserver-build.sh
@@ -22,9 +22,20 @@ sudo apt-get update
 # Toolchain MUST succeed (apt is transactional: one unlocatable package aborts
 # the whole install, so keep the essentials separate from the maybe-renamed X
 # libs — otherwise a missing lib takes git/meson down with it, as it did).
+# debian-ports can briefly hold an inconsistent sid/unreleased state for
+# hurd-amd64: the arch:all git-man moves ahead (e.g. 2.55.0-1) while the hurd
+# git binary lags behind, so plain `git` is unresolvable ("git-man (<< ...)
+# ... not installable"). Fall back to the coherent git/git-man pair pinned to
+# unreleased (e.g. 2.53.0-1+hurd.1); drop this once the ports buildd catches up.
 echo "==> install toolchain (required)"
-sudo apt-get install -y --no-install-recommends \
+if ! sudo apt-get install -y --no-install-recommends \
     git build-essential meson ninja-build pkg-config ca-certificates
+then
+    echo "==> toolchain install failed; retrying with git/git-man pinned to unreleased"
+    sudo apt-get install -y --no-install-recommends \
+        git/unreleased git-man/unreleased build-essential meson ninja-build \
+        pkg-config ca-certificates
+fi
 
 # X libraries + helpers: best-effort, one at a time, so a package the Hurd port
 # lacks or renames only skips itself (named in the log); meson then reports what


### PR DESCRIPTION
## Summary

Fixes the `xserver-build-hurd` CI lane failing before any build step due to a
debian-ports package inconsistency for `hurd-amd64` (infra break, unrelated to
any code change — currently fails every PR, e.g. #3470 and any master run).

### Root cause

The arch:all `git-man` in sid moved ahead (`1:2.55.0-1`) while the hurd `git`
binary lags (`1:2.51.0-1` in sid, `1:2.53.0-1+hurd.1` in unreleased). apt picks
the newer `git-man` from sid over the coherent unreleased pair, so git's
`git-man (<< 1:2.53.0-.)` constraint can never be satisfied:

```
git:hurd-amd64=1:2.53.0-1+hurd.1 Depends git-man (< 1:2.53.0-.)
but none of the choices are installable
E: Unable to satisfy dependencies.
```

### Fix

In `.github/scripts/hurd/run-xserver-build.sh`, retry the toolchain install
with `git/unreleased git-man/unreleased` pinned when the plain install fails.

### Out of scope / follow-up

Remove the fallback once the debian-ports buildd rebuilds git for hurd-amd64
(then the plain install always succeeds). The existing parked dashboard topic
`xlibre/ci-hurd-lane-apt-deps` tracks this.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>