### PR TITLE
glamor: modesetting: Get DRI3 working without full acceleration

### DIFF
--- a/glamor/glamor.c
+++ b/glamor/glamor.c
@@ -860,76 +860,90 @@ glamor_init(ScreenPtr screen, unsigned int flags)
     if (!glamor_font_init(screen))
         goto fail;
 
-    if (!(flags & GLAMOR_NO_RENDER_ACCEL)) {
-        glamor_priv->saved_procs.block_handler = screen->BlockHandler;
-        screen->BlockHandler = _glamor_block_handler;
+    glamor_priv->saved_procs.block_handler = screen->BlockHandler;
+    screen->BlockHandler = _glamor_block_handler;
 
-        if (!glamor_composite_glyphs_init(screen)) {
-            ErrorF("Failed to initialize composite masks\n");
-            goto fail;
-        }
+    if (!glamor_composite_glyphs_init(screen)) {
+        ErrorF("Failed to initialize composite masks\n");
+        goto fail;
+    }
 
-        glamor_priv->saved_procs.create_gc = screen->CreateGC;
-        screen->CreateGC = glamor_create_gc;
+    glamor_priv->saved_procs.create_gc = screen->CreateGC;
+    screen->CreateGC = glamor_create_gc;
 
+    /*
+     * Leave all other procs intact, since we're not
+     * overriding CreatePixmap, all pixmaps will be memory,
+     * hence not accelerated, and all other routines should
+     * fall back to software (fb)
+     *
+     * This is useful when the X server is running on a system
+     * with limited gpu memory, such that it is desirable for
+     * most pixmaps to be drawn in software, but it is still
+     * desirable for DRI3 to work
+     *
+     * This is also useful when glamor is running on top
+     * of a software render and it is only used for glx support
+     */
+    if (!(glamor_priv->flags & GLAMOR_NO_RENDER_ACCEL)) {
         glamor_priv->saved_procs.create_pixmap = screen->CreatePixmap;
         screen->CreatePixmap = glamor_create_pixmap;
-
-        glamor_priv->saved_procs.get_spans = screen->GetSpans;
-        screen->GetSpans = glamor_get_spans;
-
-        glamor_priv->saved_procs.get_image = screen->GetImage;
-        screen->GetImage = glamor_get_image;
-
-        glamor_priv->saved_procs.change_window_attributes =
-            screen->ChangeWindowAttributes;
-        screen->ChangeWindowAttributes = glamor_change_window_attributes;
-
-        glamor_priv->saved_procs.copy_window = screen->CopyWindow;
-        screen->CopyWindow = glamor_copy_window;
-
-        glamor_priv->saved_procs.bitmap_to_region = screen->BitmapToRegion;
-        screen->BitmapToRegion = glamor_bitmap_to_region;
-
-        if (ps) {
-            glamor_priv->saved_procs.composite = ps->Composite;
-            ps->Composite = glamor_composite;
-
-            glamor_priv->saved_procs.trapezoids = ps->Trapezoids;
-            ps->Trapezoids = glamor_trapezoids;
-
-            glamor_priv->saved_procs.triangles = ps->Triangles;
-            ps->Triangles = glamor_triangles;
-
-            glamor_priv->saved_procs.addtraps = ps->AddTraps;
-            ps->AddTraps = glamor_add_traps;
-
-            glamor_priv->saved_procs.composite_rects = ps->CompositeRects;
-            ps->CompositeRects = glamor_composite_rectangles;
-
-            glamor_priv->saved_procs.glyphs = ps->Glyphs;
-            ps->Glyphs = glamor_composite_glyphs;
-        }
-
-        glamor_init_vbo(screen);
-
-        glamor_priv->enable_gradient_shader = TRUE;
-
-        if (!glamor_init_gradient_shader(screen)) {
-            LogMessage(X_WARNING,
-                       "glamor%d: Cannot initialize gradient shader, falling back to software rendering for gradients\n",
-                       screen->myNum);
-            glamor_priv->enable_gradient_shader = FALSE;
-        }
-
-        glamor_pixmap_init(screen);
-        glamor_sync_init(screen);
-
-        glamor_priv->screen = screen;
-
-        dixScreenHookClose(screen, glamor_close_screen);
-        dixScreenHookPixmapDestroy(screen, glamor_pixmap_destroy);
     }
+
+    glamor_priv->saved_procs.get_spans = screen->GetSpans;
+    screen->GetSpans = glamor_get_spans;
+
+    glamor_priv->saved_procs.get_image = screen->GetImage;
+    screen->GetImage = glamor_get_image;
+
+    glamor_priv->saved_procs.change_window_attributes =
+        screen->ChangeWindowAttributes;
+    screen->ChangeWindowAttributes = glamor_change_window_attributes;
+
+    glamor_priv->saved_procs.copy_window = screen->CopyWindow;
+    screen->CopyWindow = glamor_copy_window;
+
+    glamor_priv->saved_procs.bitmap_to_region = screen->BitmapToRegion;
+    screen->BitmapToRegion = glamor_bitmap_to_region;
+
+    if (ps) {
+        glamor_priv->saved_procs.composite = ps->Composite;
+        ps->Composite = glamor_composite;
+
+        glamor_priv->saved_procs.trapezoids = ps->Trapezoids;
+        ps->Trapezoids = glamor_trapezoids;
+
+        glamor_priv->saved_procs.triangles = ps->Triangles;
+        ps->Triangles = glamor_triangles;
+
+        glamor_priv->saved_procs.addtraps = ps->AddTraps;
+        ps->AddTraps = glamor_add_traps;
+
+        glamor_priv->saved_procs.composite_rects = ps->CompositeRects;
+        ps->CompositeRects = glamor_composite_rectangles;
+
+        glamor_priv->saved_procs.glyphs = ps->Glyphs;
+        ps->Glyphs = glamor_composite_glyphs;
+    }
+
+    glamor_init_vbo(screen);
+
+    glamor_priv->enable_gradient_shader = TRUE;
+
+    if (!glamor_init_gradient_shader(screen)) {
+        LogMessage(X_WARNING,
+                   "glamor%d: Cannot initialize gradient shader, falling back to software rendering for gradients\n",
+                   screen->myNum);
+        glamor_priv->enable_gradient_shader = FALSE;
+    }
+
+    glamor_pixmap_init(screen);
+    glamor_sync_init(screen);
+
+    glamor_priv->screen = screen;
+
+    dixScreenHookClose(screen, glamor_close_screen);
+    dixScreenHookPixmapDestroy(screen, glamor_pixmap_destroy);
 
     return TRUE;
 
@@ -958,38 +972,37 @@ static void glamor_close_screen(CallbackListPtr *pcbl, ScreenPtr screen, void *u
     PixmapPtr screen_pixmap;
 
     glamor_priv = glamor_get_screen_private(screen);
-    if (!(glamor_priv->flags & GLAMOR_NO_RENDER_ACCEL)) {
-        glamor_sync_close(screen);
-        glamor_composite_glyphs_fini(screen);
-    }
-
+    glamor_sync_close(screen);
+    glamor_composite_glyphs_fini(screen);
     glamor_set_glvnd_vendor(screen, NULL);
 
+    dixScreenUnhookClose(screen, glamor_close_screen);
+    dixScreenUnhookPixmapDestroy(screen, glamor_pixmap_destroy);
+
+    screen->CreateGC = glamor_priv->saved_procs.create_gc;
+
     if (!(glamor_priv->flags & GLAMOR_NO_RENDER_ACCEL)) {
-        dixScreenUnhookClose(screen, glamor_close_screen);
-        dixScreenUnhookPixmapDestroy(screen, glamor_pixmap_destroy);
-
-        screen->CreateGC = glamor_priv->saved_procs.create_gc;
         screen->CreatePixmap = glamor_priv->saved_procs.create_pixmap;
-        screen->GetSpans = glamor_priv->saved_procs.get_spans;
-        screen->ChangeWindowAttributes =
-            glamor_priv->saved_procs.change_window_attributes;
-        screen->CopyWindow = glamor_priv->saved_procs.copy_window;
-        screen->BitmapToRegion = glamor_priv->saved_procs.bitmap_to_region;
-        screen->BlockHandler = glamor_priv->saved_procs.block_handler;
-
-        PictureScreenPtr ps = GetPictureScreenIfSet(screen);
-        if (ps) {
-            ps->Composite = glamor_priv->saved_procs.composite;
-            ps->Trapezoids = glamor_priv->saved_procs.trapezoids;
-            ps->Triangles = glamor_priv->saved_procs.triangles;
-            ps->CompositeRects = glamor_priv->saved_procs.composite_rects;
-            ps->Glyphs = glamor_priv->saved_procs.glyphs;
-        }
-
-        screen_pixmap = screen->GetScreenPixmap(screen);
-        glamor_pixmap_destroy_fbo(screen_pixmap);
     }
+
+    screen->GetSpans = glamor_priv->saved_procs.get_spans;
+    screen->ChangeWindowAttributes =
+        glamor_priv->saved_procs.change_window_attributes;
+    screen->CopyWindow = glamor_priv->saved_procs.copy_window;
+    screen->BitmapToRegion = glamor_priv->saved_procs.bitmap_to_region;
+    screen->BlockHandler = glamor_priv->saved_procs.block_handler;
+
+    PictureScreenPtr ps = GetPictureScreenIfSet(screen);
+    if (ps) {
+        ps->Composite = glamor_priv->saved_procs.composite;
+        ps->Trapezoids = glamor_priv->saved_procs.trapezoids;
+        ps->Triangles = glamor_priv->saved_procs.triangles;
+        ps->CompositeRects = glamor_priv->saved_procs.composite_rects;
+        ps->Glyphs = glamor_priv->saved_procs.glyphs;
+    }
+
+    screen_pixmap = screen->GetScreenPixmap(screen);
+    glamor_pixmap_destroy_fbo(screen_pixmap);
 
     glamor_release_screen_priv(screen);
 }

--- a/glamor/glamor.c
+++ b/glamor/glamor.c
@@ -928,13 +928,15 @@ glamor_init(ScreenPtr screen, unsigned int flags)
 
     glamor_init_vbo(screen);
 
-    glamor_priv->enable_gradient_shader = TRUE;
-
-    if (!glamor_init_gradient_shader(screen)) {
-        LogMessage(X_WARNING,
-                   "glamor%d: Cannot initialize gradient shader, falling back to software rendering for gradients\n",
-                   screen->myNum);
-        glamor_priv->enable_gradient_shader = FALSE;
+    glamor_priv->enable_gradient_shader = FALSE;
+    if (!(glamor_priv->flags & GLAMOR_NO_RENDER_ACCEL)) {
+        if (!glamor_init_gradient_shader(screen)) {
+            LogMessage(X_WARNING,
+                       "glamor%d: Cannot initialize gradient shader, falling back to software rendering for gradients\n",
+                       screen->myNum);
+        } else {
+            glamor_priv->enable_gradient_shader = TRUE;
+        }
     }
 
     glamor_pixmap_init(screen);

--- a/glamor/glamor.c
+++ b/glamor/glamor.c
@@ -988,6 +988,7 @@ static void glamor_close_screen(CallbackListPtr *pcbl, ScreenPtr screen, void *u
     }
 
     screen->GetSpans = glamor_priv->saved_procs.get_spans;
+    screen->GetImage = glamor_priv->saved_procs.get_image;
     screen->ChangeWindowAttributes =
         glamor_priv->saved_procs.change_window_attributes;
     screen->CopyWindow = glamor_priv->saved_procs.copy_window;

--- a/glamor/glamor_composite_glyphs.c
+++ b/glamor/glamor_composite_glyphs.c
@@ -427,7 +427,7 @@ glamor_composite_glyphs(CARD8 op,
                  */
                 if (_X_UNLIKELY(glyph_draw->width > glyph_max_dim ||
                                 glyph_draw->height > glyph_max_dim ||
-                                !glamor_pixmap_is_memory((PixmapPtr)glyph_draw)))
+                                glamor_pixmap_is_memory((PixmapPtr)glyph_draw)))
                 {
                     if (glyphs_queued) {
                         glamor_glyphs_flush(op, src, dst, prog, glyph_atlas, glyphs_queued);

--- a/glamor/glamor_compositerects.c
+++ b/glamor/glamor_compositerects.c
@@ -195,6 +195,8 @@ glamor_composite_rectangles(CARD8 op,
         return;
     }
 
+    need_free_region = TRUE;
+
     pixmap = glamor_get_drawable_pixmap(dst->pDrawable);
     priv = glamor_get_pixmap_private(pixmap);
 
@@ -204,8 +206,6 @@ glamor_composite_rectangles(CARD8 op,
         DEBUGF("%s: fallback, dst has an alpha-map\n", __func__);
         goto fallback;
     }
-
-    need_free_region = TRUE;
 
     DEBUGF("%s: drawable extents (%d, %d),(%d, %d) x %d\n",
            __func__,

--- a/glamor/glamor_font.c
+++ b/glamor/glamor_font.c
@@ -51,6 +51,10 @@ glamor_font_get(ScreenPtr screen, FontPtr font)
     CharInfoPtr         glyph;
     unsigned long       count;
 
+    if (glamor_priv->flags & GLAMOR_NO_RENDER_ACCEL) {
+        return NULL;
+    }
+
     if (!glamor_glsl_has_ints(glamor_priv))
         return NULL;
 

--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -2400,7 +2400,6 @@ CloseScreen(ScreenPtr pScreen)
     }
 
     if (ms->drmmode.shadow_enable) {
-        ms->shadow.Remove(pScreen, pScreen->GetScreenPixmap(pScreen));
         free(ms->drmmode.shadow_fb);
         ms->drmmode.shadow_fb = NULL;
         free(ms->drmmode.shadow_fb2);

--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -1149,7 +1149,7 @@ try_enable_glamor(ScrnInfoPtr pScrn)
     if (load_glamor(pScrn)) {
         int caps = GLAMOR_EGL_CAP_NONE;
         if (ms->glamor.egl_init2(pScrn, ms->fd, &caps, 0)) {
-            ms->drmmode.glamor_gbm = !!(caps & GLAMOR_EGL_CAP_TEXTURE_GBM_BO);
+            ms->drmmode.glamor_gbm = !no_accel && (caps & GLAMOR_EGL_CAP_TEXTURE_GBM_BO);
             xf86DrvMsg(pScrn->scrnIndex, X_INFO, "glamor initialized%s\n",
                        no_accel ? " without render acceleration" : "");
             ms->drmmode.glamor = TRUE;

--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -1124,9 +1124,14 @@ try_enable_glamor(ScrnInfoPtr pScrn)
     modesettingPtr ms = modesettingPTR(pScrn);
     const char *accel_method_str = xf86GetOptValString(ms->drmmode.Options,
                                                        OPTION_ACCEL_METHOD);
-    Bool do_glamor = (!accel_method_str ||
-                      strcmp(accel_method_str, "glamor") == 0);
 
+    Bool no_accel = accel_method_str && !strcmp(accel_method_str, "dri3_only");
+
+    Bool do_glamor = (!accel_method_str ||
+                      no_accel ||
+                      !strcmp(accel_method_str, "glamor"));
+
+    ms->drmmode.no_accel = no_accel;
     ms->drmmode.glamor = FALSE;
     ms->drmmode.glamor_gbm = FALSE;
 
@@ -1145,7 +1150,8 @@ try_enable_glamor(ScrnInfoPtr pScrn)
         int caps = GLAMOR_EGL_CAP_NONE;
         if (ms->glamor.egl_init2(pScrn, ms->fd, &caps, 0)) {
             ms->drmmode.glamor_gbm = !!(caps & GLAMOR_EGL_CAP_TEXTURE_GBM_BO);
-            xf86DrvMsg(pScrn->scrnIndex, X_INFO, "glamor initialized\n");
+            xf86DrvMsg(pScrn->scrnIndex, X_INFO, "glamor initialized%s\n",
+                       no_accel ? " without render acceleration" : "");
             ms->drmmode.glamor = TRUE;
         } else {
             xf86DrvMsg(pScrn->scrnIndex, X_INFO,

--- a/hw/xfree86/drivers/video/modesetting/driver.c
+++ b/hw/xfree86/drivers/video/modesetting/driver.c
@@ -2229,7 +2229,7 @@ ScreenInit(ScreenPtr pScreen, int argc, char **argv)
         xf86DPMSInit(pScreen, xf86DPMSSet, 0);
 
 #if defined(GLAMOR) && defined(XV)
-    if (ms->drmmode.glamor) {
+    if (ms->drmmode.glamor && !ms->drmmode.no_accel) {
         XF86VideoAdaptorPtr     glamor_adaptor;
 
         glamor_adaptor = ms->glamor.xv_init(pScreen, 16);

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -4200,7 +4200,9 @@ drmmode_init(ScrnInfoPtr pScrn, drmmode_ptr drmmode)
     modesettingPtr ms = modesettingPTR(pScrn);
 
     if (drmmode->glamor) {
-        if (!ms->glamor.init(pScreen, GLAMOR_USE_EGL_SCREEN)) {
+        if (!ms->glamor.init(pScreen, drmmode->no_accel ?
+                                      GLAMOR_USE_EGL_SCREEN | GLAMOR_NO_RENDER_ACCEL :
+                                      GLAMOR_USE_EGL_SCREEN)) {
             return FALSE;
         }
 #ifdef GBM_BO_WITH_MODIFIERS

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.h
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.h
@@ -99,6 +99,7 @@ typedef struct {
     /* Broken-out options. */
     OptionInfoPtr Options;
 
+    Bool no_accel;
     Bool glamor;
     Bool glamor_gbm;
     Bool glamor_gbm_device;

--- a/hw/xfree86/drivers/video/modesetting/modesetting.man
+++ b/hw/xfree86/drivers/video/modesetting/modesetting.man
@@ -80,7 +80,8 @@ This defaults to enabled for ASPEED and Matrox G200 devices, and disabled
 otherwise.
 .TP
 .BI "Option \*qAccelMethod\*q \*q" string \*q
-One of \*qglamor\*q or \*qnone\*q.  Default: glamor.
+One of \*qglamor\*q or \*qdri3_only\*q or \*qnone\*q.  Default: glamor.
+dri3_only means that glamor is used only for DRI3, but not for accelerating any other pixmaps.
 .TP
 .BI "Option \*qPageFlip\*q \*q" boolean \*q
 Enable DRI3 page flipping.  The default is


### PR DESCRIPTION
This is useful when the X server is running on a system with limited gpu memory, such that it is desirable for
most pixmaps to be drawn in software, but it is still desirable for DRI3 to work

Use `git diff -w` for easier review

Closes: https://github.com/X11Libre/xserver/issues/1989