### PR TITLE
(master) include: compiler.h: drop noop for barrier(), mem_barrier(), write_mem_barrier()

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -119,18 +119,6 @@
 #endif
 #endif                          /* __GNUC__ */
 
-#ifndef barrier
-#define barrier()
-#endif
-
-#ifndef mem_barrier
-#define mem_barrier()           /* NOP */
-#endif
-
-#ifndef write_mem_barrier
-#define write_mem_barrier()     /* NOP */
-#endif
-
 #ifdef __GNUC__
 #if defined(__alpha__)
 


### PR DESCRIPTION
These are fallback definitions for the case we're on some platform that doesn't
have them defined above. While it seens comfortable to do so, it has the big
drawback that we don't see if some platform is missing here.

Therefore, drop them, so we'll actually see FTBS on unsupported platform
and then implement the necessary pieces.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
