### PR TITLE
(master) include: compiler.h: switch ioBase to void *

### DIFF
--- a/hw/xfree86/os-support/bsd/ppc_video.c
+++ b/hw/xfree86/os-support/bsd/ppc_video.c
@@ -50,7 +50,7 @@ xf86OSInitVidMem(VidMemInfoPtr pVidMem)
     xf86EnableIO();
 }
 
-volatile unsigned char *ioBase = MAP_FAILED;
+void *ioBase = MAP_FAILED;
 
 Bool
 xf86EnableIO()
@@ -75,11 +75,7 @@ xf86DisableIO()
 {
 
     if (ioBase != MAP_FAILED) {
-#if defined(__FreeBSD__)
-        munmap(__DEVOLATILE(unsigned char *, ioBase), 0x10000);
-#else
-        munmap(__UNVOLATILE(ioBase), 0x10000);
-#endif
+        munmap(ioBase, 0x10000);
         ioBase = MAP_FAILED;
     }
 }

--- a/hw/xfree86/os-support/linux/lnx_video.c
+++ b/hw/xfree86/os-support/linux/lnx_video.c
@@ -77,7 +77,7 @@ xf86OSInitVidMem(VidMemInfoPtr pVidMem)
 /***************************************************************************/
 
 #if defined(__powerpc__)
-volatile unsigned char *ioBase = NULL;
+void *ioBase = NULL;
 
 #ifndef __NR_pciconfig_iobase
 #define __NR_pciconfig_iobase	200
@@ -91,7 +91,7 @@ hwEnableIO(void)
 
     fd = open("/dev/mem", O_RDWR);
     if (ioBase == NULL) {
-        ioBase = (volatile unsigned char *) mmap(0, 0x20000,
+        ioBase = mmap(0, 0x20000,
                                                  PROT_READ | PROT_WRITE,
                                                  MAP_SHARED, fd, ioBase_phys);
     }

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -503,7 +503,7 @@ xf86WriteMmio32Be(__volatile__ void *base, const unsigned long offset,
 
 #include <sys/mman.h>
 
-extern _X_EXPORT volatile unsigned char *ioBase;
+extern _X_EXPORT void *ioBase;
 
 static inline unsigned char
 xf86ReadMmio8(__volatile__ void *base, const unsigned long offset)
@@ -615,7 +615,7 @@ outb(unsigned short port, unsigned char value)
 {
     if (ioBase == MAP_FAILED)
         return;
-    xf86WriteMmio8((void *) ioBase, port, value);
+    xf86WriteMmio8(ioBase, port, value);
 }
 
 static inline void
@@ -623,7 +623,7 @@ outw(unsigned short port, unsigned short value)
 {
     if (ioBase == MAP_FAILED)
         return;
-    xf86WriteMmio16Le((void *) ioBase, port, value);
+    xf86WriteMmio16Le(ioBase, port, value);
 }
 
 static inline void
@@ -631,7 +631,7 @@ outl(unsigned short port, unsigned int value)
 {
     if (ioBase == MAP_FAILED)
         return;
-    xf86WriteMmio32Le((void *) ioBase, port, value);
+    xf86WriteMmio32Le(ioBase, port, value);
 }
 
 static inline unsigned int
@@ -639,7 +639,7 @@ inb(unsigned short port)
 {
     if (ioBase == MAP_FAILED)
         return 0;
-    return xf86ReadMmio8((void *) ioBase, port);
+    return xf86ReadMmio8(ioBase, port);
 }
 
 static inline unsigned int
@@ -647,7 +647,7 @@ inw(unsigned short port)
 {
     if (ioBase == MAP_FAILED)
         return 0;
-    return xf86ReadMmio16Le((void *) ioBase, port);
+    return xf86ReadMmio16Le(ioBase, port);
 }
 
 static inline unsigned int
@@ -655,7 +655,7 @@ inl(unsigned short port)
 {
     if (ioBase == MAP_FAILED)
         return 0;
-    return xf86ReadMmio32Le((void *) ioBase, port);
+    return xf86ReadMmio32Le(ioBase, port);
 }
 
 #endif                          /* arch madness */


### PR DESCRIPTION
ioBase is an opaque mmap() result; nothing in-tree dereferences it or
does pointer arithmetic on it — all MMIO access goes through the
xf86Read/WriteMmio* helpers. Making it void *:

- removes the discarded-qualifiers warnings at the munmap() call sites
  in lnx_video.c and ppc_video.c
- drops the now-redundant (void *) casts in the inb/outb wrappers in
  compiler.h
- fixes the BSD/ppc munmap path that referenced the (undefined)
  __DEVOLATILE/__UNVOLATILE macros

ABI-neutral: the exported data symbol keeps its size and address.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
