### PR TITLE
(master) xfree86: int10: move private definitions out of public header

### DIFF
--- a/hw/xfree86/int10/generic.c
+++ b/hw/xfree86/int10/generic.c
@@ -13,7 +13,6 @@
 #include "xf86_OSproc.h"
 #include "xf86Bus.h"
 #include "compiler.h"
-#define _INT10_PRIVATE
 #include "xf86int10_priv.h"
 #include "int10Defines.h"
 #include "Pci.h"

--- a/hw/xfree86/int10/helper_exec.c
+++ b/hw/xfree86/int10/helper_exec.c
@@ -25,7 +25,6 @@
 #include "xf86_OSproc.h"
 #include "xf86Bus.h"
 #include "compiler.h"
-#define _INT10_PRIVATE
 #include "int10Defines.h"
 #include "xf86int10_priv.h"
 #include "Pci.h"

--- a/hw/xfree86/int10/helper_mem.c
+++ b/hw/xfree86/int10/helper_mem.c
@@ -12,10 +12,6 @@
 #include "xf86_OSproc.h"
 #include "compiler.h"
 #include "xf86Pci.h"
-#define _INT10_PRIVATE
-#if 0
-#include "int10Defines.h"
-#endif
 #include "xf86int10_priv.h"
 
 #define REG pInt

--- a/hw/xfree86/int10/stub.c
+++ b/hw/xfree86/int10/stub.c
@@ -8,8 +8,7 @@
 #include "xf86.h"
 #include "xf86str.h"
 #include "xf86_OSproc.h"
-#define _INT10_PRIVATE
-#include "xf86int10.h"
+#include "xf86int10_priv.h"
 
 xf86Int10InfoPtr
 xf86InitInt10(int entityIndex)

--- a/hw/xfree86/int10/xf86int10.c
+++ b/hw/xfree86/int10/xf86int10.c
@@ -7,7 +7,6 @@
 
 #include "xf86.h"
 #include "compiler.h"
-#define _INT10_PRIVATE
 #include "xf86int10_priv.h"
 #include "int10Defines.h"
 #include "Pci.h"

--- a/hw/xfree86/int10/xf86int10_priv.h
+++ b/hw/xfree86/int10/xf86int10_priv.h
@@ -5,19 +5,68 @@
  *
  *                   XFree86 int10 module
  *   execute BIOS int 10h calls in x86 real mode environment
+ *   Private internal definitions - NOT part of public DDX ABI
  */
-#ifndef _XSERVER_XF86INT10_H
-#define _XSERVER_XF86INT10_H
+#ifndef _XSERVER_XF86INT10_PRIV_H
+#define _XSERVER_XF86INT10_PRIV_H
 
 #include <X11/Xmd.h>
 #include <X11/Xdefs.h>
 #include "xf86Pci.h"
 #include "xf86int10.h"
 
-#ifdef _INT10_PRIVATE
+/* Private typedefs */
+typedef struct {
+    uint8_t save_msr;
+    uint8_t save_pos102;
+    uint8_t save_vse;
+    uint8_t save_46e8;
+} legacyVGARec, *legacyVGAPtr;
+
+/* Private macros and constants */
+#define I_S_DEFAULT_INT_VECT 0xFF065
+#define SYS_SIZE 0x100000
+#define SYS_BIOS 0xF0000
+#if 1
+#define BIOS_SIZE 0x10000
+#else                           /* a bug in DGUX requires this - let's try it */
+#define BIOS_SIZE (0x10000 - 1)
+#endif
+#define LOW_PAGE_SIZE 0x600
+#define V_RAM 0xA0000
+#define VRAM_SIZE 0x20000
+#define V_BIOS_SIZE 0x10000
+#define V_BIOS 0xC0000
+#define BIOS_SCRATCH_OFF 0x449
+#define BIOS_SCRATCH_END 0x466
+#define BIOS_SCRATCH_LEN (BIOS_SCRATCH_END - BIOS_SCRATCH_OFF + 1)
+#define HIGH_MEM V_BIOS
+#define HIGH_MEM_SIZE (SYS_BIOS - HIGH_MEM)
+#define SEG_ADR(type, seg, reg)  type((seg << 4) + (X86_##reg))
+#define SEG_EADR(type, seg, reg) type((seg << 4) + (X86_E##reg))
+
+#define X86_TF_MASK		0x00000100
+#define X86_IF_MASK		0x00000200
+#define X86_IOPL_MASK		0x00003000
+#define X86_NT_MASK		0x00004000
+#define X86_VM_MASK		0x00020000
+#define X86_AC_MASK		0x00040000
+#define X86_VIF_MASK		0x00080000      /* virtual interrupt flag */
+#define X86_VIP_MASK		0x00100000      /* virtual interrupt pending */
+#define X86_ID_MASK		0x00200000
+
+#define MEM_RB(name, addr)      (*(name)->mem->rb)((name), (addr))
+#define MEM_RW(name, addr)      (*(name)->mem->rw)((name), (addr))
+#define MEM_RL(name, addr)      (*(name)->mem->rl)((name), (addr))
+#define MEM_WB(name, addr, val) (*(name)->mem->wb)((name), (addr), (val))
+#define MEM_WW(name, addr, val) (*(name)->mem->ww)((name), (addr), (val))
+#define MEM_WL(name, addr, val) (*(name)->mem->wl)((name), (addr), (val))
+
+/* Private function declarations */
 
 /* int.c */
 int int_handler(xf86Int10InfoPtr pInt);
