### PR TITLE
(master) os: fix undefined behavior in FormatInt64() for INT64_MIN

### DIFF
--- a/os/fmt.c
+++ b/os/fmt.c
@@ -20,7 +20,7 @@ FormatInt64(int64_t num, char *string)
 
     if (num < 0) {
         string[0] = '-';
-        unum = num * -1;
+        unum = -(uint64_t)num;
         string++;
     }
     FormatUInt64(unum, string);


### PR DESCRIPTION
'num * -1' is undefined behavior when num is INT64_MIN, since the
positive value (9223372036854775808) exceeds INT64_MAX.

Fix by casting to uint64_t before negation, which is well-defined
unsigned modular arithmetic and produces the correct absolute value
for all int64_t values including INT64_MIN.

Fixes: https://github.com/X11Libre/xserver/issues/3610
Fixes: 2a41522349f250f09a8feb512889d38e5bc08ed8
Reported-by: Alex <alexzk1@users.noreply.github.com>
Signed-off-by: Defiant <defiant@x11libre.dev>

## Backport dashboard

| Branch | PR | Status |
|--------|----|--------|
| `release/25.2` | [#3615](https://github.com/X11Libre/xserver/pull/3615) | 🔄 Open |
| `release/25.1` | [#3616](https://github.com/X11Libre/xserver/pull/3616) | 🔄 Open |
| `release/25.0` | [#3617](https://github.com/X11Libre/xserver/pull/3617) | 🔄 Open |
