### PR TITLE
glamor: clear new alloc pixmaps to fix graph artifacts and VRAM leak

### DIFF
--- a/glamor/glamor.c
+++ b/glamor/glamor.c
@@ -149,15 +149,24 @@ glamor_clear_pixmap(PixmapPtr pixmap)
     glamor_screen_private *glamor_priv;
     glamor_pixmap_private *pixmap_priv;
     const struct glamor_format *pixmap_format;
+    int i;
 
     glamor_priv = glamor_get_screen_private(screen);
     pixmap_priv = glamor_get_pixmap_private(pixmap);
     pixmap_format = glamor_format_for_pixmap(pixmap);
 
     BUG_RETURN(!pixmap_priv);
-    assert(pixmap_priv->fbo != NULL);
+    if (!pixmap_priv->fbo)
+        return;
 
-    glamor_pixmap_clear_fbo(glamor_priv, pixmap_priv->fbo, pixmap_format);
+    if (pixmap_priv->fbo_array) {
+        for (i = 0; i < pixmap_priv->block_wcnt * pixmap_priv->block_hcnt; i++) {
+            if (pixmap_priv->fbo_array[i])
+                glamor_pixmap_clear_fbo(glamor_priv, pixmap_priv->fbo_array[i], pixmap_format);
+        }
+    } else {
+        glamor_pixmap_clear_fbo(glamor_priv, pixmap_priv->fbo, pixmap_format);
+    }
 }
 
 uint32_t
@@ -273,6 +282,7 @@ glamor_create_pixmap(ScreenPtr screen, int w, int h, int depth,
     }
 
     glamor_pixmap_attach_fbo(pixmap, fbo);
+    glamor_clear_pixmap(pixmap);
 
     return pixmap;
 }

--- a/glamor/glamor_fbo.c
+++ b/glamor/glamor_fbo.c
@@ -250,17 +250,15 @@ glamor_pixmap_clear_fbo(glamor_screen_private *glamor_priv, glamor_pixmap_fbo *f
 {
     glamor_make_current(glamor_priv);
 
-    assert(fbo->fb != 0 && fbo->tex != 0);
+    if (glamor_pixmap_ensure_fb(glamor_priv, fbo) != 0)
+        return;
 
-    if (glamor_priv->has_clear_texture) {
-        glClearTexImage(fbo->tex, 0, pixmap_format->format, pixmap_format->type, NULL);
-    }
-    else {
-        glamor_set_destination_pixmap_fbo(glamor_priv, fbo, 0, 0, fbo->width, fbo->height);
+    glamor_set_destination_pixmap_fbo(glamor_priv, fbo, 0, 0, fbo->width, fbo->height);
 
-        glClearColor(0.0, 0.0, 0.0, 0.0);
-        glClear(GL_COLOR_BUFFER_BIT);
-    }
+    glDisable(GL_SCISSOR_TEST);
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
 }
 
 glamor_pixmap_fbo *

--- a/meson.build
+++ b/meson.build
@@ -767,7 +767,7 @@ if build_docs or build_docs_devel
     ]
 endif
 
-module_abi_tag = 'xlibre-25'
+module_abi_tag = 'xlibre-25.0'
 
 # Include must come first, as it sets up dix-config.h
 subdir('include')


### PR DESCRIPTION
Newly allocated pixmaps backed by OpenGL textures previously left their underlying VRAM and auxiliary compression metadata uninitialized. On GPUs utilizing hardware color compression (such as Intel Arc DG2 with Flat CCS), sampling or copying from an uninitialized pixmap caused severe visual corruption (staircase artifact patterns) as well as information leaks of stale framebuffer contents.

This affected issues:
- https://github.com/X11Libre/xserver/issues/3466
- https://github.com/X11Libre/xserver/issues/3330

This commit fixed:
- calling glamor_clear_pixmap() on newly created pixmaps in glamor_create_pixmap()
- Supporting tiled pixmaps (fbo_array) in glamor_clear_pixmap()
- clearing backing FBOs via glClear(GL_COLOR_BUFFER_BIT) in glamor_pixmap_clear_fbo() to ensure proper hardware render-target and Flat CCS state initialization
- Aligning module_abi_tag to 'xlibre-25.0' in meson.build