+extern _X_EXPORT xf86Int10InfoPtr Int10Current;
 
 /* helper_exec.c */
 int setup_int(xf86Int10InfoPtr pInt);
@@ -72,6 +121,14 @@ Bool initPrimary(const void *options);
 void dprint(unsigned long start, unsigned long size);
 #endif
 
-#endif                          /* _INT10_PRIVATE */
+/* OS dependent functions */
+_X_EXPORT Bool MapCurrentInt10(xf86Int10InfoPtr pInt);
 
-#endif /* _XSERVER_XF86INT10_H */
+/* x86 executor related functions */
+_X_EXPORT Bool xf86Int10ExecSetup(xf86Int10InfoPtr pInt);
+_X_EXPORT void xf86Int10SaveRestoreBIOSVars(xf86Int10InfoPtr pInt, Bool save);
+_X_EXPORT void *xf86HandleInt10Options(ScrnInfoPtr pScrn, int entityIndex);
+_X_EXPORT BusType xf86int10GetBiosLocationType(const xf86Int10InfoPtr pInt);
+_X_EXPORT Bool xf86int10GetBiosSegment(xf86Int10InfoPtr pInt, void *base);
+
+#endif /* _XSERVER_XF86INT10_PRIV_H */

--- a/hw/xfree86/int10/xf86x86emu.c
+++ b/hw/xfree86/int10/xf86x86emu.c
@@ -8,7 +8,6 @@
 #include "xf86.h"
 #include "xf86_OSproc.h"
 #include "xf86Pci.h"
-#define _INT10_PRIVATE
 #include "xf86int10_priv.h"
 #include "int10Defines.h"
 #include <x86emu.h>

--- a/hw/xfree86/os-support/linux/int10/linux.c
+++ b/hw/xfree86/os-support/linux/int10/linux.c
@@ -8,8 +8,7 @@
 #include "xf86_OSproc.h"
 #include "xf86Pci.h"
 #include "compiler.h"
-#define _INT10_PRIVATE
-#include "xf86int10.h"
+#include "xf86int10_priv.h"
 #ifdef __sparc__
 #define DEV_MEM "/dev/fb"
 #else

--- a/hw/xfree86/os-support/linux/int10/vm86/linux_vm86.c
+++ b/hw/xfree86/os-support/linux/int10/vm86/linux_vm86.c
@@ -7,8 +7,7 @@
 #include "xf86_OSproc.h"
 #include "xf86Pci.h"
 #include "compiler.h"
-#define _INT10_PRIVATE
-#include "xf86int10.h"
+#include "xf86int10_priv.h"
 
 #define REG pInt
 

