### PR TITLE
introduce lttng-ust trace points

### DIFF
--- a/Xext/composite/compext.c
+++ b/Xext/composite/compext.c
@@ -55,6 +55,10 @@
 #include "xace.h"
 #include "protocol-versions.h"
 
+#ifdef _XLIBRE_LTTNG_UST
+#include "compext_tp.h"
+#endif
+
 static CARD8 CompositeReqCode;
 static DevPrivateKeyRec CompositeClientPrivateKeyRec;
 
@@ -128,6 +132,11 @@ ProcCompositeQueryVersion(ClientPtr client)
     X_REPLY_FIELD_CARD32(majorVersion);
     X_REPLY_FIELD_CARD32(minorVersion);
 
+    #ifdef _XLIBRE_LTTNG_UST
+
+    lttng_ust_tracepoint(xlibre_xext_composite,generic_req,client->index,stuff->compositeReqType,stuff->length);
+
+    #endif
     return X_SEND_REPLY_SIMPLE(client, reply);
 }
 
@@ -192,6 +201,10 @@ ProcCompositeCreateRegionFromBorderClip(ClientPtr client)
     X_REQUEST_HEAD_STRUCT(xCompositeCreateRegionFromBorderClipReq);
     X_REQUEST_FIELD_CARD32(region);
     X_REQUEST_FIELD_CARD32(window);
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_composite,redirect_req_simple,client->index,stuff->compositeReqType,stuff->window);
+#endif
 
     WindowPtr pWin;
     VERIFY_WINDOW(pWin, stuff->window, client, DixGetAttrAccess);
@@ -456,6 +469,10 @@ ProcCompositeRedirectWindow(ClientPtr client)
     X_REQUEST_HEAD_STRUCT(xCompositeRedirectWindowReq);
     X_REQUEST_FIELD_CARD32(window);
 
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_composite,redirect_req,client->index,stuff->compositeReqType,stuff->window,stuff->update);
+#endif
+
 #ifdef XINERAMA
     if (!compositeUseXinerama)
         return SingleCompositeRedirectWindow(client, stuff);
@@ -487,6 +504,10 @@ ProcCompositeRedirectSubwindows(ClientPtr client)
 {
     X_REQUEST_HEAD_STRUCT(xCompositeRedirectSubwindowsReq);
     X_REQUEST_FIELD_CARD32(window);
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_composite,redirect_req,client->index,stuff->compositeReqType,stuff->window,stuff->update);
+#endif
 
 #ifdef XINERAMA
     if (!compositeUseXinerama)
@@ -520,6 +541,10 @@ ProcCompositeUnredirectWindow(ClientPtr client)
     X_REQUEST_HEAD_STRUCT(xCompositeUnredirectWindowReq);
     X_REQUEST_FIELD_CARD32(window);
 
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_composite,redirect_req,client->index,stuff->compositeReqType,stuff->window,stuff->update);
+#endif
+
 #ifdef XINERAMA
     if (!compositeUseXinerama)
         return SingleCompositeUnredirectWindow(client, stuff);
@@ -551,6 +576,10 @@ ProcCompositeUnredirectSubwindows(ClientPtr client)
 {
     X_REQUEST_HEAD_STRUCT(xCompositeUnredirectSubwindowsReq);
     X_REQUEST_FIELD_CARD32(window);
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_composite,redirect_req,client->index,stuff->compositeReqType,stuff->window,stuff->update);
+#endif
 
 #ifdef XINERAMA
     if (!compositeUseXinerama)
@@ -584,6 +613,11 @@ ProcCompositeNameWindowPixmap(ClientPtr client)
     X_REQUEST_HEAD_STRUCT(xCompositeNameWindowPixmapReq);
     X_REQUEST_FIELD_CARD32(window);
     X_REQUEST_FIELD_CARD32(pixmap);
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_composite,window_pixmap_redirect_req,client->index,stuff->compositeReqType,stuff->window,stuff->pixmap);
+#endif
+
 
 #ifdef XINERAMA
     if (!compositeUseXinerama)
@@ -659,6 +693,10 @@ ProcCompositeGetOverlayWindow(ClientPtr client)
 {
     X_REQUEST_HEAD_STRUCT(xCompositeGetOverlayWindowReq);
     X_REQUEST_FIELD_CARD32(window);
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_composite,redirect_req_simple,client->index,stuff->compositeReqType,stuff->window);
+#endif
 
 #ifdef XINERAMA
     if (!compositeUseXinerama)
@@ -756,6 +794,10 @@ ProcCompositeReleaseOverlayWindow(ClientPtr client)
 {
     X_REQUEST_HEAD_STRUCT(xCompositeReleaseOverlayWindowReq);
     X_REQUEST_FIELD_CARD32(window);
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_composite,redirect_req_simple,client->index,stuff->compositeReqType,stuff->window);
+#endif
 
 #ifdef XINERAMA
     if (!compositeUseXinerama)

--- a/Xext/composite/compext_tp.c
+++ b/Xext/composite/compext_tp.c
@@ -1,0 +1,11 @@
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+
+/*
+ * The header containing our LTTNG_UST_TRACEPOINT_EVENTs.
+ */
+
+
+#include "compext_tp.h"
+

--- a/Xext/composite/compext_tp.c
+++ b/Xext/composite/compext_tp.c
@@ -1,3 +1,8 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
+ *
+ * Copyright © 2026 cepelinas9000, gtautvis@gmail.com
+ */
+
 #define LTTNG_UST_TRACEPOINT_CREATE_PROBES
 #define LTTNG_UST_TRACEPOINT_DEFINE
 

--- a/Xext/composite/compext_tp.h
+++ b/Xext/composite/compext_tp.h
@@ -1,0 +1,58 @@
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER xlibre_xext_composite
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "./compext_tp.h"
+
+#if !defined(_TP_H) || \
+defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define _TP_H
+
+#include <lttng/tracepoint.h>
+
+    LTTNG_UST_TRACEPOINT_ENUM(
+        xlibre_xext_composite,
+        composite_req,
+        LTTNG_UST_TP_ENUM_VALUES(
+            lttng_ust_field_enum_value("X_CompositeQueryVersion", 0)
+            lttng_ust_field_enum_value("X_CompositeRedirectWindow", 1)
+            lttng_ust_field_enum_value("X_CompositeRedirectSubwindows", 2)
+            lttng_ust_field_enum_value("X_CompositeUnredirectWindow", 3)
+            lttng_ust_field_enum_value("X_CompositeUnredirectSubwindows", 4)
+            lttng_ust_field_enum_value("X_CompositeCreateRegionFromBorderClip", 5)
+            lttng_ust_field_enum_value("X_CompositeNameWindowPixmap", 6)
+            lttng_ust_field_enum_value("X_CompositeGetOverlayWindow", 7)
+            lttng_ust_field_enum_value("X_CompositeReleaseOverlayWindow", 8)
+            )
+        )
+
+    LTTNG_UST_TRACEPOINT_EVENT(
+        /* Tracepoint provider name */
+        xlibre_xext_composite,
+
+        /* Tracepoint/event name */
+        generic_req,
+
+        /* List of tracepoint arguments (input) */
+        LTTNG_UST_TP_ARGS(
+            int, client_id,
+            uint8_t, _req,
+            int, size
+            ),
+
+        /* List of fields of eventual event (output) */
+        LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int,client_id,client_id)
+            lttng_ust_field_enum(xlibre_xext_composite, composite_req, uint8_t, req, _req)
+            lttng_ust_field_integer(int,req_size,size)
+            )
+        )
+
+
+#endif
+
+
+/*
+ * Add this after defining the tracepoint events to expand the macros.
+ */
+#include <lttng/tracepoint-event.h>

