### PR TITLE
(25.2) backport glamor_egl: clean up various stuff

### DIFF
--- a/Xext/dri3/dri3.c
+++ b/Xext/dri3/dri3.c
@@ -43,6 +43,7 @@ static void dri3_screen_close(CallbackListPtr *pcbl, ScreenPtr screen, void *unu
         }
         free(screen_priv->formats);
     }
+    free(screen_priv->info);
     free(screen_priv);
 
     dixScreenUnhookClose(screen, dri3_screen_close);
@@ -51,13 +52,16 @@ static void dri3_screen_close(CallbackListPtr *pcbl, ScreenPtr screen, void *unu
 Bool
 dri3_screen_init(ScreenPtr screen, const dri3_screen_info_rec *info)
 {
+    dri3_screen_priv_ptr screen_priv;
     dri3_screen_generation = serverGeneration;
 
     if (!dixRegisterPrivateKey(&dri3_screen_private_key, PRIVATE_SCREEN, 0))
         return FALSE;
 
-    if (!dri3_screen_priv(screen)) {
-        dri3_screen_priv_ptr screen_priv = calloc(1, sizeof (dri3_screen_priv_rec));
+    screen_priv = dri3_screen_priv(screen);
+
+    if (!screen_priv) {
+        screen_priv = calloc(1, sizeof (dri3_screen_priv_rec));
         if (!screen_priv)
             return FALSE;
 
@@ -66,8 +70,14 @@ dri3_screen_init(ScreenPtr screen, const dri3_screen_info_rec *info)
         dixSetPrivate(&screen->devPrivates, &dri3_screen_private_key, screen_priv);
     }
 
-    if (info)
-        dri3_screen_priv(screen)->info = info;
+    if (info) {
+        void *ptr = realloc(screen_priv->info, sizeof(*info));
+        if (!ptr) {
+            return FALSE;
+        }
+        screen_priv->info = ptr;
+        *screen_priv->info = *info;
+    }
 
     return TRUE;
 }

--- a/Xext/dri3/dri3_priv.h
+++ b/Xext/dri3/dri3_priv.h
@@ -51,7 +51,7 @@ typedef struct dri3_screen_priv {
     CARD32                      num_formats;
     dri3_dmabuf_format_ptr      formats;
 
-    const dri3_screen_info_rec *info;
+    dri3_screen_info_rec       *info;
 } dri3_screen_priv_rec, *dri3_screen_priv_ptr;
 
 #define wrap(priv,real,mem,func) {\

--- a/Xext/present/present_screen.c
+++ b/Xext/present/present_screen.c
@@ -66,6 +66,7 @@ static void present_close_screen(CallbackListPtr *pcbl, ScreenPtr screen, void *
 
     dixScreenUnhookClose(screen, present_close_screen);
     dixSetPrivate(&screen->devPrivates, &present_screen_private_key, NULL);
+    free(screen_priv->info);
     free(screen_priv);
 }
 
@@ -223,7 +224,15 @@ present_screen_init(ScreenPtr screen, present_screen_info_ptr info)
         if (!screen_priv)
             return FALSE;
 
-        screen_priv->info = info;
+        if (info) {
+            screen_priv->info = malloc(sizeof(*info));
+            if (!screen_priv->info) {
+                return FALSE;
+            }
+            *screen_priv->info = *info;
+        } else {
+            screen_priv->info = NULL;
+        }
         present_scmd_init_mode_hooks(screen_priv);
 
         present_fake_screen_init(screen);

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -2715,7 +2715,7 @@ glamor_egl_can_texture_gbm_bo(glamor_egl_priv_t *glamor_egl, int is_nvidia)
 #endif
 
 static glamor_egl_priv_t*
-glamor_egl_priv_from_conf(glamor_egl_conf_t* glamor_egl_conf, int *screen_idx)
+glamor_egl_priv_from_conf(const glamor_egl_conf_t* glamor_egl_conf, int *screen_idx)
 {
     glamor_egl_priv_t* glamor_egl;
 
@@ -2738,7 +2738,7 @@ glamor_egl_priv_from_conf(glamor_egl_conf_t* glamor_egl_conf, int *screen_idx)
 
 static Bool
 glamor_egl_prepare_and_init_display(glamor_egl_priv_t* glamor_egl, int *platform,
-                                    glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
+                                    const glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
 {
     int *dri_fd = NULL;
 
@@ -2775,7 +2775,7 @@ glamor_egl_prepare_and_init_display(glamor_egl_priv_t* glamor_egl, int *platform
 
 static Bool
 glamor_egl_check_renderer(glamor_egl_priv_t* glamor_egl, int platform,
-                          glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
+                          const glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
 {
     const char* renderer;
     const char* vendor;
@@ -2848,7 +2848,7 @@ glamor_egl_check_renderer(glamor_egl_priv_t* glamor_egl, int platform,
 
 static Bool
 glamor_egl_create_final_context(glamor_egl_priv_t* glamor_egl,
-                                glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
+                                const glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
 {
 #define GLAMOR_CHECK_EGL_EXTENSION(EXT)  \
         if (!epoxy_has_egl_extension(glamor_egl->display, "EGL_" #EXT)) {  \
@@ -2878,7 +2878,7 @@ glamor_egl_create_final_context(glamor_egl_priv_t* glamor_egl,
 
 static Bool
 glamor_egl_create_display_and_context(glamor_egl_priv_t* glamor_egl,
-                                      glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
+                                      const glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
 {
     int platform = 0;
 
@@ -2940,7 +2940,7 @@ glamor_egl_probe_dri3_direct_export(glamor_egl_priv_t* glamor_egl, int screen_id
 #ifdef GLAMOR_HAS_GBM
 static Bool
 glamor_egl_probe_dri3_gbm(glamor_egl_priv_t* glamor_egl, int *caps,
-                          glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
+                          const glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
 {
     if (!glamor_egl->can_texture_gbm_bo) {
         if (!glamor_egl_conf->gbm_forbidden) {
@@ -2964,7 +2964,7 @@ glamor_egl_probe_dri3_gbm(glamor_egl_priv_t* glamor_egl, int *caps,
 
 static Bool
 glamor_egl_probe_dri3(glamor_egl_priv_t* glamor_egl, int *caps,
-                      glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
+                      const glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
 {
     int _caps;
     if (!caps) {
@@ -3022,7 +3022,7 @@ glamor_egl_probe_dri3(glamor_egl_priv_t* glamor_egl, int *caps,
  * for the fact that we aren't actually called from ScreenInit in xf86.
  */
 Bool
-glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
+glamor_egl_init_internal(const glamor_egl_conf_t* glamor_egl_conf, int *caps)
 {
     glamor_egl_priv_t* glamor_egl;
     const char* renderer;

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -62,7 +62,10 @@
 #include "glamor_egl_ext.h"
 #include "glamor_egl_priv.h"
 #include "glamor_glx_provider.h"
+
+#ifdef DRI3
 #include "dri3.h"
+#endif
 
 #ifndef GBM_MAX_PLANES
 #define GBM_MAX_PLANES 4
@@ -1593,7 +1596,7 @@ glamor_dri3_open_client(ClientPtr client,
     return Success;
 }
 
-static dri3_screen_info_rec glamor_dri3_info = {
+static const dri3_screen_info_rec glamor_dri3_info = {
     .version = 2,
 
     .fd_from_pixmap = glamor_egl_fd_from_pixmap,
@@ -1725,7 +1728,7 @@ glamor_egl_screen_init(ScreenPtr screen, struct glamor_context *glamor_ctx)
             if (!glamor_egl->device_path)
                 glamor_egl->device_path = drmGetDeviceNameFromFd2(glamor_egl->fd);
 
-            if (!dri3_screen_init(screen, &glamor_dri3_info)) {
+            if (!dri3_screen_init(screen, &glamor_egl->dri3_info)) {
                 GLAMOR_LOG_STR(screen->myNum, X_ERROR,
                                "Failed to initialize DRI3.\n");
             }
@@ -2531,6 +2534,10 @@ glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
 
     memset(glamor_egl, 0, sizeof(*glamor_egl));
 
+#ifdef DRI3
+    glamor_egl->dri3_info = glamor_dri3_info;
+#endif
+
     if (glamor_egl_conf->glvnd_vendor) {
         glamor_egl->glvnd_vendor = strdup(glamor_egl_conf->glvnd_vendor);
         glamor_egl->exact_glvnd_vendor = !!glamor_egl->glvnd_vendor;
@@ -2571,8 +2578,8 @@ glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
     if (!epoxy_has_egl_extension(glamor_egl->display, "EGL_MESA_image_dma_buf_export")) {
         GLAMOR_LOG_STR(screen_idx, X_WARNING, "EGL extension EGL_MESA_image_dma_buf_export not available\n");
         GLAMOR_LOG_STR(screen_idx, X_WARNING, "DRI3 dmabuf export will be slower\n");
-        glamor_dri3_info.fd_from_pixmap = glamor_egl_fd_from_pixmap_slow;
-        glamor_dri3_info.fds_from_pixmap = glamor_egl_fds_from_pixmap_slow;
+        glamor_egl->dri3_info.fd_from_pixmap = glamor_egl_fd_from_pixmap_slow;
+        glamor_egl->dri3_info.fds_from_pixmap = glamor_egl_fds_from_pixmap_slow;
     }
 #endif
 
@@ -2644,7 +2651,7 @@ glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
                        "Extensions GL_EXT_EGL_image_storage and GL_OES_EGL_image are both unavailable\n");
         GLAMOR_LOG_STR(screen_idx, X_ERROR,
                        "DRI3 import will not be available\n");
-        glamor_dri3_info.pixmap_from_fds = NULL;
+        glamor_egl->dri3_info.pixmap_from_fds = NULL;
     }
 
 #if defined(GLAMOR_HAS_GBM) && defined(EGL_MESA_image_dma_buf_export)
@@ -2680,10 +2687,11 @@ glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
 #endif
 
     *caps |= GLAMOR_EGL_DEFAULT_CAPS;
-    if (!glamor_dri3_info.pixmap_from_fds) {
+#ifdef DRI3
+    if (!glamor_egl->dri3_info.pixmap_from_fds) {
         *caps &= ~GLAMOR_EGL_CAP_DRI3_IMPORT;
         /* Avoid DRI3 returning BadImplementation */
-        glamor_dri3_info.pixmap_from_fds = glamor_pixmap_from_fds_noop;
+        glamor_egl->dri3_info.pixmap_from_fds = glamor_pixmap_from_fds_noop;
     }
 
 #ifdef GLAMOR_HAS_GBM
@@ -2701,13 +2709,13 @@ glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
         }
         *caps &= ~GLAMOR_EGL_CAP_TEXTURE_GBM_BO;
         if (epoxy_has_egl_extension(glamor_egl->display, "EGL_MESA_image_dma_buf_export")) {
-            glamor_dri3_info.fd_from_pixmap = glamor_egl_fd_from_pixmap_fast;
-            glamor_dri3_info.fds_from_pixmap = glamor_egl_fds_from_pixmap_fast;
+            glamor_egl->dri3_info.fd_from_pixmap = glamor_egl_fd_from_pixmap_fast;
+            glamor_egl->dri3_info.fds_from_pixmap = glamor_egl_fds_from_pixmap_fast;
         } else {
             GLAMOR_LOG_STR(screen_idx, X_WARNING, "EGL extension EGL_MESA_image_dma_buf_export not available\n");
             GLAMOR_LOG_STR(screen_idx, X_WARNING, "DRI3 dmabuf export will be unavailable\n");
-            glamor_dri3_info.fd_from_pixmap = NULL;
-            glamor_dri3_info.fds_from_pixmap = NULL;
+            glamor_egl->dri3_info.fd_from_pixmap = NULL;
+            glamor_egl->dri3_info.fds_from_pixmap = NULL;
             *caps &= ~GLAMOR_EGL_CAP_DRI3_EXPORT;
         }
     }

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -71,6 +71,29 @@
 #define GBM_MAX_PLANES 4
 #endif
 
+/* libdrm compat */
+#ifndef DRM_FORMAT_MOD_LINEAR
+#define DRM_FORMAT_MOD_LINEAR  0ULL
+#endif
+#ifndef DRM_FORMAT_MOD_INVALID
+#define DRM_FORMAT_MOD_INVALID 0x00ffffffffffffffULL
+#endif
+#ifndef DRM_FORMAT_ARGB1555
+#define DRM_FORMAT_ARGB1555 0x35315241
+#endif
+#ifndef DRM_FORMAT_RGB565
+#define DRM_FORMAT_RGB565 0x36314752
+#endif
+#ifndef DRM_FORMAT_XRGB8888
+#define DRM_FORMAT_XRGB8888 0x34325258
+#endif
+#ifndef DRM_FORMAT_ARGB8888
+#define DRM_FORMAT_ARGB8888 0x34325241
+#endif
+#ifndef DRM_FORMAT_ARGB2101010
+#define DRM_FORMAT_ARGB2101010 0x30335241
+#endif
+
 #define GLAMOR_LOG_STR(idx, type, str) \
     do { \
         if ((idx) != -1) { \
@@ -208,7 +231,7 @@ glamor_egl_make_current(struct glamor_context *glamor_ctx)
     }
 }
 
-#if defined(GLAMOR_HAS_GBM) && defined (WITH_LIBDRM)
+#if defined(GLAMOR_HAS_GBM) && defined(WITH_LIBDRM)
 static int
 glamor_get_flink_name(int fd, int handle, int *name)
 {
@@ -599,12 +622,6 @@ glamor_egl_create_textured_pixmap_from_egl_image(PixmapPtr pixmap,
     return TRUE;
 }
 
-#ifdef WITH_LIBDRM
-/**
- * XXX We only need libdrm for fourcc's here XXX
- *
- * Perhaps we should have some compatibility defines somewhere?
- */
 static Bool
 glamor_egl_create_textured_pixmap_from_dma_bufs(PixmapPtr pixmap,
                                                 uint32_t num_fds, const int *fds,
@@ -624,7 +641,6 @@ glamor_egl_create_textured_pixmap_from_dma_bufs(PixmapPtr pixmap,
     return glamor_egl_create_textured_pixmap_from_egl_image(pixmap, image,
                                                             used_modifiers);
 }
-#endif
 
 Bool
 glamor_egl_create_textured_pixmap_from_gbm_bo(PixmapPtr pixmap,
@@ -642,7 +658,7 @@ glamor_egl_create_textured_pixmap_from_gbm_bo(PixmapPtr pixmap,
 #endif
 }
 
-#if defined(GLAMOR_HAS_GBM) && defined (WITH_LIBDRM)
+#if defined(GLAMOR_HAS_GBM) && defined(WITH_LIBDRM)
 static void
 glamor_get_name_from_bo(int gbm_fd, struct gbm_bo *bo, int *name)
 {
@@ -706,8 +722,11 @@ glamor_make_pixmap_exportable(PixmapPtr pixmap, Bool modifiers_ok)
     }
 
     /**
-     * Now that DRI3 has been decoupled from glamor, the (indirect) callers of this
+     * Now that DRI3 has been partially decoupled from gbm, the (indirect) callers of this
      * (e.g. modesetting's pageflip code) usually expect buffers that can be scanned out.
+     *
+     * Even DRI3 X clients seem to expect scanout-capable buffers.
+     * See: https://github.com/X11Libre/xserver/issues/3262
      */
 #ifdef GBM_BO_WITH_MODIFIERS
     if (modifiers_ok && glamor_egl->dmabuf_capable) {
@@ -903,7 +922,6 @@ glamor_egl_fds_from_pixmap_gbm(ScreenPtr screen, PixmapPtr pixmap, int *fds,
                                uint32_t *strides, uint32_t *offsets,
                                uint64_t *modifier)
 {
-#ifdef WITH_LIBDRM
     struct gbm_bo *bo;
     int num_fds;
 #ifdef GBM_BO_WITH_MODIFIERS
@@ -968,9 +986,6 @@ glamor_egl_fds_from_pixmap_gbm(ScreenPtr screen, PixmapPtr pixmap, int *fds,
 
     gbm_bo_destroy(bo);
     return num_fds;
-#else
-    return 0;
-#endif
 }
 #endif
 
@@ -1130,7 +1145,6 @@ glamor_egl_fd_name_from_pixmap(ScreenPtr screen,
 #endif
 }
 
-#ifdef WITH_LIBDRM
 static uint32_t
 glamor_drm_format_for_depth(CARD8 depth)
 {
@@ -1149,7 +1163,6 @@ glamor_drm_format_for_depth(CARD8 depth)
         return DRM_FORMAT_ARGB8888;
     }
 }
-#endif
 
 static Bool
 glamor_back_pixmap_from_fd_direct(PixmapPtr pixmap,
@@ -1158,7 +1171,6 @@ glamor_back_pixmap_from_fd_direct(PixmapPtr pixmap,
                                   CARD16 height,
                                   CARD16 _stride, CARD8 depth, CARD8 bpp)
 {
-#ifdef WITH_LIBDRM
     ScreenPtr screen = pixmap->drawable.pScreen;
     uint32_t format;
     const int stride = _stride;
@@ -1177,9 +1189,6 @@ glamor_back_pixmap_from_fd_direct(PixmapPtr pixmap,
                                                            width, height,
                                                            &stride, &offset,
                                                            format, DRM_FORMAT_MOD_INVALID);
-#else
-    return FALSE;
-#endif
 }
 
 #ifdef GLAMOR_HAS_GBM
@@ -1264,7 +1273,6 @@ glamor_pixmap_from_fds_direct(ScreenPtr screen,
                               CARD8 depth, CARD8 bpp,
                               uint64_t modifier)
 {
-#ifdef WITH_LIBDRM
     PixmapPtr pixmap;
     glamor_egl_priv_t *glamor_egl;
     Bool ret = FALSE;
@@ -1324,9 +1332,6 @@ error:
         return NULL;
     }
     return pixmap;
-#else
-    return NULL;
-#endif
 }
 
 #ifdef GLAMOR_HAS_GBM
@@ -1338,7 +1343,6 @@ glamor_pixmap_from_fds_gbm(ScreenPtr screen,
                            CARD8 depth, CARD8 bpp,
                            uint64_t modifier)
 {
-#ifdef WITH_LIBDRM
     PixmapPtr pixmap;
     glamor_egl_priv_t *glamor_egl;
     Bool ret = FALSE;
@@ -1391,9 +1395,6 @@ error:
         return NULL;
     }
     return pixmap;
-#else
-    return NULL;
-#endif
 }
 #endif
 
@@ -2687,12 +2688,8 @@ glamor_egl_can_texture_gbm_bo(glamor_egl_priv_t *glamor_egl, int is_nvidia)
             if (linear_only) {
                 for (uint32_t j = 0; j < num_modifiers; j++) {
                     if (
-#ifdef WITH_LIBDRM
                         (modifiers[j] == DRM_FORMAT_MOD_LINEAR) ||
                         (modifiers[j] == DRM_FORMAT_MOD_INVALID))
-#else
-                        modifiers[j] == 0) /* DRM_FORMAT_MOD_LINEAR */
-#endif
                     {
                         found = TRUE;
                         break;

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -897,13 +897,13 @@ glamor_gbm_bo_from_pixmap(ScreenPtr screen, PixmapPtr pixmap)
 #endif
 }
 
-/* Used for untextured pixmaps */
+#ifdef GLAMOR_HAS_GBM
 static int
-glamor_egl_fds_from_pixmap_slow(ScreenPtr screen, PixmapPtr pixmap, int *fds,
-                                uint32_t *strides, uint32_t *offsets,
-                                uint64_t *modifier)
+glamor_egl_fds_from_pixmap_gbm(ScreenPtr screen, PixmapPtr pixmap, int *fds,
+                               uint32_t *strides, uint32_t *offsets,
+                               uint64_t *modifier)
 {
-#if defined(GLAMOR_HAS_GBM) && defined (WITH_LIBDRM)
+#ifdef WITH_LIBDRM
     struct gbm_bo *bo;
     int num_fds;
 #ifdef GBM_BO_WITH_MODIFIERS
@@ -972,12 +972,12 @@ glamor_egl_fds_from_pixmap_slow(ScreenPtr screen, PixmapPtr pixmap, int *fds,
     return 0;
 #endif
 }
+#endif
 
-/* Used for textured pixmaps */
 static int
-glamor_egl_fds_from_pixmap_fast(ScreenPtr screen, PixmapPtr pixmap, int *fds,
-                                uint32_t *strides, uint32_t *offsets,
-                                uint64_t *modifier)
+glamor_egl_fds_from_pixmap_direct(ScreenPtr screen, PixmapPtr pixmap, int *fds,
+                                  uint32_t *strides, uint32_t *offsets,
+                                  uint64_t *modifier)
 {
 #ifdef EGL_MESA_image_dma_buf_export
     glamor_egl_priv_t *glamor_egl =
@@ -1018,27 +1018,23 @@ glamor_egl_fds_from_pixmap(ScreenPtr screen, PixmapPtr pixmap, int *fds,
                            uint32_t *strides, uint32_t *offsets,
                            uint64_t *modifier)
 {
-    static int warned = FALSE;
-    int ret = glamor_egl_fds_from_pixmap_fast(screen, pixmap, fds,
+#ifdef GLAMOR_HAS_GBM
+    glamor_egl_priv_t *glamor_egl =
+        glamor_egl_get_screen_private(screen);
+    if (glamor_egl->can_texture_gbm_bo) {
+        return glamor_egl_fds_from_pixmap_gbm(screen, pixmap, fds,
                                               strides, offsets, modifier);
-    if (ret) {
-        return ret;
     }
-
-    ret = glamor_egl_fds_from_pixmap_slow(screen, pixmap, fds,
-                                          strides, offsets, modifier);
-
-    if (!warned && ret) {
-        GLAMOR_LOG_STR(screen->myNum, X_WARNING, "glamor_egl_fds_from_pixmap_fast failed\n");
-        warned = TRUE;
-    }
-    return ret;
+#endif
+    return glamor_egl_fds_from_pixmap_direct(screen, pixmap, fds,
+                                             strides, offsets, modifier);
 }
 
-/* Used for untextured pixmaps */
+
+#ifdef GLAMOR_HAS_GBM
 static int
-glamor_egl_fd_from_pixmap_slow(ScreenPtr screen, PixmapPtr pixmap,
-                               CARD16 *stride, CARD32 *size)
+glamor_egl_fd_from_pixmap_gbm(ScreenPtr screen, PixmapPtr pixmap,
+                              CARD16 *stride, CARD32 *size)
 {
 #ifdef GBM_BO_FD
     struct gbm_bo *bo;
@@ -1061,19 +1057,19 @@ glamor_egl_fd_from_pixmap_slow(ScreenPtr screen, PixmapPtr pixmap,
     return -1;
 #endif
 }
+#endif
 
-/* Used for textured pixmaps */
 static int
-glamor_egl_fd_from_pixmap_fast(ScreenPtr screen, PixmapPtr pixmap,
-                               CARD16 *stride, CARD32 *size)
+glamor_egl_fd_from_pixmap_direct(ScreenPtr screen, PixmapPtr pixmap,
+                                 CARD16 *stride, CARD32 *size)
 {
     uint32_t strides[GBM_MAX_PLANES] = {0};
     uint32_t offsets[GBM_MAX_PLANES] = {0};
     int fds[GBM_MAX_PLANES] = {-1, -1, -1, -1};
     uint64_t modifier = 0;
 
-    int ret = glamor_egl_fds_from_pixmap_fast(screen, pixmap, fds,
-                                              strides, offsets, &modifier);
+    int ret = glamor_egl_fds_from_pixmap_direct(screen, pixmap, fds,
+                                                strides, offsets, &modifier);
 
     if (ret == 1) {
         *stride = strides[0];
@@ -1091,20 +1087,14 @@ int
 glamor_egl_fd_from_pixmap(ScreenPtr screen, PixmapPtr pixmap,
                           CARD16 *stride, CARD32 *size)
 {
-    static int warned = FALSE;
-    int fd = glamor_egl_fd_from_pixmap_fast(screen, pixmap, stride, size);
-    if (fd >= 0) {
-        return fd;
+#ifdef GLAMOR_HAS_GBM
+    glamor_egl_priv_t *glamor_egl =
+        glamor_egl_get_screen_private(screen);
+    if (glamor_egl->can_texture_gbm_bo) {
+        return glamor_egl_fd_from_pixmap_gbm(screen, pixmap, stride, size);
     }
-
-    fd = glamor_egl_fd_from_pixmap_slow(screen, pixmap, stride, size);
-
-    if (!warned && (fd >= 0)) {
-        GLAMOR_LOG_STR(screen->myNum, X_WARNING, "glamor_egl_fd_from_pixmap_fast failed\n");
-        warned = TRUE;
-    }
-
-    return fd;
+#endif
+    return glamor_egl_fd_from_pixmap_direct(screen, pixmap, stride, size);
 }
 
 int
@@ -1162,11 +1152,11 @@ glamor_drm_format_for_depth(CARD8 depth)
 #endif
 
 static Bool
-glamor_back_pixmap_from_fd_fast(PixmapPtr pixmap,
-                                int fd,
-                                CARD16 width,
-                                CARD16 height,
-                                CARD16 _stride, CARD8 depth, CARD8 bpp)
+glamor_back_pixmap_from_fd_direct(PixmapPtr pixmap,
+                                  int fd,
+                                  CARD16 width,
+                                  CARD16 height,
+                                  CARD16 _stride, CARD8 depth, CARD8 bpp)
 {
 #ifdef WITH_LIBDRM
     ScreenPtr screen = pixmap->drawable.pScreen;
@@ -1192,14 +1182,14 @@ glamor_back_pixmap_from_fd_fast(PixmapPtr pixmap,
 #endif
 }
 
-static Bool
-glamor_back_pixmap_from_fd_slow(PixmapPtr pixmap,
-                                int fd,
-                                CARD16 width,
-                                CARD16 height,
-                                CARD16 stride, CARD8 depth, CARD8 bpp)
-{
 #ifdef GLAMOR_HAS_GBM
+static Bool
+glamor_back_pixmap_from_fd_gbm(PixmapPtr pixmap,
+                               int fd,
+                               CARD16 width,
+                               CARD16 height,
+                               CARD16 stride, CARD8 depth, CARD8 bpp)
+{
     ScreenPtr screen = pixmap->drawable.pScreen;
     glamor_egl_priv_t *glamor_egl;
     struct gbm_bo *bo;
@@ -1207,11 +1197,6 @@ glamor_back_pixmap_from_fd_slow(PixmapPtr pixmap,
     Bool ret;
 
     glamor_egl = glamor_egl_get_screen_private(screen);
-
-    /* The call would fail later anyway, but this is faster */
-    if (!glamor_egl->can_texture_gbm_bo) {
-        return FALSE;
-    }
 
     if (width == 0 || height == 0) {
         return FALSE;
@@ -1233,10 +1218,8 @@ glamor_back_pixmap_from_fd_slow(PixmapPtr pixmap,
     ret = glamor_egl_create_textured_pixmap_from_gbm_bo(pixmap, bo, FALSE);
     gbm_bo_destroy(bo);
     return ret;
-#else
-    return FALSE;
-#endif
 }
+#endif
 
 /* See: https://github.com/X11Libre/xserver/issues/3262 */
 Bool
@@ -1246,12 +1229,20 @@ glamor_back_pixmap_from_fd(PixmapPtr pixmap,
                            CARD16 height,
                            CARD16 stride, CARD8 depth, CARD8 bpp)
 {
-    Bool ret = glamor_back_pixmap_from_fd_slow(pixmap, fd,
-                                               width, height,
-                                               stride, depth, bpp);
-    return ret ? ret : glamor_back_pixmap_from_fd_fast(pixmap, fd,
-                                                       width, height,
-                                                       stride, depth, bpp);
+#ifdef GLAMOR_HAS_GBM
+    ScreenPtr screen = pixmap->drawable.pScreen;
+    glamor_egl_priv_t *glamor_egl =
+        glamor_egl_get_screen_private(screen);
+
+    if (glamor_egl->can_texture_gbm_bo) {
+        return glamor_back_pixmap_from_fd_gbm(pixmap, fd,
+                                              width, height,
+                                              stride, depth, bpp);
+    }
+#endif
+    return glamor_back_pixmap_from_fd_direct(pixmap, fd,
+                                             width, height,
+                                             stride, depth, bpp);
 }
 
 static PixmapPtr
@@ -1266,12 +1257,12 @@ glamor_pixmap_from_fds_noop(ScreenPtr screen,
 }
 
 static PixmapPtr
-glamor_pixmap_from_fds_fast(ScreenPtr screen,
-                            CARD8 num_fds, const int *fds,
-                            CARD16 width, CARD16 height,
-                            const CARD32 *_strides, const CARD32 *_offsets,
-                            CARD8 depth, CARD8 bpp,
-                            uint64_t modifier)
+glamor_pixmap_from_fds_direct(ScreenPtr screen,
+                              CARD8 num_fds, const int *fds,
+                              CARD16 width, CARD16 height,
+                              const CARD32 *_strides, const CARD32 *_offsets,
+                              CARD8 depth, CARD8 bpp,
+                              uint64_t modifier)
 {
 #ifdef WITH_LIBDRM
     PixmapPtr pixmap;
@@ -1322,8 +1313,8 @@ glamor_pixmap_from_fds_fast(ScreenPtr screen,
                                                               format, modifier);
     } else {
         if (num_fds == 1) {
-            ret = glamor_back_pixmap_from_fd_fast(pixmap, fds[0], width, height,
-                                                  _strides[0], depth, bpp);
+            ret = glamor_back_pixmap_from_fd_direct(pixmap, fds[0], width, height,
+                                                    _strides[0], depth, bpp);
         }
     }
 
@@ -1338,26 +1329,22 @@ error:
 #endif
 }
 
+#ifdef GLAMOR_HAS_GBM
 static PixmapPtr
-glamor_pixmap_from_fds_slow(ScreenPtr screen,
-                            CARD8 num_fds, const int *fds,
-                            CARD16 width, CARD16 height,
-                            const CARD32 *strides, const CARD32 *offsets,
-                            CARD8 depth, CARD8 bpp,
-                            uint64_t modifier)
+glamor_pixmap_from_fds_gbm(ScreenPtr screen,
+                           CARD8 num_fds, const int *fds,
+                           CARD16 width, CARD16 height,
+                           const CARD32 *strides, const CARD32 *offsets,
+                           CARD8 depth, CARD8 bpp,
+                           uint64_t modifier)
 {
-#if defined(GLAMOR_HAS_GBM) && defined(WITH_LIBDRM)
+#ifdef WITH_LIBDRM
     PixmapPtr pixmap;
     glamor_egl_priv_t *glamor_egl;
     Bool ret = FALSE;
     int i;
 
     glamor_egl = glamor_egl_get_screen_private(screen);
-
-    /* The call would fail later anyway, but this is faster */
-    if (!glamor_egl->can_texture_gbm_bo) {
-        return FALSE;
-    }
 
     pixmap = screen->CreatePixmap(screen, 0, 0, depth, 0);
 
@@ -1391,8 +1378,8 @@ glamor_pixmap_from_fds_slow(ScreenPtr screen,
 #endif
     {
         if (num_fds == 1) {
-            ret = glamor_back_pixmap_from_fd_slow(pixmap, fds[0], width, height,
-                                                  strides[0], depth, bpp);
+            ret = glamor_back_pixmap_from_fd_gbm(pixmap, fds[0], width, height,
+                                                 strides[0], depth, bpp);
         }
     }
 
@@ -1408,6 +1395,7 @@ error:
     return NULL;
 #endif
 }
+#endif
 
 /* See: https://github.com/X11Libre/xserver/issues/3262 */
 PixmapPtr
@@ -1418,71 +1406,67 @@ glamor_pixmap_from_fds(ScreenPtr screen,
                        CARD8 depth, CARD8 bpp,
                        uint64_t modifier)
 {
-    PixmapPtr ret = glamor_pixmap_from_fds_slow(screen, num_fds, fds,
-                                                width, height,
-                                                strides, offsets,
-                                                depth, bpp, modifier);
-    return ret ? ret : glamor_pixmap_from_fds_fast(screen, num_fds, fds,
-                                                   width, height,
-                                                   strides, offsets,
-                                                   depth, bpp, modifier);
-}
-
-static PixmapPtr
-glamor_pixmap_from_fd_fast(ScreenPtr screen,
-                           int fd,
-                           CARD16 width,
-                           CARD16 height,
-                           CARD16 stride, CARD8 depth, CARD8 bpp)
-{
-    PixmapPtr pixmap;
-    bool ret;
-
-    pixmap = screen->CreatePixmap(screen, 0, 0, depth, 0);
-
-    ret = glamor_back_pixmap_from_fd_fast(pixmap, fd, width, height,
-                                          stride, depth, bpp);
-
-    if (ret == FALSE) {
-        dixDestroyPixmap(pixmap, 0);
-        return NULL;
-    }
-    return pixmap;
-}
-
-static PixmapPtr
-glamor_pixmap_from_fd_slow(ScreenPtr screen,
-                           int fd,
-                           CARD16 width,
-                           CARD16 height,
-                           CARD16 stride, CARD8 depth, CARD8 bpp)
-{
 #ifdef GLAMOR_HAS_GBM
-    PixmapPtr pixmap;
-    glamor_egl_priv_t *glamor_egl;
-    bool ret;
-
-    glamor_egl = glamor_egl_get_screen_private(screen);
-
-    /* The call would fail later anyway, but this is faster */
-    if (!glamor_egl->can_texture_gbm_bo) {
-        return FALSE;
+    glamor_egl_priv_t *glamor_egl =
+        glamor_egl_get_screen_private(screen);
+    if (glamor_egl->can_texture_gbm_bo) {
+        return glamor_pixmap_from_fds_gbm(screen, num_fds, fds,
+                                          width, height,
+                                          strides, offsets,
+                                          depth, bpp, modifier);
     }
+#endif
+    return glamor_pixmap_from_fds_direct(screen, num_fds, fds,
+                                         width, height,
+                                         strides, offsets,
+                                         depth, bpp, modifier);
+}
+
+static PixmapPtr
+glamor_pixmap_from_fd_direct(ScreenPtr screen,
+                             int fd,
+                             CARD16 width,
+                             CARD16 height,
+                             CARD16 stride, CARD8 depth, CARD8 bpp)
+{
+    PixmapPtr pixmap;
+    bool ret;
 
     pixmap = screen->CreatePixmap(screen, 0, 0, depth, 0);
 
-    ret = glamor_back_pixmap_from_fd_slow(pixmap, fd, width, height,
-                                          stride, depth, bpp);
+    ret = glamor_back_pixmap_from_fd_direct(pixmap, fd, width, height,
+                                            stride, depth, bpp);
 
     if (ret == FALSE) {
         dixDestroyPixmap(pixmap, 0);
         return NULL;
     }
     return pixmap;
-#else
-    return NULL;
-#endif
 }
+
+#ifdef GLAMOR_HAS_GBM
+static PixmapPtr
+glamor_pixmap_from_fd_gbm(ScreenPtr screen,
+                          int fd,
+                          CARD16 width,
+                          CARD16 height,
+                          CARD16 stride, CARD8 depth, CARD8 bpp)
+{
+    PixmapPtr pixmap;
+    bool ret;
+
+    pixmap = screen->CreatePixmap(screen, 0, 0, depth, 0);
+
+    ret = glamor_back_pixmap_from_fd_gbm(pixmap, fd, width, height,
+                                         stride, depth, bpp);
+
+    if (ret == FALSE) {
+        dixDestroyPixmap(pixmap, 0);
+        return NULL;
+    }
+    return pixmap;
+}
+#endif
 
 PixmapPtr
 glamor_pixmap_from_fd(ScreenPtr screen,
@@ -1491,13 +1475,18 @@ glamor_pixmap_from_fd(ScreenPtr screen,
                       CARD16 height,
                       CARD16 stride, CARD8 depth, CARD8 bpp)
 {
-    PixmapPtr ret = glamor_pixmap_from_fd_slow(screen, fd,
-                                               width, height,
-                                               stride, depth, bpp);
-
-    return ret ? ret : glamor_pixmap_from_fd_fast(screen, fd,
-                                                  width, height,
-                                                  stride, depth, bpp);
+#ifdef GLAMOR_HAS_GBM
+    glamor_egl_priv_t *glamor_egl =
+        glamor_egl_get_screen_private(screen);
+    if (glamor_egl->can_texture_gbm_bo) {
+        return glamor_pixmap_from_fd_gbm(screen, fd,
+                                         width, height,
+                                         stride, depth, bpp);
+    }
+#endif
+    return glamor_pixmap_from_fd_direct(screen, fd,
+                                        width, height,
+                                        stride, depth, bpp);
 }
 
 static Bool
@@ -1798,17 +1787,18 @@ glamor_dri3_open_client(ClientPtr client,
     return Success;
 }
 
-static const dri3_screen_info_rec glamor_dri3_info = {
+#ifdef GLAMOR_HAS_GBM
+static const dri3_screen_info_rec glamor_dri3_info_gbm = {
     .version = 2,
 
-    .fd_from_pixmap = glamor_egl_fd_from_pixmap,
+    .fd_from_pixmap = glamor_egl_fd_from_pixmap_gbm,
 
     /* Version 1 */
     .open_client = glamor_dri3_open_client,
 
     /* Version 2 */
-    .pixmap_from_fds = glamor_pixmap_from_fds,
-    .fds_from_pixmap = glamor_egl_fds_from_pixmap,
+    .pixmap_from_fds = glamor_pixmap_from_fds_gbm,
+    .fds_from_pixmap = glamor_egl_fds_from_pixmap_gbm,
     .get_formats = glamor_get_formats,
     .get_modifiers = glamor_get_modifiers,
     .get_drawable_modifiers = glamor_get_drawable_modifiers,
@@ -1816,6 +1806,27 @@ static const dri3_screen_info_rec glamor_dri3_info = {
     /* Version 4 */
     .import_syncobj = NULL, /* TODO: implement */
 };
+#endif
+
+static const dri3_screen_info_rec glamor_dri3_info_direct = {
+    .version = 2,
+
+    .fd_from_pixmap = glamor_egl_fd_from_pixmap_direct,
+
+    /* Version 1 */
+    .open_client = glamor_dri3_open_client,
+
+    /* Version 2 */
+    .pixmap_from_fds = glamor_pixmap_from_fds_direct,
+    .fds_from_pixmap = glamor_egl_fds_from_pixmap_direct,
+    .get_formats = glamor_get_formats,
+    .get_modifiers = glamor_get_modifiers,
+    .get_drawable_modifiers = glamor_get_drawable_modifiers,
+
+    /* Version 4 */
+    .import_syncobj = NULL, /* TODO: implement */
+};
+
 #endif /* DRI3 */
 
 static inline void
@@ -2897,11 +2908,8 @@ glamor_egl_create_display_and_context(glamor_egl_priv_t* glamor_egl,
 
 #ifdef DRI3
 static Bool
-glamor_egl_probe_dri3_import(glamor_egl_priv_t* glamor_egl, int screen_idx)
+glamor_egl_probe_dri3_direct_import(glamor_egl_priv_t* glamor_egl, int screen_idx)
 {
-    glamor_egl->has_EXT_EGL_image_storage = epoxy_has_gl_extension("GL_EXT_EGL_image_storage");
-    glamor_egl->has_OES_EGL_image = epoxy_has_gl_extension("GL_OES_EGL_image");
-
     if (!glamor_egl->has_EXT_EGL_image_storage && !glamor_egl->has_OES_EGL_image) {
         GLAMOR_LOG_STR(screen_idx, X_ERROR,
                        "Extensions GL_EXT_EGL_image_storage and GL_OES_EGL_image are both unavailable\n");
@@ -2911,113 +2919,101 @@ glamor_egl_probe_dri3_import(glamor_egl_priv_t* glamor_egl, int screen_idx)
         /* Avoid DRI3 returning BadImplementation */
         glamor_egl->dri3_info.pixmap_from_fds = glamor_pixmap_from_fds_noop;
         return FALSE;
-    } else
-#ifdef GLAMOR_HAS_GBM
-    if (!glamor_egl->can_texture_gbm_bo)
-#endif
-    {
-        glamor_egl->dri3_info.pixmap_from_fds = glamor_pixmap_from_fds_fast;
     }
 
     return TRUE;
 }
 
 static Bool
-glamor_egl_probe_dri3_export(glamor_egl_priv_t* glamor_egl, int screen_idx)
+glamor_egl_probe_dri3_direct_export(glamor_egl_priv_t* glamor_egl, int screen_idx)
 {
-    glamor_egl->has_image_dma_buf_export = epoxy_has_egl_extension(glamor_egl->display, "EGL_MESA_image_dma_buf_export");
-
-    if (glamor_egl->has_image_dma_buf_export) {
-#ifdef GLAMOR_HAS_GBM
-        if (!glamor_egl->can_texture_gbm_bo)
-#endif
-        {
-            glamor_egl->dri3_info.fd_from_pixmap = glamor_egl_fd_from_pixmap_fast;
-            glamor_egl->dri3_info.fds_from_pixmap = glamor_egl_fds_from_pixmap_fast;
-        }
-    } else {
-#ifdef GLAMOR_HAS_GBM
-        if (glamor_egl->can_texture_gbm_bo) {
-            GLAMOR_LOG_STR(screen_idx, X_WARNING, "EGL extension EGL_MESA_image_dma_buf_export not available\n");
-            GLAMOR_LOG_STR(screen_idx, X_WARNING, "DRI3 dmabuf export will be slower\n");
-            glamor_egl->dri3_info.fd_from_pixmap = glamor_egl_fd_from_pixmap_slow;
-            glamor_egl->dri3_info.fds_from_pixmap = glamor_egl_fds_from_pixmap_slow;
-        } else
-#endif
-        {
-            GLAMOR_LOG_STR(screen_idx, X_WARNING, "EGL extension EGL_MESA_image_dma_buf_export not available\n");
-            GLAMOR_LOG_STR(screen_idx, X_WARNING, "DRI3 dmabuf export will be unavailable\n");
-            glamor_egl->dri3_info.fd_from_pixmap = NULL;
-            glamor_egl->dri3_info.fds_from_pixmap = NULL;
-            return FALSE;
-        }
+    if (!glamor_egl->has_image_dma_buf_export) {
+        GLAMOR_LOG_STR(screen_idx, X_WARNING, "EGL extension EGL_MESA_image_dma_buf_export not available\n");
+        GLAMOR_LOG_STR(screen_idx, X_WARNING, "DRI3 dmabuf export will be unavailable\n");
+        glamor_egl->dri3_info.fd_from_pixmap = NULL;
+        glamor_egl->dri3_info.fds_from_pixmap = NULL;
+        return FALSE;
     }
 
     return TRUE;
 }
 
+#endif
+
+#ifdef GLAMOR_HAS_GBM
+static Bool
+glamor_egl_probe_dri3_gbm(glamor_egl_priv_t* glamor_egl, int *caps,
+                          glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
+{
+    if (!glamor_egl->can_texture_gbm_bo) {
+        if (!glamor_egl_conf->gbm_forbidden) {
+            GLAMOR_LOG_STR(screen_idx, X_ERROR, "Cannot texture gbm buffers\n");
+        }
+        return FALSE;
+    }
+
+    GLAMOR_LOG_STR(screen_idx, X_INFO, "Can texture gbm buffers\n");
+#ifdef DRI3
+    if (glamor_egl->has_EXT_EGL_image_storage || glamor_egl->has_OES_EGL_image) {
+        glamor_egl->dri3_info = glamor_dri3_info_gbm;
+        *caps = GLAMOR_EGL_DEFAULT_CAPS;
+        return TRUE;
+    }
+#endif
+    *caps = GLAMOR_EGL_CAP_TEXTURE_GBM_BO;
+    return FALSE;
+}
 #endif
 
 static Bool
 glamor_egl_probe_dri3(glamor_egl_priv_t* glamor_egl, int *caps,
                       glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
 {
-    Bool ret = TRUE;
     int _caps;
-
     if (!caps) {
         caps = &_caps;
     }
 
     *caps = GLAMOR_EGL_CAP_NONE;
 
+    glamor_egl->has_EXT_EGL_image_storage = epoxy_has_gl_extension("GL_EXT_EGL_image_storage");
+    glamor_egl->has_OES_EGL_image = epoxy_has_gl_extension("GL_OES_EGL_image");
+    glamor_egl->has_image_dma_buf_export = epoxy_has_egl_extension(glamor_egl->display, "EGL_MESA_image_dma_buf_export");
+
     if (glamor_egl->fd < 0) {
         return FALSE;
     }
 
+#ifdef GLAMOR_HAS_GBM
+    if (glamor_egl_probe_dri3_gbm(glamor_egl, caps, glamor_egl_conf, screen_idx)) {
+        return TRUE;
+    }
+#endif
 #ifdef DRI3
-    *caps = GLAMOR_EGL_DEFAULT_CAPS;
-    glamor_egl->dri3_info = glamor_dri3_info;
+    glamor_egl->dri3_info = glamor_dri3_info_direct;
 
-    if (!glamor_egl_probe_dri3_import(glamor_egl, screen_idx)) {
-        *caps &= ~GLAMOR_EGL_CAP_DRI3_IMPORT;
-        ret = FALSE;
-    }
+    *caps |= glamor_egl_probe_dri3_direct_import(glamor_egl, screen_idx) ?
+             GLAMOR_EGL_CAP_DRI3_IMPORT : 0;
+    *caps |= glamor_egl_probe_dri3_direct_export(glamor_egl, screen_idx) ?
+             GLAMOR_EGL_CAP_DRI3_EXPORT : 0;
 
-    if (!glamor_egl_probe_dri3_export(glamor_egl, screen_idx)) {
-        *caps &= ~GLAMOR_EGL_CAP_DRI3_EXPORT;
-        ret = FALSE;
-    }
+#define GLAMOR_EGL_CAP_DRI3_IMPORT_EXPORT (GLAMOR_EGL_CAP_DRI3_IMPORT | GLAMOR_EGL_CAP_DRI3_EXPORT)
 
     /* Some clients can handle DRI3 missing, but not partial support */
-    if (!ret) {
+    if ((*caps & GLAMOR_EGL_CAP_DRI3_IMPORT_EXPORT) != GLAMOR_EGL_CAP_DRI3_IMPORT_EXPORT) {
         if (!glamor_egl_conf->partial_dri_allowed) {
             GLAMOR_LOG_STR(screen_idx, X_INFO, "Not enabling partial DRI3 support\n");
-        } else {
-            GLAMOR_LOG_STR(screen_idx, X_INFO, "Using partial DRI3 support\n");
-            ret = TRUE;
+            *caps &= GLAMOR_EGL_CAP_TEXTURE_GBM_BO;
+            return FALSE;
         }
+        GLAMOR_LOG_STR(screen_idx, X_INFO, "Using partial DRI3 support\n");
     }
+
+    *caps |= GLAMOR_EGL_CAP_DRI3;
+    return TRUE;
 #else
-    ret = FALSE;
+    return FALSE;
 #endif
-
-#ifdef GLAMOR_HAS_GBM
-    if (glamor_egl->can_texture_gbm_bo) {
-        GLAMOR_LOG_STR(screen_idx, X_INFO, "Can texture gbm buffers\n");
-        *caps |= GLAMOR_EGL_CAP_TEXTURE_GBM_BO;
-    } else
-#endif
-    {
-#ifdef GLAMOR_HAS_GBM
-        if (!glamor_egl_conf->gbm_forbidden) {
-            GLAMOR_LOG_STR(screen_idx, X_ERROR, "Cannot texture gbm buffers\n");
-        }
-#endif
-        *caps &= ~GLAMOR_EGL_CAP_TEXTURE_GBM_BO;
-    }
-
-    return ret;
 }
 
 /**
@@ -3025,7 +3021,7 @@ glamor_egl_probe_dri3(glamor_egl_priv_t* glamor_egl, int *caps,
  * which should be modified to take an info struct and be called
  * by the DDX directly.
  *
- * Because of this, this function and surroundin code has weird workarounds
+ * Because of this, this function and surrounding code has weird workarounds
  * for the fact that we aren't actually called from ScreenInit in xf86.
  */
 Bool

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -1161,12 +1161,12 @@ glamor_drm_format_for_depth(CARD8 depth)
 }
 #endif
 
-Bool
-glamor_back_pixmap_from_fd(PixmapPtr pixmap,
-                           int fd,
-                           CARD16 width,
-                           CARD16 height,
-                           CARD16 _stride, CARD8 depth, CARD8 bpp)
+static Bool
+glamor_back_pixmap_from_fd_fast(PixmapPtr pixmap,
+                                int fd,
+                                CARD16 width,
+                                CARD16 height,
+                                CARD16 _stride, CARD8 depth, CARD8 bpp)
 {
 #ifdef WITH_LIBDRM
     ScreenPtr screen = pixmap->drawable.pScreen;
@@ -1192,6 +1192,68 @@ glamor_back_pixmap_from_fd(PixmapPtr pixmap,
 #endif
 }
 
+static Bool
+glamor_back_pixmap_from_fd_slow(PixmapPtr pixmap,
+                                int fd,
+                                CARD16 width,
+                                CARD16 height,
+                                CARD16 stride, CARD8 depth, CARD8 bpp)
+{
+#ifdef GLAMOR_HAS_GBM
+    ScreenPtr screen = pixmap->drawable.pScreen;
+    glamor_egl_priv_t *glamor_egl;
+    struct gbm_bo *bo;
+    struct gbm_import_fd_data import_data = { 0 };
+    Bool ret;
+
+    glamor_egl = glamor_egl_get_screen_private(screen);
+
+    /* The call would fail later anyway, but this is faster */
+    if (!glamor_egl->can_texture_gbm_bo) {
+        return FALSE;
+    }
+
+    if (width == 0 || height == 0) {
+        return FALSE;
+    }
+
+    import_data.fd = fd;
+    import_data.width = width;
+    import_data.height = height;
+    import_data.stride = stride;
+    import_data.format = glamor_drm_format_for_depth(depth);
+    bo = gbm_bo_import(glamor_egl->gbm, GBM_BO_IMPORT_FD, &import_data,
+                       GBM_BO_USE_RENDERING);
+    if (!bo) {
+        return FALSE;
+    }
+
+    screen->ModifyPixmapHeader(pixmap, width, height, 0, 0, stride, NULL);
+
+    ret = glamor_egl_create_textured_pixmap_from_gbm_bo(pixmap, bo, FALSE);
+    gbm_bo_destroy(bo);
+    return ret;
+#else
+    return FALSE;
+#endif
+}
+
+/* See: https://github.com/X11Libre/xserver/issues/3262 */
+Bool
+glamor_back_pixmap_from_fd(PixmapPtr pixmap,
+                           int fd,
+                           CARD16 width,
+                           CARD16 height,
+                           CARD16 stride, CARD8 depth, CARD8 bpp)
+{
+    Bool ret = glamor_back_pixmap_from_fd_slow(pixmap, fd,
+                                               width, height,
+                                               stride, depth, bpp);
+    return ret ? ret : glamor_back_pixmap_from_fd_fast(pixmap, fd,
+                                                       width, height,
+                                                       stride, depth, bpp);
+}
+
 static PixmapPtr
 glamor_pixmap_from_fds_noop(ScreenPtr screen,
                             CARD8 num_fds, const int *fds,
@@ -1203,13 +1265,13 @@ glamor_pixmap_from_fds_noop(ScreenPtr screen,
     return NULL;
 }
 
-PixmapPtr
-glamor_pixmap_from_fds(ScreenPtr screen,
-                       CARD8 num_fds, const int *fds,
-                       CARD16 width, CARD16 height,
-                       const CARD32 *_strides, const CARD32 *_offsets,
-                       CARD8 depth, CARD8 bpp,
-                       uint64_t modifier)
+static PixmapPtr
+glamor_pixmap_from_fds_fast(ScreenPtr screen,
+                            CARD8 num_fds, const int *fds,
+                            CARD16 width, CARD16 height,
+                            const CARD32 *_strides, const CARD32 *_offsets,
+                            CARD8 depth, CARD8 bpp,
+                            uint64_t modifier)
 {
 #ifdef WITH_LIBDRM
     PixmapPtr pixmap;
@@ -1260,12 +1322,158 @@ glamor_pixmap_from_fds(ScreenPtr screen,
                                                               format, modifier);
     } else {
         if (num_fds == 1) {
-            ret = glamor_back_pixmap_from_fd(pixmap, fds[0], width, height,
-                                             _strides[0], depth, bpp);
+            ret = glamor_back_pixmap_from_fd_fast(pixmap, fds[0], width, height,
+                                                  _strides[0], depth, bpp);
         }
     }
 
 error:
+    if (ret == FALSE) {
+        dixDestroyPixmap(pixmap, 0);
+        return NULL;
+    }
+    return pixmap;
+#else
+    return NULL;
+#endif
+}
+
+static PixmapPtr
+glamor_pixmap_from_fds_slow(ScreenPtr screen,
+                            CARD8 num_fds, const int *fds,
+                            CARD16 width, CARD16 height,
+                            const CARD32 *strides, const CARD32 *offsets,
+                            CARD8 depth, CARD8 bpp,
+                            uint64_t modifier)
+{
+#if defined(GLAMOR_HAS_GBM) && defined(WITH_LIBDRM)
+    PixmapPtr pixmap;
+    glamor_egl_priv_t *glamor_egl;
+    Bool ret = FALSE;
+    int i;
+
+    glamor_egl = glamor_egl_get_screen_private(screen);
+
+    /* The call would fail later anyway, but this is faster */
+    if (!glamor_egl->can_texture_gbm_bo) {
+        return FALSE;
+    }
+
+    pixmap = screen->CreatePixmap(screen, 0, 0, depth, 0);
+
+#ifdef GBM_BO_WITH_MODIFIERS
+    if (glamor_egl->dmabuf_capable && modifier != DRM_FORMAT_MOD_INVALID) {
+        struct gbm_import_fd_modifier_data import_data = { 0 };
+        struct gbm_bo *bo;
+
+        if (width == 0 || height == 0) {
+            goto error;
+        }
+
+        import_data.width = width;
+        import_data.height = height;
+        import_data.format = glamor_drm_format_for_depth(depth);
+        import_data.num_fds = num_fds;
+        import_data.modifier = modifier;
+        for (i = 0; i < num_fds; i++) {
+            import_data.fds[i] = fds[i];
+            import_data.strides[i] = strides[i];
+            import_data.offsets[i] = offsets[i];
+        }
+        bo = gbm_bo_import(glamor_egl->gbm, GBM_BO_IMPORT_FD_MODIFIER, &import_data,
+                           GBM_BO_USE_RENDERING);
+        if (bo) {
+            screen->ModifyPixmapHeader(pixmap, width, height, 0, 0, strides[0], NULL);
+            ret = glamor_egl_create_textured_pixmap_from_gbm_bo(pixmap, bo, TRUE);
+            gbm_bo_destroy(bo);
+        }
+    } else
+#endif
+    {
+        if (num_fds == 1) {
+            ret = glamor_back_pixmap_from_fd_slow(pixmap, fds[0], width, height,
+                                                  strides[0], depth, bpp);
+        }
+    }
+
+#ifdef GBM_BO_WITH_MODIFIERS
+error:
+#endif
+    if (ret == FALSE) {
+        dixDestroyPixmap(pixmap, 0);
+        return NULL;
+    }
+    return pixmap;
+#else
+    return NULL;
+#endif
+}
+
+/* See: https://github.com/X11Libre/xserver/issues/3262 */
+PixmapPtr
+glamor_pixmap_from_fds(ScreenPtr screen,
+                       CARD8 num_fds, const int *fds,
+                       CARD16 width, CARD16 height,
+                       const CARD32 *strides, const CARD32 *offsets,
+                       CARD8 depth, CARD8 bpp,
+                       uint64_t modifier)
+{
+    PixmapPtr ret = glamor_pixmap_from_fds_slow(screen, num_fds, fds,
+                                                width, height,
+                                                strides, offsets,
+                                                depth, bpp, modifier);
+    return ret ? ret : glamor_pixmap_from_fds_fast(screen, num_fds, fds,
+                                                   width, height,
+                                                   strides, offsets,
+                                                   depth, bpp, modifier);
+}
+
+static PixmapPtr
+glamor_pixmap_from_fd_fast(ScreenPtr screen,
+                           int fd,
+                           CARD16 width,
+                           CARD16 height,
+                           CARD16 stride, CARD8 depth, CARD8 bpp)
+{
+    PixmapPtr pixmap;
+    bool ret;
+
+    pixmap = screen->CreatePixmap(screen, 0, 0, depth, 0);
+
+    ret = glamor_back_pixmap_from_fd_fast(pixmap, fd, width, height,
+                                          stride, depth, bpp);
+
+    if (ret == FALSE) {
+        dixDestroyPixmap(pixmap, 0);
+        return NULL;
+    }
+    return pixmap;
+}
+
+static PixmapPtr
+glamor_pixmap_from_fd_slow(ScreenPtr screen,
+                           int fd,
+                           CARD16 width,
+                           CARD16 height,
+                           CARD16 stride, CARD8 depth, CARD8 bpp)
+{
+#ifdef GLAMOR_HAS_GBM
+    PixmapPtr pixmap;
+    glamor_egl_priv_t *glamor_egl;
+    bool ret;
+
+    glamor_egl = glamor_egl_get_screen_private(screen);
+
+    /* The call would fail later anyway, but this is faster */
+    if (!glamor_egl->can_texture_gbm_bo) {
+        return FALSE;
+    }
+
+    pixmap = screen->CreatePixmap(screen, 0, 0, depth, 0);
+
+    ret = glamor_back_pixmap_from_fd_slow(pixmap, fd, width, height,
+                                          stride, depth, bpp);
+
     if (ret == FALSE) {
         dixDestroyPixmap(pixmap, 0);
         return NULL;
@@ -1283,19 +1491,13 @@ glamor_pixmap_from_fd(ScreenPtr screen,
                       CARD16 height,
                       CARD16 stride, CARD8 depth, CARD8 bpp)
 {
-    PixmapPtr pixmap;
-    Bool ret;
+    PixmapPtr ret = glamor_pixmap_from_fd_slow(screen, fd,
+                                               width, height,
+                                               stride, depth, bpp);
 
-    pixmap = screen->CreatePixmap(screen, 0, 0, depth, 0);
-
-    ret = glamor_back_pixmap_from_fd(pixmap, fd, width, height,
-                                     stride, depth, bpp);
-
-    if (ret == FALSE) {
-        dixDestroyPixmap(pixmap, 0);
-        return NULL;
-    }
-    return pixmap;
+    return ret ? ret : glamor_pixmap_from_fd_fast(screen, fd,
+                                                  width, height,
+                                                  stride, depth, bpp);
 }
 
 static Bool
@@ -2709,6 +2911,12 @@ glamor_egl_probe_dri3_import(glamor_egl_priv_t* glamor_egl, int screen_idx)
         /* Avoid DRI3 returning BadImplementation */
         glamor_egl->dri3_info.pixmap_from_fds = glamor_pixmap_from_fds_noop;
         return FALSE;
+    } else
+#ifdef GLAMOR_HAS_GBM
+    if (!glamor_egl->can_texture_gbm_bo)
+#endif
+    {
+        glamor_egl->dri3_info.pixmap_from_fds = glamor_pixmap_from_fds_fast;
     }
 
     return TRUE;

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -2951,7 +2951,9 @@ glamor_egl_probe_dri3_gbm(glamor_egl_priv_t* glamor_egl, int *caps,
 
     GLAMOR_LOG_STR(screen_idx, X_INFO, "Can texture gbm buffers\n");
 #ifdef DRI3
-    if (glamor_egl->has_EXT_EGL_image_storage || glamor_egl->has_OES_EGL_image) {
+    if (!glamor_egl_conf->direct_dri3_only &&
+        (glamor_egl->has_EXT_EGL_image_storage ||
+         glamor_egl->has_OES_EGL_image)) {
         glamor_egl->dri3_info = glamor_dri3_info_gbm;
         *caps = GLAMOR_EGL_DEFAULT_CAPS;
         return TRUE;
@@ -3007,6 +3009,7 @@ glamor_egl_probe_dri3(glamor_egl_priv_t* glamor_egl, int *caps,
     }
 
     *caps |= GLAMOR_EGL_CAP_DRI3;
+    GLAMOR_LOG_STR(screen_idx, X_INFO, "Using the direct DRI3 implementation (experimental)\n");
     return TRUE;
 #else
     return FALSE;

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -1721,6 +1721,8 @@ glamor_egl_screen_init(ScreenPtr screen, struct glamor_context *glamor_ctx)
          * to stay out of the way and let it init DRI3 on its own.
          */
         if (!(glamor_priv->flags & GLAMOR_NO_DRI3)) {
+            const dri3_screen_info_rec dri3_info = glamor_egl->dri3_info;
+
             /* To do DRI3 device FD generation, we need to open a new fd
              * to the same device we were handed in originally.
              */
@@ -1728,7 +1730,7 @@ glamor_egl_screen_init(ScreenPtr screen, struct glamor_context *glamor_ctx)
             if (!glamor_egl->device_path)
                 glamor_egl->device_path = drmGetDeviceNameFromFd2(glamor_egl->fd);
 
-            if (!dri3_screen_init(screen, &glamor_egl->dri3_info)) {
+            if (!dri3_screen_init(screen, &dri3_info)) {
                 GLAMOR_LOG_STR(screen->myNum, X_ERROR,
                                "Failed to initialize DRI3.\n");
             }

--- a/glamor/glamor_egl.c
+++ b/glamor/glamor_egl.c
@@ -677,7 +677,7 @@ glamor_make_pixmap_exportable(PixmapPtr pixmap, Bool modifiers_ok)
         (modifiers_ok || !pixmap_priv->used_modifiers))
         return TRUE;
 
-    if (!glamor_egl->gbm || !glamor_egl->can_texture_gbm_bo) {
+    if (!glamor_egl->can_texture_gbm_bo) {
         return FALSE;
     }
 
@@ -2504,41 +2504,33 @@ glamor_egl_can_texture_gbm_bo(glamor_egl_priv_t *glamor_egl, int is_nvidia)
 }
 #endif
 
-Bool
-glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
+static glamor_egl_priv_t*
+glamor_egl_priv_from_conf(glamor_egl_conf_t* glamor_egl_conf, int *screen_idx)
 {
-    const char *renderer;
-    const char *vendor;
-    glamor_egl_priv_t* glamor_egl = NULL;
-    int *dri_fd = NULL;
-    int platform = 0;
-    int screen_idx = -1;
-    int _caps;
-    int is_nvidia = FALSE;
-
-    if (!caps) {
-        caps = &_caps;
-    }
-
-    *caps = GLAMOR_EGL_CAP_NONE;
+    glamor_egl_priv_t* glamor_egl;
 
     if (glamor_egl_conf->GLAMOR_EGL_PRIV_PROC) {
         glamor_egl_get_screen_private = glamor_egl_conf->GLAMOR_EGL_PRIV_PROC;
         glamor_egl = glamor_egl_conf->glamor_egl_priv;
+        *screen_idx = -1;
     } else {
         if (!glamor_egl_conf->screen ||
             !glamor_egl_init_screen_private(glamor_egl_conf->screen)) {
-            goto error;
+            return NULL;
         }
         glamor_egl = glamor_egl_get_screen_private(glamor_egl_conf->screen);
-        screen_idx = glamor_egl_conf->screen->myNum;
+        *screen_idx = glamor_egl_conf->screen->myNum;
     }
 
     memset(glamor_egl, 0, sizeof(*glamor_egl));
+    return glamor_egl;
+}
 
-#ifdef DRI3
-    glamor_egl->dri3_info = glamor_dri3_info;
-#endif
+static Bool
+glamor_egl_prepare_and_init_display(glamor_egl_priv_t* glamor_egl, int *platform,
+                                    glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
+{
+    int *dri_fd = NULL;
 
     if (glamor_egl_conf->glvnd_vendor) {
         glamor_egl->glvnd_vendor = strdup(glamor_egl_conf->glvnd_vendor);
@@ -2564,40 +2556,20 @@ glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
         dri_fd = &glamor_egl->fd;
     }
 
-    if (!glamor_egl_init_display(glamor_egl, screen_idx, dri_fd, &platform)) {
-        goto error;
+    if (!glamor_egl_init_display(glamor_egl, screen_idx, dri_fd, platform)) {
+        return FALSE;
     }
 
-#define GLAMOR_CHECK_EGL_EXTENSION(EXT)  \
-	if (!epoxy_has_egl_extension(glamor_egl->display, "EGL_" #EXT)) {  \
-		GLAMOR_LOG_STR(screen_idx, X_ERROR, "EGL_" #EXT " required.\n");  \
-		goto error;  \
-	}
+    return TRUE;
+}
 
-    GLAMOR_CHECK_EGL_EXTENSION(KHR_surfaceless_context);
-
-#ifdef GLAMOR_HAS_GBM
-    if (!epoxy_has_egl_extension(glamor_egl->display, "EGL_MESA_image_dma_buf_export")) {
-        GLAMOR_LOG_STR(screen_idx, X_WARNING, "EGL extension EGL_MESA_image_dma_buf_export not available\n");
-        GLAMOR_LOG_STR(screen_idx, X_WARNING, "DRI3 dmabuf export will be slower\n");
-        glamor_egl->dri3_info.fd_from_pixmap = glamor_egl_fd_from_pixmap_slow;
-        glamor_egl->dri3_info.fds_from_pixmap = glamor_egl_fds_from_pixmap_slow;
-    }
-#endif
-
-    if (!glamor_egl_conf->force_es) {
-        glamor_egl_try_big_gl_api(glamor_egl, screen_idx);
-    }
-
-    if (glamor_egl->context == EGL_NO_CONTEXT && !glamor_egl_conf->es_disallowed) {
-        glamor_egl_try_gles_api(glamor_egl, screen_idx);
-    }
-
-    if (glamor_egl->context == EGL_NO_CONTEXT) {
-        GLAMOR_LOG_STR(screen_idx, X_ERROR,
-                       "Failed to create GL or GLES2 contexts\n");
-        goto error;
-    }
+static Bool
+glamor_egl_check_renderer(glamor_egl_priv_t* glamor_egl, int platform,
+                          glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
+{
+    const char* renderer;
+    const char* vendor;
+    int is_nvidia;
 
     renderer = (const char*)glGetString(GL_RENDERER);
     vendor = (const char*)glGetString(GL_VENDOR);
@@ -2614,12 +2586,12 @@ glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
         if (!renderer) {
             GLAMOR_LOG_STR(screen_idx, X_ERROR,
                            "glGetString() returned NULL, your GL is broken\n");
-            goto error;
+            return FALSE;
         }
         if (strstr(renderer, "softpipe")) {
             GLAMOR_LOG_STR(screen_idx, X_INFO,
                            "Refusing to try glamor on softpipe\n");
-            goto error;
+            return FALSE;
         }
         if (!strncmp("llvmpipe", renderer, sizeof("llvmpipe") - 1)) {
             if (glamor_egl_conf->llvmpipe_allowed)
@@ -2628,37 +2600,10 @@ glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
             else {
                 GLAMOR_LOG_STR(screen_idx, X_INFO,
                                "Refusing to try glamor on llvmpipe\n");
-                 goto error;
+                 return FALSE;
             }
         }
     }
-
-    /*
-     * Force the next glamor_make_current call to set the right context
-     * (in case of multiple GPUs using glamor)
-     */
-    lastGLContext = NULL;
-
-    /* XXX From here on, glamor initialization should not fail completely XXX */
-
-    if (glamor_egl->fd < 0) {
-        goto glamor_no_dri;
-    }
-
-    glamor_egl->has_EXT_EGL_image_storage = epoxy_has_gl_extension("GL_EXT_EGL_image_storage");
-    glamor_egl->has_OES_EGL_image = epoxy_has_gl_extension("GL_OES_EGL_image");
-
-    if (!glamor_egl->has_EXT_EGL_image_storage && !glamor_egl->has_OES_EGL_image) {
-        GLAMOR_LOG_STR(screen_idx, X_ERROR,
-                       "Extensions GL_EXT_EGL_image_storage and GL_OES_EGL_image are both unavailable\n");
-        GLAMOR_LOG_STR(screen_idx, X_ERROR,
-                       "DRI3 import will not be available\n");
-        glamor_egl->dri3_info.pixmap_from_fds = NULL;
-    }
-
-#if defined(GLAMOR_HAS_GBM) && defined(EGL_MESA_image_dma_buf_export)
-    glamor_egl->has_image_dma_buf_export = epoxy_has_egl_extension(glamor_egl->display, "EGL_MESA_image_dma_buf_export");
-#endif
 
     if (epoxy_has_egl_extension(glamor_egl->display,
                                 "EGL_EXT_image_dma_buf_import") &&
@@ -2688,50 +2633,215 @@ glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
     }
 #endif
 
-    *caps |= GLAMOR_EGL_DEFAULT_CAPS;
+    return TRUE;
+}
+
+static Bool
+glamor_egl_create_final_context(glamor_egl_priv_t* glamor_egl,
+                                glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
+{
+#define GLAMOR_CHECK_EGL_EXTENSION(EXT)  \
+        if (!epoxy_has_egl_extension(glamor_egl->display, "EGL_" #EXT)) {  \
+                GLAMOR_LOG_STR(screen_idx, X_ERROR, "EGL_" #EXT " required.\n");  \
+                return FALSE;  \
+        }
+
+    GLAMOR_CHECK_EGL_EXTENSION(KHR_surfaceless_context);
+
+    if (!glamor_egl_conf->force_es) {
+        glamor_egl_try_big_gl_api(glamor_egl, screen_idx);
+    }
+
+    if (glamor_egl->context == EGL_NO_CONTEXT && !glamor_egl_conf->es_disallowed) {
+        glamor_egl_try_gles_api(glamor_egl, screen_idx);
+    }
+
+    if (glamor_egl->context == EGL_NO_CONTEXT) {
+        GLAMOR_LOG_STR(screen_idx, X_ERROR,
+                       "Failed to create GL or GLES2 contexts\n");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+
+static Bool
+glamor_egl_create_display_and_context(glamor_egl_priv_t* glamor_egl,
+                                      glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
+{
+    int platform = 0;
+
+    if (!glamor_egl_prepare_and_init_display(glamor_egl, &platform, glamor_egl_conf, screen_idx)) {
+        return FALSE;
+    }
+
+    if (!glamor_egl_create_final_context(glamor_egl, glamor_egl_conf, screen_idx)) {
+        return FALSE;
+    }
+
+    if (!glamor_egl_check_renderer(glamor_egl, platform, glamor_egl_conf, screen_idx)) {
+        return FALSE;
+    }
+
+    /*
+     * Force the next glamor_make_current call to set the right context
+     * (in case of multiple GPUs using glamor)
+     */
+    lastGLContext = NULL;
+
+    return TRUE;
+}
+
 #ifdef DRI3
-    if (!glamor_egl->dri3_info.pixmap_from_fds) {
-        *caps &= ~GLAMOR_EGL_CAP_DRI3_IMPORT;
+static Bool
+glamor_egl_probe_dri3_import(glamor_egl_priv_t* glamor_egl, int screen_idx)
+{
+    glamor_egl->has_EXT_EGL_image_storage = epoxy_has_gl_extension("GL_EXT_EGL_image_storage");
+    glamor_egl->has_OES_EGL_image = epoxy_has_gl_extension("GL_OES_EGL_image");
+
+    if (!glamor_egl->has_EXT_EGL_image_storage && !glamor_egl->has_OES_EGL_image) {
+        GLAMOR_LOG_STR(screen_idx, X_ERROR,
+                       "Extensions GL_EXT_EGL_image_storage and GL_OES_EGL_image are both unavailable\n");
+        GLAMOR_LOG_STR(screen_idx, X_ERROR,
+                       "DRI3 import will not be available\n");
+
         /* Avoid DRI3 returning BadImplementation */
         glamor_egl->dri3_info.pixmap_from_fds = glamor_pixmap_from_fds_noop;
+        return FALSE;
     }
 
-#ifdef GLAMOR_HAS_GBM
-    if (glamor_egl->can_texture_gbm_bo) {
-        GLAMOR_LOG_STR(screen_idx, X_INFO, "Can texture gbm buffers\n");
-    }
-#endif
+    return TRUE;
+}
 
+static Bool
+glamor_egl_probe_dri3_export(glamor_egl_priv_t* glamor_egl, int screen_idx)
+{
+    glamor_egl->has_image_dma_buf_export = epoxy_has_egl_extension(glamor_egl->display, "EGL_MESA_image_dma_buf_export");
+
+    if (glamor_egl->has_image_dma_buf_export) {
 #ifdef GLAMOR_HAS_GBM
-    if (!glamor_egl->gbm || !glamor_egl->can_texture_gbm_bo)
+        if (!glamor_egl->can_texture_gbm_bo)
 #endif
-    {
-        if (!glamor_egl_conf->gbm_forbidden) {
-            GLAMOR_LOG_STR(screen_idx, X_ERROR, "Cannot texture gbm buffers\n");
-        }
-        *caps &= ~GLAMOR_EGL_CAP_TEXTURE_GBM_BO;
-        if (epoxy_has_egl_extension(glamor_egl->display, "EGL_MESA_image_dma_buf_export")) {
+        {
             glamor_egl->dri3_info.fd_from_pixmap = glamor_egl_fd_from_pixmap_fast;
             glamor_egl->dri3_info.fds_from_pixmap = glamor_egl_fds_from_pixmap_fast;
-        } else {
+        }
+    } else {
+#ifdef GLAMOR_HAS_GBM
+        if (glamor_egl->can_texture_gbm_bo) {
+            GLAMOR_LOG_STR(screen_idx, X_WARNING, "EGL extension EGL_MESA_image_dma_buf_export not available\n");
+            GLAMOR_LOG_STR(screen_idx, X_WARNING, "DRI3 dmabuf export will be slower\n");
+            glamor_egl->dri3_info.fd_from_pixmap = glamor_egl_fd_from_pixmap_slow;
+            glamor_egl->dri3_info.fds_from_pixmap = glamor_egl_fds_from_pixmap_slow;
+        } else
+#endif
+        {
             GLAMOR_LOG_STR(screen_idx, X_WARNING, "EGL extension EGL_MESA_image_dma_buf_export not available\n");
             GLAMOR_LOG_STR(screen_idx, X_WARNING, "DRI3 dmabuf export will be unavailable\n");
             glamor_egl->dri3_info.fd_from_pixmap = NULL;
             glamor_egl->dri3_info.fds_from_pixmap = NULL;
-            *caps &= ~GLAMOR_EGL_CAP_DRI3_EXPORT;
+            return FALSE;
         }
     }
 
-#define GLAMOR_EGL_CAP_DRI3_BASE (GLAMOR_EGL_CAP_DRI3_IMPORT | GLAMOR_EGL_CAP_DRI3_EXPORT)
+    return TRUE;
+}
+
+#endif
+
+static Bool
+glamor_egl_probe_dri3(glamor_egl_priv_t* glamor_egl, int *caps,
+                      glamor_egl_conf_t* glamor_egl_conf, int screen_idx)
+{
+    Bool ret = TRUE;
+    int _caps;
+
+    if (!caps) {
+        caps = &_caps;
+    }
+
+    *caps = GLAMOR_EGL_CAP_NONE;
+
+    if (glamor_egl->fd < 0) {
+        return FALSE;
+    }
+
+#ifdef DRI3
+    *caps = GLAMOR_EGL_DEFAULT_CAPS;
+    glamor_egl->dri3_info = glamor_dri3_info;
+
+    if (!glamor_egl_probe_dri3_import(glamor_egl, screen_idx)) {
+        *caps &= ~GLAMOR_EGL_CAP_DRI3_IMPORT;
+        ret = FALSE;
+    }
+
+    if (!glamor_egl_probe_dri3_export(glamor_egl, screen_idx)) {
+        *caps &= ~GLAMOR_EGL_CAP_DRI3_EXPORT;
+        ret = FALSE;
+    }
 
     /* Some clients can handle DRI3 missing, but not partial support */
-    if ((*caps & GLAMOR_EGL_CAP_DRI3_BASE) != GLAMOR_EGL_CAP_DRI3_BASE) {
+    if (!ret) {
         if (!glamor_egl_conf->partial_dri_allowed) {
             GLAMOR_LOG_STR(screen_idx, X_INFO, "Not enabling partial DRI3 support\n");
-            goto glamor_no_dri;
         } else {
             GLAMOR_LOG_STR(screen_idx, X_INFO, "Using partial DRI3 support\n");
+            ret = TRUE;
         }
+    }
+#else
+    ret = FALSE;
+#endif
+
+#ifdef GLAMOR_HAS_GBM
+    if (glamor_egl->can_texture_gbm_bo) {
+        GLAMOR_LOG_STR(screen_idx, X_INFO, "Can texture gbm buffers\n");
+        *caps |= GLAMOR_EGL_CAP_TEXTURE_GBM_BO;
+    } else
+#endif
+    {
+#ifdef GLAMOR_HAS_GBM
+        if (!glamor_egl_conf->gbm_forbidden) {
+            GLAMOR_LOG_STR(screen_idx, X_ERROR, "Cannot texture gbm buffers\n");
+        }
+#endif
+        *caps &= ~GLAMOR_EGL_CAP_TEXTURE_GBM_BO;
+    }
+
+    return ret;
+}
+
+/**
+ * Most of these really should be done in glamor_egl_screen_init,
+ * which should be modified to take an info struct and be called
+ * by the DDX directly.
+ *
+ * Because of this, this function and surroundin code has weird workarounds
+ * for the fact that we aren't actually called from ScreenInit in xf86.
+ */
+Bool
+glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps)
+{
+    glamor_egl_priv_t* glamor_egl;
+    const char* renderer;
+    int screen_idx = -1;
+
+    glamor_egl = glamor_egl_priv_from_conf(glamor_egl_conf, &screen_idx);
+    if (!glamor_egl) {
+        goto error;
+    }
+
+    if (!glamor_egl_create_display_and_context(glamor_egl, glamor_egl_conf, screen_idx)) {
+        goto error;
+    }
+
+    /* XXX From here on, glamor initialization should not fail completely XXX */
+
+    renderer = (const char*)glGetString(GL_RENDERER);
+
+    if (!glamor_egl_probe_dri3(glamor_egl, caps, glamor_egl_conf, screen_idx)) {
+        goto glamor_no_dri;
     }
 
     GLAMOR_LOG_MESSAGE(screen_idx, X_INFO, "DRI3 X acceleration enabled on %s\n", renderer);

--- a/glamor/glamor_egl.h
+++ b/glamor/glamor_egl.h
@@ -56,6 +56,8 @@ typedef struct {
     int fd; /* /dev/dri/cardxx */
     int gbm_forbidden; /* If glamor should not use libgbm, even if available */
 
+    int direct_dri3_only; /* If glamor should only use the direct DRI3 implementation */
+
     int auto_dri; /* If glamor should try to automatically enable DRI3 support */
     int partial_dri_allowed; /* If glamor should initialize DRI3, even if only some operations are available */
 

--- a/glamor/glamor_egl.h
+++ b/glamor/glamor_egl.h
@@ -77,7 +77,7 @@ typedef struct {
  * If caps is not NULL, it will be set to a bitmask containing
  * information about glamor.
  */
-Bool glamor_egl_init_internal(glamor_egl_conf_t* glamor_egl_conf, int *caps);
+Bool glamor_egl_init_internal(const glamor_egl_conf_t* glamor_egl_conf, int *caps);
 
 /*
  * Create an EGLDisplay from a native display type. This is a little quirky

--- a/glamor/glamor_egl_priv.h
+++ b/glamor/glamor_egl_priv.h
@@ -18,6 +18,10 @@
 #include "scrnintstr.h"
 #include "glamor_egl_ext.h"
 
+#ifdef DRI3
+#include "dri3.h"
+#endif
+
 #ifdef GLAMOR_HAS_GBM
 #include <gbm.h>
 #endif
@@ -29,6 +33,10 @@ typedef struct glamor_egl_screen_private {
     char *glvnd_vendor; /* glvnd vendor library name or driver name */
     int exact_glvnd_vendor; /* If the glvnd vendor should be assumed valid with no checks */
     void* server_private;
+
+#ifdef DRI3
+    dri3_screen_info_rec dri3_info;
+#endif
 
 #ifdef GLAMOR_HAS_GBM
     struct gbm_device *gbm;

--- a/glamor/glamor_egl_priv.h
+++ b/glamor/glamor_egl_priv.h
@@ -42,11 +42,9 @@ typedef struct glamor_egl_screen_private {
     struct gbm_device *gbm;
     int fast_gbm_import;
     int can_texture_gbm_bo;
-#ifdef EGL_MESA_image_dma_buf_export
-    int has_image_dma_buf_export;
-#endif
 #endif
 
+    int has_image_dma_buf_export;
     int has_EXT_EGL_image_storage;
     int has_OES_EGL_image;
 

--- a/hw/xfree86/drivers/video/modesetting/present.c
+++ b/hw/xfree86/drivers/video/modesetting/present.c
@@ -508,7 +508,7 @@ ms_present_unflip(ScreenPtr screen, uint64_t event_id)
 }
 #endif
 
-static present_screen_info_rec ms_present_screen_info = {
+static const present_screen_info_rec ms_present_screen_info = {
     .version = PRESENT_SCREEN_INFO_VERSION,
 
     .get_crtc = ms_present_get_crtc,
@@ -529,6 +529,7 @@ static present_screen_info_rec ms_present_screen_info = {
 Bool
 ms_present_screen_init(ScreenPtr screen)
 {
+    present_screen_info_rec info = ms_present_screen_info;
     ScrnInfoPtr scrn = xf86ScreenToScrn(screen);
     modesettingPtr ms = modesettingPTR(scrn);
     uint64_t value;
@@ -542,10 +543,10 @@ ms_present_screen_init(ScreenPtr screen)
                             DRM_CAP_ATOMIC_ASYNC_PAGE_FLIP :
                             DRM_CAP_ASYNC_PAGE_FLIP, &value);
     if (ret == 0 && value == 1) {
-        ms_present_screen_info.capabilities |= PresentCapabilityAsync;
+        info.capabilities |= PresentCapabilityAsync;
         ms->drmmode.can_async_flip = TRUE;
         xf86DrvMsg(screen->myNum, X_INFO, "Async flip capable\n");
     }
 
-    return present_screen_init(screen, &ms_present_screen_info);
+    return present_screen_init(screen, &info);
 }

--- a/hw/xfree86/glamor_egl/glamor_xf86_egl.c
+++ b/hw/xfree86/glamor_egl/glamor_xf86_egl.c
@@ -15,12 +15,14 @@
 
 enum {
     GLAMOREGLOPT_RENDERING_API,
-    GLAMOREGLOPT_VENDOR_LIBRARY
+    GLAMOREGLOPT_VENDOR_LIBRARY,
+    GLAMOREGLOPT_DIRECT_DRI3,
 };
 
 static const OptionInfoRec GlamorEGLOptions[] = {
     { GLAMOREGLOPT_RENDERING_API, "RenderingAPI", OPTV_STRING, {0}, FALSE },
     { GLAMOREGLOPT_VENDOR_LIBRARY, "GlxVendorLibrary", OPTV_STRING, {0}, FALSE },
+    { GLAMOREGLOPT_DIRECT_DRI3, "DirectDRI3", OPTV_BOOLEAN, {0}, FALSE },
     { -1, NULL, OPTV_NONE, {0}, FALSE },
 };
 
@@ -80,6 +82,8 @@ _glamor_egl_init(ScrnInfoPtr scrn, int fd, int *caps)
         glamor_egl_conf.force_es = TRUE;
     else if (api && !strncasecmp(api, "gl", 2))
         glamor_egl_conf.es_disallowed = TRUE;
+
+    xf86GetOptValBool(options, GLAMOREGLOPT_DIRECT_DRI3, &glamor_egl_conf.direct_dri3_only);
 
     glamor_egl_conf.GLAMOR_EGL_PRIV_PROC = glamor_xf86_egl_get_screen_private;
 

--- a/hw/xfree86/man/xorg.conf.man
+++ b/hw/xfree86/man/xorg.conf.man
@@ -2246,6 +2246,10 @@ not available. This may be useful for embedded and old cards, where GL ES
 feature set works faster than GL feature set.
 Default: gl.
 .TP 7
+.BI "Option \*qDirectDRI3\*q \*q"  boolean \*q
+This option tells glamor to use the direct implementation of DRI3.
+This option is experimental, and there are known bugs with it.
+.TP 7
 .BI "Option \*qInitPrimary\*q \*q" boolean \*q
 Use the Int10 module to initialize the primary graphics card.
 Normally, only secondary cards are soft-booted using the Int10 module, as the


### PR DESCRIPTION
This is #3535 backport to 25.2 branch with dependent prs.

@stefan11111 I got multiple times cherry-pick conflicts in glamor/glamor_egl.c, all I did i was deleting extra lines - it would be wise take a little extra time if my changes correct.

I tested on Sonic DE and Cinamon 
