### PR TITLE
Add Support for DPI Auto-Detection

### DIFF
--- a/Xext/randr/rroutput.c
+++ b/Xext/randr/rroutput.c
@@ -118,7 +118,13 @@ RROutputCreate(ScreenPtr pScreen,
         static const INT32 values[2] = { 0, 960 }; // arbitrary range
         (void) RRConfigureOutputProperty(output, DPIAtom, FALSE, TRUE, FALSE,
                                          2, values);
-        INT32 value = monitorResolution ? monitorResolution : 96;
+        INT32 value;
+        if (monitorResolution > 0)
+            value = monitorResolution;
+        else if (autosetDPI)
+            value = (int) ((double) pScreen->width * 25.4 / pScreen->mmWidth);
+        else
+            value = 96;
         (void) RRChangeOutputProperty(output, DPIAtom, XA_INTEGER, 32,
                                       PropModeReplace, 1, &value, FALSE, FALSE);
     }

--- a/dix/globals.c
+++ b/dix/globals.c
@@ -119,6 +119,7 @@ TimeStamp currentTime;
 
 int defaultColorVisualClass = -1;
 int monitorResolution = 0;
+Bool autosetDPI = FALSE;
 
 Bool explicit_display = FALSE;
 char *ConnectionInfo;

--- a/hw/xfree86/common/xf86Helper.c
+++ b/hw/xfree86/common/xf86Helper.c
@@ -65,6 +65,7 @@
 #include "xf86InPriv.h"
 #include "xf86Config.h"
 #include "xf86Module_priv.h"
+#include "xf86Crtc.h"
 
 static int xf86ScrnInfoPrivateCount = 0;
 
@@ -848,6 +849,7 @@ xf86SetDpi(ScrnInfoPtr pScrn, int x, int y)
     xf86MonPtr DDC = (xf86MonPtr) (pScrn->monitor->DDC);
     int ddcWidthmm, ddcHeightmm;
     int widthErr, heightErr;
+    xf86OutputPtr compat = xf86CompatOutput(pScrn);
 
     /* XXX Maybe there is no need for widthmm/heightmm in ScrnInfoRec */
     pScrn->widthmm = pScrn->monitor->widthmm;
@@ -859,6 +861,10 @@ xf86SetDpi(ScrnInfoPtr pScrn, int x, int y)
          */
         ddcWidthmm = DDC->features.hsize * 10;  /* 10mm in 1cm */
         ddcHeightmm = DDC->features.vsize * 10; /* 10mm in 1cm */
+    }
+    else if (autosetDPI && compat && compat->mm_width > 0 && compat->mm_height > 0) {
+        ddcWidthmm = compat->mm_width;
+        ddcHeightmm = compat->mm_height;
     }
     else {
         ddcWidthmm = ddcHeightmm = 0;

--- a/hw/xfree86/modes/xf86Crtc.c
+++ b/hw/xfree86/modes/xf86Crtc.c
@@ -3228,8 +3228,10 @@ xf86OutputSetEDID(xf86OutputPtr output, xf86MonPtr edid_mon)
     free(output->MonInfo);
 
     output->MonInfo = edid_mon;
-    output->mm_width = 0;
-    output->mm_height = 0;
+    if (!autosetDPI || edid_mon) {
+        output->mm_width = 0;
+        output->mm_height = 0;
+    }
 
     if (debug_modes) {
         xf86DrvMsg(scrn->scrnIndex, X_INFO, "EDID for output %s\n",

--- a/hw/xfree86/modes/xf86RandR12.c
+++ b/hw/xfree86/modes/xf86RandR12.c
@@ -806,6 +806,12 @@ xf86RandR12CreateScreenResources(ScreenPtr pScreen)
                 mmWidth = output->conf_monitor->mon_width;
                 mmHeight = output->conf_monitor->mon_height;
             }
+            else if (autosetDPI && output &&
+                (output->mm_width > 0 &&
+                 output->mm_height > 0)) {
+                mmWidth = output->mm_width;
+                mmHeight = output->mm_height;
+            }
             else {
                 /*
                  * Otherwise, just set the screen to DEFAULT_DPI

--- a/include/globals.h
+++ b/include/globals.h
@@ -8,6 +8,7 @@
 
 extern _X_EXPORT const char *defaultFontPath;
 extern _X_EXPORT int monitorResolution;
+extern _X_EXPORT Bool autosetDPI;
 extern _X_EXPORT int defaultColorVisualClass;
 
 #endif                          /* !_XSERV_GLOBAL_H_ */

--- a/os/utils.c
+++ b/os/utils.c
@@ -502,7 +502,10 @@ ProcessCommandLine(int argc, char *argv[])
         }
         else if (strcmp(argv[i], "-dpi") == 0) {
             if (++i < argc)
-                monitorResolution = atoi(argv[i]);
+                if (strcmp(argv[i], "auto") == 0)
+                    autosetDPI = TRUE;
+                else
+                    monitorResolution = atoi(argv[i]);
             else
                 UseMsg();
         }


### PR DESCRIPTION
This PR re-adds support for DPI Auto-Detection which was available in X.Org till 21.1, but was removed. This reverts commit [35af1299](https://github.com/X11Libre/xserver/commit/35af1299e73483eaf93d913a960e1d1738bc7de6) and allows to get Auto DPI Detection back only when specified by user as:
`$ X -dpi auto`

Related Issue: [Xlibre/276](https://github.com/X11Libre/xserver/issues/276).

## Backport dashboard

| Target branch | Backport PR | Status |
|---|---|---|
| release/25.2 | #3669 | 🔄 Open |
| release/25.1 | #3668 | 🔄 Open |
| release/25.0 | — | ⏭️ Skipped (predates DPI auto-detection feature) |

_Backports based on merge commit (which includes the full feature[ `2b7cbdda1a` ] + bugfix[ `7cc65bb53c` ];
25.1/25.2 received both commits via cherry-pick)._
