### PR TITLE
mi: Simplify byte/bit order branches in miPushPixels

### DIFF
--- a/mi/mipushpxl.c
+++ b/mi/mipushpxl.c
@@ -106,16 +106,20 @@ miPushPixels(GCPtr pGC, PixmapPtr pBitMap, DrawablePtr pDrawable,
 #if 1
     MiBits startmask;
 
-    if (screenInfo.bitmapBitOrder == IMAGE_BYTE_ORDER) {
-        if (screenInfo.bitmapBitOrder == LSBFirst)
-            startmask = (MiBits) (-1) ^ LONG2CHARSSAMEORDER((MiBits) (-1) << 1);
-        else
-            startmask = (MiBits) (-1) ^ LONG2CHARSSAMEORDER((MiBits) (-1) >> 1);
-    }
-    else if (screenInfo.bitmapBitOrder == LSBFirst)
+    if (screenInfo.bitmapBitOrder == LSBFirst) {
+#if IMAGE_BYTE_ORDER == LSBFirst
+        startmask = (MiBits) (-1) ^ LONG2CHARSSAMEORDER((MiBits) (-1) << 1);
+#else
         startmask = (MiBits) (-1) ^ LONG2CHARSDIFFORDER((MiBits) (-1) << 1);
-    else
+#endif
+    }
+    else {
+#if IMAGE_BYTE_ORDER == MSBFirst
+        startmask = (MiBits) (-1) ^ LONG2CHARSSAMEORDER((MiBits) (-1) >> 1);
+#else
         startmask = (MiBits) (-1) ^ LONG2CHARSDIFFORDER((MiBits) (-1) >> 1);
+#endif
+    }
 #endif
 
     MiBits *pwLineStart = calloc(1, BitmapBytePad(dx));
@@ -166,18 +170,20 @@ miPushPixels(GCPtr pGC, PixmapPtr pBitMap, DrawablePtr pDrawable,
                 }
 #if 1
                 /* This is not quite right, but it'll do for now */
-                if (screenInfo.bitmapBitOrder == IMAGE_BYTE_ORDER) {
-                    if (screenInfo.bitmapBitOrder == LSBFirst)
-                        msk =
-                            LONG2CHARSSAMEORDER(LONG2CHARSSAMEORDER(msk) << 1);
-                    else
-                        msk =
-                            LONG2CHARSSAMEORDER(LONG2CHARSSAMEORDER(msk) >> 1);
-                }
-                else if (screenInfo.bitmapBitOrder == LSBFirst)
+                if (screenInfo.bitmapBitOrder == LSBFirst) {
+#if IMAGE_BYTE_ORDER == LSBFirst
+                    msk = LONG2CHARSSAMEORDER(LONG2CHARSSAMEORDER(msk) << 1);
+#else
                     msk = LONG2CHARSDIFFORDER(LONG2CHARSDIFFORDER(msk) << 1);
-                else
+#endif
+                }
+                else {
+#if IMAGE_BYTE_ORDER == MSBFirst
+                    msk = LONG2CHARSSAMEORDER(LONG2CHARSSAMEORDER(msk) >> 1);
+#else
                     msk = LONG2CHARSDIFFORDER(LONG2CHARSDIFFORDER(msk) >> 1);
+#endif
+                }
 #else
                 msk = SCRRIGHT(msk, 1);
 #endif
@@ -217,18 +223,20 @@ miPushPixels(GCPtr pGC, PixmapPtr pBitMap, DrawablePtr pDrawable,
                 }
 #if 1
                 /* This is not quite right, but it'll do for now */
-                if (screenInfo.bitmapBitOrder == IMAGE_BYTE_ORDER) {
-                    if (screenInfo.bitmapBitOrder == LSBFirst)
-                        msk =
-                            LONG2CHARSSAMEORDER(LONG2CHARSSAMEORDER(msk) << 1);
-                    else
-                        msk =
-                            LONG2CHARSSAMEORDER(LONG2CHARSSAMEORDER(msk) >> 1);
-                }
-                else if (screenInfo.bitmapBitOrder == LSBFirst)
+                if (screenInfo.bitmapBitOrder == LSBFirst) {
+#if IMAGE_BYTE_ORDER == LSBFirst
+                    msk = LONG2CHARSSAMEORDER(LONG2CHARSSAMEORDER(msk) << 1);
+#else
                     msk = LONG2CHARSDIFFORDER(LONG2CHARSDIFFORDER(msk) << 1);
-                else
+#endif
+                }
+                else {
+#if IMAGE_BYTE_ORDER == MSBFirst
+                    msk = LONG2CHARSSAMEORDER(LONG2CHARSSAMEORDER(msk) >> 1);
+#else
                     msk = LONG2CHARSDIFFORDER(LONG2CHARSDIFFORDER(msk) >> 1);
+#endif
+                }
 #else
                 msk = SCRRIGHT(msk, 1);
 #endif


### PR DESCRIPTION
LSBFirst - little-endian
MSBFirst - big-endian

In miPushPixels(), resolve IMAGE_BYTE_ORDER at compile time instead of mixing it into runtime
if-else chains, eliminating duplicate and unreachable condition branches.

## Backport dashboard

| Target branch | Backport PR | Status |
|---|---|---|
| release/25.2 | #3663 | 🔄 Open |
| release/25.1 | #3662 | 🔄 Open |
| release/25.0 | #3664 | 🔄 Open |

_Backports based on this PR's current head commit `3841b5b39d` (PR not merged yet — if the branch
changes before merge, the backport PRs may need re-basing; 25.0 is an adapted manual backport
because its `miPushPixels` still uses brace-less if/else chains, unlike master/25.1/25.2)._
