### PR TITLE
Fix MISRA regarding switch default statements

### DIFF
--- a/hw/vfb/InitInput.c
+++ b/hw/vfb/InitInput.c
@@ -75,6 +75,8 @@ vfbKeybdProc(DeviceIntPtr pDevice, int onoff)
         break;
     case DEVICE_CLOSE:
         break;
+    default:
+        break;
     }
     return Success;
 }
@@ -127,6 +129,9 @@ vfbMouseProc(DeviceIntPtr pDevice, int onoff)
         break;
 
     case DEVICE_CLOSE:
+        break;
+
+    default:
         break;
     }
     return Success;

--- a/hw/vfb/InitOutput.c
+++ b/hw/vfb/InitOutput.c
@@ -261,6 +261,8 @@ freeScreenInfo(vfbScreenInfoPtr pvfb)
     case NORMAL_MEMORY_FB:
         free(pvfb->pXWDHeader);
         break;
+    default:
+        break;
     }
 
     free(pvfb->crtcs);
@@ -719,6 +721,8 @@ vfbAllocateFramebufferMemory(vfbScreenInfoPtr pvfb)
     case NORMAL_MEMORY_FB:
         pvfb->pXWDHeader = (XWDFileHeader *) calloc(1, pvfb->sizeInBytes);
         break;
+    default:
+        break;
     }
 
     if (pvfb->pXWDHeader) {
@@ -1094,6 +1098,7 @@ vfbScreenInit(ScreenPtr pScreen, int argc, char **argv)
         break;
     default:
         return FALSE;
+        break;
     }
 
     miSetPixmapDepths();

--- a/hw/xfree86/parser/Flags.c
+++ b/hw/xfree86/parser/Flags.c
@@ -100,6 +100,15 @@ xf86parseFlagsSection(XF86ConfFlagsPtr ptr)
         int strvalue = FALSE;
         int tokentype;
 
