### PR TITLE
(release/25.2) mi: guard against NULL event pointer

### DIFF
--- a/mi/mipointer.c
+++ b/mi/mipointer.c
@@ -704,7 +704,7 @@ miPointerSetPosition(DeviceIntPtr pDev, int mode, double *screenx,
 
     /* check if we generated any barrier events and if so, update root x/y
      * to the fully constrained coords */
-    if (should_constrain_barriers) {
+    if (should_constrain_barriers && nevents && events) {
         for (i = 0; i < *nevents; i++) {
             if (events[i].any.type == ET_BarrierHit ||
                 events[i].any.type == ET_BarrierLeave) {


### PR DESCRIPTION
In miPointerSetPosition(), ensure nevents and events pointers are non-NULL
before checking for and updating barrier event coordinates to avoid potential
NULL pointer dereferences.

Backport of https://github.com/X11Libre/xserver/pull/3645

(cherry picked from commit 11bb4b1b730101fbd0ad8892d0490497d90134fe)
