### PR TITLE
(master) darwin: Set thread priorities to user interactive or user initiated as appropriate

### DIFF
--- a/hw/xquartz/X11Application.m
+++ b/hw/xquartz/X11Application.m
@@ -866,6 +866,9 @@ create_thread(void *(*func)(void *), void *arg)
     pthread_attr_init(&attr);
     pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM);
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    if (&pthread_attr_set_qos_class_np) {
+        pthread_attr_set_qos_class_np(&attr, QOS_CLASS_USER_INITIATED, 0);
+    }
     pthread_create(&tid, &attr, func, arg);
     pthread_attr_destroy(&attr);
 

--- a/hw/xquartz/darwinEvents.c
+++ b/hw/xquartz/darwinEvents.c
@@ -129,6 +129,9 @@ create_thread(void *(*func)(void *), void *arg)
     pthread_attr_init(&attr);
     pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM);
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    if (&pthread_attr_set_qos_class_np) {
+        pthread_attr_set_qos_class_np(&attr, QOS_CLASS_USER_INITIATED, 0);
+    }
     pthread_create(&tid, &attr, func, arg);
     pthread_attr_destroy(&attr);
 

--- a/hw/xquartz/quartzStartup.c
+++ b/hw/xquartz/quartzStartup.c
@@ -72,6 +72,9 @@ create_thread(void *func, void *arg)
     pthread_attr_init(&attr);
     pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM);
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    if (&pthread_attr_set_qos_class_np) {
+        pthread_attr_set_qos_class_np(&attr, QOS_CLASS_USER_INTERACTIVE, 0);
+    }
     pthread_create(&tid, &attr, func, arg);
     pthread_attr_destroy(&attr);
 

--- a/os/inputthread.c
+++ b/os/inputthread.c
@@ -483,6 +483,12 @@ InputThreadInit(void)
     if (pthread_attr_setscope(&attr, PTHREAD_SCOPE_SYSTEM) != 0)
         ErrorF("input-thread: error setting thread scope\n");
 
+#ifdef __APPLE__
+    if (&pthread_attr_set_qos_class_np) {
+        pthread_attr_set_qos_class_np(&attr, QOS_CLASS_USER_INTERACTIVE, 0);
+    }
+#endif
+
     DebugF("input-thread: creating thread\n");
     pthread_create(&inputThreadInfo->thread, &attr,
                    &InputThreadDoWork, NULL);


### PR DESCRIPTION
Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>

## Backport dashboard

| Branch | PR | Status |
|--------|----|--------|
| `release/25.2` | [#3573](https://github.com/X11Libre/xserver/pull/3573) | 🔄 Open |
| `release/25.1` | — | — |
| `release/25.0` | [#3605](https://github.com/X11Libre/xserver/pull/3605) | 🔄 Open |
