### PR TITLE
(master) xfree86: drm_platform: fix dead -1 error path in xf86PlatformReprobeDevice()

### DIFF
--- a/hw/xfree86/os-support/shared/drm_platform.c
+++ b/hw/xfree86/os-support/shared/drm_platform.c
@@ -128,7 +128,7 @@ xf86PlatformDeviceCheckBusID(struct xf86_platform_device *device, const char *bu
 void
 xf86PlatformReprobeDevice(int index, struct OdevAttributes *attribs)
 {
-    bool ret;
+    int ret;
     char *dpath = attribs->path;
 
     ret = get_drm_info(attribs, dpath, index);


### PR DESCRIPTION
Commit 58f140059b (xfree86: use stdbool's 'bool' instead of 'Bool') changed
the local 'ret' variable in xf86PlatformReprobeDevice() to bool, but
xf86platformAddDevice() returns int (-1 on error). Comparing bool against -1
is always false, so the failure path silently became dead code, and gcc's
-Werror=bool-compare turns it into a hard build error on the CI lanes.

Restore int so the error check actually works again.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
