### PR TITLE
(xorg) (master) test/pyxtest: use int.bit_count() for virtual mods

### DIFF
--- a/test/pyxtest/proto/xkb.py
+++ b/test/pyxtest/proto/xkb.py
@@ -264,7 +264,7 @@ class GetMapReply:
 
         # 5. Virtual mods (skip)
         if virtual_mods:
-            n_vmods = bin(virtual_mods).count("1")
+            n_vmods = virtual_mods.bit_count()
             offset += (n_vmods + 3) & ~3
 
         # 6. Explicit components


### PR DESCRIPTION
Replace bin(n).count("1") with bit_count() (ruff FURB161).

Assisted-by: AI
Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2265>
