### PR TITLE
(release/25.1) xquartz: add missing os/log_priv.h include for DebugF declaration

### DIFF
--- a/hw/xquartz/xpr/dri.c
+++ b/hw/xquartz/xpr/dri.c
@@ -47,6 +47,7 @@
 #include <sys/stat.h>
 
 #include "miext/extinit_priv.h"
+#include "os/log_priv.h"
 
 #include "misc.h"
 #include "dixstruct.h"


### PR DESCRIPTION
dri.c uses DebugF() (line 305) which is defined as a macro in
os/log_priv.h. This header was missing on release/25.1, causing
build failure on macOS with -Wimplicit-function-declaration promoted
to error.

Master already has this include; this is a pre-existing omission on
the release/25.1 branch.
