### PR TITLE
(release/25.1) miext/sync/misyncfd.c: fix NULL deref on uninitialized screens

### DIFF
--- a/miext/sync/misyncfd.c
+++ b/miext/sync/misyncfd.c
@@ -79,21 +79,18 @@ Bool miSyncFdScreenInit(ScreenPtr pScreen,
         return FALSE;
 
     if (!dixPrivateKeyRegistered(&syncFdScreenPrivateKey)) {
-        if (!dixRegisterPrivateKey(&syncFdScreenPrivateKey, PRIVATE_SCREEN, 0))
+        if (!dixRegisterPrivateKey(&syncFdScreenPrivateKey, PRIVATE_SCREEN, sizeof(SyncFdScreenPrivateRec)))
             return FALSE;
     }
 
-    priv = calloc(1, sizeof (SyncFdScreenPrivateRec));
-    if (!priv)
-        return FALSE;
+    priv = sync_fd_screen_priv(pScreen);
+    memset(priv, 0, sizeof(*priv));
 
     /* Will require version checks when there are multiple versions
      * of the funcs structure
      */
 
     priv->funcs = *funcs;
-
-    dixSetPrivate(&pScreen->devPrivates, &syncFdScreenPrivateKey, priv);
 
     return TRUE;
 }

--- a/miext/sync/misyncfd.c
+++ b/miext/sync/misyncfd.c
@@ -38,9 +38,20 @@ typedef struct _SyncFdScreenPrivate {
 
 static inline SyncFdScreenPrivatePtr sync_fd_screen_priv(ScreenPtr pScreen)
 {
+    SyncFdScreenPrivatePtr      priv;
+
     if (!dixPrivateKeyRegistered(&syncFdScreenPrivateKey))
         return NULL;
-    return dixLookupPrivate(&pScreen->devPrivates, &syncFdScreenPrivateKey);
+
+    /* The private is preallocated on every screen as soon as the key is
+     * registered by any single screen, so its mere presence says nothing.
+     * Only screens that went through miSyncFdScreenInit() have funcs set.
+     */
+    priv = dixLookupPrivate(&pScreen->devPrivates, &syncFdScreenPrivateKey);
+    if (priv->funcs.version <= 0)
+        return NULL;
+
+    return priv;
 }
 
 int
@@ -83,7 +94,7 @@ Bool miSyncFdScreenInit(ScreenPtr pScreen,
             return FALSE;
     }
 
-    priv = sync_fd_screen_priv(pScreen);
+    priv = dixLookupPrivate(&pScreen->devPrivates, &syncFdScreenPrivateKey);
     memset(priv, 0, sizeof(*priv));
 
     /* Will require version checks when there are multiple versions


### PR DESCRIPTION
Backport of [#3647](https://github.com/X11Libre/xserver/pull/3647) (miext/sync/misyncfd.c: fix NULL deref on uninitialized screens)

Original issue: #3629 — Multi-GPU crash on XSyncCreateFenceFromFD with NVIDIA blob under PRIME. Fix uses filled-in funcs as sentinel instead of private's presence.

Master PR merged: 950ed3f56c2b6561c2ffcf193b9fa1fb460c4e68
