### PR TITLE
(release/25.0) security: add integer overflow checks in allocation calculations

### DIFF
--- a/fb/fbpixmap.c
+++ b/fb/fbpixmap.c
@@ -41,14 +41,29 @@ fbCreatePixmap(ScreenPtr pScreen, int width, int height, int depth,
     int base;
     int bpp = BitsPerPixel(depth);
 
+    /* Check for integer overflow in width * bpp */
+    if (bpp > 0 && width > INT_MAX / (size_t)bpp)
+        return NullPixmap;
+    /* Check for overflow in the calculation of paddedWidth */
+    {
+        size_t width_bytes = (size_t)width * (size_t)bpp;
+        if (width_bytes > (SIZE_MAX - FB_MASK) >> FB_SHIFT)
+            return NullPixmap;
+    }
     paddedWidth = ((width * bpp + FB_MASK) >> FB_SHIFT) * sizeof(FbBits);
     if (paddedWidth / 4 > 32767 || height > 32767)
+        return NullPixmap;
+    /* Check for integer overflow in height * paddedWidth */
+    if (paddedWidth > 0 && (size_t)height > SIZE_MAX / paddedWidth)
         return NullPixmap;
     datasize = height * paddedWidth;
     base = pScreen->totalPixmapSize;
     adjust = 0;
     if (base & 7)
         adjust = 8 - (base & 7);
+    /* Check for overflow in datasize + adjust */
+    if (datasize > SIZE_MAX - (size_t)adjust)
+        return NullPixmap;
     datasize += adjust;
 #ifdef FB_DEBUG
     datasize += 2 * paddedWidth;

--- a/hw/xfree86/common/xf86fbman.c
+++ b/hw/xfree86/common/xf86fbman.c
@@ -876,6 +876,11 @@ localAllocateOffscreenLinear(ScreenPtr pScreen,
             /* pitch and granularity aren't a perfect match, let's allocate
              * a bit more so we can align later on
              */
+            /* Check for integer overflow before addition */
+            if (length > INT_MAX - (gran - 1)) {
+                free(link);
+                return NULL;
+            }
             length += gran - 1;
         }
     }