--- a/Xext/composite/compext_tp.h
+++ b/Xext/composite/compext_tp.h
@@ -1,3 +1,8 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
+ *
+ * Copyright © 2026 cepelinas9000, gtautvis@gmail.com
+ */
+
 #undef LTTNG_UST_TRACEPOINT_PROVIDER
 #define LTTNG_UST_TRACEPOINT_PROVIDER xlibre_xext_composite
 
@@ -48,7 +53,76 @@ defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
             )
         )
 
+    LTTNG_UST_TRACEPOINT_EVENT(
+        /* Tracepoint provider name */
+        xlibre_xext_composite,
 
+        /* Tracepoint/event name */
+        redirect_req,
+
+        /* List of tracepoint arguments (input) */
+        LTTNG_UST_TP_ARGS(
+            int, client_id,
+            uint8_t, _req,
+            uint32_t, window,
+            uint8_t, update
+            ),
+
+        /* List of fields of eventual event (output) */
+        LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int,client_id,client_id)
+            lttng_ust_field_enum(xlibre_xext_composite, composite_req, uint8_t, req, _req)
+            lttng_ust_field_integer_hex(uint32_t,window,window)
+            lttng_ust_field_integer_hex(uint8_t,update,update)
+            )
+        )
+
+    LTTNG_UST_TRACEPOINT_EVENT(
+        /* Tracepoint provider name */
+        xlibre_xext_composite,
+
+        /* Tracepoint/event name */
+        redirect_req_simple,
+
+        /* List of tracepoint arguments (input) */
+        LTTNG_UST_TP_ARGS(
+            int, client_id,
+            uint8_t, _req,
+            uint32_t, window
+            ),
+
+        /* List of fields of eventual event (output) */
+        LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int,client_id,client_id)
+            lttng_ust_field_enum(xlibre_xext_composite, composite_req, uint8_t, req, _req)
+            lttng_ust_field_integer_hex(uint32_t,window,window)
+            )
+        )
+
+
+    LTTNG_UST_TRACEPOINT_EVENT(
+        /* Tracepoint provider name */
+        xlibre_xext_composite,
+
+        /* Tracepoint/event name */
+        window_pixmap_redirect_req,
+
+        /* List of tracepoint arguments (input) */
+        LTTNG_UST_TP_ARGS(
+            int, client_id,
+            uint8_t, _req,
+            uint32_t, window,
+            uint32_t, pixmap
+            ),
+
+        /* List of fields of eventual event (output) */
+        LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int,client_id,client_id)
+            lttng_ust_field_enum(xlibre_xext_composite, composite_req, uint8_t, req, _req)
+            lttng_ust_field_integer_hex(uint32_t,window,window)
+            lttng_ust_field_integer_hex(uint32_t,pixmap,pixmap)
+            )
+        )
 #endif
 
 

--- a/Xext/composite/meson.build
+++ b/Xext/composite/meson.build
@@ -6,8 +6,17 @@ srcs_composite = [
     'compwindow.c',
 ]
 
+compext_deps = common_dep
+
+if build_lttngust
+    srcs_composite += [ 'compext_tp.c' ]
+    compext_deps += [ lttng_ust_dep ]
+endif
+
+
+
 libxserver_composite = static_library('xserver_composite',
     srcs_composite,
     include_directories: inc,
-    dependencies: common_dep,
+    dependencies: compext_deps,
 )

--- a/Xext/damage/damageext.c
+++ b/Xext/damage/damageext.c
@@ -44,6 +44,10 @@
 #include "protocol-versions.h"
 #include "dixstruct_priv.h"
 
+#ifdef _XLIBRE_LTTNG_UST
+#include "damageext_tp.h"
+#endif
+
 typedef struct _DamageClient {
     CARD32 major_version;
     CARD32 minor_version;
@@ -221,6 +225,10 @@ ProcDamageQueryVersion(ClientPtr client)
 
     DamageClientPtr pDamageClient = GetDamageClient(client);
 
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_damage,generic_req,client->index,stuff->damageReqType,stuff->length);
+#endif
+
     xDamageQueryVersionReply reply = { 0 };
     if (stuff->majorVersion < SERVER_DAMAGE_MAJOR_VERSION) {
         reply.majorVersion = stuff->majorVersion;
@@ -333,6 +341,11 @@ ProcDamageCreate(ClientPtr client)
     X_REQUEST_FIELD_CARD32(damage);
     X_REQUEST_FIELD_CARD32(drawable);
 
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_damage,generic_req2,client->index,stuff->damageReqType,stuff->damage,stuff->drawable);
+#endif
+
+
 #ifdef XINERAMA
     if (damageUseXinerama)
         return PanoramiXDamageCreate(client, stuff);
@@ -347,6 +360,11 @@ ProcDamageDestroy(ClientPtr client)
 {
     X_REQUEST_HEAD_STRUCT(xDamageDestroyReq);
     X_REQUEST_FIELD_CARD32(damage);
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_damage,generic_req2,client->index,stuff->damageReqType,stuff->damage,0);
+#endif
+
 
     DamageExtPtr pDamageExt;
     VERIFY_DAMAGEEXT(pDamageExt, stuff->damage, client, DixDestroyAccess);
@@ -441,6 +459,10 @@ ProcDamageSubtract(ClientPtr client)
     X_REQUEST_FIELD_CARD32(repair);
     X_REQUEST_FIELD_CARD32(parts);
 
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_damage,generic_req2,client->index,stuff->damageReqType,stuff->damage,0);
+#endif
+
     DamageExtPtr pDamageExt;
     RegionPtr pRepair;
     RegionPtr pParts;
@@ -475,6 +497,10 @@ ProcDamageAdd(ClientPtr client)
     X_REQUEST_HEAD_STRUCT(xDamageAddReq);
     X_REQUEST_FIELD_CARD32(drawable);
     X_REQUEST_FIELD_CARD32(region);
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_damage,generic_req2,client->index,stuff->damageReqType,0,stuff->drawable);
+#endif
 
     DrawablePtr pDrawable;
     RegionPtr pRegion;

--- a/Xext/damage/damageext_tp.c
+++ b/Xext/damage/damageext_tp.c
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
+ *
+ * Copyright © 2026 cepelinas9000, gtautvis@gmail.com
+ */
+
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+
+/*
+ * The header containing our LTTNG_UST_TRACEPOINT_EVENTs.
+ */
+
+
+#include "damageext_tp.h"

