### PR TITLE
(release/25.0) mi: Simplify byte/bit order branches in miPushPixels

### DIFF
--- a/mi/mipushpxl.c
+++ b/mi/mipushpxl.c
@@ -104,15 +104,20 @@ miPushPixels(GCPtr pGC, PixmapPtr pBitMap, DrawablePtr pDrawable,
 #if 1
     MiBits startmask;
 
-    if (screenInfo.bitmapBitOrder == IMAGE_BYTE_ORDER)
-        if (screenInfo.bitmapBitOrder == LSBFirst)
-            startmask = (MiBits) (-1) ^ LONG2CHARSSAMEORDER((MiBits) (-1) << 1);
-        else
-            startmask = (MiBits) (-1) ^ LONG2CHARSSAMEORDER((MiBits) (-1) >> 1);
-    else if (screenInfo.bitmapBitOrder == LSBFirst)
+    if (screenInfo.bitmapBitOrder == LSBFirst) {
+#if IMAGE_BYTE_ORDER == LSBFirst
+        startmask = (MiBits) (-1) ^ LONG2CHARSSAMEORDER((MiBits) (-1) << 1);
+#else
         startmask = (MiBits) (-1) ^ LONG2CHARSDIFFORDER((MiBits) (-1) << 1);
-    else
+#endif
+    }
+    else {
+#if IMAGE_BYTE_ORDER == MSBFirst
+        startmask = (MiBits) (-1) ^ LONG2CHARSSAMEORDER((MiBits) (-1) >> 1);
+#else
         startmask = (MiBits) (-1) ^ LONG2CHARSDIFFORDER((MiBits) (-1) >> 1);
+#endif
+    }
 #endif
 
     MiBits *pwLineStart = calloc(1, BitmapBytePad(dx));
@@ -163,17 +168,24 @@ miPushPixels(GCPtr pGC, PixmapPtr pBitMap, DrawablePtr pDrawable,
                 }
 #if 1
                 /* This is not quite right, but it'll do for now */
-                if (screenInfo.bitmapBitOrder == IMAGE_BYTE_ORDER)
-                    if (screenInfo.bitmapBitOrder == LSBFirst)
-                        msk =
-                            LONG2CHARSSAMEORDER(LONG2CHARSSAMEORDER(msk) << 1);
-                    else
-                        msk =
-                            LONG2CHARSSAMEORDER(LONG2CHARSSAMEORDER(msk) >> 1);
-                else if (screenInfo.bitmapBitOrder == LSBFirst)
-                    msk = LONG2CHARSDIFFORDER(LONG2CHARSDIFFORDER(msk) << 1);
-                else
-                    msk = LONG2CHARSDIFFORDER(LONG2CHARSDIFFORDER(msk) >> 1);
+                if (screenInfo.bitmapBitOrder == LSBFirst) {
+#if IMAGE_BYTE_ORDER == LSBFirst
+                    msk =
+                        LONG2CHARSSAMEORDER(LONG2CHARSSAMEORDER(msk) << 1);
+#else
+                    msk =
+                        LONG2CHARSDIFFORDER(LONG2CHARSDIFFORDER(msk) << 1);
+#endif
+                }
+                else {
+#if IMAGE_BYTE_ORDER == MSBFirst
+                    msk =
+                        LONG2CHARSSAMEORDER(LONG2CHARSSAMEORDER(msk) >> 1);
+#else
+                    msk =
+                        LONG2CHARSDIFFORDER(LONG2CHARSDIFFORDER(msk) >> 1);
+#endif
+                }
 #else
                 msk = SCRRIGHT(msk, 1);
 #endif
@@ -213,17 +225,24 @@ miPushPixels(GCPtr pGC, PixmapPtr pBitMap, DrawablePtr pDrawable,
                 }
 #if 1
                 /* This is not quite right, but it'll do for now */
-                if (screenInfo.bitmapBitOrder == IMAGE_BYTE_ORDER)
-                    if (screenInfo.bitmapBitOrder == LSBFirst)
-                        msk =
-                            LONG2CHARSSAMEORDER(LONG2CHARSSAMEORDER(msk) << 1);
-                    else
-                        msk =
-                            LONG2CHARSSAMEORDER(LONG2CHARSSAMEORDER(msk) >> 1);
-                else if (screenInfo.bitmapBitOrder == LSBFirst)
-                    msk = LONG2CHARSDIFFORDER(LONG2CHARSDIFFORDER(msk) << 1);
-                else
-                    msk = LONG2CHARSDIFFORDER(LONG2CHARSDIFFORDER(msk) >> 1);
+                if (screenInfo.bitmapBitOrder == LSBFirst) {
+#if IMAGE_BYTE_ORDER == LSBFirst
+                    msk =
+                        LONG2CHARSSAMEORDER(LONG2CHARSSAMEORDER(msk) << 1);
+#else
+                    msk =
+                        LONG2CHARSDIFFORDER(LONG2CHARSDIFFORDER(msk) << 1);
+#endif
+                }
+                else {
+#if IMAGE_BYTE_ORDER == MSBFirst
+                    msk =
+                        LONG2CHARSSAMEORDER(LONG2CHARSSAMEORDER(msk) >> 1);
+#else
+                    msk =
+                        LONG2CHARSDIFFORDER(LONG2CHARSDIFFORDER(msk) >> 1);
+#endif
+                }
 #else
                 msk = SCRRIGHT(msk, 1);
 #endif


### PR DESCRIPTION
LSBFirst - little-endian
MSBFirst - big-endian

In miPushPixels(), resolve IMAGE_BYTE_ORDER at compile time instead of mixing it into runtime
if-else chains, eliminating duplicate and unreachable condition branches.

Backport of https://github.com/X11Libre/xserver/pull/3642 (based on its current head commit
3841b5b39d447d1ad1db23e9a05b3784fa0117bf; original PR not merged yet)

(cherry picked from commit 3841b5b39d447d1ad1db23e9a05b3784fa0117bf)
