### PR TITLE
(release/25.1) composite: Fix PanoramiX overlay window release

### DIFF
--- a/composite/compext.c
+++ b/composite/compext.c
@@ -808,8 +808,8 @@ ProcCompositeReleaseOverlayWindow(ClientPtr client)
 
     XINERAMA_FOR_EACH_SCREEN_BACKWARD({
         if ((rc = dixLookupResourceByType((void **) &pWin, win->info[walkScreenIdx].id,
-                                          XRT_WINDOW, client,
-                                          DixUnknownAccess))) {
+                                          X11_RESTYPE_WINDOW, client,
+                                          DixGetAttrAccess))) {
             client->errorValue = stuff->window;
             return rc;
         }


### PR DESCRIPTION
Backport of [#3550](https://github.com/X11Libre/xserver/pull/3550) (master)

PanoramiX overlay resources contain physical window IDs for each
screen. Look them up as regular window resources when releasing the
client's overlay reference.

Signed-off-by: Xinhao Liu <liuxinhao@kylinsec.com.cn>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2259>