--- a/Xext/damage/damageext_tp.h
+++ b/Xext/damage/damageext_tp.h
@@ -1,0 +1,83 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
+ *
+ * Copyright © 2026 cepelinas9000, gtautvis@gmail.com
+ */
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER xlibre_xext_damage
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "./damageext_tp.h"
+
+#if !defined(_TP_H) || \
+defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define _TP_H
+
+#include <lttng/tracepoint.h>
+
+    LTTNG_UST_TRACEPOINT_ENUM(
+        xlibre_xext_damage,
+        damage_req,
+        LTTNG_UST_TP_ENUM_VALUES(
+            lttng_ust_field_enum_value("X_DamageQueryVersion", 0)
+            lttng_ust_field_enum_value("X_DamageCreate", 1)
+            lttng_ust_field_enum_value("X_DamageDestroy", 2)
+            lttng_ust_field_enum_value("X_DamageSubtract", 3)
+            lttng_ust_field_enum_value("X_DamageAdd", 4)
+
+            )
+        )
+
+
+    LTTNG_UST_TRACEPOINT_EVENT(
+        /* Tracepoint provider name */
+        xlibre_xext_damage,
+
+        /* Tracepoint/event name */
+        generic_req,
+
+        /* List of tracepoint arguments (input) */
+        LTTNG_UST_TP_ARGS(
+            int, client_id,
+            uint8_t, _req,
+            int, size
+            ),
+
+        /* List of fields of eventual event (output) */
+        LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int,client_id,client_id)
+            lttng_ust_field_enum(xlibre_xext_damage, damage_req, uint8_t, req, _req)
+            lttng_ust_field_integer(int,req_size,size)
+            )
+        )
+
+    LTTNG_UST_TRACEPOINT_EVENT(
+        /* Tracepoint provider name */
+        xlibre_xext_damage,
+
+        /* Tracepoint/event name */
+        generic_req2,
+
+        /* List of tracepoint arguments (input) */
+        LTTNG_UST_TP_ARGS(
+            int, client_id,
+            uint8_t, _req,
+            uint32_t, damage,
+            uint32_t, drawable
+            ),
+
+        /* List of fields of eventual event (output) */
+        LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int,client_id,client_id)
+            lttng_ust_field_enum(xlibre_xext_damage, damage_req, uint8_t, req, _req)
+            lttng_ust_field_integer_hex(uint32_t,drawable,drawable)
+            lttng_ust_field_integer_hex(uint32_t,damage,damage)
+            )
+        )
+
+#endif
+
+
+/*
+ * Add this after defining the tracepoint events to expand the macros.
+ */
+#include <lttng/tracepoint-event.h>

--- a/Xext/damage/meson.build
+++ b/Xext/damage/meson.build
@@ -2,8 +2,16 @@ srcs_damageext = [
 	'damageext.c',
 ]
 
+damageext_deps = [ common_dep ]
+
+if build_lttngust
+    srcs_damageext += [ 'damageext_tp.c' ]
+    damageext_deps += [ lttng_ust_dep ]
+endif
+
+
 libxserver_damageext = static_library('xserver_damageext',
 	srcs_damageext,
 	include_directories: inc,
-	dependencies: common_dep,
+	dependencies: damageext_deps,
 )

--- a/Xext/dri3/dri3_request.c
+++ b/Xext/dri3/dri3_request.c
@@ -37,6 +37,11 @@
 #include <drm_fourcc.h>
 #include "dixstruct_priv.h"
 
+#ifdef _XLIBRE_LTTNG_UST
+
+#include "dri3_tp.h"
+#endif
+
 static Bool
 dri3_screen_can_one_point_one(ScreenPtr screen)
 {
@@ -80,6 +85,10 @@ proc_dri3_query_version(ClientPtr client)
     X_REQUEST_HEAD_STRUCT(xDRI3QueryVersionReq);
     X_REQUEST_FIELD_CARD32(majorVersion);
     X_REQUEST_FIELD_CARD32(minorVersion);
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_dri3,generic_req,client->index,stuff->dri3ReqType,stuff->length);
+#endif
 
     xDRI3QueryVersionReply reply = {
         .majorVersion = SERVER_DRI3_MAJOR_VERSION,
@@ -164,6 +173,10 @@ proc_dri3_open(ClientPtr client)
     X_REQUEST_FIELD_CARD32(drawable);
     X_REQUEST_FIELD_CARD32(provider);
 
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_dri3,generic_req,client->index,stuff->dri3ReqType,stuff->length);
+#endif
+
     if (!RRProviderType) {
         return BadMatch;
     }
@@ -203,6 +216,11 @@ proc_dri3_pixmap_from_buffer(ClientPtr client)
     X_REQUEST_FIELD_CARD16(width);
     X_REQUEST_FIELD_CARD16(height);
     X_REQUEST_FIELD_CARD16(stride);
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_dri3,generic_req,client->index,stuff->dri3ReqType,stuff->length);
+#endif
+
 
     SetReqFds(client, 1);
     LEGAL_NEW_RESOURCE(stuff->pixmap, client);
@@ -272,6 +290,11 @@ proc_dri3_buffer_from_pixmap(ClientPtr client)
     X_REQUEST_HEAD_STRUCT(xDRI3BufferFromPixmapReq);
     X_REQUEST_FIELD_CARD32(pixmap);
 
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_dri3,drawable_fd_req,client->index,stuff->dri3ReqType,stuff->pixmap);
+#endif
+
+
     PixmapPtr pixmap;
     int rc = dixLookupResourceByType((void **) &pixmap, stuff->pixmap, X11_RESTYPE_PIXMAP,
                                  client, DixWriteAccess);
@@ -308,9 +331,14 @@ proc_dri3_buffer_from_pixmap(ClientPtr client)
 static int
 proc_dri3_fence_from_fd(ClientPtr client)
 {
+
     X_REQUEST_HEAD_STRUCT(xDRI3FenceFromFDReq);
     X_REQUEST_FIELD_CARD32(drawable);
     X_REQUEST_FIELD_CARD32(fence);
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_dri3,drawable_fd_req,client->index,stuff->dri3ReqType,stuff->drawable);
+#endif
 
     SetReqFds(client, 1);
     LEGAL_NEW_RESOURCE(stuff->fence, client);
@@ -336,6 +364,10 @@ proc_dri3_fd_from_fence(ClientPtr client)
     X_REQUEST_HEAD_STRUCT(xDRI3FDFromFenceReq);
     X_REQUEST_FIELD_CARD32(drawable);
     X_REQUEST_FIELD_CARD32(fence);
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_dri3,generic_req,client->index,stuff->dri3ReqType,stuff->length);
+#endif
 
     xDRI3FDFromFenceReply reply = {
         .nfd = 1,
@@ -366,6 +398,10 @@ proc_dri3_get_supported_modifiers(ClientPtr client)
 {
     X_REQUEST_HEAD_STRUCT(xDRI3GetSupportedModifiersReq);
     X_REQUEST_FIELD_CARD32(window);
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_dri3,generic_req,client->index,stuff->dri3ReqType,stuff->length);
+#endif
 
     WindowPtr window;
     int status = dixLookupWindow(&window, stuff->window, client, DixGetAttrAccess);
@@ -418,6 +454,10 @@ proc_dri3_pixmap_from_buffers(ClientPtr client)
     X_REQUEST_FIELD_CARD32(stride3);
     X_REQUEST_FIELD_CARD32(offset3);
     X_REQUEST_FIELD_CARD64(modifier);
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_dri3,drawable_fd_req,client->index,stuff->dri3ReqType,stuff->pixmap);
+#endif
 
     SetReqFds(client, stuff->num_buffers);
     LEGAL_NEW_RESOURCE(stuff->pixmap, client);
@@ -511,6 +551,10 @@ proc_dri3_buffers_from_pixmap(ClientPtr client)
     X_REQUEST_HEAD_STRUCT(xDRI3BuffersFromPixmapReq);
     X_REQUEST_FIELD_CARD32(pixmap);
 
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_dri3,drawable_fd_req,client->index,stuff->dri3ReqType,stuff->pixmap);
+#endif
+
     PixmapPtr pixmap;
     int rc = dixLookupResourceByType((void **) &pixmap, stuff->pixmap, X11_RESTYPE_PIXMAP,
                                  client, DixWriteAccess);
@@ -562,6 +606,10 @@ proc_dri3_set_drm_device_in_use(ClientPtr client)
     X_REQUEST_FIELD_CARD32(drmMajor);
     X_REQUEST_FIELD_CARD32(drmMinor);
 
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_dri3,generic_req,client->index,stuff->dri3ReqType,stuff->length);
+#endif
+
     WindowPtr window;
     int status = dixLookupWindow(&window, stuff->window, client,
                              DixGetAttrAccess);
