### PR TITLE
(master) include: compiler.h: restore MIPS port I/O port access (12-year-old bug)

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -398,9 +398,47 @@ inl(unsigned long port)
                                        IOPortBase);
 }
 
-#if defined(__mips__)
-#ifdef __linux__                    /* don't mess with other OSs */
-#if X_BYTE_ORDER == X_BIG_ENDIAN
+#elif defined(__mips__)
+
+#  if defined(__mips64)
+#    define __XLIBRE_MIPS_PORT_TYPE unsigned long
+#    define __XLIBRE_MIPS_PORT_ADDR(port) (((unsigned long)(port)) + IOPortBase)
+#  else
+#    define __XLIBRE_MIPS_PORT_TYPE unsigned short
+#    define __XLIBRE_MIPS_PORT_ADDR(port) (((unsigned short)(port)) + IOPortBase)
+#  endif
+
+extern _X_EXPORT unsigned int IOPortBase;      /* Memory mapped I/O port area */
+
+static inline void outb(__XLIBRE_MIPS_PORT_TYPE port, unsigned char val) {
+    *(volatile unsigned char *)(__XLIBRE_MIPS_PORT_ADDR(port)) = val;
+}
+
+static inline void outw(__XLIBRE_MIPS_PORT_TYPE port, unsigned short val) {
+    *(volatile unsigned short *)(__XLIBRE_MIPS_PORT_ADDR(port)) = val;
+}
+
+static inline void outl(__XLIBRE_MIPS_PORT_TYPE port, unsigned int val) {
+    *(volatile unsigned int *)(__XLIBRE_MIPS_PORT_ADDR(port)) = val;
+}
+
+static inline unsigned int inb(__XLIBRE_MIPS_PORT_TYPE port) {
+    return *(volatile unsigned char *)(__XLIBRE_MIPS_PORT_ADDR(port));
+}
+
+static inline unsigned int inw(__XLIBRE_MIPS_PORT_TYPE port) {
+    return *(volatile unsigned short *)(__XLIBRE_MIPS_PORT_ADDR(port));
+}
+
+static inline unsigned int inl(__XLIBRE_MIPS_PORT_TYPE port) {
+    return *(volatile unsigned int *)(__XLIBRE_MIPS_PORT_ADDR(port));
+}
+
+#  undef __XLIBRE_MIPS_PORT_TYPE
+#  undef __XLIBRE_MIPS_PORT_ADDR
+
+#  ifdef __linux__                    /* don't mess with other OSs */
+#    if X_BYTE_ORDER == X_BIG_ENDIAN
 static inline unsigned int
 xf86ReadMmio32Be(__volatile__ void *base, const unsigned long offset)
 {
@@ -422,9 +460,8 @@ xf86WriteMmio32Be(__volatile__ void *base, const unsigned long offset,
     __asm__ __volatile__("sw %0, 0(%1)":        /* No outputs */
                          :"r"(val), "r"(addr));
 }
-#endif
-#endif                          /* !__linux__ */
-#endif                          /* __mips__ */
+#    endif /* X_BYTE_ORDER == X_BIG_ENDIAN */
+#  endif /* __linux__ */
 
 #elif defined(__powerpc__)
 


### PR DESCRIPTION
With commit b5141a1fab4d45c1af62db8dc712deb9776668a9 (2014-07-22,
"xfree86: Simplify a bunch of OS and arch conditionals"), the MIPS
port I/O and MMIO code has been incorrectly nested inside the
`#elif defined(__arm32__) && !defined(__linux__)` - thus impossible
to ever become active.

Ergo: MIPS support was broken all the time, Xservers compiled on MIPS
lacked basic IO support.

Fixes: b5141a1fab4d45c1af62db8dc712deb9776668a9
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>

---

## Backport Dashboard

| Branch | Status | PR |
|--------|--------|----|
| `release/25.2` | 🔄 Open | [#3499](https://github.com/X11Libre/xserver/pull/3499) |
| `release/25.1` | 🔄 Open | [#3497](https://github.com/X11Libre/xserver/pull/3497) |
| `release/25.0` | 🔄 Open | [#3498](https://github.com/X11Libre/xserver/pull/3498) |