--- a/include/xf86int10.h
+++ b/include/xf86int10.h
@@ -1,4 +1,3 @@
-
 /*
  *                   XFree86 int10 module
  *   execute BIOS int 10h calls in x86 real mode environment
@@ -53,13 +52,6 @@ typedef struct _int10Mem {
     void (*wl) (xf86Int10InfoPtr, int, uint32_t);
 } int10MemRec, *int10MemPtr;
 
-typedef struct {
-    uint8_t save_msr;
-    uint8_t save_pos102;
-    uint8_t save_vse;
-    uint8_t save_46e8;
-} legacyVGARec, *legacyVGAPtr;
-
 /* OS dependent functions */
 extern _X_EXPORT xf86Int10InfoPtr xf86InitInt10(int entityIndex);
 extern _X_EXPORT xf86Int10InfoPtr xf86ExtendedInitInt10(int entityIndex,
@@ -74,66 +66,4 @@ extern _X_EXPORT void *xf86int10Addr(xf86Int10InfoPtr pInt, uint32_t addr);
 /* x86 executor related functions */
 extern _X_EXPORT void xf86ExecX86int10(xf86Int10InfoPtr pInt);
 
-#ifdef _INT10_PRIVATE
-
-#define I_S_DEFAULT_INT_VECT 0xFF065
-#define SYS_SIZE 0x100000
-#define SYS_BIOS 0xF0000
-#if 1
-#define BIOS_SIZE 0x10000
-#else                           /* a bug in DGUX requires this - let's try it */
-#define BIOS_SIZE (0x10000 - 1)
-#endif
-#define LOW_PAGE_SIZE 0x600
-#define V_RAM 0xA0000
-#define VRAM_SIZE 0x20000
-#define V_BIOS_SIZE 0x10000
-#define V_BIOS 0xC0000
-#define BIOS_SCRATCH_OFF 0x449
-#define BIOS_SCRATCH_END 0x466
-#define BIOS_SCRATCH_LEN (BIOS_SCRATCH_END - BIOS_SCRATCH_OFF + 1)
-#define HIGH_MEM V_BIOS
-#define HIGH_MEM_SIZE (SYS_BIOS - HIGH_MEM)
-#define SEG_ADR(type, seg, reg)  type((seg << 4) + (X86_##reg))
-#define SEG_EADR(type, seg, reg) type((seg << 4) + (X86_E##reg))
-
-#define X86_TF_MASK		0x00000100
-#define X86_IF_MASK		0x00000200
-#define X86_IOPL_MASK		0x00003000
-#define X86_NT_MASK		0x00004000
-#define X86_VM_MASK		0x00020000
-#define X86_AC_MASK		0x00040000
-#define X86_VIF_MASK		0x00080000      /* virtual interrupt flag */
-#define X86_VIP_MASK		0x00100000      /* virtual interrupt pending */
-#define X86_ID_MASK		0x00200000
-
-#define MEM_RB(name, addr)      (*(name)->mem->rb)((name), (addr))
-#define MEM_RW(name, addr)      (*(name)->mem->rw)((name), (addr))
-#define MEM_RL(name, addr)      (*(name)->mem->rl)((name), (addr))
-#define MEM_WB(name, addr, val) (*(name)->mem->wb)((name), (addr), (val))
-#define MEM_WW(name, addr, val) (*(name)->mem->ww)((name), (addr), (val))
-#define MEM_WL(name, addr, val) (*(name)->mem->wl)((name), (addr), (val))
-
-/* OS dependent functions */
-extern _X_EXPORT Bool MapCurrentInt10(xf86Int10InfoPtr pInt);
-
-/* x86 executor related functions */
-extern _X_EXPORT Bool xf86Int10ExecSetup(xf86Int10InfoPtr pInt);
-
-/* int.c */
-extern _X_EXPORT xf86Int10InfoPtr Int10Current;
-
-#if defined (_PC)
-extern _X_EXPORT void xf86Int10SaveRestoreBIOSVars(xf86Int10InfoPtr pInt,
-                                                   Bool save);
-#endif
-
-extern _X_EXPORT void *xf86HandleInt10Options(ScrnInfoPtr pScrn,
-                                              int entityIndex);
-extern _X_EXPORT BusType xf86int10GetBiosLocationType(const xf86Int10InfoPtr
-                                                      pInt);
-extern _X_EXPORT Bool xf86int10GetBiosSegment(xf86Int10InfoPtr pInt,
-                                              void *base);
-
-#endif                          /* _INT10_PRIVATE */
 #endif                          /* _XF86INT10_H */


### PR DESCRIPTION
the definitions gated behind _INT10_PRIVATE define aren't accessible
to any external driver (neither are they used by proprietary Nvidia
driver), so no need to keep them in a public header file.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
