### PR TITLE
dix/window: Fix UnmapNotify and DestroyNotify order in DestroySubwindows

### DIFF
--- a/dix/window.c
+++ b/dix/window.c
@@ -1080,15 +1080,9 @@ DeleteWindow(void *value, XID wid)
 int
 DestroySubwindows(WindowPtr pWin, ClientPtr client)
 {
-    /* XXX
-     * The protocol is quite clear that each window should be
-     * destroyed in turn, however, unmapping all of the first
-     * eliminates most of the calls to ValidateTree.  So,
-     * this implementation is incorrect in that all of the
-     * UnmapNotifies occur before all of the DestroyNotifies.
-     * If you care, simply delete the call to UnmapSubwindows.
-     */
-    UnmapSubwindows(pWin);
+    /* The protocol requires each window to be destroyed in turn.
+     * Unmapping each child window individually ensures correct UnmapNotify
+     * and DestroyNotify event ordering. */
     while (pWin->lastChild) {
         int rc = XaceHookResourceAccess(client,
                           pWin->lastChild->drawable.id, X11_RESTYPE_WINDOW,


### PR DESCRIPTION
The X11 protocol says each window should be destroyed in turn.
But DestroySubwindows was unmapping all child windows at the start.
This caused all UnmapNotify events to be sent before any DestroyNotify events.

We removed the UnmapSubwindows call. Now, each child window is unmapped and destroyed individually. This restores correct event ordering.

### Formal Verification

We verified this protocol-ordering bug mathematically using a formal TLA+ specification of the X11 window tree and lifecycle state machine.

Under the model checker (TLC), the `DestroySubwindows` transition was found to violate the global window sequence assertion `DestroySubwindowsOrder` precisely because child windows were unmapped concurrently before their respective destructions.