### PR TITLE
(master) include: new header for arch specific membarrier inline functions

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -48,68 +48,13 @@
  */
 
 #ifndef _COMPILER_H
-
 #define _COMPILER_H
 
 #ifndef _X_EXPORT
 #include <X11/Xfuncproto.h>
 #endif
 
-#include <pixman.h>             /* for uint*_t types */
-
-#ifdef __i386__
-
-#ifdef __SSE__
-#define write_mem_barrier() __asm__ __volatile__ ("sfence" : : : "memory")
-#else
-#define write_mem_barrier() __asm__ __volatile__ ("lock; addl $0,0(%%esp)" : : : "memory")
-#endif
-
-#ifdef __SSE2__
-#define mem_barrier() __asm__ __volatile__ ("mfence" : : : "memory")
-#else
-#define mem_barrier() __asm__ __volatile__ ("lock; addl $0,0(%%esp)" : : : "memory")
-#endif
-
-#elif defined __alpha__
-
-#define mem_barrier() __asm__ __volatile__ ("mb" : : : "memory")
-#define write_mem_barrier() __asm__ __volatile__ ("wmb" : : : "memory")
-
-#elif defined __amd64__
-
-#define mem_barrier() __asm__ __volatile__ ("mfence" : : : "memory")
-#define write_mem_barrier() __asm__ __volatile__ ("sfence" : : : "memory")
-
-#elif defined __ia64__
-
-#define mem_barrier()        __asm__ __volatile__ ("mf" : : : "memory")
-#define write_mem_barrier()  __asm__ __volatile__ ("mf" : : : "memory")
-
-#elif defined __mips__
-     /* Note: sync instruction requires MIPS II instruction set */
-#define mem_barrier()		\
-	__asm__ __volatile__(		\
-		".set   push\n\t"	\
-		".set   noreorder\n\t"	\
-		".set   mips2\n\t"	\
-		"sync\n\t"		\
-		".set   pop"		\
-		: /* no output */	\
-		: /* no input */	\
-		: "memory")
-#define write_mem_barrier() mem_barrier()
-
-#elif defined __powerpc__
-
-#define mem_barrier()       __builtin_ppc_eieio()
-#define write_mem_barrier() __builtin_ppc_eieio()
-
-#elif defined __sparc__
-
-#define mem_barrier()           /* XXX: nop for now */
-#define write_mem_barrier()     /* XXX: nop for now */
-#endif
+#include "xlibre_membarrier.h" /* backwards compat, remove in ABI-26 */
 
 #if defined(__alpha__)
 

--- a/include/meson.build
+++ b/include/meson.build
@@ -571,6 +571,7 @@ if build_xorg_sdk
             'xf86Crtc.h',
             'xf86Modes.h',
             'xf86RandR12.h',
+            'xlibre_membarrier.h',
         ],
         install_dir: xorgsdkdir,
     )

--- a/include/xlibre_membarrier.h
+++ b/include/xlibre_membarrier.h
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
+ *
+ * @brief platform/architecture specific memory barrier functions
+ *
+ * Copyright © 2026 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef __XLIBRE_SDK_MEMBARRIER_H
+#define __XLIBRE_SDK_MEMBARRIER_H
+
+__attribute__((always_inline)) static inline void xlibre_mem_barrier_read(void)
+{
+#ifdef __i386__
+#  ifdef __SSE2__
+    __asm__ __volatile__ ("mfence" : : : "memory");
+#  else
+    __asm__ __volatile__ ("lock; addl $0,0(%%esp)" : : : "memory");
+#  endif
+#elif defined __alpha__
+    __asm__ __volatile__ ("mb" : : : "memory");
+#elif defined __amd64__
+    __asm__ __volatile__ ("mfence" : : : "memory");
+#elif defined __ia64__
+    __asm__ __volatile__ ("mf" : : : "memory");
+#elif defined __mips__
+    __asm__ __volatile__(
+        ".set   push\n\t"
+        ".set   noreorder\n\t"
+        ".set   mips2\n\t"
+        "sync\n\t"
+        ".set   pop"
+        : /* no output */
+        : /* no input */
+        : "memory");
+#elif defined __powerpc__
+    __builtin_ppc_eieio();
+#elif defined __sparc__
+    /* NOP */
+#endif
+}
+
+__attribute__((always_inline)) static inline void xlibre_mem_barrier_write(void)
+{
+#ifdef __i386__
+#ifdef __SSE__
+    __asm__ __volatile__ ("sfence" : : : "memory");
+#else
+    __asm__ __volatile__ ("lock; addl $0,0(%%esp)" : : : "memory");
+#endif
+#elif defined __alpha__
+    __asm__ __volatile__ ("wmb" : : : "memory");
+#elif defined __amd64__
+    __asm__ __volatile__ ("sfence" : : : "memory");
+#elif defined __ia64__
+    __asm__ __volatile__ ("mf" : : : "memory");
+#elif defined __mips__
+    mem_barrier();
+#elif defined __powerpc__
+    __builtin_ppc_eieio();
+#elif defined __sparc__
+    /* NOP */
+#endif
+}
+
+/*
+ * @deprecated just backwards compat with older drivers - will be removed in ABI-26
+ */
+__attribute__((always_inline)) static inline void mem_barrier(void) {
+    xlibre_mem_barrier_read();
+}
+
+/*
+ * @deprecated just backwards compat with older drivers - will be removed in ABI-26
+ */
+__attribute__((always_inline)) static inline void write_mem_barrier(void) {
+    xlibre_mem_barrier_write();
+}
+
+#endif /* __XLIBRE_SDK_MEMBARRIER_H */


### PR DESCRIPTION
replace the macro wood in compiler.h by a set of inline functions,
placed in a separate header file. for backwards compat, compiler.h
will always include that new header, and the header defines inline's
providing the old names.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
