### PR TITLE
modesetting: fix permanent black screen after a failed EnterVT

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -60,6 +60,7 @@
 #include "fb.h"
 #include "xf86i2c.h"
 #include "xf86Crtc.h"
+#include "xf86RandR12.h"
 #include "miscstruct.h"
 #include "dixstruct.h"
 #include "xf86xv.h"
@@ -2273,7 +2274,7 @@ LeaveVT(ScrnInfoPtr pScrn)
 }
 
 /*
- * This gets called when gaining control of the VT, and from ScreenInit().
+ * This gets called when gaining control of the VT.
  */
 static Bool
 EnterVT(ScrnInfoPtr pScrn)
@@ -2301,7 +2302,7 @@ EnterVT(ScrnInfoPtr pScrn)
          * can hopefully correct the situation
          */
         RRSetChanged(xf86ScrnToScreen(pScrn));
-        RRTellChanged(xf86ScrnToScreen(pScrn));
+        xf86RandR12TellChanged(xf86ScrnToScreen(pScrn));
     }
 
     return TRUE;


### PR DESCRIPTION
## Symptom

If a modeset fails while regaining the VT, the screen stays black for the rest
of the session. `xrandr` reports the output connected at the expected mode and
position, and `xrandr --auto` does nothing at all.

## Cause

On failure `drmmode_set_desired_modes()` clears `crtc->enabled` so the rest of
the server stops using that CRTC. From then on every call explicitly blanks it
(`drmModeSetCrtc(..., 0, 0, 0, NULL, 0, NULL)` ) and skips it.

`EnterVT()` then calls `RRTellChanged()` so a desktop can put the configuration
back, but that only delivers events built from RandR's own state, and nothing
has updated that state. Clients are told something changed and find everything
as it was, so no repair is possible. This includes `xrandr`, which computes no
difference and sends no request.

`xf86DisableUnusedFunctions()` does call `xf86_crtc_notify()`, but that hook is
only ever installed by DRI1 (`hw/xfree86/dri/dri.c`), so on a DRI2/DRI3 server
it is a no-op and callers have to notify RandR themselves. `xf86SetSingleMode()`
is the precedent: it does the same thing.

## Fix

Use `xf86RandR12TellChanged()`, which runs `xf86RandR12CrtcNotify()` per CRTC
before telling clients. RandR then learns the CRTC is off and the existing
recovery path works. Also drops the claim that `EnterVT()` is called from
`ScreenInit()`, it is not.

This does not stop the CRTC being disabled and does not self-heal. It addresses
the server leaving RandR out of sync when a modeset on VT enter fails for any
reason.

## Reproducer

The VT-switch race similar to https://github.com/X11Libre/xf86-input-libinput/pull/39.
With a graphical session on VT1, and a plain terminal on VT2, run this from VT2:

    chvt 1; chvt 2

Be aware that this may also kill the input (and is unrecoverable with seatd).

## Evidence

`xrandr` output after a failed EnterVT, unpatched vs patched:

    -eDP-1 connected 1920x1080+0+0 (normal left inverted ...)
    -   1920x1080     60.05*+  60.05
    +eDP-1 connected (normal left inverted ...)
    +   1920x1080     60.05 +  60.05

Unpatched, the screen is black while that first form persists, and
`xrandr --auto` is a no-op against it. Patched, the output is correctly
reported as having no mode, and `xrandr --auto` alone restores the display.
Before the fix that needed `--off` first, to force a change RandR considered
real.

## Testing

After the patch, the following command correctly recovers the black screen on
VT1, run it from VT2:

    chvt 1; sleep 1; DISPLAY=:0 XAUTHORITY=/path/to/.Xauthority xrandr --output eDP-1 --auto
