### PR TITLE
(master) test: silence -Wanalyzer-null-argument warnings in strndup tests

### DIFF
--- a/test/string.c
+++ b/test/string.c
@@ -52,8 +52,9 @@ strndup_checks(void)
     char *firsthalf = strndup(sample, 8);
     char *secondhalf = strndup(sample + 8, 8);
 
-    assert(firsthalf);
-    assert(secondhalf);
+    assert(firsthalf != NULL);
+    assert(secondhalf != NULL);
+
     assert(strcmp(firsthalf, "01234567") == 0);
     assert(strcmp(secondhalf, "89abcdef") == 0);
 
@@ -61,7 +62,7 @@ strndup_checks(void)
     free(secondhalf);
 
     allofit = strndup(sample, 20);
-    assert(allofit);
+    assert(allofit != NULL);
     assert(strcmp(allofit, sample) == 0);
     free(allofit);
 }


### PR DESCRIPTION
Catch malloc failures before calling strcmp() with them.

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2272>
