### PR TITLE
(master) xfree86: os-support: sparc: drop some obsolete asm functions

### DIFF
--- a/hw/xfree86/os-support/solaris/solaris-sparcv8plus.S
+++ b/hw/xfree86/os-support/solaris/solaris-sparcv8plus.S
@@ -114,25 +114,3 @@
 	sta	%o2, [%o0 + %o1] 0x88
 	membar	#StoreStore|#StoreLoad
 	FUNCTION_END(xf86WriteMmio32Le)
-
-	FUNCTION_START(xf86WriteMmio8NB, 0)
-	add	%o0, %o1, %o0
-	stba	%o2, [%o0] 0x88
-	FUNCTION_END(xf86WriteMmio8NB)
-
-	FUNCTION_START(xf86WriteMmio16BeNB, 0)
-	sth	%o2, [%o0 + %o1]
-	FUNCTION_END(xf86WriteMmio16BeNB)
-
-	FUNCTION_START(xf86WriteMmio16LeNB, 0)
-	stha	%o2, [%o0 + %o1] 0x88
-	FUNCTION_END(xf86WriteMmio16LeNB)
-
-	FUNCTION_START(xf86WriteMmio32BeNB, 0)
-	st	%o2, [%o0 + %o1]
-	FUNCTION_END(xf86WriteMmio32BeNB)
-
-	FUNCTION_START(xf86WriteMmio32LeNB, 0)
-	sta	%o2, [%o0 + %o1] 0x88
-	FUNCTION_END(xf86WriteMmio32LeNB)
-


### PR DESCRIPTION
those haven't been used (neither by xserver nor drivers) for
long time now, so let's drop the old remains.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
