### PR TITLE
miext/sync/misyncfd.c: fix NULL deref on uninitialized screens

### DIFF
--- a/miext/sync/misyncfd.c
+++ b/miext/sync/misyncfd.c
@@ -38,9 +38,20 @@ typedef struct _SyncFdScreenPrivate {
 
 static inline SyncFdScreenPrivatePtr sync_fd_screen_priv(ScreenPtr pScreen)
 {
+    SyncFdScreenPrivatePtr      priv;
+
     if (!dixPrivateKeyRegistered(&syncFdScreenPrivateKey))
         return NULL;
-    return dixLookupPrivate(&pScreen->devPrivates, &syncFdScreenPrivateKey);
+
+    /* The private is preallocated on every screen as soon as the key is
+     * registered by any single screen, so its mere presence says nothing.
+     * Only screens that went through miSyncFdScreenInit() have funcs set.
+     */
+    priv = dixLookupPrivate(&pScreen->devPrivates, &syncFdScreenPrivateKey);
+    if (priv->funcs.version <= 0)
+        return NULL;
+
+    return priv;
 }
 
 int
@@ -83,7 +94,7 @@ Bool miSyncFdScreenInit(ScreenPtr pScreen,
             return FALSE;
     }
 
-    priv = sync_fd_screen_priv(pScreen);
+    priv = dixLookupPrivate(&pScreen->devPrivates, &syncFdScreenPrivateKey);
     memset(priv, 0, sizeof(*priv));
 
     /* Will require version checks when there are multiple versions


### PR DESCRIPTION
852128f18 made the screen private preallocated, so it exists on every screen as soon as the single global key is registered. sync_fd_screen_priv() therefore never returns NULL again, which breaks the "already initialized" check in miSyncFdScreenInit() and the guards in miSyncInitFenceFromFD() / miSyncFDFromFence(), which then call through a zeroed funcs pointer.

Multi-GPU setups crash on this: with glamor on one screen and a non-glamor driver (NVIDIA blob under PRIME) on the other, XSyncCreateFenceFromFD on the latter kills the server.

Use a filled-in funcs as the sentinel instead of the private's presence.

Fixes https://github.com/X11Libre/xserver/issues/3629

**Backport tracking for PR #3647 (miext/sync/misyncfd.c: fix NULL deref on uninitialized screens)**

| Release | Backport PR | Status |
|---------|-------------|--------|
| release/25.2 | [#3673](https://github.com/X11Libre/xserver/pull/3673) | 🔄 Open |
| release/25.1 | [#3674](https://github.com/X11Libre/xserver/pull/3674) | 🔄 Open |
| release/25.0 | [#3675](https://github.com/X11Libre/xserver/pull/3675) | 🔄 Open |

---

*Original issue: #3629 — Multi-GPU crash on XSyncCreateFenceFromFD with NVIDIA blob under PRIME. Fix uses filled-in funcs as sentinel instead of private's presence.*
