### PR TITLE
(release/25.0) security: fix buffer overflows in winprefs.c

### DIFF
--- a/hw/xwin/winprefs.c
+++ b/hw/xwin/winprefs.c
@@ -514,12 +514,21 @@ LoadImageComma(char *fname, char *iconDirectory, int sx, int sy, int flags)
                           MAKEINTRESOURCE(i), IMAGE_ICON, sx, sy, flags);
     }
     else {
-        char *file = calloc(1, PATH_MAX + NAME_MAX + 2);
+        size_t len_icon = 0, len_fname = strlen(fname);
+        size_t needed;
+        char *file;
 
+        if (iconDirectory)
+            len_icon = strlen(iconDirectory);
+        needed = len_icon;
+        if (len_icon > 0 && iconDirectory[len_icon - 1] != '\\')
+            needed++;  // space for backslash
+        needed += len_fname + 1; // +1 for null terminator
+
+        file = malloc(needed);
         if (!file)
             return NULL;
-
-        file[0] = 0;
+        file[0] = '\0';
 
         /* If fname starts 'X:\', it's an absolute Windows path, do nothing */
         if (!(fname[0] && fname[1] == ':' && fname[2] == '\\')) {
@@ -527,9 +536,8 @@ LoadImageComma(char *fname, char *iconDirectory, int sx, int sy, int flags)
                 /* Otherwise, prepend the default icon directory, which
                    currently must be in absolute Windows path form */
                 strcpy(file, iconDirectory);
-                if (iconDirectory[0])
-                    if (iconDirectory[strlen(iconDirectory) - 1] != '\\')
-                        strcat(file, "\\");
+                if (iconDirectory[0] && file[strlen(file) - 1] != '\\')
+                    strcat(file, "\\");
             }
         }
         strcat(file, fname);
@@ -657,11 +665,11 @@ LoadPreferences(void)
     /* Now try and find a ~/.xwinrc file */
     home = getenv("HOME");
     if (home) {
-        strcpy(fname, home);
-        if (fname[strlen(fname) - 1] != '/')
-            strcat(fname, "/");
-        strcat(fname, ".XWinrc");
-        parsed = winPrefsLoadPreferences(fname);
+        if (snprintf(fname, sizeof(fname), "%s/.XWinrc", home) >= (int)sizeof(fname)) {
+            ErrorF("HOME path too long, ignoring ~/.XWinrc\n");
+        } else {
+            parsed = winPrefsLoadPreferences(fname);
+        }
     }
 
     /* No home file found, check system default */


### PR DESCRIPTION
Backport of [#3580](https://github.com/X11Libre/xserver/pull/3580) (master)

- LoadImageComma: dynamically allocate buffer based on path lengths instead of fixed-size stack buffer
- LoadPreferences: use snprintf to avoid overflow when constructing ~/.XWinrc path

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
