### PR TITLE
(release/25.0) modesetting: force software cursor for vm gpus

### DIFF
--- a/hw/xfree86/drivers/modesetting/driver.c
+++ b/hw/xfree86/drivers/modesetting/driver.c
@@ -1136,6 +1136,34 @@ ms_get_drm_master_fd(ScrnInfoPtr pScrn)
     return TRUE;
 }
 
+/**
+ * This function exist because there are necesary extra work around for correct behaviour,
+ * for example: force software rendering for cursor.
+ */
+static inline bool
+ms_is_running_virtual_gpu(drmmode_ptr drmmode)
+{
+    drmVersionPtr version = drmGetVersion(drmmode->fd);
+    if (!version) {
+        return false;
+    }
+
+    if (!version->name ||
+        strstr(version->name, "bochs-drm") ||
+        strstr(version->name, "evdi") ||
+        strstr(version->name, "vboxvideo") ||
+        strstr(version->name, "virtio_gpu") ||
+        strstr(version->name, "vkms") ||
+        strstr(version->name, "vmwgfx") ||
+        strstr(version->name, "qxl" )) {
+        drmFreeVersion(version);
+        return true;
+    }
+
+    drmFreeVersion(version);
+    return false;
+}
+
 static Bool
 PreInit(ScrnInfoPtr pScrn, int flags)
 {
@@ -1230,6 +1258,27 @@ PreInit(ScrnInfoPtr pScrn, int flags)
 
     if (xf86ReturnOptValBool(ms->drmmode.Options, OPTION_SW_CURSOR, FALSE)) {
         ms->drmmode.sw_cursor = TRUE;
+    } else {
+        /* we have situation where cursor in virtual envirioment doesn't work as expected and can be confusing for users, for example under qemu:
+         * - if display backend is `gtk`, by default cursor is showed when window is out of focus and hidden when in focus (it have to be rendered by vm gpu in software).
+         * - if display backend us `sdl` it always shows cursor regardless of drmModeSetCursor2 & friends settings
+         * - if vm run under spice backed using qxl display, the rendering application (remote-viewer) behaves correctly
+         *  for more detail see : https://www.qemu.org/docs/master/system/qemu-manpage.html search `show-cursor`
+         *
+         *  until better solution is found, force software cursor
+        */
+        if (ms_is_running_virtual_gpu(&ms->drmmode)){
+
+            drmVersionPtr version = drmGetVersion(ms->drmmode.fd);
+            const char *name="N/A";
+            if (version){
+                name = version->name;
+            }
+            xf86DrvMsg(pScrn->scrnIndex, X_WARNING, "Forcing software cursor on virtual machine driver %s due to known issues\n", name);
+            drmFreeVersion(version);
+
+            ms->drmmode.sw_cursor = TRUE;
+        }
     }
 
     ms->max_cursor_width = 64;

--- a/hw/xfree86/drivers/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/modesetting/drmmode_display.c
@@ -4383,40 +4383,6 @@ drmmode_uevent_fini(ScrnInfoPtr scrn, drmmode_ptr drmmode)
 #endif
 }
 
