### PR TITLE
xnest: Check malloc return values in GCOps to avoid NULL dereferences

### DIFF
--- a/hw/xnest/GCOps.c
+++ b/hw/xnest/GCOps.c
@@ -189,8 +189,14 @@ xnestBitBlitHelper(GCPtr pGC)
                 default:
                 {
                     struct xnest_event_queue *q = malloc(sizeof(struct xnest_event_queue));
-                    q->event = event;
-                    xorg_list_add(&q->entry, &xnestUpstreamInfo.eventQueue.entry);
+                    if (q) {
+                        q->event = event;
+                        xorg_list_add(&q->entry, &xnestUpstreamInfo.eventQueue.entry);
+                    }
+                    else {
+                        free(event);
+                    }
+                    break;
                 }
             }
         }
@@ -343,6 +349,8 @@ xnestPolyText8(DrawablePtr pDrawable, GCPtr pGC, int x, int y, int count,
     // won't get more than 254 elements, since it's already processed by doPolyText()
     int const bufsize = sizeof(xTextElt) + count;
     uint8_t *buffer = malloc(bufsize);
+    if (!buffer)
+        return x;
     xTextElt *elt = (xTextElt*)buffer;
     elt->len = count;
     elt->delta = 0;
@@ -369,6 +377,8 @@ xnestPolyText16(DrawablePtr pDrawable, GCPtr pGC, int x, int y, int count,
     // won't get more than 254 elements, since it's already processed by doPolyText()
     int const bufsize = sizeof(xTextElt) + count*2;
     uint8_t *buffer = malloc(bufsize);
+    if (!buffer)
+        return x;
     xTextElt *elt = (xTextElt*)buffer;
     elt->len = count;
     elt->delta = 0;


### PR DESCRIPTION
malloc() require check on valid ptr

Check malloc() return values for NULL in xnestBitBlitHelper(), xnestPolyText8(), and
xnestPolyText16() to prevent potential NULL pointer dereferences.

## Backport dashboard

| Target branch | Backport PR | Status |
|---|---|---|
| release/25.2 | #3667 | 🔄 Open |
| release/25.1 | #3666 | 🔄 Open |
| release/25.0 | #3665 | 🔄 Open |

_Backports based on this PR's current head commit `eae9444a66` (PR not merged yet — if the branch
changes before merge, the backport PRs may need re-basing)._
