### PR TITLE
(release/25.1) fb: Avoid potential out-of-bounds shift amounts in fbBlt

### DIFF
--- a/fb/fbblt.c
+++ b/fb/fbblt.c
@@ -221,9 +221,13 @@ fbBlt(FbBits * srcLine,
             leftShift = srcX - dstX;
             rightShift = FB_UNIT - leftShift;
         }
-        else {
+        else if (srcX < dstX) {
             rightShift = dstX - srcX;
             leftShift = FB_UNIT - rightShift;
+        }
+        else {
+            leftShift = 0;
+            rightShift = 0;
         }
         while (height--) {
             src = srcLine;


### PR DESCRIPTION
fb: Avoid potential out-of-bounds shift amounts in fbBlt

When srcX == dstX, the original code computed leftShift = FB_UNIT, causing
undefined behavior when shifting by the bit width. Added explicit handling for
this case with both shifts = 0.

Backport of https://github.com/X11Libre/xserver/pull/3636 (based on its current head commit
8efcc601e26cb2e812067da1a057d12287eef1f9; original PR not merged yet)

(cherry picked from commit 8efcc601e26cb2e812067da1a057d12287eef1f9)