@@ -582,6 +630,10 @@ proc_dri3_import_syncobj(ClientPtr client)
     X_REQUEST_HEAD_STRUCT(xDRI3ImportSyncobjReq);
     X_REQUEST_FIELD_CARD32(syncobj);
     X_REQUEST_FIELD_CARD32(drawable);
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_dri3,generic_req,client->index,stuff->dri3ReqType,stuff->length);
+#endif
 
     SetReqFds(client, 1);
     LEGAL_NEW_RESOURCE(stuff->syncobj, client);
@@ -606,6 +658,10 @@ proc_dri3_free_syncobj(ClientPtr client)
 {
     X_REQUEST_HEAD_STRUCT(xDRI3FreeSyncobjReq);
     X_REQUEST_FIELD_CARD32(syncobj);
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_xext_dri3,generic_req,client->index,stuff->dri3ReqType,stuff->length);
+#endif
 
     struct dri3_syncobj *syncobj;
     int status = dixLookupResourceByType((void **) &syncobj, stuff->syncobj,

--- a/Xext/dri3/dri3_tp.c
+++ b/Xext/dri3/dri3_tp.c
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
+ *
+ * Copyright © 2026 cepelinas9000, gtautvis@gmail.com
+ */
+
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+
+/*
+ * The header containing our LTTNG_UST_TRACEPOINT_EVENTs.
+ */
+
+
+#include "dri3_tp.h"

--- a/Xext/dri3/dri3_tp.h
+++ b/Xext/dri3/dri3_tp.h
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
+ *
+ * Copyright © 2026 cepelinas9000, gtautvis@gmail.com
+ */
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER xlibre_xext_dri3
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "./dri3_tp.h"
+
+#if !defined(_TP_H) || \
+defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define _TP_H
+
+#include <lttng/tracepoint.h>
+
+    LTTNG_UST_TRACEPOINT_ENUM(
+        xlibre_xext_dri3,
+        dri3_req,
+        LTTNG_UST_TP_ENUM_VALUES(
+            lttng_ust_field_enum_value("X_DRI3QueryVersion", 0)
+            lttng_ust_field_enum_value("X_DRI3Open", 1)
+            lttng_ust_field_enum_value("X_DRI3PixmapFromBuffer", 2)
+            lttng_ust_field_enum_value("X_DRI3BufferFromPixmap", 3)
+            lttng_ust_field_enum_value("X_DRI3FenceFromFD", 4)
+            lttng_ust_field_enum_value("X_DRI3FDFromFence", 5)
+            lttng_ust_field_enum_value("xDRI3GetSupportedModifiers", 6)
+            lttng_ust_field_enum_value("xDRI3PixmapFromBuffers", 7)
+            lttng_ust_field_enum_value("xDRI3BuffersFromPixmap", 8)
+            lttng_ust_field_enum_value("xDRI3SetDRMDeviceInUse", 9)
+            lttng_ust_field_enum_value("xDRI3ImportSyncobj", 10)
+            lttng_ust_field_enum_value("xDRI3FreeSyncobj", 11)
+
+            )
+        )
+
+
+    LTTNG_UST_TRACEPOINT_EVENT(
+        /* Tracepoint provider name */
+        xlibre_xext_dri3,
+
+        /* Tracepoint/event name */
+        generic_req,
+
+        /* List of tracepoint arguments (input) */
+        LTTNG_UST_TP_ARGS(
+            int, client_id,
+            uint8_t, _req,
+            int, size
+            ),
+
+        /* List of fields of eventual event (output) */
+        LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int,client_id,client_id)
+            lttng_ust_field_enum(xlibre_xext_dri3, dri3_req, uint8_t, req, _req)
+            lttng_ust_field_integer(int,req_size,size)
+            )
+        )
+
+    LTTNG_UST_TRACEPOINT_EVENT(
+        /* Tracepoint provider name */
+        xlibre_xext_dri3,
+
+        /* Opetation where drawable as parameter: Fence and Pixmap to buffer */
+        drawable_fd_req,
+
+        /* List of tracepoint arguments (input) */
+        LTTNG_UST_TP_ARGS(
+            int, client_id,
+            uint8_t, _req,
+            uint32_t, drawable
+            ),
+
+        /* List of fields of eventual event (output) */
+        LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int,client_id,client_id)
+            lttng_ust_field_enum(xlibre_xext_dri3, dri3_req, uint8_t, req, _req)
+            lttng_ust_field_integer_hex(int32_t,drawable,drawable)
+            )
+
+        )
+
+#endif
+
+
+/*
+ * Add this after defining the tracepoint events to expand the macros.
+ */
+#include <lttng/tracepoint-event.h>

--- a/Xext/dri3/meson.build
+++ b/Xext/dri3/meson.build
@@ -4,11 +4,18 @@ srcs_dri3 = [
     'dri3_screen.c',
 ]
 
+dri3_deps = [ common_dep, libdrm_dep ]
+
+if build_lttngust
+    srcs_dri3 += [ 'dri3_tp.c' ]
+    dri3_deps += [ lttng_ust_dep ]
+endif
+
 libxserver_dri3 = []
 if build_dri3
     libxserver_dri3 = static_library('xserver_dri3',
         srcs_dri3,
         include_directories: inc,
-        dependencies: [ common_dep, libdrm_dep ],
+        dependencies: dri3_deps,
         )
 endif

--- a/dix/dispatch.c
+++ b/dix/dispatch.c
@@ -152,6 +152,10 @@ Equipment Corporation.
 #include "xkbsrv.h"
 #include "dixstruct_priv.h"
 
+#ifdef _XLIBRE_LTTNG_UST
+#include "xlibre_gentracing_tp.h"
+#endif
+
 #define mskcnt ((MAXCLIENTS + 31) / 32)
 #define BITMASK(i) (1U << ((i) & 31))
 #define MASKIDX(i) ((i) >> 5)
@@ -1800,6 +1804,10 @@ ProcCopyArea(ClientPtr client)
     int rc;
 
     REQUEST_SIZE_MATCH(xCopyAreaReq);
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_dix,CopyArea,client->index,stuff->srcDrawable,stuff->dstDrawable,stuff->srcX,stuff->srcY,stuff->dstX,stuff->dstY,stuff->width,stuff->height);
+#endif
 
     VALIDATE_DRAWABLE_AND_GC(stuff->dstDrawable, pDst, DixWriteAccess);
     if (stuff->dstDrawable != stuff->srcDrawable) {
@@ -3711,6 +3719,11 @@ CloseDownClient(ClientPtr client)
 #ifdef XSERVER_DTRACE
         XSERVER_CLIENT_DISCONNECT(client->index);
 #endif
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_dix,print,client->index,"client disconnected");
+#endif
+
         if (client->index < nextFreeClientID)
             nextFreeClientID = client->index;
         clients[client->index] = NULL;
@@ -3923,6 +3936,11 @@ SendConnSetup(ClientPtr client, const char *reason)
         CallCallbacks((&ClientStateCallback), (void *) &clientinfo);
     }
     CancelDispatchExceptionTimer();
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_dix,print,client->index,"client connected");
+#endif
+
     return Success;
 }
 

--- a/dix/meson.build
+++ b/dix/meson.build
@@ -43,6 +43,12 @@ srcs_dix = [
     'window.c',
 ]
 
