### PR TITLE
Fix MISRA switch xfree86 parser and xnest

### DIFF
--- a/hw/xfree86/parser/Layout.c
+++ b/hw/xfree86/parser/Layout.c
@@ -184,6 +184,7 @@ xf86parseLayoutSection(void)
                     aptr->adj_where = CONF_ADJ_OBSOLETE;
                 else
                     aptr->adj_where = CONF_ADJ_ABSOLUTE;
+                break;
             }
             switch (aptr->adj_where) {
             case CONF_ADJ_ABSOLUTE:
@@ -257,7 +258,9 @@ xf86parseLayoutSection(void)
                     Error(SCREEN_MSG);
                 }
                 aptr->adj_right_str = xf86_lex_val.str;
-
+                break;
+            default:
+                break;
             }
             ptr->lay_adjacency_lst = (XF86ConfAdjacencyPtr)
                 xf86addListItem((glp) ptr->lay_adjacency_lst, (glp) aptr);
@@ -358,6 +361,8 @@ xf86printLayoutSection(FILE * cf, XF86ConfLayoutPtr ptr)
             case CONF_ADJ_RELATIVE:
                 fprintf(cf, " Relative \"%s\" %d %d\n", aptr->adj_refscreen,
                         aptr->adj_x, aptr->adj_y);
+                break;
+            default:
                 break;
             }
         }

--- a/hw/xfree86/parser/Module.c
+++ b/hw/xfree86/parser/Module.c
@@ -104,6 +104,7 @@ xf86parseModuleSubSection(XF86LoadPtr head, char *name)
             xf86parseError(UNEXPECTED_EOF_MSG);
             free(ptr);
             return NULL;
+            break;
         default:
             xf86parseError(INVALID_KEYWORD_MSG, xf86tokenString());
             free(ptr);
@@ -216,11 +217,8 @@ xf86printModuleSection(FILE * cf, XF86ConfModulePtr ptr)
             else
                 fputc('\n', cf);
             break;
-#if 0
         default:
-            fprintf(cf, "#\tUnknown type  \"%s\"\n", lptr->load_name);
             break;
-#endif
         }
     }
 }

--- a/hw/xfree86/parser/Monitor.c
+++ b/hw/xfree86/parser/Monitor.c
@@ -381,6 +381,7 @@ xf86parseVerboseMode(void)
             break;
         default:
             Error("Unexpected token in verbose \"Mode\" entry\n");
+            break;
         }
     }
     if (!had_dotclock)
@@ -480,6 +481,7 @@ xf86parseMonitorSection(void)
                         ptr->mon_hsync[ptr->mon_n_hsync].lo;
                     ptr->mon_n_hsync++;
                     goto HorizDone;
+                    break;
                 }
                 ptr->mon_n_hsync++;
             } while ((token = xf86getSubToken(&(ptr->mon_comment))) == NUMBER);
@@ -515,6 +517,7 @@ xf86parseMonitorSection(void)
                         ptr->mon_vrefresh[ptr->mon_n_vrefresh].lo;
                     ptr->mon_n_vrefresh++;
                     goto VertDone;
+                    break;
                 }
                 if (ptr->mon_n_vrefresh >= CONF_MAX_VREFRESH)
                     Error("Sorry. Too many vertical refresh intervals.");

--- a/hw/xnest/Pointer.c
+++ b/hw/xnest/Pointer.c
@@ -123,6 +123,8 @@ xnestPointerProc(DeviceIntPtr pDev, int onoff)
         break;
     case DEVICE_CLOSE:
         break;
+    default:
+        break;
     }
     return Success;
 }

--- a/hw/xnest/Screen.c
+++ b/hw/xnest/Screen.c
@@ -106,6 +106,9 @@ xnestSaveScreen(ScreenPtr pScreen, int what)
             xcb_unmap_window(xnestUpstreamInfo.conn, xnestScreenSaverWindows[pScreen->myNum]);
             xnestSetInstalledColormapWindows(pScreen);
             break;
+
+        default:
+            break;
         }
         return TRUE;
     }


### PR DESCRIPTION
- Add missing default labels to switch statements in Layout.c, Module.c, Pointer.c, and Screen.c
- Add missing unconditional break statements to switch clauses in Layout.c, Module.c, and Monitor.c

MISRA rule: https://www.mathworks.com/help/bugfinder/ref/misrac2012rule16.1.html

This affected disscussions:
- https://github.com/orgs/X11Libre/discussions/199
- https://github.com/orgs/X11Libre/discussions/163