### PR TITLE
(release/25.0) kdrive/ephyr: Fix typo when checking for `EGL_KHR_platform_x11`

### DIFF
--- a/hw/kdrive/ephyr/ephyr_glamor.c
+++ b/hw/kdrive/ephyr/ephyr_glamor.c
@@ -241,7 +241,7 @@ ephyr_glamor_connect(void)
     }
 
     if (epoxy_has_egl_extension(EGL_NO_DISPLAY, "EGL_EXT_platform_x11") ||
-        epoxy_has_egl_extension(EGL_NO_DISPLAY, "EGL_KHR_platform_x11)")) {
+        epoxy_has_egl_extension(EGL_NO_DISPLAY, "EGL_KHR_platform_x11")) {
         void *lib = NULL;
         xcb_connection_t *ret = NULL;
         void *(*x_open_display)(void *) =


### PR DESCRIPTION
Backport of [#1897](https://github.com/X11Libre/xserver/pull/1897) (master)

Signed-off-by: stefan11111 <stefan11111github@gmail.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2268>
