### PR TITLE
(master) lnx_video: fix -Werror=unused-variable for alpha

### DIFF
--- a/hw/xfree86/os-support/linux/lnx_video.c
+++ b/hw/xfree86/os-support/linux/lnx_video.c
@@ -113,12 +113,6 @@ hwDisableIO(void)
 static Bool
 hwEnableIO(void)
 {
-    short i;
-    size_t n=0;
-    int begin, end;
-    char *buf=NULL, target[5];
-    FILE *fp;
-
     /* xf86-video-vesa and others (at least mach64) need access to all I/O ports */
     if (iopl(3)) {
         ErrorF("xf86EnableIO: failed to set I/O privilege level to 3 (%s)\n",
@@ -136,6 +130,12 @@ hwEnableIO(void)
     }
 
 #if !defined(__alpha__)
+    short i;
+    size_t n=0;
+    int begin, end;
+    char *buf=NULL, target[5];
+    FILE *fp;
+
     target[4] = '\0';
 
     /* trap access to the keyboard controller(s) and timer chip(s) */


### PR DESCRIPTION
Variables i, n, begin, end, buf, target, fp were declared at function
scope but only used inside the #if !defined(__alpha__) block. For
__alpha__ builds this triggered -Werror=unused-variable.

Move the declarations inside the #if block so they exist only where
actually used. No functional change for other architectures.