+libxserver_dix_extra_deps = []
+if build_lttngust
+    srcs_dix += [ 'xlibre_gentracing_tp.c' ]
+    libxserver_dix_extra_deps += [ lttng_ust_dep ]
+endif
+
 atom_generator = generator(
     find_program('generate-atoms'),
     output: '@BASENAME@.c',
@@ -65,7 +71,7 @@ dtrace_dep = declare_dependency(sources: [dtrace_src, dtrace_hdr])
 libxserver_dix = static_library('xserver_dix',
     [ srcs_dix, builtinatoms_src ],
     include_directories: inc,
-    dependencies: [ dtrace_dep, common_dep, ]
+    dependencies: [ dtrace_dep, common_dep, ] + libxserver_dix_extra_deps
 )
 
 libxserver_main = static_library('xserver_main',

--- a/dix/xlibre_gentracing_tp.c
+++ b/dix/xlibre_gentracing_tp.c
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
+ *
+ * Copyright © 2026 cepelinas9000, gtautvis@gmail.com
+ */
+
+/* Generic lttng-ust dix tracing stuff */
+
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+#include "xlibre_gentracing_tp.h"

--- a/dix/xlibre_gentracing_tp.h
+++ b/dix/xlibre_gentracing_tp.h
@@ -1,0 +1,87 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
+ *
+ * Copyright © 2026 cepelinas9000, gtautvis@gmail.com
+ */
+
+/* Generic lttng-ust diz tracing  */
+
+
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER xlibre_dix
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "./xlibre_gentracing_tp.h"
+
+#if !defined(_TP_H) || \
+defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define _TP_H
+
+#include <lttng/tracepoint.h>
+
+
+    /* generic string print event (simpler and prefixed version of https://lttng.org/man/3/lttng_ust_vtracef/v2.13/ ) */
+    LTTNG_UST_TRACEPOINT_EVENT(
+        /* Tracepoint provider name */
+        xlibre_dix,
+
+        /* Tracepoint/event name */
+        print,
+
+        /* List of tracepoint arguments (input) */
+        LTTNG_UST_TP_ARGS(
+            int, client_id,
+            const char*,str
+            ),
+
+        /* List of fields of eventual event (output) */
+        LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int,client_id,client_id)
+            lttng_ust_field_string(msg,str)
+            )
+        )
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    /* Tracepoint provider name */
+    xlibre_dix,
+
+    /* Tracepoint/event name */
+    CopyArea,
+
+    /* List of tracepoint arguments (input) */
+    LTTNG_UST_TP_ARGS(
+        int, client_id,
+        uint32_t, src_drawable,
+        uint32_t, dst_drawable,
+        uint32_t, srcX,
+        uint32_t, srcY,
+        uint32_t, dstX,
+        uint32_t,  dstY,
+        uint32_t, width,
+        uint32_t, height
+
+        ),
+
+    /* List of fields of eventual event (output) */
+    LTTNG_UST_TP_FIELDS(
+        lttng_ust_field_integer(int,client_id,client_id)
+        lttng_ust_field_integer_hex(uint32_t, src, src_drawable)
+        lttng_ust_field_integer_hex(uint32_t, dst, dst_drawable)
+
+        lttng_ust_field_integer(uint32_t, srcX, srcX)
+        lttng_ust_field_integer(uint32_t, srcY, srcY)
+
+        lttng_ust_field_integer(uint32_t, dstX, dstX)
+        lttng_ust_field_integer(uint32_t, dstY, dstY)
+
+        lttng_ust_field_integer(uint32_t, width, width)
+        lttng_ust_field_integer(uint32_t, height, height)
+
+        )
+    )
+#endif
+
+
+/*
+ * Add this after defining the tracepoint events to expand the macros.
+ */
+#include <lttng/tracepoint-event.h>

