### PR TITLE
(master) xkb: Fix -Wcalloc-transposed-args warning in _XkbCopyGeom()

### DIFF
--- a/Xext/xkeyboard/xkbUtils.c
+++ b/Xext/xkeyboard/xkbUtils.c
@@ -1435,7 +1435,7 @@ _XkbCopyGeom(XkbDescPtr src, XkbDescPtr dst)
     /* geometry */
     if (src->geom) {
         if (!dst->geom) {
-            dst->geom = calloc(sizeof(XkbGeometryRec), 1);
+            dst->geom = calloc(1, sizeof(XkbGeometryRec));
             if (!dst->geom)
                 return FALSE;
         }


### PR DESCRIPTION
Reported by gcc 16.1:
xkb/xkbUtils.c:1440:39: warning: ‘calloc’ sizes specified with ‘sizeof’ in
the earlier argument and not in the later argument [-Wcalloc-transposed-args]
 1440 |             dst->geom = calloc(sizeof(XkbGeometryRec), 1);
      |                                       ^~~~~~~~~~~~~~

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2272>

## Backport dashboard

| Branch | PR | Status |
|--------|----|--------|
| `release/25.2` | [#3566](https://github.com/X11Libre/xserver/pull/3566) | 🔄 Open |
| `release/25.1` | [#3586](https://github.com/X11Libre/xserver/pull/3586) | 🔄 Open |
| `release/25.0` | — | — |
