### PR TITLE
(master) xfree86: platform bus: return bool from xf86platformAddDevice()

### DIFF
--- a/hw/xfree86/common/xf86platformBus.c
+++ b/hw/xfree86/common/xf86platformBus.c
@@ -719,7 +719,7 @@ xf86PlatformFindHotplugDriver(int dev_index)
     return hp_driver;
 }
 
-int
+bool
 xf86platformAddDevice(const char *driver_name, int index)
 {
     int i, old_screens, scr_index, scrnum;
@@ -727,7 +727,7 @@ xf86platformAddDevice(const char *driver_name, int index)
     screenLayoutPtr layout;
 
     if (!xf86Info.autoAddGPU)
-        return -1;
+        return FALSE;
 
     /* Load modesetting driver if no driver given, or driver open failed */
     if (!driver_name || !xf86LoadOneModule(driver_name, NULL)) {
@@ -747,14 +747,14 @@ xf86platformAddDevice(const char *driver_name, int index)
 
     if (!drvp) {
         ErrorF("can't find driver %s for hotplugged device\n", driver_name);
-        return -1;
+        return FALSE;
     }
 
     old_screens = xf86NumGPUScreens;
     doPlatformProbe(&xf86_platform_devices[index], drvp, NULL,
                     PLATFORM_PROBE_GPU_SCREEN, 0);
     if (old_screens == xf86NumGPUScreens)
-        return -1;
+        return FALSE;
     i = old_screens;
 
     for (layout = xf86ConfigLayout.screens; layout->screen != NULL;
@@ -770,7 +770,7 @@ xf86platformAddDevice(const char *driver_name, int index)
     if (!xf86GPUScreens[i]->configured) {
         ErrorF("hotplugged device %d didn't configure\n", i);
         xf86DeleteScreen(xf86GPUScreens[i]);
-        return -1;
+        return FALSE;
     }
 
    /*
@@ -787,7 +787,7 @@ xf86platformAddDevice(const char *driver_name, int index)
        xf86DeleteScreen(xf86GPUScreens[i]);
        xf86UnclaimPlatformSlot(&xf86_platform_devices[index], NULL);
        xf86NumGPUScreens = old_screens;
-       return -1;
+       return FALSE;
    }
    dixSetPrivate(&xf86GPUScreens[i]->pScreen->devPrivates,
                  xf86ScreenKey, xf86GPUScreens[i]);
@@ -799,7 +799,7 @@ xf86platformAddDevice(const char *driver_name, int index)
        xf86DeleteScreen(xf86GPUScreens[i]);
        xf86UnclaimPlatformSlot(&xf86_platform_devices[index], NULL);
        xf86NumGPUScreens = old_screens;
-       return -1;
+       return FALSE;
    }
    /* attach unbound to the configured protocol screen (or 0) */
    scrnum = xf86GPUScreens[i]->confScreen->screennum;
@@ -811,7 +811,7 @@ xf86platformAddDevice(const char *driver_name, int index)
    RRResourcesChanged(xf86Screens[scrnum]->pScreen);
    RRTellChanged(xf86Screens[scrnum]->pScreen);
 
-   return 0;
+   return TRUE;
 }
 
 void

--- a/hw/xfree86/common/xf86platformBus_priv.h
+++ b/hw/xfree86/common/xf86platformBus_priv.h
@@ -36,7 +36,7 @@ int xf86_add_platform_device(struct OdevAttributes *attribs, Bool unowned);
 int xf86_remove_platform_device(int dev_index);
 Bool xf86_get_platform_device_unowned(int index);
 
-int xf86platformAddDevice(const char *driver_name, int index);
+bool xf86platformAddDevice(const char *driver_name, int index);
 void xf86platformRemoveDevice(int index);
 
 void xf86platformVTProbe(void);

--- a/hw/xfree86/os-support/shared/drm_platform.c
+++ b/hw/xfree86/os-support/shared/drm_platform.c
@@ -137,7 +137,7 @@ xf86PlatformReprobeDevice(int index, struct OdevAttributes *attribs)
         return;
     }
     ret = xf86platformAddDevice(xf86PlatformFindHotplugDriver(index), index);
-    if (ret == -1)
+    if (!ret)
         xf86_remove_platform_device(index);
 }
 
@@ -183,7 +183,7 @@ out_free:
 void NewGPUDeviceRequest(struct OdevAttributes *attribs)
 {
     int old_num = xf86_num_platform_devices;
-    int ret;
+    bool ret;
     const char *driver_name;
 
     xf86PlatformDeviceProbe(attribs);
@@ -199,7 +199,7 @@ void NewGPUDeviceRequest(struct OdevAttributes *attribs)
     driver_name = xf86PlatformFindHotplugDriver(xf86_num_platform_devices - 1);
 
     ret = xf86platformAddDevice(driver_name, xf86_num_platform_devices-1);
-    if (ret == -1)
+    if (!ret)
         xf86_remove_platform_device(xf86_num_platform_devices-1);
 
     ErrorF("xf86: found device %d\n", xf86_num_platform_devices);


### PR DESCRIPTION
xf86platformAddDevice() only ever returns 0 (success) or -1 (failure),
so switch its signature to bool. This is the proper fix for the broken
error path introduced by commit 58f140059b (xfree86: use stdbool's
'bool' instead of 'Bool' for local variables), which changed the local
'ret' in xf86PlatformReprobeDevice() to bool while the function still
returned int: comparing bool against -1 is always false, so the failure
path silently became dead code, and gcc's -Werror=bool-compare turned
it into a hard build error on the CI lanes.

Instead of reverting the local variable to int (the pragmatic one-line
fix), make the API itself bool-typed: return TRUE on success, FALSE on
error, and adapt both callers to use !ret. This keeps the bool sweep
consistent and prevents the same trap for future callers.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
