### PR TITLE
dix, Xi: remove spurious dereference when checking function pointers

### DIFF
--- a/Xext/xinput/xiwarppointer.c
+++ b/Xext/xinput/xiwarppointer.c
@@ -181,7 +181,7 @@ ProcXIWarpPointer(ClientPtr client)
     pDev->last.valuators[1] = y;
     miPointerUpdateSprite(pDev);
 
-    if (*newScreen->CursorWarpedTo)
+    if (newScreen->CursorWarpedTo)
         (*newScreen->CursorWarpedTo) (pDev, newScreen, client,
                                       dest, pSprite, x, y);
 

--- a/dix/events.c
+++ b/dix/events.c
@@ -930,7 +930,7 @@ ConfineCursorToWindow(DeviceIntPtr pDev, WindowPtr pWin, Bool generateEvents,
         CheckPhysLimits(pDev, pSprite->current, generateEvents,
                         confineToScreen, pWin->drawable.pScreen);
 
-        if (*pScreen->CursorConfinedTo)
+        if (pScreen->CursorConfinedTo)
             (*pScreen->CursorConfinedTo) (pDev, pScreen, pWin);
     }
 }
@@ -3733,7 +3733,7 @@ ProcWarpPointer(ClientPtr client)
     else if (!PointerConfinedToScreen(dev)) {
         NewCurrentScreen(dev, newScreen, x, y);
     }
-    if (*newScreen->CursorWarpedTo)
+    if (newScreen->CursorWarpedTo)
         (*newScreen->CursorWarpedTo) (dev, newScreen, client,
                                       dest, pSprite, x, y);
     return Success;


### PR DESCRIPTION
Check CursorConfinedTo and CursorWarpedTo function pointers directly without dereferencing them in 'if' conditions in events and xiwarppointer