### PR TITLE
Initialize variables to avoid potential undefined behavior and silence

### DIFF
--- a/Xext/damage/damageext.c
+++ b/Xext/damage/damageext.c
@@ -599,7 +599,7 @@ PanoramiXDamageCreate(ClientPtr client, xDamageCreateReq *stuff)
     int rc = doDamageCreate(client, &(damage->ext), stuff);
     if (rc == Success && draw->type == XRT_WINDOW) {
         XINERAMA_FOR_EACH_SCREEN_FORWARD({
-            DrawablePtr pDrawable;
+            DrawablePtr pDrawable = NULL;
             DamagePtr pDamage = DamageCreate(PanoramiXDamageReport,
                                              PanoramiXDamageExtDestroy,
                                              DamageReportRawRegion,

--- a/Xext/glx/glx_dri/glxdri2.c
+++ b/Xext/glx/glx_dri/glxdri2.c
@@ -446,7 +446,7 @@ create_driver_context(__GLXDRIcontext * context,
     context->driContext = NULL;
 
     if (screen->dri2->base.version >= 3) {
-        uint32_t ctx_attribs[4 * 2];
+        uint32_t ctx_attribs[4 * 2] = { 0 };
         unsigned num_ctx_attribs = 0;
         unsigned dri_err = 0;
         unsigned major_ver;

--- a/dix/colormap.c
+++ b/dix/colormap.c
@@ -877,7 +877,7 @@ FindColor(ColormapPtr pmap, EntryPtr pentFirst, int size, xrgb * prgb,
         return Success;
 
     /* Now remember the pixel, for freeing later */
-    int *nump;
+    int *nump = NULL;
     Pixel **pixp = NULL;
     switch (channel) {
     case PSEUDOMAP:

--- a/dix/window.c
+++ b/dix/window.c
@@ -225,7 +225,8 @@ get_window_name(WindowPtr pWin)
 static void
 log_window_info(WindowPtr pWin, int depth)
 {
-    const char *win_name, *visibility;
+    const char *win_name;
+    const char *visibility = "unknown";
     BoxPtr rects;
 
     for (int i = 0; i < (depth << 2); i++)

--- a/exa/exa_render.c
+++ b/exa/exa_render.c
@@ -638,7 +638,7 @@ exaTryDriverComposite(CARD8 op,
     RegionRec region;
     BoxPtr pbox;
     int nbox;
-    int src_off_x, src_off_y, mask_off_x = 0, mask_off_y = 0, dst_off_x, dst_off_y;
+    int src_off_x = 0, src_off_y = 0, mask_off_x = 0, mask_off_y = 0, dst_off_x, dst_off_y;
     PixmapPtr pSrcPix = NULL, pMaskPix = NULL, pDstPix;
     ExaPixmapPrivPtr pSrcExaPix = NULL, pMaskExaPix = NULL, pDstExaPix;
 


### PR DESCRIPTION
Begin of work on rewriting to comply with the MISRA C standard.
- dix/colormap: initialize 'nump' to NULL in FindColor()
- dix/window: initialize 'visibility' default string in log_window_info()
- exa/exa_render: initialize 'src_off_x' and 'src_off_y' to 0 in exaTryDriverComposite()
- Xext/damage: initialize 'pDrawable' to NULL in PanoramiXDamageCreate()
- Xext/glx: zero-initialize 'ctx_attribs' in create_driver_context()

MISRA Rule: https://www.mathworks.com/help/bugfinder/ref/misrac2012rule9.1.html

This affected disscussions:
- https://github.com/orgs/X11Libre/discussions/199
- https://github.com/orgs/X11Libre/discussions/163

@Sniperq2 