### PR TITLE
modesetting: Fix use-after-free when aborting queued events

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/vblank.c
+++ b/hw/xfree86/drivers/video/modesetting/vblank.c
@@ -548,7 +548,7 @@ ms_drm_abort(ScrnInfoPtr scrn, Bool (*match)(void *data, void *match_data),
     struct ms_drm_queue *q;
 
     xorg_list_for_each_entry(q, &ms_drm_queue, list) {
-        if (match(q->data, match_data)) {
+        if (!q->aborted && match(q->data, match_data)) {
             ms_drm_abort_one(q);
             break;
         }


### PR DESCRIPTION
`ms_drm_abort` calls the `match` function pointer for every event in the queued event list

However, present frees the event data when aborting an event, so when `ms_drm_abort` was getting called after an aborted event, in was calling `match` with a dangling pointer, leading to an use-after-free

See: https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/2290