### PR TITLE
(xorg) (release/25.2) kdrive: Don't fixup the cursor position twice in KdCursorOffScreen

### DIFF
--- a/hw/kdrive/src/kinput.c
+++ b/hw/kdrive/src/kinput.c
@@ -2186,12 +2186,12 @@ KdCursorOffScreen(ScreenPtr *ppScreen, int *x, int *y)
 
     if (*x < 0)
         *x += pNewScreen->width;
+    else if (*x >= pScreen->width)
+        *x -= pScreen->width;
+
     if (*y < 0)
         *y += pNewScreen->height;
-
-    if (*x >= pScreen->width)
-        *x -= pScreen->width;
-    if (*y >= pScreen->height)
+    else if (*y >= pScreen->height)
         *y -= pScreen->height;
 
     *ppScreen = pNewScreen;


### PR DESCRIPTION
Backport of [#3562](https://github.com/X11Libre/xserver/pull/3562) (master)

The intent of the code is to take the coordinates of the cursor
and adjust them so that they are where they are supposed to be on
the new screen.

If we're moving up on a screen with a larger height that the one
we are on, *y < 0, so we fix it by adding the new screen's height.
Since the height is larger, and the code was lacking an else branch,
it thinks that we are now moving down, so it incorrectly subtracts
the old screen height, making the cursor end up somewhere it's not
supposed to be.

Reproducer:
`Xephyr -softCursor -origin 0,0 -screen 400x300 -softCursor -origin 0,-300  -screen 800x600`
Move the cursor from up from the first screen to the second screen,
and the cursor ends up somewhere it's not supposed to be.
Fix sizes for the Xephyr screens to fit on the monitor.

Signed-off-by: stefan11111 <stefan11111github@gmail.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2249>
