### PR TITLE
modesetting: force software cursor for virutal gpus

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -1018,6 +1018,35 @@ ms_window_update_async_flip_modifiers(WindowPtr win, Bool async_flip)
     priv->async_flip_modifiers = async_flip;
 }
 
+/**
+ * This function exist because there are necesary extra work around for correct behaviour,
+ * for example: force software rendering for cursor.
+ */
+static inline bool
+ms_is_running_virtual_gpu(drmmode_ptr drmmode)
+{
+    drmVersionPtr version = drmGetVersion(drmmode->fd);
+    if (!version) {
+        return false;
+    }
+
+    if (!version->name ||
+        strstr(version->name, "bochs-drm") ||
+        strstr(version->name, "evdi") ||
+        strstr(version->name, "vboxvideo") ||
+        strstr(version->name, "virtio_gpu") ||
+        strstr(version->name, "vkms") ||
+        strstr(version->name, "vmwgfx") ||
+        strstr(version->name, "qxl" )) {
+        drmFreeVersion(version);
+        return true;
+    }
+
+    drmFreeVersion(version);
+    return false;
+}
+
+
 static void
 FreeScreen(ScrnInfoPtr pScrn)
 {
@@ -1331,6 +1360,27 @@ PreInit(ScrnInfoPtr pScrn, int flags)
 
     if (xf86ReturnOptValBool(ms->drmmode.Options, OPTION_SW_CURSOR, FALSE)) {
         ms->drmmode.sw_cursor = TRUE;
+    } else {
+        /* we have situation where cursor in virtual envirioment doesn't work as expected and can be confusing for users, for example under qemu:
+         * - if display backend is `gtk`, by default cursor is showed when window is out of focus and hidden when in focus (it have to be rendered by vm gpu in software).
+         * - if display backend us `sdl` it always shows cursor regardless of drmModeSetCursor2 & friends settings
+         * - if vm run under spice backed using qxl display, the rendering application (remote-viewer) behaves correctly
+         *  for more detail see : https://www.qemu.org/docs/master/system/qemu-manpage.html search `show-cursor`
+         *
+         *  until better solution is found, force software cursor
+        */
+        if (ms_is_running_virtual_gpu(&ms->drmmode)){
+
+            drmVersionPtr version = drmGetVersion(ms->drmmode.fd);
+            const char *name="N/A";
+            if (version){
+                name = version->name;
+            }
+            xf86DrvMsg(pScrn->scrnIndex, X_WARNING, "Forcing software cursor on virtual machine driver %s due to known issues\n", name);
+            drmFreeVersion(version);
+
+            ms->drmmode.sw_cursor = TRUE;
+        }
     }
 
     try_enable_glamor(pScrn);

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -4654,39 +4654,6 @@ drmmode_reset_cursor(drmmode_crtc_private_ptr drmmode_crtc)
     drmmode_crtc->cursor_pitches = NULL;
 }
 
-/**
- * Some setups have different requirements for the
- * cursor pitch compared to intel and nvidia.
- *
- * See: https://github.com/X11Libre/xserver/issues/1816
- *
- * This function detects whether we are running in a vm,
- * or on bare metal.
- *
- * Driver names are taken from https://drmdb.emersion.fr/drivers
- */
-static inline Bool
-drmmode_legacy_cursor_probe_allowed(drmmode_ptr drmmode)
-{
-    drmVersionPtr version = drmGetVersion(drmmode->fd);
-    if (!version) {
-        return FALSE;
-    }
-
-    if (!version->name ||
-        strstr(version->name, "bochs-drm") ||
-        strstr(version->name, "evdi") ||
-        strstr(version->name, "vboxvideo") ||
-        strstr(version->name, "virtio_gpu") ||
-        strstr(version->name, "vkms") ||
-        strstr(version->name, "vmwgfx")) {
-        drmFreeVersion(version);
-        return FALSE;
-    }
-
-    drmFreeVersion(version);
-    return TRUE;
-}
 
 /*
  * This is the old probe method for the minimum cursor size.
@@ -4707,10 +4674,6 @@ static void drmmode_probe_cursor_size(xf86CrtcPtr crtc)
     }
 
     drmmode_crtc->cursor_probed = TRUE;
-
-    if (!drmmode_legacy_cursor_probe_allowed(drmmode)) {
-        return;
-    }
 
     xf86DrvMsg(crtc->scrn->scrnIndex, X_WARNING,
                "Probing the cursor size using the old method\n");

--- a/hw/xfree86/drivers/video/modesetting/modesetting.man
+++ b/hw/xfree86/drivers/video/modesetting/modesetting.man
@@ -48,6 +48,10 @@ are supported:
 .BI "Option \*qSWcursor\*q \*q" boolean \*q
 Selects software cursor.  The default is
 .B off.
+
+Note: due to issues with cursor rendering this option will be forced
+.B on
+if it is running under bochs-drm, evdi, vboxvideo, virtio_gpu, vkms, vmwgfx or qxl drm driver.
 .TP
 .BI "Option \*qCursorSize\*q \*q" string \*q
 The size of the cursor.


### PR DESCRIPTION
*edited to force software cursor if virutal gpu detected*

Force software cursor virtual gpu driver detected and not rely on frontend compostion.
 
When a hardware cursor is used with QXL or VirtIO-GPU, its behavior depends on the frontend behaviour (application window) of the virtualization software. With QEMU, this behavior is inconsistent when used with default parameters:
- `-display gtk` shows the cursor by default when the window loses focus and hides it when focus is regained.
- `-display sdl` keeps the cursor visible by default.
- with the QXL driver via the SPICE remote-viewer, the cursor sprite blended, but shows interleaving bugs.

Until we found fix with consistent behavior by default (when no SWCursor option is given) force software cursor.

---

## Backport

| Target branch | Backport PR | Status |
|---------------|-------------|--------|
| `release/25.2` | [open](https://github.com/X11Libre/xserver/pull/3649) | 🔄 Open |
| `release/25.1` | [open](https://github.com/X11Libre/xserver/pull/3650) | 🔄 Open |
| `release/25.0` | [open](https://github.com/X11Libre/xserver/pull/3651) | 🔄 Open |
