### PR TITLE
(release/25.0) rootless: fix dangling screen pixmap on RootlessUpdateScreenPixmap() OOM

### DIFF
--- a/miext/rootless/rootlessScreen.c
+++ b/miext/rootless/rootlessScreen.c
@@ -115,9 +115,15 @@ RootlessUpdateScreenPixmap(ScreenPtr pScreen)
 
     if (s->pixmap_data_size < rowbytes) {
         /*
-         * Allocate before releasing the old buffer.  On failure the pixmap
-         * must keep pointing at storage that is still valid and still covers
-         * the geometry we last published.
+         * Allocate the replacement before releasing the old buffer: on
+         * failure the pixmap must keep pointing at storage that is still
+         * valid and still covers the geometry we last published.  (Freeing
+         * first used to leave s->pixmap_data -- and the screen pixmap pPix,
+         * via its earlier ModifyPixmapHeader() call -- dangling, and since
+         * pixmap_data_size got bumped before the failure check, a later
+         * same-or-smaller-size call would see pixmap_data_size < rowbytes
+         * as false and skip reallocating forever, pinning the dangling
+         * state permanently.)
          */
         void *data = calloc(1, rowbytes);
 


### PR DESCRIPTION
On a calloc() failure while growing the rootless screen pixmap buffer, the
old buffer was already freed and pixmap_data_size already bumped to the new
(larger) size before the failure check -- leaving s->pixmap_data (and the
screen pixmap pPix, still pointing at the freed block via its prior
ModifyPixmapHeader() call) dangling. Worse, because pixmap_data_size was
already bumped, a later same-or-smaller-size call sees pixmap_data_size <
rowbytes as false and skips reallocating forever, permanently pinning the
dangling state instead of retrying.

Trigger: real host memory pressure during a rootless (Xquartz-style DDX)
geometry change.

Fix: allocate the replacement into a temporary first; only free the old
buffer and update pixmap_data_size/pixmap_data together once the new
allocation has succeeded.

Found via a fleet-directed alloc-fail/UAF sweep of Xext/, mi/, and miext/,
not from a live crash report. Verification note: miext/rootless/ only
compiles into hw/xquartz, which this Linux build has disabled -- checked
with a standalone `gcc -fsyntax-only` pass instead of the normal
ninja+meson-test build/test cycle used for the other fixes in this sweep.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit d536dde7b42cdddcb153f612ae66270944fb0e0c)


---

Backport of [master PR #3277](https://github.com/X11Libre/xserver/pull/3277) (rootless: fix dangling screen pixmap on RootlessUpdateScreenPixmap() OOM).


---

**Backport series** of [master PR #3277](https://github.com/X11Libre/xserver/pull/3277) — same fix on every maintained release line:

- **release/25.2 → PR #3507**
- **release/25.1 → PR #3508**
- **release/25.0 → PR #3509**

This is the **25.0** copy (base `release/25.0`). The others are linked above.
