### PR TITLE
(master) Xephyr: fix setting physical output size

### DIFF
--- a/hw/kdrive/ephyr/ephyr.c
+++ b/hw/kdrive/ephyr/ephyr.c
@@ -465,6 +465,14 @@ ephyrRandRGetInfo(ScreenPtr pScreen, Rotation * rotations)
                            screen->width,
                            screen->height, screen->width_mm, screen->height_mm);
 
+    if (hostx_want_fullscreen()) {
+        RROutputPtr pOutput = RRFirstOutput(pScreen);
+        if (pOutput)
+            RROutputSetPhysicalSize(pOutput,
+                                    scrpriv->win_width_mm,
+                                    scrpriv->win_height_mm);
+    }
+
     randr = KdSubRotation(scrpriv->randr, screen->randr);
 
     RRRegisterRate(pScreen, pSize, rate);

--- a/hw/kdrive/ephyr/ephyr.h
+++ b/hw/kdrive/ephyr/ephyr.h
@@ -73,6 +73,7 @@ typedef struct _ephyrScrPriv {
     Bool win_explicit_position;
     int win_x, win_y;
     int win_width, win_height;
+    int win_width_mm, win_height_mm;
     int server_depth;
     const char *output;         /* Set via -output option */
     unsigned char *fb_data;     /* only used when host bpp != server bpp */

--- a/hw/kdrive/ephyr/hostx.c
+++ b/hw/kdrive/ephyr/hostx.c
@@ -253,7 +253,8 @@ hostx_want_preexisting_window(KdScreenInfo *screen)
 void
 hostx_get_output_geometry(const char *output,
                           int *x, int *y,
-                          int *width, int *height)
+                          int *width, int *height,
+                          int *width_mm, int *height_mm)
 {
     int i, name_len = 0, output_found = FALSE;
     xcb_generic_error_t *error;
@@ -347,6 +348,8 @@ hostx_get_output_geometry(const char *output,
             *y = crtc_info_r->y;
             *width = crtc_info_r->width;
             *height = crtc_info_r->height;
+            *width_mm = output_info_r->mm_width;
+            *height_mm = output_info_r->mm_height;
 
             free(crtc_info_r);
         }
@@ -649,8 +652,10 @@ hostx_init(void)
                                 "(ctrl+shift grabs mouse and keyboard)");
 
             if (HostX.use_fullscreen) {
-                scrpriv->win_width  = xscreen->width_in_pixels;
-                scrpriv->win_height = xscreen->height_in_pixels;
+                scrpriv->win_width     = xscreen->width_in_pixels;
+                scrpriv->win_height    = xscreen->height_in_pixels;
+                scrpriv->win_width_mm  = xscreen->width_in_millimeters;
+                scrpriv->win_height_mm = xscreen->height_in_millimeters;
 
                 hostx_set_fullscreen_hint();
             }
@@ -659,7 +664,9 @@ hostx_init(void)
                                           &scrpriv->win_x,
                                           &scrpriv->win_y,
                                           &scrpriv->win_width,
-                                          &scrpriv->win_height);
+                                          &scrpriv->win_height,
+                                          &scrpriv->win_width_mm,
+                                          &scrpriv->win_height_mm);
 
                 HostX.use_fullscreen = TRUE;
                 hostx_set_fullscreen_hint();

--- a/hw/kdrive/ephyr/hostx.h
+++ b/hw/kdrive/ephyr/hostx.h
@@ -84,7 +84,8 @@ xcb_cursor_t
 void
  hostx_get_output_geometry(const char *output,
                            int *x, int *y,
-                           int *width, int *height);
+                           int *width, int *height,
+                           int *width_mm, int *height_mm);
 
 void
  hostx_use_fullscreen(void);


### PR DESCRIPTION
Providing physical size via RRRegisterSize() is not enough - physical
size is a property of the output, not resolution and needs to be set
separately. Furhermore, get the physical output size using RandR if
-output is used, to match specific output, not the whole screen.

With this, `Xephyr -output OUTPUT_NAME` properly copies not only
resolution but also physical size of the named output.

Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2240>

## Backport dashboard

| Branch | PR | Status |
|--------|----|--------|
| `release/25.2` | [#3564](https://github.com/X11Libre/xserver/pull/3564) | 🔄 Open |
| `release/25.1` | [#3584](https://github.com/X11Libre/xserver/pull/3584) | 🔄 Open |
| `release/25.0` | [#3599](https://github.com/X11Libre/xserver/pull/3599) | 🔄 Open |