--- a/hw/xfree86/drivers/video/modesetting/dri2.c
+++ b/hw/xfree86/drivers/video/modesetting/dri2.c
@@ -726,6 +726,8 @@ ms_dri2_schedule_wait_msc(ClientPtr client, DrawablePtr draw, CARD64 target_msc,
 
     /* Get current count */
     ret = ms_get_crtc_ust_msc(crtc, &current_ust, &current_msc);
+    if (ret)
+        goto out_free;
 
     /*
      * If divisor is zero, or current_msc is smaller than target_msc,

--- a/hw/xfree86/drivers/video/modesetting/driver.h
+++ b/hw/xfree86/drivers/video/modesetting/driver.h
@@ -142,7 +142,6 @@ typedef struct _modesettingRec {
     uint32_t cursor_image_height;
 
     Bool has_queue_sequence;
-    Bool tried_queue_sequence;
 
     Bool kms_has_modifiers;
 

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -2840,6 +2840,7 @@ drmmode_crtc_init(ScrnInfoPtr pScrn, drmmode_ptr drmmode, drmModeResPtr mode_res
     xorg_list_init(&drmmode_crtc->mode_list);
     xorg_list_init(&drmmode_crtc->tearfree.dri_flip_list);
     drmmode_crtc->next_msc = UINT64_MAX;
+    drmmode_crtc->msc_seen = UINT64_MAX;
 
     /* Setup the fallback cursor immediately. */
     drmmode_crtc->cursor.dimensions = malloc(sizeof(drmmode_cursor_dim_rec));

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.h
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.h
@@ -226,6 +226,8 @@ typedef struct {
      */
     uint32_t msc_prev;
     uint64_t msc_high;
+    /* Last observed position, never set from queue write-backs */
+    uint64_t msc_seen;
     /** @} */
 
     uint64_t next_msc;

--- a/hw/xfree86/drivers/video/modesetting/meson.build
+++ b/hw/xfree86/drivers/video/modesetting/meson.build
@@ -8,6 +8,20 @@ modesetting_srcs = [
     'vblank.c',
 ]
 
+modesetting_deps = [
+    common_dep,
+    udev_dep,
+    libdrm_dep,
+    gbm_dep,
+]
+
+
+if build_lttngust
+    modesetting_srcs += [ 'modesetting_tp.c' ]
+    modesetting_deps += [ lttng_ust_dep ]
+endif
+
+
 shared_module(
     'modesetting_drv',
     modesetting_srcs,
@@ -15,12 +29,7 @@ shared_module(
 
     include_directories: [inc, xorg_inc],
     c_args: xorg_c_args,
-    dependencies: [
-        common_dep,
-        udev_dep,
-        libdrm_dep,
-        gbm_dep,
-    ],
+    dependencies: modesetting_deps,
 
     install: true,
     install_dir: join_paths(module_abi_dir, 'drivers'),

--- a/hw/xfree86/drivers/video/modesetting/modesetting_tp.c
+++ b/hw/xfree86/drivers/video/modesetting/modesetting_tp.c
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
+ *
+ * Copyright © 2026 cepelinas9000, gtautvis@gmail.com
+ */
+
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+
+/*
+ * The header containing our LTTNG_UST_TRACEPOINT_EVENTs.
+ */
+
+
+#include "modesetting_tp.h"

--- a/hw/xfree86/drivers/video/modesetting/modesetting_tp.h
+++ b/hw/xfree86/drivers/video/modesetting/modesetting_tp.h
@@ -1,0 +1,177 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
+ *
+ * Copyright © 2026 cepelinas9000, gtautvis@gmail.com
+ */
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER xlibre_modesetting
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "modesetting_tp.h"
+
+#if !defined(_TP_H) || \
+defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define _TP_H
+
+#include <lttng/tracepoint.h>
+
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    /* Tracepoint provider name */
+    xlibre_modesetting,
+
+
+    vblank_screen_init,
+        LTTNG_UST_TP_ARGS(
+            int, screen_num,
+            int, has_queue_sequence
+        ),
+
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int,screen_num,screen_num)
+            lttng_ust_field_integer(int,has_queue_sequence,has_queue_sequence)
+        )
+    )
+
+
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    /* Tracepoint provider name */
+    xlibre_modesetting,
+
+    /* has queue sequence */
+    ms_queue_vblank_has_qs,
+
+    LTTNG_UST_TP_ARGS(
+        int, screen_num,
+        int, crtc_id,
+        uint32_t, drm_flags,
+        uint64_t, msc,
+        uint32_t, seq,
+        int, drmCrtc_ret,
+        bool, msc_queued_valid,
+        uint64_t, msc_queued
+        ),
+
+    LTTNG_UST_TP_FIELDS(
+        lttng_ust_field_integer(int,screen_num,screen_num)
+        lttng_ust_field_integer(int,crtc_id,crtc_id)
+        lttng_ust_field_integer_hex(uint32_t,drm_flags,drm_flags)
+        lttng_ust_field_integer(uint64_t,msc,msc)
+        lttng_ust_field_integer(uint32_t,seq,seq)
+        lttng_ust_field_integer(int,drmCrtc_ret,drmCrtc_ret)
+        lttng_ust_field_integer(int,msc_queued_valid,msc_queued_valid)
+        lttng_ust_field_integer(uint64_t,msc_queued,msc_queued)
+        )
+    )
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    /* Tracepoint provider name */
+    xlibre_modesetting,
+
+    /* has queue sequence */
+    ms_queue_vblank_no_qs,
+
+    LTTNG_UST_TP_ARGS(
+        int, screen_num,
+        int, crtc_id,
+        uint32_t, drm_flags,
+        uint64_t, msc,
+        uint32_t, seq,
+        int, drmWaitVB_ret,
+        bool, msc_queued_valid,
+        uint64_t, msc_queued
+        ),
+
+    LTTNG_UST_TP_FIELDS(
+        lttng_ust_field_integer(int,screen_num,screen_num)
+        lttng_ust_field_integer(int,crtc_id,crtc_id)
+        lttng_ust_field_integer_hex(uint32_t,drm_flags,drm_flags)
+        lttng_ust_field_integer(uint64_t,msc,msc)
+        lttng_ust_field_integer(uint32_t,seq,seq)
+        lttng_ust_field_integer(int,drmWaitVB_ret,drmWaitVB_ret)
+        lttng_ust_field_integer(int,msc_queued_valid,msc_queued_valid)
+        lttng_ust_field_integer(uint64_t,msc_queued,msc_queued)
+        )
+    )
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    /* Tracepoint provider name */
+    xlibre_modesetting,
+
+    /* has queue sequence */
+    ms_queue_vblank_abort,
+
+    LTTNG_UST_TP_ARGS(
+        int, screen_num,
+        int, crtc_id,
+        uint32_t, queue_flags,
+        uint64_t, msc,
+        uint32_t, seq
+        ),
+
+    LTTNG_UST_TP_FIELDS(
+        lttng_ust_field_integer(int,screen_num,screen_num)
+        lttng_ust_field_integer(int,crtc_id,crtc_id)
+        lttng_ust_field_integer_hex(uint32_t,queue_flags,queue_flags)
+        lttng_ust_field_integer(uint64_t,msc,msc)
+        lttng_ust_field_integer(uint32_t,seq,seq)
+        )
+    )
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    /* Tracepoint provider name */
+    xlibre_modesetting,
+
+    /* has queue sequence */
+    ms_get_kernel_ust_msc_has_qs,
+
+    LTTNG_UST_TP_ARGS(
+        int, screen_num,
+        int, crtc_id,
+        int, drmCrtcGet_ret,
+        uint64_t, msc,
+        uint64_t, ust
+
+        ),
+
+    LTTNG_UST_TP_FIELDS(
+        lttng_ust_field_integer(int,screen_num,screen_num)
+        lttng_ust_field_integer(int,crtc_id,crtc_id)
+        lttng_ust_field_integer(int,drmCrtcGet_ret,drmCrtcGet_ret)
+        lttng_ust_field_integer(uint64_t,msc,msc)
+        lttng_ust_field_integer(uint32_t,ust,ust)
+        )
+    )
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    /* Tracepoint provider name */
+    xlibre_modesetting,
+
+    /* has queue sequence */
+    ms_get_kernel_ust_msc_no_qs,
+
+    LTTNG_UST_TP_ARGS(
+        int, screen_num,
+        int, crtc_id,
+        int, drmWaitVB_ret,
+        uint64_t, msc,
+        uint64_t, ust
+
+        ),
+
+    LTTNG_UST_TP_FIELDS(
+        lttng_ust_field_integer(int,screen_num,screen_num)
+        lttng_ust_field_integer(int,crtc_id,crtc_id)
+        lttng_ust_field_integer(int,drmWaitVB_ret,drmWaitVB_ret)
+        lttng_ust_field_integer_hex(uint64_t,msc,msc)
+        lttng_ust_field_integer_hex(uint32_t,ust,ust)
+        )
+    )
+
+
+#endif
+
+/*
+ * Add this after defining the tracepoint events to expand the macros.
+ */
+#include <lttng/tracepoint-event.h>

--- a/hw/xfree86/drivers/video/modesetting/vblank.c
+++ b/hw/xfree86/drivers/video/modesetting/vblank.c
@@ -316,6 +316,19 @@ ms_queue_vblank(xf86CrtcPtr crtc, ms_queue_flag flags,
     drmVBlank vbl;
     int ret;
 
+    if (!(flags & MS_QUEUE_RELATIVE)) {
+        if (drmmode_crtc->msc_seen == UINT64_MAX) {
+            /* No observed position for this CRTC yet, so nothing to verify against */
+            flags = MS_QUEUE_RELATIVE;
+            msc = 1;
+        } else if ((int64_t)(msc - drmmode_crtc->msc_seen) <= 0) {
+            /* drm_vblank_passed() looks back only 2^23 seqs, so an older target
+             * parks forever; relative 0 fires now, as the kernel would have */
+            flags = MS_QUEUE_RELATIVE | (flags & MS_QUEUE_NEXT_ON_MISS);
+            msc = 0;
+        }
+    }
+
     /* Try coalescing this event into another to avoid event queue exhaustion */
     if (flags == MS_QUEUE_ABSOLUTE && ms_queue_coalesce(crtc, seq, msc))
         return TRUE;
@@ -425,11 +438,13 @@ ms_get_crtc_ust_msc(xf86CrtcPtr crtc, CARD64 *ust, CARD64 *msc)
     ScreenPtr screen = crtc->randr_crtc->pScreen;
     ScrnInfoPtr scrn = xf86ScreenToScrn(screen);
     modesettingPtr ms = modesettingPTR(scrn);
+    drmmode_crtc_private_ptr drmmode_crtc = crtc->driver_private;
     uint64_t kernel_msc;
 
     if (!ms_get_kernel_ust_msc(crtc, &kernel_msc, ust))
         return BadMatch;
     *msc = ms_kernel_msc_to_crtc_msc(crtc, kernel_msc, ms->has_queue_sequence);
+    drmmode_crtc->msc_seen = *msc;
 
     return Success;
 }
