### PR TITLE
(master) test/pyxtest: remove unnecessary pass in X11ConnectionError

### DIFF
--- a/test/pyxtest/xclient.py
+++ b/test/pyxtest/xclient.py
@@ -24,8 +24,6 @@ from proto import xkb
 class X11ConnectionError(Exception):
     """Raised when the X11 connection fails."""
 
-    pass
-
 
 @dataclass
 class XExtensionData:


### PR DESCRIPTION
Empty exception subclasses do not need a pass body (ruff PIE790).

Assisted-by: AI
Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2265>
