### PR TITLE
(release/25.0) security: fix insecure temporary file usage and command injection

### DIFF
--- a/hw/xquartz/mach-startup/bundle-main.c
+++ b/hw/xquartz/mach-startup/bundle-main.c
@@ -268,7 +268,20 @@ create_socket(char *filename_out)
     size_t try, try_max;
 
     for (try = 0, try_max = 5; try < try_max; try++) {
-        tmpnam(filename_out);
+        /* Generate a unique temporary filename using mkstemp to avoid
+           symlink attacks and race conditions. */
+        char template[PATH_MAX];
+        int fd;
+
+        snprintf(template, sizeof(template), "%s/xorg-XXXXXX", P_tmpdir);
+        fd = mkstemp(template);
+        if (fd == -1) {
+            ErrorF("X11.app: mkstemp failed: %s\n", strerror(errno));
+            continue;
+        }
+        close(fd);
+        unlink(template);
+        strlcpy(filename_out, template, PATH_MAX);
 
         /* Setup servaddr_un */
         memset(&servaddr_un, 0, sizeof(struct sockaddr_un));

--- a/xkb/ddxLoad.c
+++ b/xkb/ddxLoad.c
@@ -38,6 +38,10 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <X11/extensions/XI.h>
 #include <X11/extensions/XKM.h>
 
+#ifdef WIN32
+#include <windows.h>
+#endif
+
 #include "dix/dix_priv.h"
 #include "os/log_priv.h"
 #include "os/osdep.h"
@@ -60,6 +64,32 @@ THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #else
 #define PATHSEPARATOR "/"
 #endif
+
+/* Validate that a path contains only safe characters (alphanumeric, /, \, :, ., _, -)
+   to prevent command injection when passed to system() or popen(). */
+static Bool
+safe_path(const char *path)
+{
+    if (!path)
+        return FALSE;
+    for (; *path; path++) {
+        unsigned char c = (unsigned char)*path;
+        if (isalnum(c))
+            continue;
+        switch (c) {
+        case '/':
+        case '\\':
+        case ':':
+        case '.':
+        case '_':
+        case '-':
+            break;
+        default:
+            return FALSE;
+        }
+    }
+    return TRUE;
+}
 
 static unsigned
 LoadXKM(unsigned want, unsigned need, const char *keymap, XkbDescPtr *xkbRtrn);
@@ -121,39 +151,55 @@ RunXkbComp(xkbcomp_buffer_callback callback, void *userdata)
     const char *xkbbindir = emptystring;
     const char *xkbbindirsep = emptystring;
 
-#ifdef WIN32
-    /* WIN32 has no popen. The input must be stored in a file which is
-       used as input for xkbcomp. xkbcomp does not read from stdin. */
-    char tmpname[PATH_MAX] = { 0 };
-    const char *xkmfile = tmpname;
-#else
-    const char *xkmfile = "-";
-#endif
+ #ifdef WIN32
+     /* WIN32 has no popen. The input must be stored in a file which is
+        used as input for xkbcomp. xkbcomp does not read from stdin. */
+     char tmpname[PATH_MAX] = { 0 };
+     const char *xkmfile = tmpname;
+ #else
+     const char *xkmfile = "-";
+ #endif
 
-    snprintf(keymap, sizeof(keymap), "server-%s", display);
+     snprintf(keymap, sizeof(keymap), "server-%s", display);
 
-    OutputDirectory(xkm_output_dir, sizeof(xkm_output_dir));
+     OutputDirectory(xkm_output_dir, sizeof(xkm_output_dir));
 
-#ifdef WIN32
-    strcpy(tmpname, Win32TempDir());
-    strcat(tmpname, "\\xkb_XXXXXX");
-    (void) mktemp(tmpname);
-#endif
+ #ifdef WIN32
+     /* Secure temporary file creation: GetTempFileName atomically creates
+        a unique file, avoiding race conditions and symlink attacks. */
+     if (!GetTempFileNameA(Win32TempDir(), "xkb", 0, tmpname)) {
+         LogMessage(X_ERROR, "XKB: Failed to create temporary file\n");
+         free(buf);
+         return NULL;
+     }
+ #endif
 
-    if (XkbBaseDirectory != NULL) {
-        if (asprintf(&xkbbasedirflag, "\"-R%s\"", XkbBaseDirectory) == -1)
-            xkbbasedirflag = NULL;
-    }
+     if (XkbBaseDirectory != NULL) {
+         /* Validate to prevent command injection */
+         if (!safe_path(XkbBaseDirectory)) {
+             LogMessage(X_ERROR, "XKB: XkbBaseDirectory contains unsafe characters\n");
+             free(buf);
+             return NULL;
+         }
+         if (asprintf(&xkbbasedirflag, "\"-R%s\"", XkbBaseDirectory) == -1)
+             xkbbasedirflag = NULL;
+     }
 
-    if (XkbBinDirectory != NULL) {
-        int ld = strlen(XkbBinDirectory);
-        int lps = strlen(PATHSEPARATOR);
+     if (XkbBinDirectory != NULL) {
+         /* Validate to prevent command injection */
+         if (!safe_path(XkbBinDirectory)) {
+             LogMessage(X_ERROR, "XKB: XkbBinDirectory contains unsafe characters\n");
+             free(buf);
+             return NULL;
+         }
+         int ld = strlen(XkbBinDirectory);
+         int lps = strlen(PATHSEPARATOR);
 
-        xkbbindir = XkbBinDirectory;
+         xkbbindir = XkbBinDirectory;
 
-        if ((ld >= lps) && (strcmp(xkbbindir + ld - lps, PATHSEPARATOR) != 0)) {
-            xkbbindirsep = PATHSEPARATOR;
-        }
+         if ((ld >= lps) && (strcmp(xkbbindir + ld - lps, PATHSEPARATOR) != 0)) {
+             xkbbindirsep = PATHSEPARATOR;
+         }
     }
 
     if (asprintf(&buf,


### PR DESCRIPTION
Backport of [#3579](https://github.com/X11Libre/xserver/pull/3579) (master)

- xkb/ddxLoad.c: replace mktemp() with GetTempFileNameA() on Windows;
- xkb/ddxLoad.c: add safe_path() validation and sanitize XkbBaseDirectory and XkbBinDirectory;
- bundle-main.c: replace tmpnam() with mkstemp() and unlink to prevent symlink attacks.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
