### PR TITLE
(master) xinput: make barrier event emission NULL-safe in input_constrain_cursor()

### DIFF
--- a/Xext/xinput/xibarriers.c
+++ b/Xext/xinput/xibarriers.c
@@ -423,6 +423,7 @@ input_constrain_cursor(DeviceIntPtr dev, ScreenPtr pScreen,
     };
     InternalEvent *barrier_events = events;
     DeviceIntPtr master;
+    bool can_emit = events && nevents;
 
     if (nevents)
         *nevents = 0;
@@ -490,9 +491,11 @@ input_constrain_cursor(DeviceIntPtr dev, ScreenPtr pScreen,
 
         /* root x/y is filled in later */
 
-        barrier_events->barrier_event = ev;
-        barrier_events++;
-        *nevents += 1;
+        if (can_emit) {
+            barrier_events->barrier_event = ev;
+            barrier_events++;
+            *nevents += 1;
+        }
     }
 
     xorg_list_for_each_entry(c, &cs->barriers, entry) {
@@ -527,9 +530,11 @@ input_constrain_cursor(DeviceIntPtr dev, ScreenPtr pScreen,
 
         /* root x/y is filled in later */
 
-        barrier_events->barrier_event = ev;
-        barrier_events++;
-        *nevents += 1;
+        if (can_emit) {
+            barrier_events->barrier_event = ev;
+            barrier_events++;
+            *nevents += 1;
+        }
 
         /* If we've left the hit box, this is the
          * start of a new event ID. */


### PR DESCRIPTION
input_constrain_cursor() writes pointer-barrier hit/leave events into the
caller-supplied events buffer and bumps *nevents. It dereferenced both
unconditionally (barrier_events->barrier_event = ev; *nevents += 1), so
calling it with a NULL events/nevents pair crashed on the first barrier.

Callers do not pass NULL today (the only NULL call, GetTouchEvents ->
positionSprite(), is hardcoded to Absolute mode where this function's
barrier paths are skipped), but the function is a straightforward
NULL-safety hazard. Guard event emission on a can_emit flag derived from
both pointers, while still performing the barrier clamping so cursor
coordinates are constrained correctly even when no events can be emitted.
