### PR TITLE
(release/25.0) damage, exa: Add NULL checks for DamagePtr in damage helpers and exaPutImage

### DIFF
--- a/exa/exa_accel.c
+++ b/exa/exa_accel.c
@@ -172,7 +172,7 @@ exaDoPutImage(DrawablePtr pDrawable, GCPtr pGC, int depth, int x, int y,
         pixmaps[0].as_dst = TRUE;
         pixmaps[0].as_src = FALSE;
         pixmaps[0].pPix = pPix;
-        pixmaps[0].pReg = DamagePendingRegion(pExaPixmap->pDamage);
+        pixmaps[0].pReg = NULL;
 
         exaDoMigration(pixmaps, 1, TRUE);
     }

--- a/miext/damage/damage.c
+++ b/miext/damage/damage.c
@@ -1867,19 +1867,20 @@ DamageSubtract(DamagePtr pDamage, const RegionPtr pRegion)
 void
 DamageEmpty(DamagePtr pDamage)
 {
-    RegionEmpty(&pDamage->damage);
+    if (pDamage)
+        RegionEmpty(&pDamage->damage);
 }
 
 RegionPtr
 DamageRegion(DamagePtr pDamage)
 {
-    return &pDamage->damage;
+    return pDamage ? &pDamage->damage : NULL;
 }
 
 RegionPtr
 DamagePendingRegion(DamagePtr pDamage)
 {
-    return &pDamage->pendingDamage;
+    return pDamage ? &pDamage->pendingDamage : NULL;
 }
 
 void


### PR DESCRIPTION
Return NULL from DamageRegion() and DamagePendingRegion() (and check in
  DamageEmpty()) when passed a NULL DamagePtr
In exaDoPutImage(), explicitly set migration pReg to NULL since
  pExaPixmap->pDamage is guaranteed to be NULL there

(cherry picked from commit cf0d4a34567b7b2ed1005ce20205fcd43e6564f8)


---

Backport of #3646 (`damage, exa: Add NULL checks for DamagePtr in damage helpers`).