### PR TITLE
modesetting: don't advertise TearFree for a pixmap we never checked

### DIFF
--- a/hw/xfree86/drivers/video/modesetting/present.c
+++ b/hw/xfree86/drivers/video/modesetting/present.c
@@ -323,6 +323,7 @@ ms_present_check_flip(RRCrtcPtr crtc,
     ScrnInfoPtr scrn = xf86ScreenToScrn(screen);
     modesettingPtr ms = modesettingPTR(scrn);
     bool async_flip = !sync_flip;
+    bool pixmap_unchecked = false;
 
     if (reason)
         *reason = PRESENT_FLIP_REASON_UNKNOWN;
@@ -343,11 +344,17 @@ ms_present_check_flip(RRCrtcPtr crtc,
      *
      * See: https://github.com/X11Libre/xserver/issues/1812
      * See: https://github.com/X11Libre/xserver/issues/1754
+     *
+     * Bailing out here skips ms_present_check_unflip(), so nothing is known
+     * about the pixmap yet: not its format, not its modifier, not whether the
+     * scanout could ever take it. Say nothing about TearFree in that case
+     * rather than claim a presentation path we have not verified.
      */
     if (window->drawable.x != 0 || window->drawable.y != 0 ||
         window->drawable.x != pixmap->screen_x || window->drawable.y != pixmap->screen_y ||
         window->drawable.width != pixmap->drawable.width ||
         window->drawable.height != pixmap->drawable.height) {
+        pixmap_unchecked = true;
         goto no_flip;
     }
 
@@ -374,7 +381,7 @@ ms_present_check_flip(RRCrtcPtr crtc,
 
 no_flip:
     /* Export some info about TearFree if Present can't flip anyway */
-    if (reason && *reason == PRESENT_FLIP_REASON_UNKNOWN) {
+    if (reason && *reason == PRESENT_FLIP_REASON_UNKNOWN && !pixmap_unchecked) {
         xf86CrtcPtr xf86_crtc = crtc->devPrivate;
         drmmode_crtc_private_ptr drmmode_crtc = xf86_crtc->driver_private;
         drmmode_tearfree_ptr trf = &drmmode_crtc->tearfree;


### PR DESCRIPTION
This is a way we found to fix https://github.com/X11Libre/xserver/issues/3680. I assume I have bare idea how this fixes the issue, but not 100% understanding the code path.
Also I don't know if this could affect https://github.com/X11Libre/xserver/issues/1812 or other things fixed by 2e31b2fdc00fea7c27350e32ebe496c81fc07288.
Please see if this is a good solution or at least it points to the direction for a good one. And if approved, would go to 25.2 branch too. Full llm description:

ms_present_check_flip() bails out early when the window and the pixmap do not match exactly, which is what keeps a misaligned pixmap out of ms_present_check_unflip() and its gbm_bo_from_pixmap() call. But that early exit lands in the no_flip block, which then reports one of the TearFree flip reasons.

At that point nothing is known about the pixmap: not its format, not its modifier, not whether the scanout could ever take it. Reporting TearFree tells Present to adjust exec_msc and to expect a completion from a fake flip that the driver may never be able to register, in which case present_execute() falls back to guessing completion_msc = crtc_msc + 1. Two presentations that guess the same MSC then complete at the same MSC, which destroys a frame and wrecks the cadence of a client pacing on those completions.

Say nothing about TearFree on that path instead. The crash guard stays, and a presentation that did get its pixmap checked still gets the TearFree reasons as before.