### PR TITLE
(master) rootless: Keep the screen pixmap header consistent with its allocation

### DIFF
--- a/miext/rootless/rootlessScreen.c
+++ b/miext/rootless/rootlessScreen.c
@@ -108,6 +108,8 @@ RootlessUpdateScreenPixmap(ScreenPtr pScreen)
     pPix = (*pScreen->GetScreenPixmap) (pScreen);
     if (pPix == NULL) {
         pPix = (*pScreen->CreatePixmap) (pScreen, 0, 0, pScreen->rootDepth, 0);
+        if (pPix == NULL)
+            return;
         (*pScreen->SetScreenPixmap) (pPix);
     }
 
@@ -135,14 +137,31 @@ RootlessUpdateScreenPixmap(ScreenPtr pScreen)
 
         memset(s->pixmap_data, 0xFF, s->pixmap_data_size);
 
-        pScreen->ModifyPixmapHeader(pPix, pScreen->width, pScreen->height,
-                                    pScreen->rootDepth,
-                                    BitsPerPixel(pScreen->rootDepth),
-                                    0, s->pixmap_data);
-        /* ModifyPixmapHeader ignores zero arguments, so install rowbytes
-           by hand. */
-        pPix->devKind = 0;
+        free(s->pixmap_data);
+        s->pixmap_data = data;
+        s->pixmap_data_size = rowbytes;
     }
+
+    if (s->pixmap_data == NULL)
+        return;
+
+    /*
+     * Republish the geometry on every call.  The branch above only runs when
+     * the buffer grows, so a screen that shrinks would otherwise keep
+     * advertising its previous, larger size.
+     */
+    pScreen->ModifyPixmapHeader(pPix, pScreen->width, pScreen->height,
+                                pScreen->rootDepth,
+                                BitsPerPixel(pScreen->rootDepth),
+                                0, s->pixmap_data);
+
+    /*
+     * A zero devKind is what makes every row alias row 0, and that is what
+     * keeps a one-scanline allocation in bounds vertically.  Passing devKind
+     * as zero above leaves the field untouched rather than setting it, so
+     * install it here -- this line is load-bearing, not a fixup of rowbytes.
+     */
+    pPix->devKind = 0;
 }
 
 /*


### PR DESCRIPTION
RootlessUpdateScreenPixmap freed the old backing store before attempting the replacement allocation and returned early
on failure, leaving the screen pixmap's devPrivate.ptr pointing at freed memory.

The published geometry was also only refreshed when the buffer grew, so a screen that shrinks kept advertising its
previous, larger size.

Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>

## Backport dashboard

| Branch | PR | Status |
|--------|----|--------|
| `release/25.2` | — | — |
| `release/25.1` | [#3594](https://github.com/X11Libre/xserver/pull/3594) | 🔄 Open |
| `release/25.0` | [#3607](https://github.com/X11Libre/xserver/pull/3607) | 🔄 Open |
