### PR TITLE
(release/25.2) mi: fix double-free/UAF in miDCInitialize() on miSpriteInitialize() failure

### DIFF
--- a/mi/midispcur.c
+++ b/mi/midispcur.c
@@ -107,6 +107,15 @@ miDCInitialize(ScreenPtr pScreen, miPointerScreenFuncPtr screenFuncs)
     dixSetPrivate(&pScreen->devPrivates, miDCScreenKey, pScreenPriv);
 
     if (!miSpriteInitialize(pScreen, screenFuncs)) {
+        /*
+         * Both the CloseScreen hook and the devPrivates slot were already
+         * set above (dixScreenHookPostClose()/dixSetPrivate()); undo both
+         * before freeing pScreenPriv, or miDCCloseScreen() looks it up as
+         * a live pointer at screen close, uses it (UAF via
+         * miDCSwitchScreenCursor()), and frees it again (double-free).
+         */
+        dixScreenUnhookPostClose(pScreen, miDCCloseScreen);
+        dixSetPrivate(&pScreen->devPrivates, miDCScreenKey, NULL);
         free((void *) pScreenPriv);
         return FALSE;
     }


### PR DESCRIPTION
Backport of master PR #3276: mi: fix double-free/UAF in miDCInitialize() on miSpriteInitialize() failure

miDCInitialize() registers the CloseScreen hook (miDCCloseScreen, via dixScreenHookPostClose()) and stores pScreenPriv into the screen's devPrivates *before* calling miSpriteInitialize(). On failure it only freed pScreenPriv, leaving both the hook armed and the devPrivates slot pointing at now-freed memory.

This isn't just "a caller that ignores the Bool return could look it up later" -- the hook it already registered guarantees the problem fires on every subsequent screen close: miDCCloseScreen() looks up the dangling pointer via dixLookupPrivate(), passes it to miDCSwitchScreenCursor() (dereferencing freed memory, e.g. dixDestroyPixmap() on pScreenPriv->sourceBits), and then frees pScreenPriv a second time.

Trigger: any allocation failure inside miSpriteInitialize() during screen init (a DDX like vfb/kdrive/xfree86/xnest/xwin calling miDCInitialize()) sets this up; the actual crash fires later, at screen close.

Fix: unhook the CloseScreen callback and clear the devPrivates slot before freeing pScreenPriv, matching what miDCCloseScreen() itself does on the normal teardown path.

Found via a fleet-directed alloc-fail/UAF sweep of Xext/, mi/, and miext/, not from a live crash report.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
(cherry picked from commit 2ba0ed012f692a3925559f207d1147688f1ba2f8)

---

**Original master PR:** [#3276](https://github.com/X11Libre/xserver/pull/3276)