### PR TITLE
(release/25.0) xf86: prevent passing NULL pointer as strcpy destination

### DIFF
--- a/hw/xfree86/common/xf86Configure.c
+++ b/hw/xfree86/common/xf86Configure.c
@@ -462,7 +462,7 @@ handle_detailed_input(struct detailed_monitor_section *det_mon, void *data)
 
     switch (det_mon->type) {
     case DS_NAME:
-        ptr->mon_modelname = realloc(ptr->mon_modelname,
+        ptr->mon_modelname = XNFrealloc(ptr->mon_modelname,
                                      strlen((char *) (det_mon->section.name)) +
                                      1);
         assert(ptr->mon_modelname);


### PR DESCRIPTION
Reported by gcc 16.1:
hw/xfree86/common/xf86Configure.c:463:9: warning: use of NULL where non-null
 expected [CWE-476] [-Wanalyzer-null-argument]
  463 |         strcpy(ptr->mon_modelname, (char *) (det_mon->section.name));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ‘handle_detailed_input’: events 1-5
  458 |     switch (det_mon->type) {
      |     ^~~~~~
      |     |
      |     (1) following ‘case 252:’ branch... ─>─┐
      |                                            │
      |                                            │
      |┌───────────────────────────────────────────┘
  459 |│    case DS_NAME:
      |│    ~~~~
      |│    |
      |└───>(2) ...to here
  460 |         ptr->mon_modelname = realloc(ptr->mon_modelname,
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                            | |
      |                            | (3) when ‘realloc’ fails
      |                            (4) using NULL here
  461 |                                      strlen((char *) (det_mon->section.name)) +
      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  462 |                                      1);
      |                                      ~~
  463 |         strcpy(ptr->mon_modelname, (char *) (det_mon->section.name));
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |         |
      |         (5) ⚠  argument 1 (‘realloc(*(struct <anonymous> *)data.mon_modelname,  strlen(&*det_mon.section.name) + 1)’) NULL where non-null expected

note: argument 1 of ‘strcpy’ must be non-null

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
Part-of: <https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2272>
