### PR TITLE
xfree86: seatd-libseat: minor bug fixes in the libseat code

### DIFF
--- a/hw/xfree86/common/seatd-libseat.h
+++ b/hw/xfree86/common/seatd-libseat.h
@@ -46,7 +46,7 @@ extern void seatd_libseat_fini(void);
  **/
 _X_EXPORT
 extern int seatd_libseat_open_graphics(const char *path);
-extern void seatd_libseat_open_device(InputInfoPtr p,int *fd,Bool *paus);
+extern void seatd_libseat_open_device(InputInfoPtr p, int *fd, Bool *paus);
 extern void seatd_libseat_close_device(InputInfoPtr p);
 extern int seatd_libseat_switch_session(int session);
 extern Bool seatd_libseat_controls_session(void);
@@ -55,7 +55,7 @@ extern Bool seatd_libseat_controls_session(void);
 static inline int seatd_libseat_init(bool KeepTty_state) {(void)KeepTty_state; return -1; }
 static inline void seatd_libseat_fini(void) {};
 static inline int seatd_libseat_open_graphics(const char *path) {(void)path; return -1; }
-static inline void seatd_libseat_open_device(void *p,int *fd, Bool *paus) { (void)p;(void)fd;(void)paus; }
+static inline void seatd_libseat_open_device(void *p, int *fd, Bool *paus) { (void)p;(void)fd;(void)paus; }
 static inline void seatd_libseat_close_device(void *p) { (void)p;}
 static inline int seatd_libseat_switch_session(int session) { return -1; }
 static inline Bool seatd_libseat_controls_session(void) { return FALSE; }

--- a/hw/xfree86/common/xf86Xinput.c
+++ b/hw/xfree86/common/xf86Xinput.c
@@ -985,10 +985,10 @@ xf86NewInputDevice(InputInfoPtr pInfo, DeviceIntPtr *pdev, BOOL enable)
     if (path && pInfo->major == 0 && pInfo->minor == 0)
         xf86stat(path, &pInfo->major, &pInfo->minor);
 