-/**
- * Some setups have different requirements for the
- * cursor pitch compared to intel and nvidia. 
- *
- * See: https://github.com/X11Libre/xserver/issues/1816
- * 
- * This function detects whether we are running in a vm,
- * or on bare metal.
- * 
- * Driver names are taken from https://drmdb.emersion.fr/drivers
- */
-static inline Bool
-drmmode_legacy_cursor_probe_allowed(drmmode_ptr drmmode)
-{
-    drmVersionPtr version = drmGetVersion(drmmode->fd);
-    if (!version) {
-        return FALSE;
-    } 
- 
-    if (!version->name ||
-        strstr(version->name, "bochs-drm") ||
-        strstr(version->name, "evdi") ||
-        strstr(version->name, "vboxvideo") ||
-        strstr(version->name, "virtio_gpu") ||
-        strstr(version->name, "vkms") ||
-        strstr(version->name, "vmwgfx")) {
-        drmFreeVersion(version);
-        return FALSE;
-    }
-
-    drmFreeVersion(version);
-    return TRUE;
-}
-
 static void drmmode_probe_cursor_size(xf86CrtcPtr crtc)
 {
     modesettingPtr ms = modesettingPTR(crtc->scrn);
@@ -4428,45 +4394,42 @@ static void drmmode_probe_cursor_size(xf86CrtcPtr crtc)
     ms->min_cursor_width = ms->max_cursor_width;
     ms->min_cursor_height = ms->max_cursor_height;
 
-    if (drmmode_legacy_cursor_probe_allowed(drmmode)) {
+    /* probe square min first */
+    for (size = 1; size <= ms->max_cursor_width &&
+             size <= ms->max_cursor_height; size *= 2) {
+        int ret;
 
-      /* probe square min first */
-      for (size = 1; size <= ms->max_cursor_width &&
-               size <= ms->max_cursor_height; size *= 2) {
-          int ret;
-
-          ret = drmModeSetCursor2(drmmode->fd, drmmode_crtc->mode_crtc->crtc_id,
+        ret = drmModeSetCursor2(drmmode->fd, drmmode_crtc->mode_crtc->crtc_id,
                                 handle, size, size, 0, 0);
-          if (ret == 0)
-              break;
-      }
-
-      /* check if smaller width works with non-square */
-      for (width = 1; width <= size; width *= 2) {
-          int ret;
-
-          ret = drmModeSetCursor2(drmmode->fd, drmmode_crtc->mode_crtc->crtc_id,
-                                  handle, width, size, 0, 0);
-          if (ret == 0) {
-              ms->min_cursor_width = width;
-              break;
-          }
-      }
-
-      /* check if smaller height works with non-square */
-      for (height = 1; height <= size; height *= 2) {
-          int ret;
-
-          ret = drmModeSetCursor2(drmmode->fd, drmmode_crtc->mode_crtc->crtc_id,
-                                  handle, size, height, 0, 0);
-          if (ret == 0) {
-              ms->min_cursor_height = height;
-              break;
-          }
-      }
-
-      drmModeSetCursor2(drmmode->fd, drmmode_crtc->mode_crtc->crtc_id, 0, 0, 0, 0, 0);
+        if (ret == 0)
+            break;
     }
+
+    /* check if smaller width works with non-square */
+    for (width = 1; width <= size; width *= 2) {
+        int ret;
+
+        ret = drmModeSetCursor2(drmmode->fd, drmmode_crtc->mode_crtc->crtc_id,
+                                handle, width, size, 0, 0);
+        if (ret == 0) {
+            ms->min_cursor_width = width;
+            break;
+        }
+    }
+
+    /* check if smaller height works with non-square */
+    for (height = 1; height <= size; height *= 2) {
+        int ret;
+
+        ret = drmModeSetCursor2(drmmode->fd, drmmode_crtc->mode_crtc->crtc_id,
+                                handle, size, height, 0, 0);
+        if (ret == 0) {
+            ms->min_cursor_height = height;
+            break;
+        }
+    }
+
+    drmModeSetCursor2(drmmode->fd, drmmode_crtc->mode_crtc->crtc_id, 0, 0, 0, 0, 0);
 }
 
 /* create front and cursor BOs */

--- a/hw/xfree86/drivers/modesetting/modesetting.man
+++ b/hw/xfree86/drivers/modesetting/modesetting.man
@@ -48,6 +48,10 @@ are supported:
 .BI "Option \*qSWcursor\*q \*q" boolean \*q
 Selects software cursor.  The default is
 .B off.
++
++Note: due to issues with cursor rendering this option will be forced
++.B on
++if it is running under bochs-drm, evdi, vboxvideo, virtio_gpu, vkms, vmwgfx or qxl drm driver.
 .TP
 .BI "Option \*qkmsdev\*q \*q" string \*q
 The framebuffer device to use. Default: /dev/dri/card0.


### PR DESCRIPTION
This commit refactors 61aa2ede91132e9230d0cf2b491bf2d618bcc8cd to always force the software cursor (and disable power
consumption optimizations) when a known VM DRM driver is running. This is done because cursor behavior varies depending
on the VM frontend, leading to inconsistencies:

* if the display backend is gtk, the cursor is shown by default when the window is out of focus and hidden when in focus
  (it must be rendered by the VM GPU in software).
* if the display backend is sdl, it always shows the cursor, regardless of drmModeSetCursor2 and related function calls.
* if the VM runs under a Spice backend using the QXL display, the rendering application (remote-viewer) behaves
  correctly.

For more details, see the QEMU manpage (search for show-cursor):
https://www.qemu.org/docs/master/system/qemu-manpage.html

Until a better solution is found, force the software cursor.

fixes: https://github.com/X11Libre/xserver/issues/3477

Adapted for release/25.0: modesetting driver lives at
hw/xfree86/drivers/modesetting/ and drmmode_probe_cursor_size wraps the whole
probe in the (now removed) drmmode_legacy_cursor_probe_allowed() check, so the
block is de-indented in addition to dropping the helper.

Signed-off-by: Tautvis <gtautvis@gmail.com>
(cherry picked from commit 70fda9ffbf5c7789e9e0130281e0040f5ffa1302)
