### PR TITLE
(master) include: compiler.h: ppc64el eieio barrier fallback for GCC 12.2

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -563,7 +563,7 @@ xf86WriteMmio8(__volatile__ void *base, const unsigned long offset,
         __volatile__("stbx %1,%2,%3\n\t":"=m"
                      (*((volatile unsigned char *) base + offset))
                      :"r"(val), "b"(base), "r"(offset));
-    __builtin_ppc_eieio();
+    xlibre_mem_barrier_write();
 }
 
 static inline void
@@ -574,7 +574,7 @@ xf86WriteMmio16Le(__volatile__ void *base, const unsigned long offset,
         __volatile__("sthbrx %1,%2,%3\n\t":"=m"
                      (*((volatile unsigned char *) base + offset))
                      :"r"(val), "b"(base), "r"(offset));
-    __builtin_ppc_eieio();
+    xlibre_mem_barrier_write();
 }
 
 static inline void
@@ -585,7 +585,7 @@ xf86WriteMmio16Be(__volatile__ void *base, const unsigned long offset,
         __volatile__("sthx %1,%2,%3\n\t":"=m"
                      (*((volatile unsigned char *) base + offset))
                      :"r"(val), "b"(base), "r"(offset));
-    __builtin_ppc_eieio();
+    xlibre_mem_barrier_write();
 }
 
 static inline void
@@ -596,7 +596,7 @@ xf86WriteMmio32Le(__volatile__ void *base, const unsigned long offset,
         __volatile__("stwbrx %1,%2,%3\n\t":"=m"
                      (*((volatile unsigned char *) base + offset))
                      :"r"(val), "b"(base), "r"(offset));
-    __builtin_ppc_eieio();
+    xlibre_mem_barrier_write();
 }
 
 static inline void
@@ -607,7 +607,7 @@ xf86WriteMmio32Be(__volatile__ void *base, const unsigned long offset,
         __volatile__("stwx %1,%2,%3\n\t":"=m"
                      (*((volatile unsigned char *) base + offset))
                      :"r"(val), "b"(base), "r"(offset));
-    __builtin_ppc_eieio();
+    xlibre_mem_barrier_write();
 }
 
 static inline void

--- a/include/xlibre_membarrier.h
+++ b/include/xlibre_membarrier.h
@@ -32,7 +32,11 @@ __attribute__((always_inline)) static inline void xlibre_mem_barrier_read(void)
         : /* no input */
         : "memory");
 #elif defined __powerpc__
+#  if defined(__powerpc64__) || !defined(__has_builtin) || !__has_builtin(__builtin_ppc_eieio)
+    __asm__ __volatile__ ("eieio" : : : "memory");
+#  else
     __builtin_ppc_eieio();
+#  endif
 #elif defined __sparc__
     /* NOP */
 #endif
@@ -53,9 +57,13 @@ __attribute__((always_inline)) static inline void xlibre_mem_barrier_write(void)
 #elif defined __ia64__
     __asm__ __volatile__ ("mf" : : : "memory");
 #elif defined __mips__
-    mem_barrier();
+    xlibre_mem_barrier_read();
 #elif defined __powerpc__
+#  if defined(__powerpc64__) || !defined(__has_builtin) || !__has_builtin(__builtin_ppc_eieio)
+    __asm__ __volatile__ ("eieio" : : : "memory");
+#  else
     __builtin_ppc_eieio();
+#  endif
 #elif defined __sparc__
     /* NOP */
 #endif


### PR DESCRIPTION
__builtin_ppc_eieio() is not available on ppc64le (little-endian) with
GCC 12.2 ("implicit declaration of function '__builtin_ppc_eieio'"),
breaking the CI native build lanes for ppc64el. Use an asm("eieio")
fallback on ppc64 (and whenever __has_builtin cannot confirm the
builtin), and route the xf86WriteMmio* barriers through
write_mem_barrier() so there is a single arch-correct place.

Validated: powerpc64le-linux-gnu-gcc-12 -fsyntax-only passes with the
fix and fails with "implicit declaration" without it.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
