### PR TITLE
xfree86: drop parentheses from non-expression macro arguments

### DIFF
--- a/hw/xfree86/os-support/int10Defines.h
+++ b/hw/xfree86/os-support/int10Defines.h
@@ -34,9 +34,9 @@
 
 #define CPU_R(type,name,num) \
 	(((type *)&(((struct vm86_struct *)REG->cpuRegs)->regs.name))[(num)])
-#define CPU_RD(name,num) CPU_R(CARD32,(name),(num))
-#define CPU_RW(name,num) CPU_R(CARD16,(name),(num))
-#define CPU_RB(name,num) CPU_R(CARD8,(name),(num))
+#define CPU_RD(name,num) CPU_R(CARD32,name,(num))
+#define CPU_RW(name,num) CPU_R(CARD16,name,(num))
+#define CPU_RB(name,num) CPU_R(CARD8,name,(num))
 
 #define X86_EAX CPU_RD(eax,0)
 #define X86_EBX CPU_RD(ebx,0)

--- a/hw/xfree86/x86emu/x86emu/x86emui.h
+++ b/hw/xfree86/x86emu/x86emu/x86emui.h
@@ -43,7 +43,7 @@
 
 #define	_INLINE static
 
-#define	X86EMU_UNUSED(v)	(v)
+#define	X86EMU_UNUSED(v)	v
 
 #include "x86emu.h"
 #include "x86emu/regs.h"


### PR DESCRIPTION
#2944 added parentheses around macro arguments as a blanket policy. That is
correct where the argument is an expression, but a few of the arguments it
touched are not, and there the parentheses either fail to compile or silently
change what the declaration means.

#3117 already fixed one of those (`DB()`). This fixes the two remaining ones,
in `int10Defines.h` and `x86emui.h`.

Note that int10 does not currently build, for reasons unrelated to this. Those
fixes will follow in a separate PR.