@@ -886,7 +891,19 @@ localAllocateOffscreenLinear(ScreenPtr pScreen,
     }
     else {
         w = pitch;
-        h = (length + pitch - 1) / pitch;
+        /* Calculate h = ceil(length / pitch) safely without overflow */
+        if (pitch <= 0) {
+            free(link);
+            return NULL;
+        }
+        /* (length + pitch - 1) can overflow, use alternative */
+        h = (length - 1) / pitch + 1;
+    }
+
+    /* Check for overflow in h * w (both int, result stored in int) */
+    if (h > 0 && w > INT_MAX / h) {
+        free(link);
+        return NULL;
     }
 
     if ((area = localAllocateOffscreenArea(pScreen, w, h, gran,

--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
@@ -3690,7 +3690,28 @@ drmmode_xf86crtc_resize(ScrnInfoPtr scrn, int width, int height)
     }
 
     if (drmmode->shadow_enable) {
-        uint32_t size = scrn->displayWidth * scrn->virtualY * cpp;
+        size_t size_bytes;
+        uint32_t size;
+
+        /* Check for zero dimensions */
+        if (scrn->displayWidth == 0 || scrn->virtualY == 0 || cpp == 0)
+            goto fail;
+
+        /* Check for overflow in width * height */
+        if ((size_t)scrn->displayWidth > SIZE_MAX / (size_t)scrn->virtualY)
+            goto fail;
+        size_bytes = (size_t)scrn->displayWidth * (size_t)scrn->virtualY;
+
+        /* Check for overflow in size_bytes * cpp */
+        if (size_bytes > SIZE_MAX / (size_t)cpp)
+            goto fail;
+        size_bytes *= (size_t)cpp;
+
+        /* Ensure the result fits in uint32_t */
+        if (size_bytes > UINT32_MAX)
+            goto fail;
+        size = (uint32_t)size_bytes;
+
         new_pixels = calloc(1, size);
         if (new_pixels == NULL)
             goto fail;
@@ -3699,7 +3720,24 @@ drmmode_xf86crtc_resize(ScrnInfoPtr scrn, int width, int height)
     }
 
     if (drmmode->shadow_enable2) {
-        uint32_t size = scrn->displayWidth * scrn->virtualY * cpp;
+        size_t size_bytes;
+        uint32_t size;
+
+        if (scrn->displayWidth == 0 || scrn->virtualY == 0 || cpp == 0)
+            goto fail;
+
+        if ((size_t)scrn->displayWidth > SIZE_MAX / (size_t)scrn->virtualY)
+            goto fail;
+        size_bytes = (size_t)scrn->displayWidth * (size_t)scrn->virtualY;
+
+        if (size_bytes > SIZE_MAX / (size_t)cpp)
+            goto fail;
+        size_bytes *= (size_t)cpp;
+
+        if (size_bytes > UINT32_MAX)
+            goto fail;
+        size = (uint32_t)size_bytes;
+
         void *fb2 = calloc(1, size);
         free(drmmode->shadow_fb2);
         drmmode->shadow_fb2 = fb2;

--- a/hw/xnest/Color.c
+++ b/hw/xnest/Color.c
@@ -102,7 +102,12 @@ xnestCreateColormap(ColormapPtr pCmap)
     case StaticGray:           /* read only */
     case StaticColor:          /* read only */
     {
-        uint32_t *colors = malloc(ncolors * sizeof(uint32_t));
+        uint32_t *colors;
+        if (ncolors > SIZE_MAX / sizeof(uint32_t))
+            return FALSE;
+        colors = malloc(ncolors * sizeof(uint32_t));
+        if (!colors)
+            return FALSE;
         for (int i = 0; i < ncolors; i++)
             colors[i] = i;
         return load_colormap(pCmap, ncolors, colors);
@@ -111,7 +116,12 @@ xnestCreateColormap(ColormapPtr pCmap)
 
     case TrueColor:            /* read only */
     {
-        uint32_t *colors = malloc(ncolors * sizeof(uint32_t));
+        uint32_t *colors;
+        if (ncolors > SIZE_MAX / sizeof(uint32_t))
+            return FALSE;
+        colors = malloc(ncolors * sizeof(uint32_t));
+        if (!colors)
+            return FALSE;
         Pixel red = 0, redInc = lowbit(pVisual->redMask);
         Pixel green = 0, greenInc = lowbit(pVisual->greenMask);
         Pixel blue = 0, blueInc = lowbit(pVisual->blueMask);

--- a/hw/xquartz/xpr/xprScreen.c
+++ b/hw/xquartz/xpr/xprScreen.c
@@ -224,6 +224,8 @@ xprAddPseudoramiXScreens(int *x, int *y, int *width, int *height,
     if (CGDisplayIsCaptured(kCGDirectMainDisplay))
         displayCount = 1;
 
+    if (displayCount > SIZE_MAX / sizeof(CGDirectDisplayID))
+        FatalError("Invalid display count for allocation.\n");
     displayList = malloc(displayCount * sizeof(CGDirectDisplayID));
     if (!displayList)
         FatalError("Unable to allocate memory for list of displays.\n");


### PR DESCRIPTION
Backport of [#3578](https://github.com/X11Libre/xserver/pull/3578) (master)

- fb/fbpixmap.c: check width*bpp and height*paddedWidth overflows
- hw/xfree86/common/xf86fbman.c: check length+gran-1 overflow, safe h computation, h*w overflow
- hw/xfree86/drivers/modesetting/drmmode_display.c: validate multiplications before allocating shadow buffers
- hw/xquartz/xpr/xprScreen.c: check displayCount * sizeof overflow
- hw/xnest/Color.c: check ncolors * sizeof(uint32_t) overflow

These prevent potential heap overflows due to wrapped sizes.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
