### PR TITLE
(master) exa: silence -Wold-style-declaration warning from gcc 16

### DIFF
--- a/exa/exa_accel.c
+++ b/exa/exa_accel.c
@@ -239,7 +239,7 @@ exaPutImage(DrawablePtr pDrawable, GCPtr pGC, int depth, int x, int y,
                          bits);
 }
 
-static Bool inline
+static inline Bool
 exaCopyNtoNTwoDir(DrawablePtr pSrcDrawable, DrawablePtr pDstDrawable,
                   GCPtr pGC, BoxPtr pbox, int nbox, int dx, int dy)
 {


### PR DESCRIPTION
exa/exa_accel.c:239:1: warning: ‘inline’ is not at beginning of declaration
 [-Wold-style-declaration]
  239 | static Bool inline
      | ^~~~~~

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2272>

## Backport dashboard

| Branch | PR | Status |
|--------|----|--------|
| `release/25.2` | [#3569](https://github.com/X11Libre/xserver/pull/3569) | 🔄 Open |
| `release/25.1` | [#3589](https://github.com/X11Libre/xserver/pull/3589) | 🔄 Open |
| `release/25.0` | — | — |
