### PR TITLE
(master) composite: Fix PanoramiX overlay window release

### DIFF
--- a/Xext/composite/compext.c
+++ b/Xext/composite/compext.c
@@ -774,8 +774,8 @@ ProcCompositeReleaseOverlayWindow(ClientPtr client)
 
     XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         if ((rc = dixLookupResourceByType((void **) &pWin, win->info[walkScreenIdx].id,
-                                          XRT_WINDOW, client,
-                                          DixUnknownAccess))) {
+                                          X11_RESTYPE_WINDOW, client,
+                                          DixGetAttrAccess))) {
             client->errorValue = stuff->window;
             return rc;
         }


### PR DESCRIPTION
PanoramiX overlay resources contain physical window IDs for each
screen. Look them up as regular window resources when releasing the
client's overlay reference.

Signed-off-by: Xinhao Liu <liuxinhao@kylinsec.com.cn>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2259>

## Backport dashboard

| Branch | PR | Status |
|--------|----|--------|
| `release/25.2` | [#3565](https://github.com/X11Libre/xserver/pull/3565) | 🔄 Open |
| `release/25.1` | [#3585](https://github.com/X11Libre/xserver/pull/3585) | 🔄 Open |
| `release/25.0` | [#3600](https://github.com/X11Libre/xserver/pull/3600) | 🔄 Open |