-    if (path && (drv->capabilities & XI86_DRV_CAP_SERVER_FD)){
+    if (path && (drv->capabilities & XI86_DRV_CAP_SERVER_FD)) {
         int fd = systemd_logind_take_fd(pInfo->major, pInfo->minor,
                                         path, &paused);
-        seatd_libseat_open_device(pInfo,&fd,&paused);
+        seatd_libseat_open_device(pInfo, &fd, &paused);
         if (fd != -1) {
             if (paused) {
                 /* Put on new_input_devices list for delayed probe */

--- a/hw/xfree86/os-support/shared/drm_platform.c
+++ b/hw/xfree86/os-support/shared/drm_platform.c
@@ -33,7 +33,7 @@ get_drm_info(struct OdevAttributes *attribs, char *path, int delayed_index)
     LogMessage(X_INFO, "Platform probe for %s\n", attribs->syspath);
 
     fd = seatd_libseat_open_graphics(path);
-    if (fd != -1) {
+    if (fd >= 0) {
         attribs->fd = fd;
         server_fd = TRUE;
     } else {

--- a/hw/xfree86/os-support/shared/seatd-libseat.c
+++ b/hw/xfree86/os-support/shared/seatd-libseat.c
@@ -82,7 +82,7 @@ enable_seat(struct libseat *seat, void *userdata)
     /* Reactivate all input devices */
     for (pInfo = xf86InputDevs; pInfo; pInfo = pInfo->next)
         if (pInfo->flags & XI86_SERVER_FD){
-            if (xf86CheckIntOption(pInfo->options, "libseat_id", -1) > 0){
+            if (xf86CheckIntOption(pInfo->options, "libseat_id", -1) >= 0){
                 int fd = -1, paused = FALSE;
                 seatd_libseat_open_device(pInfo, &fd, &paused);
                 xf86EnableInputDeviceForVTSwitch(pInfo);

--- a/hw/xfree86/os-support/shared/seatd-libseat.c
+++ b/hw/xfree86/os-support/shared/seatd-libseat.c
@@ -317,13 +317,13 @@ seatd_libseat_open_device(InputInfoPtr p, int *pfd, Bool *paused)
     char *path = xf86CheckStrOption(p->options, "Device", NULL);
 
     if (!libseat_active()) {
-        return;
+        goto out;
     }
     if (!seat_info.vt_active) {
         *pfd = -2; /* Invalid, but not -1. See xf86NewInputDevice() */
         *paused = TRUE;
         LogMessage(X_INFO, "seatd_libseat paused %s\n", path);
-        return;
+        goto out;
     }
     fd = check_duplicate_device(p->major,p->minor);
     if (fd < 0) {
@@ -332,7 +332,7 @@ seatd_libseat_open_device(InputInfoPtr p, int *pfd, Bool *paused)
             fd = -errno;
             LogMessage(X_ERROR, "seatd_libseat open %s (%d) failed: %d\n",
                        path, id, fd);
-            return;
+            goto out;
         }
     }
     else {
@@ -343,6 +343,8 @@ seatd_libseat_open_device(InputInfoPtr p, int *pfd, Bool *paused)
     p->options = xf86ReplaceIntOption(p->options, "fd", fd);
     p->options = xf86ReplaceIntOption(p->options, "libseat_id", id);
     LogMessage(X_INFO, "seatd_libseat opened %s (%d:%d)\n", path, id, fd);
+out:
+    free(path);
 }
 
 /*
@@ -356,15 +358,15 @@ seatd_libseat_close_device(InputInfoPtr p)
     int id = xf86CheckIntOption(p->options, "libseat_id", -1);
 
     if (!libseat_active())
-        return;
+        goto out;
     LogMessage(X_INFO, "seatd_libseat try close %s (%d:%d)\n", path, id, fd);
     if (fd < 0) {
         LogMessage(X_ERROR, "seatd_libseat device not open (%s)\n", path);
-        return;
+        goto out;
     }
     if (id < 0) {
         LogMessage(X_ERROR, "seatd_libseat no libseat ID\n");
-        return;
+        goto out;
     }
     if (libseat_close_device(seat_info.client, id)) {
         LogMessage(X_ERROR, "seatd_libseat close failed %d\n", -errno);
@@ -374,6 +376,8 @@ seatd_libseat_close_device(InputInfoPtr p)
         p->fd = -1;
         p->options = xf86ReplaceIntOption(p->options, "fd", -1);
     }
+out:
+    free(path);
 }
 
 /*

--- a/hw/xfree86/os-support/shared/seatd-libseat.c
+++ b/hw/xfree86/os-support/shared/seatd-libseat.c
@@ -371,11 +371,9 @@ seatd_libseat_close_device(InputInfoPtr p)
     if (libseat_close_device(seat_info.client, id)) {
         LogMessage(X_ERROR, "seatd_libseat close failed %d\n", -errno);
     }
-    else {
-        close(fd);
-        p->fd = -1;
-        p->options = xf86ReplaceIntOption(p->options, "fd", -1);
-    }
+    close(fd);
+    p->fd = -1;
+    p->options = xf86ReplaceIntOption(p->options, "fd", -1);
 out:
     free(path);
 }

--- a/hw/xfree86/os-support/shared/seatd-libseat.c
+++ b/hw/xfree86/os-support/shared/seatd-libseat.c
@@ -261,7 +261,6 @@ seatd_libseat_fini(void)
  * Return
  *   file descriptor (>=0) if all is ok.
  *   -EPERM (-1) if the libseat client is not activated
- *   -EAGAIN (-11) if the VT is not active
  *   -errno from libseat_open_device if device access failed
  */
 int
@@ -325,7 +324,7 @@ seatd_libseat_open_device(InputInfoPtr p, int *pfd, Bool *paused)
         LogMessage(X_INFO, "seatd_libseat paused %s\n", path);
         goto out;
     }
-    fd = check_duplicate_device(p->major,p->minor);
+    fd = check_duplicate_device(p->major, p->minor);
     if (fd < 0) {
         LogMessage(X_INFO, "seatd_libseat try open %s\n", path);
         if ((id = libseat_open_device(seat_info.client, path, &fd)) == -1) {
@@ -393,13 +392,13 @@ seatd_libseat_controls_session(void){
 int
 seatd_libseat_switch_session(int session)
 {
-    int ret=0;
+    int ret = 0;
 
     LogMessage(X_INFO, "seatd_libseat switch VT %d\n", session);
     if ((ret = libseat_switch_session(seat_info.client, session)) < 0) {
         LogMessage(X_ERROR, "seatd_libseat switch VT failed with %d\n", -errno);
         goto ret;
     }
- ret:
+ret:
     return ret;
 }


### PR DESCRIPTION
This is a couple of small, self-contained fixes for things I found in the seatd/libseat
integration while chasing an unrelated VT switch bug. Each commit is one fix and
its message describes the rationale; everything here is verifiable by inspection,
and the good paths behave as before.

- Two string leaks: `xf86CheckStrOption()` returns a strdup'd copy that neither
  `seatd_libseat_open_device()` nor `seatd_libseat_close_device()` ever freed.
- An fd leak: a failed `libseat_close_device()` RPC left our copy of the fd open
  and `pInfo->fd` pointing at a device being released. The fd is ours regardless
  of the RPC result, so close and invalidate it unconditionally.
- Two sign-check slips: `seatd_libseat_open_graphics()` returns -errno, and only
  -EPERM happens to equal the -1 that `get_drm_info()` tested for, so other
  errors (-EACCES, -EBUSY, ...) were stored as a working server fd. Similarly,
  `enable_seat()` skipped libseat device id 0, which is valid on the logind and
  noop backends (they return the fd as the id); `check_duplicate_device()`
  already tests `>= 0`.
- A doc comment promising an -EAGAIN that is never returned, and some
  brace/comma spacing (cosmetics are the last commit).
