### PR TITLE
(release/25.1) fix getrandom fallback

### DIFF
--- a/os/osdep.h
+++ b/os/osdep.h
@@ -54,6 +54,9 @@ SOFTWARE.
 #include <limits.h>
 #include <signal.h>
 #include <stddef.h>
+#ifdef HAVE_GETRANDOM
+#include <sys/random.h>
+#endif
 #include <X11/Xos.h>
 #include <X11/Xmd.h>
 #include <X11/Xdefs.h>
@@ -89,10 +92,10 @@ extern Bool NewOutputPending;
 static inline void arc4random_buf(void *buf, size_t nbytes)
 {
     ssize_t ret;
-    int pos = 0;
+    ssize_t pos = 0;
 #ifdef HAVE_GETRANDOM
-    while (pos < len) {
-        ret = getrandom(buf + pos, len - pos, 0);
+    while (pos < nbytes) {
+        ret = getrandom((unsigned char*)buf + pos, nbytes - pos, 0);
         if (ret <= 0) {
             if (ret < 0 && errno == EINTR)
                 continue;


### PR DESCRIPTION
Backport of [#3536](https://github.com/X11Libre/xserver/pull/3536) (master).

Fixes [#3034](https://github.com/X11Libre/xserver/issues/3034).

Tested with musl on real 32- and 64-bit MIPS and PowerPC hardware, including little- and big-endian systems.
More precisely: an iBook G4, a PowerMac G5 and two OpenWrt routers.

**Adapted for release/25.1:** also fixes `int pos` → `ssize_t pos` for type consistency (matching master).