### PR TITLE
(master) include: compiler.h: inline sparc barrier() macro

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -110,7 +110,6 @@
 
 #elif defined __sparc__
 
-#define barrier() __asm__ __volatile__ (".word 0x8143e00a" : : : "memory")
 #define mem_barrier()           /* XXX: nop for now */
 #define write_mem_barrier()     /* XXX: nop for now */
 #endif
@@ -247,8 +246,7 @@ outb(unsigned long port, unsigned char val)
 {
     __asm__ __volatile__("stba %0, [%1] %2":    /* No outputs */
                          :"r"(val), "r"(port), "i"(ASI_PL));
-
-    barrier();
+    __asm__ __volatile__ (".word 0x8143e00a" : : : "memory");
 }
 
 static inline void
@@ -256,8 +254,7 @@ outw(unsigned long port, unsigned short val)
 {
     __asm__ __volatile__("stha %0, [%1] %2":    /* No outputs */
                          :"r"(val), "r"(port), "i"(ASI_PL));
-
-    barrier();
+    __asm__ __volatile__ (".word 0x8143e00a" : : : "memory");
 }
 
 static inline void
@@ -265,8 +262,7 @@ outl(unsigned long port, unsigned int val)
 {
     __asm__ __volatile__("sta %0, [%1] %2":     /* No outputs */
                          :"r"(val), "r"(port), "i"(ASI_PL));
-
-    barrier();
+    __asm__ __volatile__ (".word 0x8143e00a" : : : "memory");
 }
 
 static inline unsigned int
@@ -367,8 +363,7 @@ xf86WriteMmio8(__volatile__ void *base, const unsigned long offset,
 
     __asm__ __volatile__("stba %0, [%1] %2":    /* No outputs */
                          :"r"(val), "r"(addr), "i"(ASI_PL));
-
-    barrier();
+    __asm__ __volatile__ (".word 0x8143e00a" : : : "memory");
 }
 
 static inline void
@@ -379,8 +374,7 @@ xf86WriteMmio16Be(__volatile__ void *base, const unsigned long offset,
 
     __asm__ __volatile__("sth %0, [%1]":        /* No outputs */
                          :"r"(val), "r"(addr));
-
-    barrier();
+    __asm__ __volatile__ (".word 0x8143e00a" : : : "memory");
 }
 
 static inline void
@@ -391,8 +385,7 @@ xf86WriteMmio16Le(__volatile__ void *base, const unsigned long offset,
 
     __asm__ __volatile__("stha %0, [%1] %2":    /* No outputs */
                          :"r"(val), "r"(addr), "i"(ASI_PL));
-
-    barrier();
+    __asm__ __volatile__ (".word 0x8143e00a" : : : "memory");
 }
 
 static inline void
@@ -403,8 +396,7 @@ xf86WriteMmio32Be(__volatile__ void *base, const unsigned long offset,
 
     __asm__ __volatile__("st %0, [%1]": /* No outputs */
                          :"r"(val), "r"(addr));
-
-    barrier();
+    __asm__ __volatile__ (".word 0x8143e00a" : : : "memory");
 }
 
 static inline void
@@ -415,8 +407,7 @@ xf86WriteMmio32Le(__volatile__ void *base, const unsigned long offset,
 
     __asm__ __volatile__("sta %0, [%1] %2":     /* No outputs */
                          :"r"(val), "r"(addr), "i"(ASI_PL));
-
-    barrier();
+    __asm__ __volatile__ (".word 0x8143e00a" : : : "memory");
 }
 
 #elif defined(__arm32__) && !defined(__linux__)


### PR DESCRIPTION
This macro is only defined on sparc and used in sparc-specific
inline functions, so we can directly inline that one line into
those inline functions.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
