### PR TITLE
Xi: Guard against NULL event pointer

### DIFF
--- a/Xext/xinput/exevents.c
+++ b/Xext/xinput/exevents.c
@@ -1193,7 +1193,7 @@ TouchPuntToNextOwner(DeviceIntPtr dev, TouchPointInfoPtr ti,
     int accepted_early = listener->state == TOUCH_LISTENER_EARLY_ACCEPT;
 
     /* Deliver the ownership */
-    if (listener->state == TOUCH_LISTENER_AWAITING_OWNER || accepted_early)
+    if ((listener->state == TOUCH_LISTENER_AWAITING_OWNER || accepted_early) && ev)
         DeliverTouchEvents(dev, ti, (InternalEvent *) ev,
                            listener->listener);
     else if (listener->state == TOUCH_LISTENER_AWAITING_BEGIN) {
@@ -2196,6 +2196,9 @@ DeliverTouchEvents(DeviceIntPtr dev, TouchPointInfoPtr ti,
                    InternalEvent *ev, XID resource)
 {
     int i;
+
+    if (!ev)
+        return;
 
     if (ev->any.type == ET_TouchBegin &&
         !(ev->device_event.flags & (TOUCH_CLIENT_ID | TOUCH_REPLAYING)))


### PR DESCRIPTION
Check that 'ev' is not NULL before attempting to deliver touch ownership
events in TouchPuntToNextOwner(), and add a defensive null check in
DeliverTouchEvents() to avoid potential NULL pointer dereferences

## Backport dashboard

| Target branch | Backport PR | Status |
|---|---|---|
| release/25.2 | #3659 | 🔄 Open |
| release/25.1 | #3661 | 🔄 Open |
| release/25.0 | #3660 | 🔄 Open |

_Backports based on this PR's current head commit `bf3b21df4` (PR not merged yet — if the branch
changes before merge, the backport PRs may need to be re-based/updated to the final merged state)._
