### PR TITLE
(release/25.0) xnest: Check malloc return values in GCOps to avoid NULL dereferences

### DIFF
--- a/hw/xnest/GCOps.c
+++ b/hw/xnest/GCOps.c
@@ -190,8 +190,14 @@ xnestBitBlitHelper(GCPtr pGC)
                 default:
                 {
                     struct xnest_event_queue *q = malloc(sizeof(struct xnest_event_queue));
-                    q->event = event;
-                    xorg_list_add(&q->entry, &xnestUpstreamInfo.eventQueue.entry);
+                    if (q) {
+                        q->event = event;
+                        xorg_list_add(&q->entry, &xnestUpstreamInfo.eventQueue.entry);
+                    }
+                    else {
+                        free(event);
+                    }
+                    break;
                 }
             }
         }
@@ -344,6 +350,8 @@ xnestPolyText8(DrawablePtr pDrawable, GCPtr pGC, int x, int y, int count,
     // won't get more than 254 elements, since it's already processed by doPolyText()
     int const bufsize = sizeof(xTextElt) + count;
     uint8_t *buffer = malloc(bufsize);
+    if (!buffer)
+        return x;
     xTextElt *elt = (xTextElt*)buffer;
     elt->len = count;
     elt->delta = 0;
@@ -370,6 +378,8 @@ xnestPolyText16(DrawablePtr pDrawable, GCPtr pGC, int x, int y, int count,
     // won't get more than 254 elements, since it's already processed by doPolyText()
     int const bufsize = sizeof(xTextElt) + count*2;
     uint8_t *buffer = malloc(bufsize);
+    if (!buffer)
+        return x;
     xTextElt *elt = (xTextElt*)buffer;
     elt->len = count;
     elt->delta = 0;


### PR DESCRIPTION
malloc() require check on valid ptr

Check malloc() return values for NULL in xnestBitBlitHelper(), xnestPolyText8(), and
xnestPolyText16() to prevent potential NULL pointer dereferences.

Backport of https://github.com/X11Libre/xserver/pull/3637 (based on its current head commit
eae9444a66a65bacafc5109f22ce35462d2dd22f; original PR not merged yet)

(cherry picked from commit eae9444a66a65bacafc5109f22ce35462d2dd22f)
