### PR TITLE
cygwin CI: install python312-lxml instead of python39-lxml

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -965,7 +965,7 @@ jobs:
                    libxcb-render-devel, libxcb-render-util-devel,
                    libxcb-shape-devel, libxcb-util-devel, libxcb-xkb-devel,
                    libxcvt-devel, libxkbfile-devel, font-util,
-                   khronos-opengl-registry, python39-lxml, xkbcomp-devel,
+                   khronos-opengl-registry, python312-lxml, xkbcomp-devel,
                    xkeyboard-config, git
 
             - name: Cygwin ccache cache


### PR DESCRIPTION
## Problem

The `xserver-build-cygwin` CI lane fails on every PR (also on unmodified
release branches) with:

```
hw/xwin/glx/meson.build:6:4: ERROR: Problem encountered: python3 lxml module not found
```

## Root cause

The workflow installs `python39` + `python39-lxml`, but the Cygwin `meson`
runtime resolves to `/usr/bin/python3.12.exe` (`python312` is pulled in
transitively as a meson dependency). The `python3` module inside meson
therefore points at Python 3.12, where no `lxml` module is wired up.

## Fix

Install `python312-lxml` instead, i.e. the lxml binding for the interpreter
that meson actually uses.

## Verification

- `xserver-build-cygwin` lane: build + `ninja test` green (see this PR's CI).
- Workflow-only change, no source impact.