### PR TITLE
mi: guard against NULL event pointer

### DIFF
--- a/mi/mipointer.c
+++ b/mi/mipointer.c
@@ -702,7 +702,7 @@ miPointerSetPosition(DeviceIntPtr pDev, int mode, double *screenx,
 
     /* check if we generated any barrier events and if so, update root x/y
      * to the fully constrained coords */
-    if (should_constrain_barriers) {
+    if (should_constrain_barriers && nevents && events) {
         for (i = 0; i < *nevents; i++) {
             if (events[i].any.type == ET_BarrierHit ||
                 events[i].any.type == ET_BarrierLeave) {


### PR DESCRIPTION
In miPointerSetPosition(), ensure nevents and events pointers are non-NULL
before checking for and updating barrier event coordinates to avoid potential
NULL pointer dereferences

## Backport dashboard

| Target branch | Backport PR | Status |
|---|---|---|
| release/25.2 | #3658 | 🔄 Open |
| release/25.1 | #3657 | 🔄 Open |
| release/25.0 | #3656 | 🔄 Open |
