### PR TITLE
[master] modesetting: fix use-after-free in DRM event queue rescan using new list macro

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/vblank.c
+++ b/hw/xfree86/drivers/video/modesetting/vblank.c
@@ -32,6 +32,7 @@
 
 #include <xf86.h>
 #include <xf86Crtc.h>
+#include "os/list_priv.h"
 #include "driver.h"
 #include "drmmode_display.h"
 
@@ -513,12 +514,11 @@ ms_drm_abort_one(struct ms_drm_queue *q)
 static void
 ms_drm_abort_scrn(ScrnInfoPtr scrn)
 {
-    struct ms_drm_queue *q, *tmp;
+    struct ms_drm_queue *q;
 
-    xorg_list_for_each_entry_safe(q, tmp, &ms_drm_queue, list) {
-        if (q->scrn == scrn)
-            ms_drm_abort_one(q);
-    }
+    xlibre_list_for_each_entry_restart(q, &ms_drm_queue, list,
+                                       q->scrn == scrn && !q->aborted,
+                                       ms_drm_abort_one(q));
 }
 
 /**
@@ -527,9 +527,9 @@ ms_drm_abort_scrn(ScrnInfoPtr scrn)
 void
 ms_drm_abort_seq(ScrnInfoPtr scrn, uint32_t seq)
 {
-    struct ms_drm_queue *q, *tmp;
+    struct ms_drm_queue *q;
 
-    xorg_list_for_each_entry_safe(q, tmp, &ms_drm_queue, list) {
+    xorg_list_for_each_entry(q, &ms_drm_queue, list) {
         if (q->seq == seq) {
             ms_drm_abort_one(q);
             break;
@@ -562,7 +562,7 @@ ms_drm_abort(ScrnInfoPtr scrn, Bool (*match)(void *data, void *match_data),
 static void
 ms_drm_sequence_handler(int fd, uint64_t frame, uint64_t ns, Bool is64bit, uint64_t user_data)
 {
-    struct ms_drm_queue *q, *tmp;
+    struct ms_drm_queue *q;
     uint32_t seq = (uint32_t) user_data;
     xf86CrtcPtr crtc = NULL;
     drmmode_crtc_private_ptr drmmode_crtc;
@@ -590,14 +590,12 @@ ms_drm_sequence_handler(int fd, uint64_t frame, uint64_t ns, Bool is64bit, uint6
         return;
 
     /* Now run all of the vblank events for this CRTC with an expired MSC */
-    xorg_list_for_each_entry_safe(q, tmp, &ms_drm_queue, list) {
-        if (q->crtc == crtc && q->msc <= msc) {
-            xorg_list_del(&q->list);
-            if (!q->aborted)
-                q->handler(msc, ns / 1000, q->data);
-            free(q);
-        }
-    }
+    xlibre_list_for_each_entry_restart(q, &ms_drm_queue, list,
+                                       q->crtc == crtc && q->msc <= msc,
+                                       do { xorg_list_del(&q->list);
+                                            if (!q->aborted)
+                                                q->handler(msc, ns / 1000, q->data);
+                                            free(q); } while (0));
 
     /* Find this CRTC's next queued MSC and next non-queued MSC to be handled */
     msc = UINT64_MAX;
@@ -619,10 +617,9 @@ ms_drm_sequence_handler(int fd, uint64_t frame, uint64_t ns, Bool is64bit, uint6
     if (msc < next_msc && !ms_queue_vblank(crtc, MS_QUEUE_ABSOLUTE, msc, NULL, seq)) {
         xf86DrvMsg(crtc->scrn->scrnIndex, X_WARNING,
                    "failed to queue next vblank event, aborting lost events\n");
-        xorg_list_for_each_entry_safe(q, tmp, &ms_drm_queue, list) {
-            if (q->crtc == crtc && q->msc < next_msc)
-                ms_drm_abort_one(q);
-        }
+        xlibre_list_for_each_entry_restart(q, &ms_drm_queue, list,
+                                           q->crtc == crtc && q->msc < next_msc && !q->aborted,
+                                           ms_drm_abort_one(q));
     }
 }
 

--- a/os/list_priv.h
+++ b/os/list_priv.h
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: X11 OR MIT OR AGPL-3.0-or-later
+ *
+ * Copyright © 2026 Enrico Weigelt, metux IT consult <info@metux.net>
+ */
+#ifndef _XLIBRE_OS_LIST_PRIV_H_
+#define _XLIBRE_OS_LIST_PRIV_H_
+
+#include "include/list.h"
+
+/**
+ * @brief iterate @p head, executing @p action after each @p cond match,
+ *        restarting the iteration from the head afterwards.
+ *
+ * xorg_list_for_each_entry_safe() only protects against removal of the
+ * current element (@p pos): it caches the next pointer before the loop body
+ * runs and resumes from it. That is unsafe if the loop body -- or a callback
+ * it invokes (e.g. a vblank/pageflip handler) -- removes and frees arbitrary
+ * other list entries, in particular the cached next element. Resuming from
+ * the freed element would then dereference memory that was already free()'d
+ * (use-after-free).
+ *
+ * This macro instead restarts the scan from the list head after every
+ * match, so it is correct whenever such callbacks may mutate the list
+ * arbitrarily. Each match (re)scans the remaining list from the head, i.e.
+ * the cost is O(n) per match (quadratic for n matches), which is acceptable
+ * for short lists with few matches.
+ *
+ * @warning state that must be re-evaluated across restarts has to be derived
+ *          from @p cond, not assumed from the loop position (iteration always
+ *          begins again at the first list entry after a match).
+ *
+ * @param pos    Iterator variable of the type of the list elements.
+ * @param head   List head.
+ * @param member Member name of the struct xorg_list in the list elements.
+ * @param cond   Condition selecting entries to act on (re-evaluated each pass).
+ * @param action Statement to execute for each matching entry.
+ */
+#define xlibre_list_for_each_entry_restart(pos, head, member, cond, action) \
+    do {                                                                   \
+        int _xlibre_list_restarted_;                                       \
+        do {                                                               \
+            _xlibre_list_restarted_ = 0;                                   \
+            xorg_list_for_each_entry(pos, head, member) {                  \
+                if (cond) {                                                \
+                    action;                                                \
+                    _xlibre_list_restarted_ = 1;                           \
+                    break;                                                 \
+                }                                                          \
+            }                                                              \
+        } while (_xlibre_list_restarted_);                                 \
+    } while (0)
+
+#endif /* _XLIBRE_OS_LIST_PRIV_H_ */


### PR DESCRIPTION
Replace the three DRM event-queue loops in `vblank.c` that were using `xorg_list_for_each_entry_safe()` with the new `xlibre_list_for_each_entry_restart()` macro from `os/list_priv.h`.

The `safe` variant is only safe against removal of the *current* element; it caches the next pointer and resumes from it. When the loop body or a callback it invokes removes/frees arbitrary other entries (the queue handlers call out to Present/DRI2/TearFree, which can abort and free other queued events), that cached pointer dangles and the loop dereferences freed memory (use-after-free). The new macro restarts the scan from the head after each match.

Related: #3631