+        if (token == DEFAULTLAYOUT) {
+            strvalue = TRUE;
+            hasvalue = TRUE;
+        }
+        else if (token == BLANKTIME || token == STANDBYTIME ||
+                 token == SUSPENDTIME || token == OFFTIME) {
+            hasvalue = TRUE;
+        }
+
         switch (token) {
         case COMMENT:
             ptr->flg_comment = xf86addComment(ptr->flg_comment, xf86_lex_val.str);
@@ -108,15 +117,12 @@ xf86parseFlagsSection(XF86ConfFlagsPtr ptr)
             break;
             /*
              * these old keywords are turned into standard generic options.
-             * we fall through here on purpose
              */
         case DEFAULTLAYOUT:
-            strvalue = TRUE;
         case BLANKTIME:
         case STANDBYTIME:
         case SUSPENDTIME:
         case OFFTIME:
-            hasvalue = TRUE;
         case DONTZAP:
         case DONTZOOM:
         case DISABLEVIDMODE:

--- a/hw/xfree86/parser/InputClass.c
+++ b/hw/xfree86/parser/InputClass.c
@@ -150,9 +150,8 @@ xf86parseInputClassSection(void)
             ptr->option_lst = xf86parseOption(ptr->option_lst);
             break;
         case NOMATCH_PRODUCT:
-            negated = TRUE;
-            /* fallthrough */
         case MATCH_PRODUCT:
+            negated = (token == NOMATCH_PRODUCT);
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchProduct");
             else {
@@ -163,9 +162,8 @@ xf86parseInputClassSection(void)
             }
             break;
         case NOMATCH_VENDOR:
-            negated = TRUE;
-            /* fallthrough */
         case MATCH_VENDOR:
+            negated = (token == NOMATCH_VENDOR);
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchVendor");
             else {
@@ -176,9 +174,8 @@ xf86parseInputClassSection(void)
             }
             break;
         case NOMATCH_DEVICE_PATH:
-            negated = TRUE;
-            /* fallthrough */
         case MATCH_DEVICE_PATH:
+            negated = (token == NOMATCH_DEVICE_PATH);
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchDevicePath");
             else {
@@ -189,9 +186,8 @@ xf86parseInputClassSection(void)
             }
             break;
         case NOMATCH_OS:
-            negated = TRUE;
-            /* fallthrough */
         case MATCH_OS:
+            negated = (token == NOMATCH_OS);
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchOS");
             else {
@@ -202,9 +198,8 @@ xf86parseInputClassSection(void)
             }
             break;
         case NOMATCH_PNPID:
-            negated = TRUE;
-            /* fallthrough */
         case MATCH_PNPID:
+            negated = (token == NOMATCH_PNPID);
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchPnPID");
             else {
@@ -215,9 +210,8 @@ xf86parseInputClassSection(void)
             }
             break;
         case NOMATCH_USBID:
-            negated = TRUE;
-            /* fallthrough */
         case MATCH_USBID:
+            negated = (token == NOMATCH_USBID);
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchUSBID");
             else {
@@ -228,9 +222,8 @@ xf86parseInputClassSection(void)
             }
             break;
         case NOMATCH_DRIVER:
-            negated = TRUE;
-            /* fallthrough */
         case MATCH_DRIVER:
+            negated = (token == NOMATCH_DRIVER);
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchDriver");
             else {
@@ -241,9 +234,8 @@ xf86parseInputClassSection(void)
             }
             break;
         case NOMATCH_TAG:
-            negated = TRUE;
-            /* fallthrough */
         case MATCH_TAG:
+            negated = (token == NOMATCH_TAG);
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchTag");
             else {
@@ -254,9 +246,8 @@ xf86parseInputClassSection(void)
             }
             break;
         case NOMATCH_LAYOUT:
-            negated = TRUE;
-            /* fallthrough */
         case MATCH_LAYOUT:
+            negated = (token == NOMATCH_LAYOUT);
             if (xf86getSubToken(&(ptr->comment)) != XF86_TOKEN_STRING)
                 Error(QUOTE_MSG, "MatchLayout");
             else {

--- a/hw/xnest/Color.c
+++ b/hw/xnest/Color.c
@@ -142,6 +142,9 @@ xnestCreateColormap(ColormapPtr pCmap)
 
     case DirectColor:          /* read and write */
         break;
+
+    default:
+        break;
     }
 
     return TRUE;

--- a/hw/xnest/GC.c
+++ b/hw/xnest/GC.c
@@ -310,6 +310,9 @@ xnestChangeClip(GCPtr pGC, int type, void *pValue, int nRects)
             nRects,
             (xcb_rectangle_t*)pValue);
         break;
+
+    default:
+        break;
     }
 
     switch (type) {

--- a/hw/xnest/GCOps.c
+++ b/hw/xnest/GCOps.c
@@ -191,6 +191,7 @@ xnestBitBlitHelper(GCPtr pGC)
                     struct xnest_event_queue *q = malloc(sizeof(struct xnest_event_queue));
                     q->event = event;
                     xorg_list_add(&q->entry, &xnestUpstreamInfo.eventQueue.entry);
+                    break;
                 }
             }
         }

--- a/hw/xnest/Keyboard.c
+++ b/hw/xnest/Keyboard.c
@@ -239,6 +239,8 @@ xnestKeyboardProc(DeviceIntPtr pDev, int onoff)
         break;
     case DEVICE_CLOSE:
         break;
+    default:
+        break;
     }
     return Success;
 


### PR DESCRIPTION
- Add missing default labels to switch statements in xnest (Color, GC, Keyboard) and vfb (InitInput, InitOutput)
- Add missing break statements to switch clauses in xnest (GCOps) and vfb (InitOutput)
- Eliminate non-empty fallthroughs in xfree86 parser (Flags, InputClass) by grouping cases and properly terminating clauses with break

MISRA rule: https://www.mathworks.com/help/bugfinder/ref/misrac2012rule16.1.html

This affected disscussions:
- https://github.com/orgs/X11Libre/discussions/199
- https://github.com/orgs/X11Libre/discussions/163