### PR TITLE
(master) test/pyxtest: catch OSError when closing Xlib display

### DIFF
--- a/test/pyxtest/xclient.py
+++ b/test/pyxtest/xclient.py
@@ -575,7 +575,8 @@ class XlibConnection:
     def close(self):
         try:
             self.display.close()
-        except Exception:
+        except OSError:
+            # Display may already be closed (e.g. server gone).
             pass
 
     def __enter__(self):


### PR DESCRIPTION
Avoid a blind Exception catch around display.close() (ruff BLE001/S110).

Assisted-by: AI
Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2265>
