### PR TITLE
(master) Handle -Wimplicit-fallthrough warnings from gcc 16.1

### DIFF
--- a/Xext/xkeyboard/ddxBeep.c
+++ b/Xext/xkeyboard/ddxBeep.c
@@ -139,6 +139,7 @@ _XkbDDXBeepExpire(OsTimerPtr timer, CARD32 now, void *arg)
     switch (xkbInfo->beepType) {
     default:
         ErrorF("[xkb] Unknown beep type %d\n", xkbInfo->beepType);
+        /* fallthrough */
     case _BEEP_NONE:
         duration = 0;
         break;
@@ -207,6 +208,7 @@ _XkbDDXBeepExpire(OsTimerPtr timer, CARD32 now, void *arg)
     case _BEEP_LED_CHANGE:
         if (name == None)
             name = ledChange;
+        /* fallthrough */
     case _BEEP_FEATURE_CHANGE:
         if (name == None)
             name = featureChange;
@@ -237,9 +239,11 @@ _XkbDDXBeepExpire(OsTimerPtr timer, CARD32 now, void *arg)
     case _BEEP_SLOW_PRESS:
         if (name == None)
             name = slowPress;
+        /* fallthrough */
     case _BEEP_SLOW_ACCEPT:
         if (name == None)
             name = slowAccept;
+        /* fallthrough */
     case _BEEP_SLOW_RELEASE:
         if (name == None)
             name = slowRelease;
@@ -249,6 +253,7 @@ _XkbDDXBeepExpire(OsTimerPtr timer, CARD32 now, void *arg)
     case _BEEP_BOUNCE_REJECT:
         if (name == None)
             name = bounceReject;
+        /* fallthrough */
     case _BEEP_SLOW_REJECT:
         if (name == None)
             name = slowReject;

--- a/Xext/xtest/xtest.c
+++ b/Xext/xtest/xtest.c
@@ -302,14 +302,19 @@ ProcXTestFakeInput(ClientPtr client)
             switch (dv->num_valuators) {
             case 6:
                 valuators[base + 5] = dv->valuator5;
+                /* fallthrough */
             case 5:
                 valuators[base + 4] = dv->valuator4;
+                /* fallthrough */
             case 4:
                 valuators[base + 3] = dv->valuator3;
+                /* fallthrough */
             case 3:
                 valuators[base + 2] = dv->valuator2;
+                /* fallthrough */
             case 2:
                 valuators[base + 1] = dv->valuator1;
+                /* fallthrough */
             case 1:
                 valuators[base] = dv->valuator0;
                 break;

--- a/hw/kdrive/src/kinput.c
+++ b/hw/kdrive/src/kinput.c
@@ -423,18 +423,25 @@ KdPointerProc(DeviceIntPtr pDevice, int onoff)
         default:
         case 7:
             btn_labels[6] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_HWHEEL_RIGHT);
+            /* fallthrough */
         case 6:
             btn_labels[5] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_HWHEEL_LEFT);
+            /* fallthrough */
         case 5:
             btn_labels[4] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_WHEEL_DOWN);
+            /* fallthrough */
         case 4:
             btn_labels[3] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_WHEEL_UP);
+            /* fallthrough */
         case 3:
             btn_labels[2] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_RIGHT);
+            /* fallthrough */
         case 2:
             btn_labels[1] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_MIDDLE);
+            /* fallthrough */
         case 1:
             btn_labels[0] = XIGetKnownProperty(BTN_LABEL_PROP_BTN_LEFT);
+            /* fallthrough */
         case 0:
             break;
         }

--- a/hw/xfree86/common/xf86fbman.c
+++ b/hw/xfree86/common/xf86fbman.c
@@ -585,6 +585,7 @@ localQueryLargestOffscreenArea(ScreenPtr pScreen,
             pbox = RegionRects(newRegion);
             break;
         }
+        /* fallthrough */
     case 1:
         if (offman->NumUsedAreas) {
             FBLinkPtr pLink;
@@ -607,6 +608,7 @@ localQueryLargestOffscreenArea(ScreenPtr pScreen,
             pbox = RegionRects(newRegion);
             break;
         }
+        /* fallthrough */
     default:
         nbox = RegionNumRects(offman->FreeBoxes);
         pbox = RegionRects(offman->FreeBoxes);

--- a/hw/xfree86/drivers/video/modesetting/dri2.c
+++ b/hw/xfree86/drivers/video/modesetting/dri2.c
@@ -653,7 +653,7 @@ ms_dri2_frame_event_handler(uint64_t msc,
             ms_dri2_exchange_buffers(drawable, frame_info->front, frame_info->back);
             break;
         }
-        /* else fall through to blit */
+        /* else fall through */
     case MS_DRI2_QUEUE_SWAP:
         ms_dri2_blit_swap(drawable, frame_info->front, frame_info->back);
         DRI2SwapComplete(frame_info->client, drawable, msc, tv_sec, tv_usec,

--- a/hw/xfree86/parser/Flags.c
+++ b/hw/xfree86/parser/Flags.c
@@ -112,11 +112,13 @@ xf86parseFlagsSection(XF86ConfFlagsPtr ptr)
              */
         case DEFAULTLAYOUT:
             strvalue = TRUE;
+            /* fallthrough */
         case BLANKTIME:
         case STANDBYTIME:
         case SUSPENDTIME:
         case OFFTIME:
             hasvalue = TRUE;
+            /* fallthrough */
         case DONTZAP:
         case DONTZOOM:
         case DISABLEVIDMODE:

--- a/include/fb.h
+++ b/include/fb.h
@@ -191,6 +191,7 @@ typedef int FbStride;
 	break; \
     case sizeof (FbBits) - 3: \
 	FbStorePart((dst),sizeof (FbBits) - 3,CARD8,(xor)); \
+	/* fallthrough */ \
     case sizeof (FbBits) - 2: \
 	FbStorePart((dst),sizeof (FbBits) - 2,CARD16,(xor)); \
 	break; \

--- a/mi/miarc.c
+++ b/mi/miarc.c
@@ -1436,6 +1436,7 @@ miArcJoin(DrawablePtr pDraw, GCPtr pGC, miArcFacePtr pLeft,
             polyLen = 5;
             break;
         }
+        /* fallthrough */
     case JoinBevel:
         poly[0] = corner;
         poly[1] = center;


### PR DESCRIPTION
Gets rid of 36 -Wimplicit-fallthrough warnings

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2272>

## Backport dashboard

| Branch | PR | Status |
|--------|----|--------|
| `release/25.2` | [#3570](https://github.com/X11Libre/xserver/pull/3570) | 🔄 Open |
| `release/25.1` | [#3590](https://github.com/X11Libre/xserver/pull/3590) | 🔄 Open |
| `release/25.0` | — | — |
