### PR TITLE
fb: Avoid potential out-of-bounds shift amounts in fbBlt

### DIFF
--- a/fb/fbblt.c
+++ b/fb/fbblt.c
@@ -222,9 +222,13 @@ fbBlt(FbBits * srcLine,
             leftShift = srcX - dstX;
             rightShift = FB_UNIT - leftShift;
         }
-        else {
+        else if (srcX < dstX) {
             rightShift = dstX - srcX;
             leftShift = FB_UNIT - rightShift;
+        }
+        else {
+            leftShift = 0;
+            rightShift = 0;
         }
         while (height--) {
             src = srcLine;


### PR DESCRIPTION
fb: Avoid potential out-of-bounds shift amounts in fbBlt

When srcX == dstX, the original code computed leftShift = FB_UNIT, causing
undefined behavior when shifting by the bit width. Added explicit handling for
this case with both shifts = 0.

## Backport dashboard

| Target branch | Backport PR | Status |
|---|---|---|
| release/25.2 | #3672 | 🔄 Open |
| release/25.1 | #3671 | 🔄 Open |
| release/25.0 | #3670 | 🔄 Open |

_Backports based on this PR's current head commit `8efcc601e2` (PR not merged yet — if the branch
changes before merge, the backport PRs may need re-basing)._
