### PR TITLE
dix/property: Fix commit and notification order in ProcRotateProperties

### DIFF
--- a/dix/property.c
+++ b/dix/property.c
@@ -244,14 +244,15 @@ ProcRotateProperties(ClientPtr client)
             delta += p.nAtoms;
         for (int i = 0; i < p.nAtoms; i++) {
             int j = (i + delta) % p.nAtoms;
-            deliverPropertyNotifyEvent(pWin, PropertyNewValue, props[i]);
-            notifyVRRMode(client, pWin, PropertyNewValue, props[i]);
-
             /* Preserve name and devPrivates */
             props[j]->type = saved[i].type;
             props[j]->format = saved[i].format;
             props[j]->size = saved[i].size;
             props[j]->data = saved[i].data;
+        }
+        for (int i = 0; i < p.nAtoms; i++) {
+            deliverPropertyNotifyEvent(pWin, PropertyNewValue, props[i]);
+            notifyVRRMode(client, pWin, PropertyNewValue, props[i]);
         }
     }
  out:


### PR DESCRIPTION
ProcRotateProperties was delivering notify events and updating the VRR state from the pre-rotation values. This happened before the new rotated property data was copied into memory.

By splitting this logic into two loops, we perform all memory rotations first. Then we deliver events and update the VRR mode using the final committed states. This prevents delivering stale property values.

### Formal Verification

We verified this commit-ordering bug mathematically using a formal TLA+ specification of the X11 property registry and modesetting VRR state machine.

Under the model checker (TLC), the `ProcRotateProperties` transition violated the safety invariant `CommitEventConsistency` because notifications and VRR derivations were evaluated before the rotated property values were committed to memory.