### PR TITLE
(xorg) (master) test/pyxtest: fix ruff I001/UP035 import ordering

### DIFF
--- a/test/pyxtest/conftest.py
+++ b/test/pyxtest/conftest.py
@@ -9,8 +9,9 @@ import warnings
 import pytest
 from pathlib import Path
 
-from xserver import ExternalXServer, XServerProcess
+import pytest
 from xclient import RawX11Connection, X11ConnectionError, XlibConnection
+from xserver import ExternalXServer, XServerProcess
 
 
 def pytest_addoption(parser):

--- a/test/pyxtest/test_fb.py
+++ b/test/pyxtest/test_fb.py
@@ -7,7 +7,6 @@ import tempfile
 import time
 
 import pytest
-
 from proto import pcf, x11
 from xclient import X11Error
 

--- a/test/pyxtest/test_font.py
+++ b/test/pyxtest/test_font.py
@@ -6,7 +6,6 @@ import os
 import time
 
 import pytest
-
 from proto import x11
 from xclient import X11Reply
 

--- a/test/pyxtest/test_glamor.py
+++ b/test/pyxtest/test_glamor.py
@@ -7,7 +7,6 @@ import tempfile
 import time
 
 import pytest
-
 from proto import pcf, x11
 from xclient import X11Error
 

--- a/test/pyxtest/test_glx.py
+++ b/test/pyxtest/test_glx.py
@@ -6,7 +6,6 @@ import struct
 import time
 
 import pytest
-
 from proto import glx
 from xclient import Extension, X11Error, X11Reply
 

--- a/test/pyxtest/test_present.py
+++ b/test/pyxtest/test_present.py
@@ -3,7 +3,6 @@
 # Tests for Present extension.
 
 import pytest
-
 from proto import present
 from xclient import BadWindow, Extension, X11Error
 

--- a/test/pyxtest/test_randr.py
+++ b/test/pyxtest/test_randr.py
@@ -5,7 +5,6 @@
 import struct
 
 import pytest
-
 from proto import randr
 from xclient import BadIDChoice, BadLength, Extension, X11Error, X11Reply
 

--- a/test/pyxtest/test_record.py
+++ b/test/pyxtest/test_record.py
@@ -5,7 +5,6 @@
 import time
 
 import pytest
-
 from proto import record
 from xclient import Extension
 

--- a/test/pyxtest/test_render.py
+++ b/test/pyxtest/test_render.py
@@ -5,7 +5,6 @@
 import struct
 
 import pytest
-
 from proto import render
 from xclient import Extension, X11Error, X11Reply
 

--- a/test/pyxtest/test_screensaver.py
+++ b/test/pyxtest/test_screensaver.py
@@ -5,7 +5,6 @@
 import time
 
 import pytest
-
 from proto import screensaver, x11
 from xclient import Extension
 

--- a/test/pyxtest/test_shm.py
+++ b/test/pyxtest/test_shm.py
@@ -5,7 +5,6 @@
 import struct
 
 import pytest
-
 from proto import shm
 from xclient import Extension, X11Reply
 

--- a/test/pyxtest/test_sync.py
+++ b/test/pyxtest/test_sync.py
@@ -6,9 +6,8 @@ import struct
 import time
 
 import pytest
-
 from proto import sync
-from xclient import Extension, X11Error, X11Reply, RawX11Connection
+from xclient import Extension, RawX11Connection, X11Error, X11Reply
 
 
 @pytest.fixture

--- a/test/pyxtest/test_vidmode.py
+++ b/test/pyxtest/test_vidmode.py
@@ -5,7 +5,6 @@
 import struct
 
 import pytest
-
 from proto import vidmode
 from xclient import Extension, X11Error, X11Reply
 

--- a/test/pyxtest/test_xi.py
+++ b/test/pyxtest/test_xi.py
@@ -5,9 +5,8 @@
 import struct
 
 import pytest
-
 from proto import xi
-from xclient import BadLength, BadWindow, BadValue, Extension, X11Error, X11Reply
+from xclient import BadLength, BadValue, BadWindow, Extension, X11Error, X11Reply
 
 
 @pytest.fixture

--- a/test/pyxtest/test_xinerama.py
+++ b/test/pyxtest/test_xinerama.py
@@ -3,7 +3,6 @@
 # Tests for XINERAMA (PanoramiX / pseudoramiX) extension.
 
 import pytest
-
 from proto import xinerama
 from xclient import Extension, X11Reply
 

--- a/test/pyxtest/test_xkb.py
+++ b/test/pyxtest/test_xkb.py
@@ -7,7 +7,6 @@ import struct
 import time
 
 import pytest
-
 from proto import xkb
 from xclient import BadLength, BadMatch, BadValue, X11Error, X11Reply
 

--- a/test/pyxtest/test_xres.py
+++ b/test/pyxtest/test_xres.py
@@ -5,7 +5,6 @@
 import struct
 
 import pytest
-
 from proto import xres
 from xclient import Extension, X11Reply
 

--- a/test/pyxtest/xclient.py
+++ b/test/pyxtest/xclient.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Protocol, runtime_checkable
 
+from proto import xkb
 from proto.bigrequests import BigRequestsEnableRequest
 from proto.x11 import (
     ChangeKeyboardMappingRequest,
@@ -18,7 +19,6 @@ from proto.x11 import (
     InternAtomRequest,
     QueryExtensionRequest,
 )
-from proto import xkb
 
 
 class X11ConnectionError(Exception):

--- a/test/pyxtest/xserver.py
+++ b/test/pyxtest/xserver.py
@@ -6,16 +6,15 @@
 # optionally under valgrind or with AddressSanitizer (ASAN) support,
 # with automatic display number allocation via the -displayfd mechanism.
 
-from typing import Iterator
-
 import os
 import select
 import shutil
-import sys
 import subprocess
+import sys
 import tempfile
 import time
 import warnings
+from collections.abc import Iterator
 from pathlib import Path
 
 from asan import AsanError


### PR DESCRIPTION
Organize import blocks and import Iterator from collections.abc.

Assisted-by: AI
Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2265>
