### PR TITLE
(release/25.2) xquartz: Stop drawing before handing a frame to xp_frame_draw()

### DIFF
--- a/hw/xquartz/xpr/xprAppleWM.c
+++ b/hw/xquartz/xpr/xprAppleWM.c
@@ -127,6 +127,12 @@ xprFrameDraw(WindowPtr pWin,
     if (wid == 0)
         return BadWindow;
 
+    /* xp_frame_draw() renders the decorations into the window's backing store, so the frame must not be locked for
+     * our own drawing when it runs.  Otherwise Xplugin re-enters the backing lock on an already-locked window, which
+     * remaps the backing store out from under whichever of the two writers loses the race.
+     */
+    RootlessStopDrawing(pWin, FALSE);
+
     if (xp_frame_draw(wid, class, attr, outer, inner,
                       title_len, title_bytes) != Success) {
         return BadValue;


### PR DESCRIPTION
Backport of [#3556](https://github.com/X11Libre/xserver/pull/3556) (master)

xp_frame_draw() renders the window decorations into the frame's backing store from Xplugin's async queue, but
xprFrameDraw() was the only AppleWM handler that did not stop drawing first.  When quartz-wm sends AppleWMFrameDraw
while the server still holds the frame locked, Xplugin re-enters the backing lock on an already-locked window and the
backing store is remapped out from under one of the two writers, surfacing as a SIGBUS writing into a read-only CG
backing store mapping.

This removes the self-inflicted overlap and brings the handler in line with its siblings.  It narrows the race rather
than closing it: the ordering problem between the async frame draw and the backing lock is tracked separately.

Fixes: https://github.com/XQuartz/XQuartz/issues/352
Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
