### PR TITLE
25.2: cygwin CI: install python312-lxml instead of python39-lxml

### DIFF
--- a/.github/workflows/build-xserver.yml
+++ b/.github/workflows/build-xserver.yml
@@ -418,7 +418,7 @@ jobs:
                    libxcb-render-devel, libxcb-render-util-devel,
                    libxcb-shape-devel, libxcb-util-devel, libxcb-xkb-devel,
                    libxcvt-devel, libxkbfile-devel, font-util,
-                   khronos-opengl-registry, python39-lxml, xkbcomp-devel,
+                   khronos-opengl-registry, python312-lxml, xkbcomp-devel,
                    xkeyboard-config, git
 
             - name: Cygwin ccache cache


### PR DESCRIPTION
Backport of the merged master fix (PR #3692, b6384684a1) to release/25.2.

The Cygwin CI lane breaks with 'hw/xwin/glx/meson.build:6:4: ERROR: Problem encountered: python3 lxml module not found' because python39-lxml is installed but meson runs /usr/bin/python3.12.exe. Switch the package to python312-lxml.

Only the workflow line changes (minimal backport).