### PR TITLE
damage, exa: Add NULL checks for DamagePtr in damage helpers

### DIFF
--- a/exa/exa_accel.c
+++ b/exa/exa_accel.c
@@ -177,7 +177,7 @@ exaDoPutImage(DrawablePtr pDrawable, GCPtr pGC, int depth, int x, int y,
         pixmaps[0].as_dst = TRUE;
         pixmaps[0].as_src = FALSE;
         pixmaps[0].pPix = pPix;
-        pixmaps[0].pReg = DamagePendingRegion(pExaPixmap->pDamage);
+        pixmaps[0].pReg = NULL;
 
         exaDoMigration(pixmaps, 1, TRUE);
     }

--- a/miext/damage/damage.c
+++ b/miext/damage/damage.c
@@ -1864,19 +1864,20 @@ DamageSubtract(DamagePtr pDamage, const RegionPtr pRegion)
 void
 DamageEmpty(DamagePtr pDamage)
 {
-    RegionEmpty(&pDamage->damage);
+    if (pDamage)
+        RegionEmpty(&pDamage->damage);
 }
 
 RegionPtr
 DamageRegion(DamagePtr pDamage)
 {
-    return &pDamage->damage;
+    return pDamage ? &pDamage->damage : NULL;
 }
 
 RegionPtr
 DamagePendingRegion(DamagePtr pDamage)
 {
-    return &pDamage->pendingDamage;
+    return pDamage ? &pDamage->pendingDamage : NULL;
 }
 
 void


### PR DESCRIPTION
Return NULL from DamageRegion() and DamagePendingRegion() (and check in DamageEmpty()) when passed a NULL DamagePtr
In exaDoPutImage(), explicitly set migration pReg to NULL since pExaPixmap->pDamage is guaranteed to be NULL there

---

## Backport dashboard

| Branch  | Backport PR | Status |
|---------|-------------|--------|
| release/25.2 | #3652 | 🔄 Open |
| release/25.1 | #3653 | 🔄 Open |
| release/25.0 | #3654 | 🔄 Open |