### PR TITLE
(release/25.2) xf86: prevent passing NULL pointer as strcat() destination

### DIFF
--- a/hw/xfree86/parser/Files.c
+++ b/hw/xfree86/parser/Files.c
@@ -55,6 +55,7 @@
 #include <assert.h>
 
 #include <X11/Xos.h>
+#include "os.h"
 #include "xf86Parser.h"
 #include "xf86tokens.h"
 #include "Configint.h"
@@ -113,8 +114,7 @@ xf86parseFilesSection(XF86ConfFilesPtr ptr)
                     j = TRUE;
                 }
             }
-            ptr->file_fontpath = realloc(ptr->file_fontpath, i);
-            assert(ptr->file_fontpath);
+            ptr->file_fontpath = XNFrealloc(ptr->file_fontpath, i);
             if (j)
                 strcat(ptr->file_fontpath, ",");
             strcat(ptr->file_fontpath, str);
@@ -139,8 +139,7 @@ xf86parseFilesSection(XF86ConfFilesPtr ptr)
                     l = TRUE;
                 }
             }
-            ptr->file_modulepath = realloc(ptr->file_modulepath, k);
-            assert(ptr->file_modulepath);
+            ptr->file_modulepath = XNFrealloc(ptr->file_modulepath, k);
             if (l)
                 strcat(ptr->file_modulepath, ",");
 


### PR DESCRIPTION
Backport of [#3568](https://github.com/X11Libre/xserver/pull/3568) (master)

Reported by gcc 16.1:
hw/xfree86/parser/Files.c:119:17: warning: use of NULL where non-null
 expected [CWE-476] [-Wanalyzer-null-argument]
  119 |                 strcat(ptr->file_fontpath, ",");
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
......
  117 |             ptr->file_fontpath = realloc(ptr->file_fontpath, i);
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                | |
      |                                | (9) when ‘realloc’ fails
      |                                (10) using NULL here
  118 |             if (j)
      |                ~
      |                |
      |                (11) following ‘true’ branch (when ‘j != 0’)... ─>─┐
      |                                                                   │
      |                                                                   │
      |┌──────────────────────────────────────────────────────────────────┘
  119 |│                strcat(ptr->file_fontpath, ",");
      |│                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |│                |
      |└───────────────>(12) ...to here
      |                 (13) ⚠  argument 1 (‘realloc(*ptr.file_fontpath, (long unsigned int)i)’) NULL where non-null expected
<built-in>: note: argument 1 of ‘__builtin_strlen’ must be non-null
......
      |                                                                   │
      |┌──────────────────────────────────────────────────────────────────┘
  121 |│            strcat(ptr->file_fontpath, str);
      |│            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |│            |         |
      |│            |         (10) using NULL here
      |└───────────>(9) ...to here
      |             (11) ⚠  argument 1 (‘*ptr.file_fontpath’) NULL where non-null expected
note: argument 1 of ‘strcat’ must be non-null

hw/xfree86/parser/Files.c:144:17: warning: use of NULL where non-null expected [CWE-476] [-Wanalyzer-null-argument]
  144 |                 strcat(ptr->file_modulepath, ",");
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
......
  142 |             ptr->file_modulepath = realloc(ptr->file_modulepath, k);
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                  | |
      |                                  | (9) when ‘realloc’ fails
      |                                  (10) using NULL here
  143 |             if (l)
      |                ~
      |                |
      |                (11) following ‘true’ branch (when ‘l != 0’)... ─>─┐
      |                                                                   │
      |                                                                   │
      |┌──────────────────────────────────────────────────────────────────┘
  144 |│                strcat(ptr->file_modulepath, ",");
      |│                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |│                |
      |└───────────────>(12) ...to here
      |                 (13) ⚠  argument 1 (‘realloc(*ptr.file_modulepath, (long unsigned int)k)’) NULL where non-null expected
<built-in>: note: argument 1 of ‘__builtin_strlen’ must be non-null
......
      |                                                                   │
      |┌──────────────────────────────────────────────────────────────────┘
  146 |│            strcat(ptr->file_modulepath, str);
      |│            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |│            |         |
      |│            |         (10) using NULL here
      |└───────────>(9) ...to here
      |             (11) ⚠  argument 1 (‘*ptr.file_modulepath’) NULL where non-null expected
note: argument 1 of ‘strcat’ must be non-null

Also clears two -Wanalyzer-malloc-leak warnings for leaking the old
pointer when realloc() failed, now that realloc() cannot fail.

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2272>
