### PR TITLE
(master) include: compiler.h: use internally

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -632,37 +632,37 @@ inl(unsigned short port)
 
 static inline int MMIO_IN8(void *Base, unsigned long Offset)
 {
-    mem_barrier();
+    xlibre_mem_barrier_read();
     return *(CARD8 *) ((unsigned long) Base + (Offset));
 }
 
 static inline int MMIO_IN16(void *Base, unsigned long Offset)
 {
-    mem_barrier();
+    xlibre_mem_barrier_read();
     return *(CARD16 *) ((unsigned long) Base + (Offset));
 }
 
 static inline int MMIO_IN32(void *Base, unsigned long Offset)
 {
-    mem_barrier();
+    xlibre_mem_barrier_read();
     return *(CARD32 *) ((unsigned long) Base + (Offset));
 }
 
 static inline void MMIO_OUT8(void *Base, unsigned long Offset, int Value)
 {
-    write_mem_barrier();
+    xlibre_mem_barrier_write();
     *(CARD8 *) ((unsigned long) Base + (Offset)) = Value;
 }
 
 static inline void MMIO_OUT16(void *Base, unsigned long Offset, int Value)
 {
-    write_mem_barrier();
+    xlibre_mem_barrier_write();
     *(CARD16 *) ((unsigned long) Base + (Offset)) = Value;
 }
 
 static inline void MMIO_OUT32(void *Base, unsigned long Offset, int Value)
 {
-    write_mem_barrier();
+    xlibre_mem_barrier_write();
     *(CARD32 *) ((unsigned long) Base + (Offset)) = Value;
 }
 


### PR DESCRIPTION
since 17227134f8dce027cec390f44d3fdb07823a8e3d we have our new
xlibre_mem_barrier_(read|write) functions, which are wrapped by
the old mem_barrier() and write_mem_barrier() functions.

Not it's a good time for getting rid of that indirection within
the header. The wrappers are still available for driver compat.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