@@ -589,6 +604,9 @@ ms_drm_sequence_handler(int fd, uint64_t frame, uint64_t ns, Bool is64bit, uint6
     if (!crtc)
         return;
 
+    drmmode_crtc = crtc->driver_private;
+    drmmode_crtc->msc_seen = msc;
+
     /* Now run all of the vblank events for this CRTC with an expired MSC */
     xorg_list_for_each_entry_safe(q, tmp, &ms_drm_queue, list) {
         if (q->crtc == crtc && q->msc <= msc) {
@@ -614,7 +632,6 @@ ms_drm_sequence_handler(int fd, uint64_t frame, uint64_t ns, Bool is64bit, uint6
     }
 
     /* Queue an event if the next queued MSC isn't soon enough */
-    drmmode_crtc = crtc->driver_private;
     drmmode_crtc->next_msc = next_msc;
     if (msc < next_msc && !ms_queue_vblank(crtc, MS_QUEUE_ABSOLUTE, msc, NULL, seq)) {
         xf86DrvMsg(crtc->scrn->scrnIndex, X_WARNING,

--- a/hw/xfree86/drivers/video/modesetting/vblank.c
+++ b/hw/xfree86/drivers/video/modesetting/vblank.c
@@ -231,18 +231,15 @@ ms_get_kernel_ust_msc(xf86CrtcPtr crtc,
     drmVBlank vbl;
     int ret;
 
-    if (ms->has_queue_sequence || !ms->tried_queue_sequence) {
+    if (ms->has_queue_sequence) {
         uint64_t ns;
-        ms->tried_queue_sequence = TRUE;
 
         ret = drmCrtcGetSequence(ms->fd, drmmode_crtc->mode_crtc->crtc_id,
                                  msc, &ns);
-        if (ret != -1 || (errno != ENOTTY && errno != EINVAL)) {
-            ms->has_queue_sequence = TRUE;
-            if (ret == 0)
-                *ust = ns / 1000;
-            return ret == 0;
-        }
+        if (ret)
+            return FALSE;
+        *ust = ns / 1000;
+        return TRUE;
     }
     /* Get current count */
     vbl.request.type = DRM_VBLANK_RELATIVE | drmmode_crtc->vblank_pipe;
@@ -335,11 +332,9 @@ ms_queue_vblank(xf86CrtcPtr crtc, ms_queue_flag flags,
 
     for (;;) {
         /* Queue an event at the specified sequence */
-        if (ms->has_queue_sequence || !ms->tried_queue_sequence) {
+        if (ms->has_queue_sequence) {
             uint32_t drm_flags = 0;
             uint64_t kernel_queued;
-
-            ms->tried_queue_sequence = TRUE;
 
             if (flags & MS_QUEUE_RELATIVE)
                 drm_flags |= DRM_CRTC_SEQUENCE_RELATIVE;
@@ -353,34 +348,28 @@ ms_queue_vblank(xf86CrtcPtr crtc, ms_queue_flag flags,
                 ms_drm_set_seq_queued(seq, msc);
                 if (msc_queued)
                     *msc_queued = msc;
-                ms->has_queue_sequence = TRUE;
                 return TRUE;
             }
+        } else {
+            vbl.request.type = DRM_VBLANK_EVENT | drmmode_crtc->vblank_pipe;
+            if (flags & MS_QUEUE_RELATIVE)
+                vbl.request.type |= DRM_VBLANK_RELATIVE;
+            else
+                vbl.request.type |= DRM_VBLANK_ABSOLUTE;
+            if (flags & MS_QUEUE_NEXT_ON_MISS)
+                vbl.request.type |= DRM_VBLANK_NEXTONMISS;
 
-            if (ret != -1 || (errno != ENOTTY && errno != EINVAL)) {
-                ms->has_queue_sequence = TRUE;
-                goto check;
+            vbl.request.sequence = msc;
+            vbl.request.signal = seq;
+            ret = drmWaitVBlank(ms->fd, &vbl);
+            if (ret == 0) {
+                msc = ms_kernel_msc_to_crtc_msc(crtc, vbl.reply.sequence, FALSE);
+                ms_drm_set_seq_queued(seq, msc);
+                if (msc_queued)
+                    *msc_queued = msc;
+                return TRUE;
             }
         }
-        vbl.request.type = DRM_VBLANK_EVENT | drmmode_crtc->vblank_pipe;
-        if (flags & MS_QUEUE_RELATIVE)
-            vbl.request.type |= DRM_VBLANK_RELATIVE;
-        else
-            vbl.request.type |= DRM_VBLANK_ABSOLUTE;
-        if (flags & MS_QUEUE_NEXT_ON_MISS)
-            vbl.request.type |= DRM_VBLANK_NEXTONMISS;
-
-        vbl.request.sequence = msc;
-        vbl.request.signal = seq;
-        ret = drmWaitVBlank(ms->fd, &vbl);
-        if (ret == 0) {
-            msc = ms_kernel_msc_to_crtc_msc(crtc, vbl.reply.sequence, FALSE);
-            ms_drm_set_seq_queued(seq, msc);
-            if (msc_queued)
-                *msc_queued = msc;
-            return TRUE;
-        }
-    check:
         if (errno != EBUSY) {
             ms_drm_abort_seq(scrn, seq);
             return FALSE;
@@ -671,6 +660,8 @@ ms_vblank_screen_init(ScreenPtr screen)
     ScrnInfoPtr scrn = xf86ScreenToScrn(screen);
     modesettingPtr ms = modesettingPTR(scrn);
     modesettingEntPtr ms_ent = ms_ent_priv(scrn);
+    uint64_t dummy_msc, dummy_ns;
+
     xorg_list_init(&ms_drm_queue);
 
     ms->event_context.version = 4;
@@ -688,6 +679,10 @@ ms_vblank_screen_init(ScreenPtr screen)
         ms_ent->fd_wakeup_ref = 1;
     } else
         ms_ent->fd_wakeup_ref++;
+
+    /* ID 0 is never valid and fails with ENOENT when the ioctl is available */
+    ms->has_queue_sequence =
+        !drmCrtcGetSequence(ms->fd, 0, &dummy_msc, &dummy_ns) || errno == ENOENT;
 
     return TRUE;
 }

--- a/hw/xfree86/drivers/video/modesetting/vblank.c
+++ b/hw/xfree86/drivers/video/modesetting/vblank.c
@@ -35,6 +35,11 @@
 #include "driver.h"
 #include "drmmode_display.h"
 
+#ifdef _XLIBRE_LTTNG_UST
+#include "modesetting_tp.h"
+#endif
+
+
 /**
  * Tracking for outstanding events queued to the kernel.
  *
@@ -236,9 +241,18 @@ ms_get_kernel_ust_msc(xf86CrtcPtr crtc,
 
         ret = drmCrtcGetSequence(ms->fd, drmmode_crtc->mode_crtc->crtc_id,
                                  msc, &ns);
-        if (ret)
+        if (ret){
+#ifdef _XLIBRE_LTTNG_UST
+            lttng_ust_tracepoint(xlibre_modesetting,ms_get_kernel_ust_msc_has_qs,scrn->scrnIndex,drmmode_crtc->mode_crtc->crtc_id,ret,*msc,*ust);
+#endif
             return FALSE;
+
+        }
         *ust = ns / 1000;
+#ifdef _XLIBRE_LTTNG_UST
+        lttng_ust_tracepoint(xlibre_modesetting,ms_get_kernel_ust_msc_has_qs,scrn->scrnIndex,drmmode_crtc->mode_crtc->crtc_id,ret,*msc,*ust);
+#endif
+
         return TRUE;
     }
     /* Get current count */
@@ -249,10 +263,19 @@ ms_get_kernel_ust_msc(xf86CrtcPtr crtc,
     if (ret) {
         *msc = 0;
         *ust = 0;
+#ifdef _XLIBRE_LTTNG_UST
+        lttng_ust_tracepoint(xlibre_modesetting,ms_get_kernel_ust_msc_no_qs,scrn->scrnIndex,drmmode_crtc->mode_crtc->crtc_id,ret,*msc,*ust);
+#endif
+
         return FALSE;
     } else {
         *msc = vbl.reply.sequence;
         *ust = (CARD64) vbl.reply.tval_sec * 1000000 + vbl.reply.tval_usec;
+
+#ifdef _XLIBRE_LTTNG_UST
+        lttng_ust_tracepoint(xlibre_modesetting,ms_get_kernel_ust_msc_no_qs,scrn->scrnIndex,drmmode_crtc->mode_crtc->crtc_id,ret,*msc,*ust);
+#endif
+
         return TRUE;
     }
 }
@@ -344,11 +367,19 @@ ms_queue_vblank(xf86CrtcPtr crtc, ms_queue_flag flags,
             ret = drmCrtcQueueSequence(ms->fd, drmmode_crtc->mode_crtc->crtc_id,
                                        drm_flags, msc, &kernel_queued, seq);
             if (ret == 0) {
+                uint64_t msc_orig = msc;
                 msc = ms_kernel_msc_to_crtc_msc(crtc, kernel_queued, TRUE);
                 ms_drm_set_seq_queued(seq, msc);
                 if (msc_queued)
                     *msc_queued = msc;
+#ifdef _XLIBRE_LTTNG_UST
+                lttng_ust_tracepoint(xlibre_modesetting,ms_queue_vblank_has_qs,scrn->scrnIndex,drmmode_crtc->mode_crtc->crtc_id,drm_flags,msc_orig,seq,ret,1,msc);
+#endif
                 return TRUE;
+            } else {
+#ifdef _XLIBRE_LTTNG_UST
+                lttng_ust_tracepoint(xlibre_modesetting,ms_queue_vblank_has_qs,scrn->scrnIndex,drmmode_crtc->mode_crtc->crtc_id,drm_flags,msc,seq,ret,0,0);
+#endif
             }
         } else {
             vbl.request.type = DRM_VBLANK_EVENT | drmmode_crtc->vblank_pipe;
@@ -363,14 +394,27 @@ ms_queue_vblank(xf86CrtcPtr crtc, ms_queue_flag flags,
             vbl.request.signal = seq;
             ret = drmWaitVBlank(ms->fd, &vbl);
             if (ret == 0) {
+                uint64_t msc_orig = msc;
                 msc = ms_kernel_msc_to_crtc_msc(crtc, vbl.reply.sequence, FALSE);
                 ms_drm_set_seq_queued(seq, msc);
                 if (msc_queued)
                     *msc_queued = msc;
+#ifdef _XLIBRE_LTTNG_UST
+                lttng_ust_tracepoint(xlibre_modesetting,ms_queue_vblank_no_qs,scrn->scrnIndex,drmmode_crtc->mode_crtc->crtc_id,vbl.request.type,msc_orig,seq,ret,1,msc);
+#endif
+
                 return TRUE;
+            } else {
+#ifdef _XLIBRE_LTTNG_UST
+                lttng_ust_tracepoint(xlibre_modesetting,ms_queue_vblank_no_qs,scrn->scrnIndex,drmmode_crtc->mode_crtc->crtc_id,vbl.request.type,msc,seq,ret,0,0);
+#endif
+
             }
         }
         if (errno != EBUSY) {
+#ifdef _XLIBRE_LTTNG_UST
+            lttng_ust_tracepoint(xlibre_modesetting,ms_queue_vblank_abort,scrn->scrnIndex,drmmode_crtc->mode_crtc->crtc_id,flags,msc,seq);
+#endif
             ms_drm_abort_seq(scrn, seq);
             return FALSE;
         }
@@ -683,6 +727,10 @@ ms_vblank_screen_init(ScreenPtr screen)
     /* ID 0 is never valid and fails with ENOENT when the ioctl is available */
     ms->has_queue_sequence =
         !drmCrtcGetSequence(ms->fd, 0, &dummy_msc, &dummy_ns) || errno == ENOENT;
+
+#ifdef _XLIBRE_LTTNG_UST
+    lttng_ust_tracepoint(xlibre_modesetting,vblank_screen_init,scrn->scrnIndex,ms->has_queue_sequence);
+#endif
 
     return TRUE;
 }

--- a/meson.build
+++ b/meson.build
@@ -137,6 +137,16 @@ if not libsystemd_daemon_dep.found()
     libsystemd_daemon_dep = dependency('libsystemd-daemon', required: false)
 endif
 
+
+build_lttngust = false
+
+if get_option('tracing_lttng')
+    build_lttngust = true
+    lttng_ust_dep = dependency('lttng-ust',version : '>= 2.12.0')
+    conf_data.set('_XLIBRE_LTTNG_UST', '1')
+
+endif
+
 build_hashtable = false
 
 # Resolve default values of some options

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -181,3 +181,7 @@ option('test_rendercheck_triangles', type: 'boolean', value: false,
        description: 'testsuite: run rendercheck triangles tests (might fail on Xephyr)')
 option('test_xephyr_gles', type: 'boolean', value: true,
        description: 'testsuite: run gles2/gles3 tests on Xephyr (might fail w/o DRI)')
+
+# tracing
+option('tracing_lttng', type : 'boolean', value : false,
+       description: 'tracing_lttng: compile with lttng-ust tracing support')


### PR DESCRIPTION
I know it in territory https://xkcd.com/927/ , because there are `DTRACE` in code mentioned.

It need some rethink. It just solves following problem: provide fancy printf type function across hosts with timestamps & stuff, have minimal impact during normal DE execution (I mean running under lightdm - which closes all stdout fds...):

<img width="1869" height="837" alt="image" src="https://github.com/user-attachments/assets/6f3d362c-9a3a-4581-b9da-ab3b0321e6cf" />

*snapshot running babeltrace in "realtime"*

To try it, firstly on debugger system start relay daemon (if not running)
```
 $ lttng-relayd
```

on debugee system (you need have running lttng-sessionda and to check avaible events use `lttng list -u`):
```
 # lttng create --live=10000 --set-url net://192.168.1.2 # debugger ip
 # lttng enable-event -u xlibre_*
 # lttng start

```

Back on debugger system:
```
 $  babeltrace2 convert -i lttng-live net://localhost
net://localhost/host/SonicDE/auto-20260814-130658 (timer = 10000, 13 stream(s), 0 client(s) connected, CTF 1.8)

 $ babeltrace2 convert -i lttng-live net://localhost/host/SonicDE/auto-20260814-130658
[16:20:58.383714703] (+?.?????????) SonicDE xlibre_dix:CopyArea: { cpu_id = 10 }, { client_id = 33, src = 0x4200016, dst = 0x420000E, srcX = 3, srcY = 79, dstX = 3, dstY = 79, width = 1614, height = 540 }
[16:20:58.383760955] (+0.000046252) SonicDE xlibre_dix:CopyArea: { cpu_id = 10 }, { client_id = 33, src = 0x4200016, dst = 0x420000E, srcX = 3, srcY = 634, dstX = 3, dstY = 634, width = 1, height = 15 }
[16:20:58.383763566] (+0.000002611) SonicDE xlibre_dix:CopyArea: { cpu_id = 10 }, { client_id = 33, src = 0x4200016, dst = 0x420000E, srcX = 1612, srcY = 634, dstX = 1612, dstY = 634, width = 5, height = 15 }
```