### PR TITLE
(release/25.0) rootless: Fix two region leaks

### DIFF
--- a/miext/rootless/rootlessValTree.c
+++ b/miext/rootless/rootlessValTree.c
@@ -519,6 +519,7 @@ RootlessMiValidateTree(WindowPtr pRoot, /* Parent to validate */
     }
 
     RegionUninit(&childClip);
+    RegionUninit(&exposed);
 
     /* The root is never clipped by its children, so nothing on the root
        is ever exposed by moving or mapping its children. */

--- a/miext/rootless/rootlessWindow.c
+++ b/miext/rootless/rootlessWindow.c
@@ -402,6 +402,8 @@ RootlessEnsureFrame(WindowPtr pWin)
         RL_DEBUG_MSG("implementation failed to create frame!\n");
         free(winRec);
         SETWINREC(pWin, NULL);
+        if (pShape != NULL)
+            RegionUninit(&shape);
         return NULL;
     }
 


### PR DESCRIPTION
Backport of [#3558](https://github.com/X11Libre/xserver/pull/3558) (master)

RootlessEnsureFrame returns without releasing a shaped window's region when the implementation refuses to create the
frame, and RootlessMiValidateTree never releases the exposed region it hands to RootlessComputeClips -- upstream
miValidateTree does.

Both are longstanding.

Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
