### PR TITLE
(master) include: compiler.h: use <sys/mman.h> instead of MAP_FAILED fallback in powerpc branch

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -428,9 +428,7 @@ xf86WriteMmio32Be(__volatile__ void *base, const unsigned long offset,
 
 #elif defined(__powerpc__)
 
-#ifndef MAP_FAILED
-#define MAP_FAILED ((void *)-1)
-#endif
+#include <sys/mman.h>
 
 extern _X_EXPORT volatile unsigned char *ioBase;
 


### PR DESCRIPTION
In the `__powerpc__` branch of `include/compiler.h` the in/out port-I/O accessors
compare `ioBase` against `MAP_FAILED`. The header currently provides a hand-rolled
`#ifndef MAP_FAILED / #define MAP_FAILED ((void *)-1)` fallback for that.

`MAP_FAILED` is POSIX-mandated and provided by `<sys/mman.h>` on every powerpc
platform the server builds on (Linux, the BSDs, Darwin) — the hand-written
fallback only serves antique C libraries. This drops it and includes the
authoritative system definition instead, scoped to the powerpc branch (the only
branch using `MAP_FAILED`).

Note: driver source that includes `compiler.h` and uses these accessors (e.g.
`xf86-video-tdfx`'s `tdfx_io.c`) never includes `<sys/mman.h>` itself, so this
include also keeps `MAP_FAILED` in scope for those out-of-tree consumers.
