### PR TITLE
Xext/present: Copy the present info struct instead of just the pointer

### DIFF
--- a/Xext/present/present_screen.c
+++ b/Xext/present/present_screen.c
@@ -75,6 +75,7 @@ static void present_close_screen(CallbackListPtr *pcbl, ScreenPtr screen, void *
 
     dixScreenUnhookClose(screen, present_close_screen);
     dixSetPrivate(&screen->devPrivates, &present_screen_private_key, NULL);
+    free(screen_priv->info);
     free(screen_priv);
 }
 
@@ -232,7 +233,15 @@ present_screen_init(ScreenPtr screen, present_screen_info_ptr info)
         if (!screen_priv)
             return FALSE;
 
-        screen_priv->info = info;
+        if (info) {
+            screen_priv->info = malloc(sizeof(*info));
+            if (!screen_priv->info) {
+                return FALSE;
+            }
+            *screen_priv->info = *info;
+        } else {
+            screen_priv->info = NULL;
+        }
         present_scmd_init_mode_hooks(screen_priv);
 
         present_fake_screen_init(screen);

--- a/hw/xfree86/drivers/video/modesetting/present.c
+++ b/hw/xfree86/drivers/video/modesetting/present.c
@@ -509,7 +509,7 @@ ms_present_unflip(ScreenPtr screen, uint64_t event_id)
 }
 #endif
 
-static present_screen_info_rec ms_present_screen_info = {
+static const present_screen_info_rec ms_present_screen_info = {
     .version = PRESENT_SCREEN_INFO_VERSION,
 
     .get_crtc = ms_present_get_crtc,
@@ -530,6 +530,7 @@ static present_screen_info_rec ms_present_screen_info = {
 Bool
 ms_present_screen_init(ScreenPtr screen)
 {
+    present_screen_info_rec info = ms_present_screen_info;
     ScrnInfoPtr scrn = xf86ScreenToScrn(screen);
     modesettingPtr ms = modesettingPTR(scrn);
     uint64_t value;
@@ -543,10 +544,10 @@ ms_present_screen_init(ScreenPtr screen)
                             DRM_CAP_ATOMIC_ASYNC_PAGE_FLIP :
                             DRM_CAP_ASYNC_PAGE_FLIP, &value);
     if (ret == 0 && value == 1) {
-        ms_present_screen_info.capabilities |= PresentCapabilityAsync;
+        info.capabilities |= PresentCapabilityAsync;
         ms->drmmode.can_async_flip = TRUE;
         xf86DrvMsg(screen->myNum, X_INFO, "Async flip capable\n");
     }
 
-    return present_screen_init(screen, &ms_present_screen_info);
+    return present_screen_init(screen, &info);
 }


### PR DESCRIPTION
When using multiple screens with different present capabilities, we need to store the present screen info for each screen.

Instead of forcing callers to store copies of the screen info struct for each screen, just copy it in `present_screen_init`