### PR TITLE
meson: match on host CPU family, and unbreak -Dint10=stub

### DIFF
--- a/hw/xfree86/int10/meson.build
+++ b/hw/xfree86/int10/meson.build
@@ -7,7 +7,7 @@ srcs_xorg_int10 = [
 int10_c_args = [xorg_c_args]
 int10_link = []
 
-if host_machine.cpu() == 'i386' or host_machine.cpu() == 'x86_64'
+if host_machine.cpu_family() in ['x86', 'x86_64']
     int10_c_args += '-D_PC'
 endif
 

--- a/hw/xfree86/int10/meson.build
+++ b/hw/xfree86/int10/meson.build
@@ -1,9 +1,6 @@
 srcs_xorg_int10 = [
     'vbe.c',
     'vbeModes.c',
-    'helper_exec.c',
-    'helper_mem.c',
-    'xf86int10.c',
     'xf86int10module.c',
 ]
 
@@ -16,7 +13,12 @@ endif
 
 if int10 == 'stub'
     srcs_xorg_int10 += 'stub.c'
-    int10_c_args += '-D_VM86_LINUX'
+else
+    srcs_xorg_int10 += [
+        'helper_exec.c',
+        'helper_mem.c',
+        'xf86int10.c',
+    ]
 endif
 
 if int10 == 'x86emu'

--- a/meson.build
+++ b/meson.build
@@ -327,10 +327,10 @@ message('IPv6 support: ' + (build_ipv6 ? 'YES' : 'NO'))
 int10 = get_option('int10')
 if int10 == 'auto'
     int10 = 'x86emu'
-    if host_machine.cpu() == 'ppc' and host_machine.system() == 'freebsd'
+    if host_machine.cpu_family() in ['ppc', 'ppc64'] and host_machine.system() == 'freebsd'
         int10 = 'stub'
     endif
-    if host_machine.cpu() == 'arm'
+    if host_machine.cpu_family() == 'arm'
         int10 = 'stub'
     endif
 endif
@@ -619,9 +619,7 @@ endif
 build_acpi = false
 if (get_option('linux_acpi') == true and
    host_machine.system() == 'linux')
-    if (host_machine.cpu() == 'x86' or
-       host_machine.cpu() == 'x86_64' or
-       host_machine.cpu() == 'ia64')
+    if host_machine.cpu_family() in ['x86', 'x86_64', 'ia64']
         build_acpi = true
     endif
 endif


### PR DESCRIPTION
This PR contains two related build-system fixes. Both are mistranslations of the
autotools build that have been carried since the meson port.

## 1. `-Dint10=stub` does not build

`hw/xfree86/int10/Makefile.am` compiled `stub.c` + `xf86int10module.c` for
`INT10_STUB`, and gave `helper_exec.c`, `helper_mem.c` and `xf86int10.c` to the
vm86 and x86emu backends only. The meson port put all three in the list shared
by every backend, and copied `-D_VM86_LINUX` from the autotools stub branch,
where it had been inert because neither stub source includes `int10Defines.h`.

`meson setup -Dint10=stub && ninja`, with #3611 in:

```
ld: stub.c.o: in function `xf86InitInt10':
stub.c:16: multiple definition of `xf86InitInt10';
helper_exec.c.o: helper_exec.c:763: first defined here
```

Without the parentheses fix it stops in the compiler instead, in the same
`int10Defines.h`. The two are independent because after this PR, the stub
build compiles none of the files involved.

`vbe.c`/`vbeModes.c` are kept in the common list since meson has always built
them into the stub module, drivers resolve `VBE*` against it, and every int10
entry point they call is defined in `stub.c`. Nothing outside `generic.c` and the
vm86 backend uses the three removed files, so the module still resolves all of
`include/xf86int10.h`: `nm -D` on the result shows the nine `xf86*Int10*`
entry points plus the `VBE*` set, same as before.

## 2. `host_machine.cpu()` is the raw machine name

`cpu()` is the unnormalized name, on Linux it is `platform.machine()`:
`'i686'`, `'armv7l'`, `'powerpc64'`; `cpu_family()` is the canonical family
(for example, in `.github/scripts/mingw32/cross-i686-w64-mingw32.txt`,
 `cpu = 'i686'`, `cpu_family = 'x86'`).

All four arch tests compare `cpu()` against family names:

* `-D_PC` (autotools `I386_VIDEO`, i.e. `i*86` and `x86_64`) tests for
  `'i386'`, which meson only reports if a cross file says so. A 32-bit x86
  build therefore compiles the `#ifndef _PC` paths (the faked interrupt vector
  table and video BIOS in `helper_mem.c`/`xf86int10.c`) and loses the BIOS
  scratch-area save/restore, on a machine that actually has it.
* ACPI tests for `cpu() == 'x86'`, which meson never returns, so 32-bit x86 has
  never built `lnx_acpi.c` under meson.
* The FreeBSD/powerpc int10 default has matched nothing since 8c54d590cbca,
  which replaced the working `'powerpc'` with the family name `'ppc'` in the
  top-level `meson.build` (in the same diff that correctly moved
  `os-support/meson.build` to `cpu_family()`).
* `arm` is the same mistake; `cpu()` reports `'armv7l'` and friends.

## Testing

* `-Dint10=stub` and `-Dint10=x86emu` build at each of the two commits.
* Full `ninja` on x86_64 with the branch applied.

## Notes

* The stub fix comes first on purpose: the second commit switches armhf to
  `-Dint10=stub`, which the `xserver-build-qemu-user` armhf lane builds, so with
  the commits the other way round that lane breaks there.
* ARM losing x86emu is the only change with a runtime effect: an ARM board with
  a PCI VGA card that needs a VBE POST will no longer get one. That is the
  declared intent of b241934238fe ("default to stub int10 implementation on arm").
  Of the 53 drivers CI builds, 20 use int10/VBE, and all of them degrade
  gracefully: each either checks the returned pointer or only passes it to
  `vbeFree()`/`vbeDoEDID()`/`xf86FreeInt10()`, which tolerate NULL.
* `-D_PC` and ACPI on 32-bit x86 Linux are enabled for the first time under
  meson, and CI has no 32-bit Linux lane (the only i686 lane is mingw32, which
  is Windows and builds neither int10 nor `lnx_acpi.c`). The `-D_PC` half is also
  what `-Dint10=vm86` needs to compile at all (without it `run_bios_int()` calls
  `SET_FLAG(F_CF)`, which lives in the x86emu-only `x86emu/regs.h`).
