### PR TITLE
xfree86: int10: unbreak -Dint10=vm86

### DIFF
--- a/hw/xfree86/int10/generic.c
+++ b/hw/xfree86/int10/generic.c
@@ -450,7 +450,7 @@ write_b(xf86Int10InfoPtr pInt, int addr, uint8_t val)
 }
 
 static void
-write_w(xf86Int10InfoPtr pInt, int addr, CARD16 val)
+write_w(xf86Int10InfoPtr pInt, int addr, uint16_t val)
 {
 #if X_BYTE_ORDER == X_LITTLE_ENDIAN
     if (OFF(addr + 1) > 0) {

--- a/hw/xfree86/int10/meson.build
+++ b/hw/xfree86/int10/meson.build
@@ -40,8 +40,8 @@ endif
 
 if int10 == 'vm86'
     srcs_xorg_int10 += [
-        'vm86/linux_vm86.c',
-        'linux.c',
+        '../os-support/linux/int10/vm86/linux_vm86.c',
+        '../os-support/linux/int10/linux.c',
     ]
     int10_c_args += '-D_VM86_LINUX'
 endif

--- a/hw/xfree86/os-support/int10Defines.h
+++ b/hw/xfree86/os-support/int10Defines.h
@@ -30,13 +30,14 @@
 
 #ifdef _VM86_LINUX
 
+#include <stdint.h>
 #include <asm/vm86.h>
 
 #define CPU_R(type,name,num) \
 	(((type *)&(((struct vm86_struct *)REG->cpuRegs)->regs.name))[(num)])
-#define CPU_RD(name,num) CPU_R(CARD32,name,(num))
-#define CPU_RW(name,num) CPU_R(CARD16,name,(num))
-#define CPU_RB(name,num) CPU_R(CARD8,name,(num))
+#define CPU_RD(name,num) CPU_R(uint32_t,name,(num))
+#define CPU_RW(name,num) CPU_R(uint16_t,name,(num))
+#define CPU_RB(name,num) CPU_R(uint8_t,name,(num))
 
 #define X86_EAX CPU_RD(eax,0)
 #define X86_EBX CPU_RD(ebx,0)

--- a/hw/xfree86/os-support/linux/int10/linux.c
+++ b/hw/xfree86/os-support/linux/int10/linux.c
@@ -33,12 +33,12 @@
 static int counter = 0;
 static x_server_generation_t int10Generation = 0;
 
-static CARD8 read_b(xf86Int10InfoPtr pInt, int addr);
-static CARD16 read_w(xf86Int10InfoPtr pInt, int addr);
-static CARD32 read_l(xf86Int10InfoPtr pInt, int addr);
-static void write_b(xf86Int10InfoPtr pInt, int addr, CARD8 val);
-static void write_w(xf86Int10InfoPtr pInt, int addr, CARD16 val);
-static void write_l(xf86Int10InfoPtr pInt, int addr, CARD32 val);
+static uint8_t read_b(xf86Int10InfoPtr pInt, int addr);
+static uint16_t read_w(xf86Int10InfoPtr pInt, int addr);
+static uint32_t read_l(xf86Int10InfoPtr pInt, int addr);
+static void write_b(xf86Int10InfoPtr pInt, int addr, uint8_t val);
+static void write_w(xf86Int10InfoPtr pInt, int addr, uint16_t val);
+static void write_l(xf86Int10InfoPtr pInt, int addr, uint32_t val);
 
 int10MemRec linuxMem = {
     read_b,
@@ -442,45 +442,44 @@ xf86Int10FreePages(xf86Int10InfoPtr pInt, void *pbase, int num)
         ((linuxInt10Priv *) pInt->private)->alloc[i] = 0;
 }
 
-static CARD8
+static uint8_t
 read_b(xf86Int10InfoPtr pInt, int addr)
 {
-    return *((CARD8 *) (memType) addr);
+    return *((uint8_t *) (memType) addr);
 }
 
-static CARD16
+static uint16_t
 read_w(xf86Int10InfoPtr pInt, int addr)
 {
-    return *((CARD16 *) (memType) addr);
+    return *((uint16_t *) (memType) addr);
 }
 
-static CARD32
+static uint32_t
 read_l(xf86Int10InfoPtr pInt, int addr)
 {
-    return *((CARD32 *) (memType) addr);
+    return *((uint32_t *) (memType) addr);
 }
 
 static void
-write_b(xf86Int10InfoPtr pInt, int addr, CARD8 val)
+write_b(xf86Int10InfoPtr pInt, int addr, uint8_t val)
 {
-    *((CARD8 *) (memType) addr) = val;
+    *((uint8_t *) (memType) addr) = val;
 }
 
 static void
-write_w(xf86Int10InfoPtr pInt, int addr, CARD16 val)
+write_w(xf86Int10InfoPtr pInt, int addr, uint16_t val)
 {
-    *((CARD16 *) (memType) addr) = val;
+    *((uint16_t *) (memType) addr) = val;
 }
 
-static
-    void
-write_l(xf86Int10InfoPtr pInt, int addr, CARD32 val)
+static void
+write_l(xf86Int10InfoPtr pInt, int addr, uint32_t val)
 {
-    *((CARD32 *) (memType) addr) = val;
+    *((uint32_t *) (memType) addr) = val;
 }
 
 void *
-xf86int10Addr(xf86Int10InfoPtr pInt, CARD32 addr)
+xf86int10Addr(xf86Int10InfoPtr pInt, uint32_t addr)
 {
     if (addr < V_RAM)
         return ((linuxInt10Priv *) pInt->private)->base + addr;

--- a/hw/xfree86/os-support/linux/int10/linux.c
+++ b/hw/xfree86/os-support/linux/int10/linux.c
@@ -6,8 +6,11 @@
 
 #include <stdbool.h>
 
+#include "os/log_priv.h"
+
 #include "xf86.h"
 #include "xf86_OSproc.h"
+#include "xf86Bus.h"
 #include "xf86Pci.h"
 #include "compiler.h"
 #include "xf86int10_priv.h"

--- a/hw/xfree86/os-support/linux/int10/linux.c
+++ b/hw/xfree86/os-support/linux/int10/linux.c
@@ -63,7 +63,7 @@ readLegacy(struct pci_device *dev, unsigned char *buf, int base, int len)
         return FALSE;
 
     memcpy(buf, map, len);
-    pci_device_unmap_legacy(dev, man, len);
+    pci_device_unmap_legacy(dev, map, len);
 
     return TRUE;
 }
@@ -212,8 +212,7 @@ xf86ExtendedInitInt10(int entityIndex, int Flags)
     Int10Current = pInt;
 
     DebugF("Mapping int area\n");
-    /* note: yes, we really are writing the 0 page here */
-    if (!readLegacy(pInt->dev, (unsigned char *) 0, 0, LOW_PAGE_SIZE)) {
+    if (!readLegacy(pInt->dev, xf86int10Addr(pInt, 0), 0, LOW_PAGE_SIZE)) {
         xf86DrvMsg(screen, X_ERROR, "Cannot read int vect\n");
         goto error3;
     }

--- a/hw/xfree86/os-support/linux/int10/vm86/linux_vm86.c
+++ b/hw/xfree86/os-support/linux/int10/vm86/linux_vm86.c
@@ -44,7 +44,6 @@ static Bool
 vm86_GP_fault(xf86Int10InfoPtr pInt)
 {
     unsigned char *csp, *lina;
-    CARD32 org_eip;
     int pref_seg;
     int done, is_rep, prefix66, prefix67;
 
@@ -93,7 +92,6 @@ vm86_GP_fault(xf86Int10InfoPtr pInt)
         }
     } while (!done);
     csp--;                      /* oops one too many */
-    org_eip = X86_EIP;
     X86_IP += (csp - lina);
 
     switch (MEM_RB(pInt, (int) csp)) {
@@ -101,7 +99,7 @@ vm86_GP_fault(xf86Int10InfoPtr pInt)
         /* NOTE: ES can't be overwritten; prefixes 66,67 should use esi,edi,ecx
          * but is anyone using extended regs in real mode? */
         /* WARNING: no test for DI wrapping! */
-        X86_EDI += port_rep_inb(pInt, X86_DX, SEG_EADR((CARD32), X86_ES, DI),
+        X86_EDI += port_rep_inb(pInt, X86_DX, SEG_EADR((uint32_t), X86_ES, DI),
                                 X86_FLAGS & DF, is_rep ? LWECX : 1);
         if (is_rep)
             LWECX_ZERO;
@@ -112,11 +110,11 @@ vm86_GP_fault(xf86Int10InfoPtr pInt)
         /* NOTE: ES can't be overwritten */
         /* WARNING: no test for _DI wrapping! */
         if (prefix66) {
-            X86_DI += port_rep_inl(pInt, X86_DX, SEG_ADR((CARD32), X86_ES, DI),
+            X86_DI += port_rep_inl(pInt, X86_DX, SEG_ADR((uint32_t), X86_ES, DI),
                                    X86_EFLAGS & DF, is_rep ? LWECX : 1);
         }
         else {
-            X86_DI += port_rep_inw(pInt, X86_DX, SEG_ADR((CARD32), X86_ES, DI),
+            X86_DI += port_rep_inw(pInt, X86_DX, SEG_ADR((uint32_t), X86_ES, DI),
                                    X86_FLAGS & DF, is_rep ? LWECX : 1);
         }
         if (is_rep)
@@ -128,7 +126,7 @@ vm86_GP_fault(xf86Int10InfoPtr pInt)
         if (pref_seg < 0)
             pref_seg = X86_DS;
         /* WARNING: no test for _SI wrapping! */
-        X86_SI += port_rep_outb(pInt, X86_DX, (CARD32) LIN_PREF_SI,
+        X86_SI += port_rep_outb(pInt, X86_DX, (uint32_t) LIN_PREF_SI,
                                 X86_FLAGS & DF, is_rep ? LWECX : 1);
         if (is_rep)
             LWECX_ZERO;
@@ -140,11 +138,11 @@ vm86_GP_fault(xf86Int10InfoPtr pInt)
             pref_seg = X86_DS;
         /* WARNING: no test for _SI wrapping! */
         if (prefix66) {
-            X86_SI += port_rep_outl(pInt, X86_DX, (CARD32) LIN_PREF_SI,
+            X86_SI += port_rep_outl(pInt, X86_DX, (uint32_t) LIN_PREF_SI,
                                     X86_EFLAGS & DF, is_rep ? LWECX : 1);
         }
         else {
-            X86_SI += port_rep_outw(pInt, X86_DX, (CARD32) LIN_PREF_SI,
+            X86_SI += port_rep_outw(pInt, X86_DX, (uint32_t) LIN_PREF_SI,
                                     X86_FLAGS & DF, is_rep ? LWECX : 1);
         }
         if (is_rep)
@@ -211,7 +209,7 @@ vm86_GP_fault(xf86Int10InfoPtr pInt)
     case 0x0f:
         xf86DrvMsg(pInt->pScrn->scrnIndex, X_ERROR,
                    "CPU 0x0f Trap at CS:EIP=0x%4.4x:0x%8.8lx\n", X86_CS,
-                   X86_EIP);
+                   (unsigned long) X86_EIP);
         goto op0ferr;
 
     default:

--- a/hw/xfree86/os-support/linux/int10/vm86/linux_vm86.c
+++ b/hw/xfree86/os-support/linux/int10/vm86/linux_vm86.c
@@ -3,6 +3,8 @@
 #include <errno.h>
 #include <string.h>
 
+#include "os/log_priv.h"
+
 #include "xf86.h"
 #include "xf86_OSproc.h"
 #include "xf86Pci.h"


### PR DESCRIPTION
~~I opened this against master, but it needs both #3611 and #3612 to be merged
first, otherwise it won't even compile. I'll rebase this once that happens.~~

## The backend

The linux vm86 int10 backend has not compiled for a long time. `-Dint10=vm86` is
a valid meson option, and on 32-bit x86 with `CONFIG_X86_LEGACY_VM86=y` it
is what runs BIOS calls on the real CPU rather than under x86emu. But nothing
builds it, so regressions have accumulated in it unnoticed:

- **1549e3037275** ("Add a Meson build system alongside autotools.") listed
  the vm86 sources relative to `hw/xfree86/int10/`, where they have never
  lived. Configure fails before anything else is reached.
- **21b216ad6ce2** ("int10: Port off xf86ReadBIOS") added a `readLegacy()`
  helper that unmaps `man`, an identifier that does not exist, and passes a
  null pointer as its destination.
- **7353ec7cb6fc** ("xfree86: Switch int10 code to stdint types") converted
  the int10 core and the public header but not this backend. On i386 `CARD32`
  is `unsigned long` while `uint32_t` is `unsigned int`, so `linux.c`'s
  accessors no longer match `int10MemRec` and its `xf86int10Addr()` conflicts
  with the prototype in `xf86int10.h`.
- **7c51bcb09318**, **1fbddfd8b13e** and **cdea9dc13342** moved `DebugF()`,
  `xf86FindScreenForEntity()` and `xf86IsEntityPrimary()` out of the headers
  these two files include.

## Testing

I built and run it on a 32-bit Debian 12 VM with a `CONFIG_X86_LEGACY_VM86=y`
kernel and `xf86-video-vesa`. XFCE4 comes up and seems to work, `Xorg.0.log`
shows the int10 module in use, and I confirmed the `vm86old` entry via the
`/sys/kernel/tracing` mechanism.