### PR TITLE
(master) sparc: xf86sbusBus: add missing includes for DebugF and screen hooks

### DIFF
--- a/hw/xfree86/common/xf86sbusBus.c
+++ b/hw/xfree86/common/xf86sbusBus.c
@@ -36,6 +36,8 @@
 #include "xf86Bus.h"
 #include "xf86sbusBus_priv.h"
 #include "xf86Sbus_priv.h"
+#include "os/log_priv.h"
+#include "dix/screen_hooks_priv.h"
 
 static int xf86nSbusInfo;
 


### PR DESCRIPTION
xf86sbusBus.c uses DebugF (from os/log_priv.h) and
dixScreenUnhook/dixScreenHookClose (from dix/screen_hooks_priv.h)
without including the respective headers. This caused
-Werror=implicit-function-declaration and -Werror=nested-externs
on SPARC builds (where xf86sbusBus.c is compiled).

Add the missing includes.
