### PR TITLE
modesetting: don't rebuild TearFree shadows for a same-size modeset

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/drmmode_display.c
+++ b/hw/xfree86/drivers/video/modesetting/drmmode_display.c
@@ -1489,6 +1489,34 @@ drmmode_create_tearfree_shadow(xf86CrtcPtr crtc)
     if (!drmmode->tearfree_enable)
         return TRUE;
 
+    /*
+     * A modeset that doesn't change the scanout dimensions — a position change,
+     * a refresh rate change, re-asserting the same mode — can keep the buffers
+     * it already has. Tearing them down and rebuilding them leaves the CRTC
+     * with nothing valid to scan out until the new ones are painted, which
+     * shows up as the display blanking on every RandR change. xf86-video-amdgpu
+     * takes the same shortcut in drmmode_crtc_scanout_create().
+     *
+     * The buffers are kept, but their contents are not: drmmode_copy_damage()
+     * reads the screen pixmap at the CRTC's position, so a CRTC that moved has
+     * to be re-seeded from its new bounds, exactly as if the buffers had just
+     * been allocated.
+     */
+    if (trf->buf[0].px && trf->buf[1].px &&
+        trf->buf[0].px->drawable.width == w &&
+        trf->buf[0].px->drawable.height == h &&
+        trf->buf[0].px->drawable.depth == crtc->scrn->depth &&
+        trf->buf[0].px->drawable.bitsPerPixel == drmmode->kbpp) {
+        for (i = 0; i < ARRAY_SIZE(trf->buf); i++) {
+            RegionUninit(&trf->buf[i].dmg);
+            RegionInit(&trf->buf[i].dmg, &crtc->bounds, 0);
+        }
+
+        drmmode_copy_damage(crtc, trf->buf[trf->back_idx ^ 1].px,
+                            &trf->buf[trf->back_idx ^ 1].dmg, TRUE);
+        return TRUE;
+    }
+
     /* Destroy the old mode's buffers and make new ones */
     drmmode_destroy_tearfree_shadow(crtc);
     for (i = 0; i < ARRAY_SIZE(trf->buf); i++) {


### PR DESCRIPTION
This is a small enchancement to the user experience.
I always used amdgpu before XLibre, but started to use modesetting by default for some months. Everytime we change resolution, it is ok to have a blank moment in the output, but just moving the output position should not create a blank moment. Amdgpu just moves the outputs without recreating it, and this PR imports the same behavior in modesetting. I had no problem in resolution changes, vt switching or anything I could test easily, but I hope more people can test too. Llm description below:

drmmode_set_mode_major() calls drmmode_create_tearfree_shadow() on every mode set, and that function unconditionally destroys both TearFree shadow buffers before allocating replacements. Between the teardown and the repaint the CRTC has nothing valid to scan out, so every RandR change -- including ones that only move a CRTC or re-assert the mode it already has -- blanks the display. With TearFree off the function returns early and the same change happens with the screens lit, which is also how xf86-video-amdgpu behaves.

Keep the buffers when the scanout dimensions are unchanged, which is what drmmode_crtc_scanout_create() in xf86-video-amdgpu does. Their contents are still re-seeded: drmmode_copy_damage() reads the screen pixmap at the CRTC's position, so a CRTC that only moved would otherwise keep displaying the pixels from its old position until something happened to damage them.

A genuine resolution change still tears down before allocating and can still blank; that case wants allocate-before-free, which is a larger change.