### PR TITLE
Fix crash on flip queue retry and use-after-free in drm event queue

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/driver.h
+++ b/hw/xfree86/drivers/video/modesetting/driver.h
@@ -215,6 +215,7 @@ void ms_drm_abort(ScrnInfoPtr scrn,
                   Bool (*match)(void *data, void *match_data),
                   void *match_data);
 void ms_drm_abort_seq(ScrnInfoPtr scrn, uint32_t seq);
+void ms_drm_set_seq_queued(uint32_t seq, uint64_t msc);
 
 Bool ms_drm_queue_is_empty(void);
 

--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -1166,6 +1166,8 @@ drmmode_SharedPixmapFlip(PixmapPtr frontTarget, xf86CrtcPtr crtc,
         return FALSE;
     }
 
+    ms_drm_set_seq_queued(ppriv_front->flip_seq, UINT64_MAX);
+
     return TRUE;
 }
 

--- a/hw/xfree86/drivers/video/modesetting/pageflip.c
+++ b/hw/xfree86/drivers/video/modesetting/pageflip.c
@@ -186,6 +186,12 @@ do_queue_flip_on_crtc(ScreenPtr screen, xf86CrtcPtr crtc, uint32_t flags,
     drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;
 
     while (drmmode_crtc_flip(crtc, fb_id, x, y, flags, (void *)(long)seq)) {
+        /* If we failed for a reason other than a busy queue, abort and return error. */
+        if (errno != EBUSY && errno != EAGAIN) {
+            ms_drm_abort_seq(crtc->scrn, seq);
+            return TRUE;
+        }
+
         /* We may have failed because the event queue was full.  Flush it
          * and retry.  If there was nothing to flush, then we failed for
          * some other reason and should just return an error.
@@ -247,6 +253,8 @@ queue_flip_on_crtc(ScreenPtr screen, xf86CrtcPtr crtc,
     if (do_queue_flip_on_crtc(screen, crtc, flags, seq, ms->drmmode.fb_id,
                               crtc->x, crtc->y))
         return QUEUE_FLIP_DRM_FLUSH_FAILED;
+
+    ms_drm_set_seq_queued(seq, UINT64_MAX);
 
     /* The page flip succeeded. */
     return QUEUE_FLIP_SUCCESS;
@@ -675,6 +683,7 @@ ms_do_tearfree_flip(ScreenPtr screen, xf86CrtcPtr crtc)
                               seq, trf->buf[idx].fb_id, 0, 0))
         goto no_flip;
 
+    ms_drm_set_seq_queued(seq, UINT64_MAX);
     trf->flip_seq = seq;
     return FALSE;
 

--- a/hw/xfree86/drivers/video/modesetting/vblank.c
+++ b/hw/xfree86/drivers/video/modesetting/vblank.c
@@ -273,7 +273,7 @@ ms_drm_set_seq_msc(uint32_t seq, uint64_t msc)
     }
 }
 
-static void
+void
 ms_drm_set_seq_queued(uint32_t seq, uint64_t msc)
 {
     drmmode_crtc_private_ptr drmmode_crtc;
@@ -513,11 +513,14 @@ ms_drm_abort_one(struct ms_drm_queue *q)
 static void
 ms_drm_abort_scrn(ScrnInfoPtr scrn)
 {
-    struct ms_drm_queue *q, *tmp;
+    struct ms_drm_queue *q;
 
-    xorg_list_for_each_entry_safe(q, tmp, &ms_drm_queue, list) {
-        if (q->scrn == scrn)
+restart:
+    xorg_list_for_each_entry(q, &ms_drm_queue, list) {
+        if (q->scrn == scrn && !q->aborted) {
             ms_drm_abort_one(q);
+            goto restart;
+        }
     }
 }
 
@@ -527,9 +530,9 @@ ms_drm_abort_scrn(ScrnInfoPtr scrn)
 void
 ms_drm_abort_seq(ScrnInfoPtr scrn, uint32_t seq)
 {
-    struct ms_drm_queue *q, *tmp;
+    struct ms_drm_queue *q;
 
-    xorg_list_for_each_entry_safe(q, tmp, &ms_drm_queue, list) {
+    xorg_list_for_each_entry(q, &ms_drm_queue, list) {
         if (q->seq == seq) {
             ms_drm_abort_one(q);
             break;
@@ -562,7 +565,7 @@ ms_drm_abort(ScrnInfoPtr scrn, Bool (*match)(void *data, void *match_data),
 static void
 ms_drm_sequence_handler(int fd, uint64_t frame, uint64_t ns, Bool is64bit, uint64_t user_data)
 {
-    struct ms_drm_queue *q, *tmp;
+    struct ms_drm_queue *q;
     uint32_t seq = (uint32_t) user_data;
     xf86CrtcPtr crtc = NULL;
     drmmode_crtc_private_ptr drmmode_crtc;
@@ -590,12 +593,14 @@ ms_drm_sequence_handler(int fd, uint64_t frame, uint64_t ns, Bool is64bit, uint6
         return;
 
     /* Now run all of the vblank events for this CRTC with an expired MSC */
-    xorg_list_for_each_entry_safe(q, tmp, &ms_drm_queue, list) {
+restart:
+    xorg_list_for_each_entry(q, &ms_drm_queue, list) {
         if (q->crtc == crtc && q->msc <= msc) {
             xorg_list_del(&q->list);
             if (!q->aborted)
                 q->handler(msc, ns / 1000, q->data);
             free(q);
+            goto restart;
         }
     }
 
@@ -619,9 +624,12 @@ ms_drm_sequence_handler(int fd, uint64_t frame, uint64_t ns, Bool is64bit, uint6
     if (msc < next_msc && !ms_queue_vblank(crtc, MS_QUEUE_ABSOLUTE, msc, NULL, seq)) {
         xf86DrvMsg(crtc->scrn->scrnIndex, X_WARNING,
                    "failed to queue next vblank event, aborting lost events\n");
-        xorg_list_for_each_entry_safe(q, tmp, &ms_drm_queue, list) {
-            if (q->crtc == crtc && q->msc < next_msc)
+restart_lost:
+        xorg_list_for_each_entry(q, &ms_drm_queue, list) {
+            if (q->crtc == crtc && q->msc < next_msc && !q->aborted) {
                 ms_drm_abort_one(q);
+                goto restart_lost;
+            }
         }
     }
 }


### PR DESCRIPTION
сheck for non-retryable errors (errno != EBUSY/EAGAIN) in do_queue_flip_on_crtc to prevent invalid retry and event flush loops I find in drm events and prevent use-after-free in ms_drm_sequence_handler and ms_drm_abort_scrn by safely restarting queue iteration when event callbacks modify DRM queue Marks page flip sequences with kernel_queued upon successful submission to prevent premature freeing of queue entries

Affected issues:
- https://github.com/X11Libre/xserver/issues/1200
- https://github.com/X11Libre/xserver/issues/2174
- https://github.com/X11Libre/xserver/issues/3432