### PR TITLE
dix: keep XI_PROP_ENABLED in sync with the real device state

### DIFF
--- a/dix/devices.c
+++ b/dix/devices.c
@@ -169,6 +169,8 @@ DeviceSetProperty(DeviceIntPtr dev, Atom property, XIPropertyValuePtr prop,
                 EnableDevice(dev, TRUE);
             else if (!(*((CARD8 *) prop->data)) && dev->enabled)
                 DisableDevice(dev, TRUE);
+            /* commit-pass errors are ignored; commit the real state */
+            *((CARD8 *) prop->data) = !!dev->enabled;
         }
     }
     else if (property == XIGetKnownProperty(XI_PROP_TRANSFORM)) {


### PR DESCRIPTION
## Symptom

`xinput list-props` reports `Device Enabled (N): 1` for a device that is in
fact disabled. Every client reading the property gets the same wrong answer.

## Cause

The `XI_PROP_ENABLED` handler in `DeviceSetProperty()` calls `EnableDevice()`,
discards the result, and returns `Success`, so the property is committed as 1
whether or not the device came up.

Returning an error instead does not help. `XIChangeDeviceProperty()` runs the
handlers twice and ignores the result of the commit pass by design:

    /* run through all handlers with checkonly TRUE, then again with
     * checkonly FALSE. Handlers MUST return error codes on the
     * checkonly run, errors on the second run are ignored */

## Fix

After attempting the requested transition, write the actual state back into
the value being committed: the handler now stores `!!dev->enabled`
unconditionally, so the property and the flag agree on every path. This also
covers the reverse case of `DisableDevice()` failing, which today is only
reachable through internal state corruption, but costs nothing to handle.

The buffer the handler receives is the one that gets stored, and the handler
has already rejected anything but a single 8-bit value, so the write is in
range. Clients watching the property see the corrected value in the
`XIPropertyModified` event that follows.

The request itself still succeeds since the check pass cannot predict whether
`DEVICE_ON` will succeed, so a client that needs to know whether the enable
worked has to read the property back. No new errors are introduced.

The stored value is now always 0 or 1. Previously a client writing any other
nonzero byte (e.g. 2) would read that byte back as long as it agreed with the
device state. Nothing could rely on that: the value was already rewritten
whenever it disagreed, and the server's own writers of this property
(`EnableDevice()`/`DisableDevice()`) only ever store 0 or 1.

## Testing

Found while debugging https://github.com/X11Libre/xf86-input-libinput/pull/39.
`xinput --enable` on the stuck devices reported success while `dev->enabled`
stayed 0 in gdb. Run the reproducer from there on a libseat session. After the
input is unrecoverable, try

    chvt 1; sleep 1; DISPLAY=:0 XAUTHORITY=/path/to/.Xauthority bash -c '
    xinput list --id-only | while read -r id; do xinput enable "${id#* }"
    xinput list-props "${id#* }" | grep "Device Enabled"; done'; chvt 2

Before the patch, this lists every device as enabled when it's in fact not.