### PR TITLE
(master) xf86Configure: include xf86sbusBus_priv.h for SPARC

### DIFF
--- a/hw/xfree86/common/xf86Configure.c
+++ b/hw/xfree86/common/xf86Configure.c
@@ -44,8 +44,7 @@
 #include "xf86DDC_priv.h"
 #include "xf86pciBus.h"
 #if (defined(__sparc__) || defined(__sparc)) && !defined(__OpenBSD__)
-#include "xf86Bus.h"
-#include "xf86Sbus_priv.h"
+#include "xf86sbusBus_priv.h"
 #endif
 #include "loaderProcs.h"
 #include "xf86Parser_priv.h"


### PR DESCRIPTION
xf86Configure.c calls xf86SbusConfigure() and xf86SbusConfigureNewDev()
for SPARC, but included hw/xfree86/os-support/bus/xf86Sbus_priv.h
which does not declare these functions. The correct header is
hw/xfree86/common/xf86sbusBus_priv.h.

This caused -Werror=implicit-function-declaration and
-Werror=nested-externs on SPARC builds.
