### PR TITLE
hw: test: list: fix Clang sanitizers security issues

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -1308,8 +1308,7 @@ drmmode_ConvertToKMode(ScrnInfoPtr scrn,
 
     kmode->flags = mode->Flags; //& FLAG_BITS;
     if (mode->name)
-        strncpy(kmode->name, mode->name, DRM_DISPLAY_MODE_LEN);
-    kmode->name[DRM_DISPLAY_MODE_LEN - 1] = 0;
+        strlcpy(kmode->name, mode->name, DRM_DISPLAY_MODE_LEN);
 
 }
 

--- a/hw/xfree86/parser/scan.c
+++ b/hw/xfree86/parser/scan.c
@@ -280,8 +280,14 @@ xf86getToken(const xf86ConfigSymTabRec * tab)
                 if (builtinConfig[builtinIndex] == NULL)
                     ret = NULL;
                 else {
-                    strlcpy(configBuf,
-                            builtinConfig[builtinIndex], CONFIG_BUF_LEN);
+                    if (!configBuf)
+                        configBuf = calloc(1, CONFIG_BUF_LEN);
+                    if (!configRBuf)
+                        configRBuf = calloc(1, CONFIG_BUF_LEN);
+                    if (configBuf) {
+                        strlcpy(configBuf,
+                                builtinConfig[builtinIndex], CONFIG_BUF_LEN);
+                    }
                     ret = configBuf;
                     builtinIndex++;
                 }
@@ -953,6 +959,10 @@ void
 xf86setBuiltinConfig(const char *config[])
 {
     builtinConfig = config;
+    if (!configBuf)
+        configBuf = calloc(1, CONFIG_BUF_LEN);
+    if (!configRBuf)
+        configRBuf = calloc(1, CONFIG_BUF_LEN);
 }
 
 void

--- a/include/list.h
+++ b/include/list.h
@@ -345,7 +345,7 @@ xorg_list_append_ndup(struct xorg_list *entry, struct xorg_list *head)
     xorg_list_entry((ptr)->prev, type, member)
 
 #define __container_of(ptr, sample, member)			\
-    container_of((ptr), typeof(*(sample)), member)
+    ((ptr) ? container_of((ptr), typeof(*(sample)), member) : NULL)
 
 /**
  * Loop through the list given by head and set pos to struct in the list.

--- a/test/input.c
+++ b/test/input.c
@@ -1888,6 +1888,7 @@ dix_enqueue_events(void)
     int i;
 
     memset(&dev, 0, sizeof(dev));
+    memset(ev, 0, sizeof(ev));
     dev.public.processInputProc = process_input_proc;
 
     memset(&spriteInfo, 0, sizeof(spriteInfo));

--- a/test/list.c
+++ b/test/list.c
@@ -70,7 +70,7 @@ static void
 test_xorg_list_add(void)
 {
     struct parent parent = { 0 };
-    struct child child[3];
+    struct child child[3] = { 0 };
     struct child *c;
 
     xorg_list_init(&parent.children);
@@ -98,7 +98,7 @@ static void
 test_xorg_list_append(void)
 {
     struct parent parent = { 0 };
-    struct child child[3];
+    struct child child[3] = { 0 };
     struct child *c;
     int i;
 
@@ -140,7 +140,7 @@ static void
 test_xorg_list_del(void)
 {
     struct parent parent = { 0 };
-    struct child child[2];
+    struct child child[2] = { 0 };
     struct child *c;
 
     xorg_list_init(&parent.children);
@@ -189,7 +189,7 @@ static void
 test_xorg_list_for_each(void)
 {
     struct parent parent = { 0 };
-    struct child child[3];
+    struct child child[3] = { 0 };
     struct child *c;
     int i = 0;
 

--- a/test/sha1.c
+++ b/test/sha1.c
@@ -57,7 +57,7 @@ sha1_test_repeated_blocks(void *data, size_t length, unsigned int repeat,
                           const char *expected_hash)
 {
     void *ctx;
-    unsigned char raw_result[20];
+    unsigned char raw_result[20] = {0};
     unsigned char hex_result[41];
 
     assert((ctx = x_sha1_init()) != NULL);


### PR DESCRIPTION

Tests with sanitizers:
[asan_ubsan_results.txt](https://github.com/user-attachments/files/30966476/asan_ubsan_results.txt)
[msan_results.txt](https://github.com/user-attachments/files/30966477/msan_results.txt)



### ASAN and UBSAN asan_ubsan_results.txt:

Fixed the issue of UndefinedBehaviorSanitizer: applying non-zero offset to null pointer in the include/list.h file. The __container_of macro tried to perform an arithmetic offset operation on a null pointer when working with macros of a list initialized with zeros.

### MSAN (MemorySanitizer) ( msan_results.txt ):
The Clang compiler is used because GCC does not support MSAN.
The MemorySanitizer error was detected: use-of-uninitialized-value in test/sha1.c. Fixed by initializing the raw_result array with zeros. Previously, it was defined by MSAN as uninitialized due to the fact that data was written to it by an external non-instrumented libmd library.
The MemorySanitizer error was detected: use-of-uninitialized-value in test/input.c when calling the EnqueueEvent function. Fixed by adding zeroing of the ev event array before using (memset(ev, 0, sizeof(ev))).