### PR TITLE
(master) rootless: Fix two region leaks

### DIFF
--- a/miext/rootless/rootlessValTree.c
+++ b/miext/rootless/rootlessValTree.c
@@ -518,6 +518,7 @@ RootlessMiValidateTree(WindowPtr pRoot, /* Parent to validate */
     }
 
     RegionUninit(&childClip);
+    RegionUninit(&exposed);
 
     /* The root is never clipped by its children, so nothing on the root
        is ever exposed by moving or mapping its children. */

--- a/miext/rootless/rootlessWindow.c
+++ b/miext/rootless/rootlessWindow.c
@@ -400,6 +400,8 @@ RootlessEnsureFrame(WindowPtr pWin)
         RL_DEBUG_MSG("implementation failed to create frame!\n");
         free(winRec);
         SETWINREC(pWin, NULL);
+        if (pShape != NULL)
+            RegionUninit(&shape);
         return NULL;
     }
 


### PR DESCRIPTION
RootlessEnsureFrame returns without releasing a shaped window's region when the implementation refuses to create the
frame, and RootlessMiValidateTree never releases the exposed region it hands to RootlessComputeClips -- upstream
miValidateTree does.

Both are longstanding.

Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>

## Backport dashboard

| Branch | PR | Status |
|--------|----|--------|
| `release/25.2` | [#3574](https://github.com/X11Libre/xserver/pull/3574) | 🔄 Open |
| `release/25.1` | [#3593](https://github.com/X11Libre/xserver/pull/3593) | 🔄 Open |
| `release/25.0` | [#3606](https://github.com/X11Libre/xserver/pull/3606) | 🔄 Open |
