### PR TITLE
(release/25.2) Xi: Guard against NULL event pointer

### DIFF
--- a/Xext/xinput/exevents.c
+++ b/Xext/xinput/exevents.c
@@ -1191,7 +1191,7 @@ TouchPuntToNextOwner(DeviceIntPtr dev, TouchPointInfoPtr ti,
     int accepted_early = listener->state == TOUCH_LISTENER_EARLY_ACCEPT;
 
     /* Deliver the ownership */
-    if (listener->state == TOUCH_LISTENER_AWAITING_OWNER || accepted_early)
+    if ((listener->state == TOUCH_LISTENER_AWAITING_OWNER || accepted_early) && ev)
         DeliverTouchEvents(dev, ti, (InternalEvent *) ev,
                            listener->listener);
     else if (listener->state == TOUCH_LISTENER_AWAITING_BEGIN) {
@@ -2194,6 +2194,9 @@ DeliverTouchEvents(DeviceIntPtr dev, TouchPointInfoPtr ti,
                    InternalEvent *ev, XID resource)
 {
     int i;
+
+    if (!ev)
+        return;
 
     if (ev->any.type == ET_TouchBegin &&
         !(ev->device_event.flags & (TOUCH_CLIENT_ID | TOUCH_REPLAYING)))


### PR DESCRIPTION
Check that 'ev' is not NULL before attempting to deliver touch ownership
events in TouchPuntToNextOwner(), and add a defensive null check in
DeliverTouchEvents() to avoid potential NULL pointer dereferences

Backport of https://github.com/X11Libre/xserver/pull/3643 (based on its current
head commit bf3b21df49bc83bf089fa103246d24449c76548b; original PR not merged yet)

(cherry picked from commit bf3b21df49bc83bf089fa103246d24449c76548b)
